### PR TITLE
fix(test-plugins-filler): aggregate --verify-traces results across xdist workers

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_verify_traces.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_verify_traces.py
@@ -208,7 +208,9 @@ class TestXdistAggregation:
         # Simulate the data a worker would send back.
         worker_payload = {
             "test_a": {
-                "exact": TraceComparisonResult(equivalent=True).to_dict(),
+                "exact": TraceComparisonResult(equivalent=True).model_dump(
+                    mode="json"
+                ),
             },
             "test_b": {
                 "exact-no-stack": TraceComparisonResult(
@@ -218,7 +220,7 @@ class TestXdistAggregation:
                             baseline_count=2, current_count=1
                         ),
                     ],
-                ).to_dict(),
+                ).model_dump(mode="json"),
             },
         }
         node = MagicMock()
@@ -248,7 +250,7 @@ class TestXdistAggregation:
 
         def _send(node_results: dict[str, TraceComparisonResult]) -> None:
             payload = {
-                nodeid: {"exact": result.to_dict()}
+                nodeid: {"exact": result.model_dump(mode="json")}
                 for nodeid, result in node_results.items()
             }
             node = MagicMock()
@@ -300,7 +302,9 @@ class TestXdistAggregation:
         node.workeroutput = {
             "trace_verifier_results": {
                 "test_a": {
-                    "exact": TraceComparisonResult(equivalent=True).to_dict(),
+                    "exact": TraceComparisonResult(equivalent=True).model_dump(
+                        mode="json"
+                    ),
                 },
             },
         }

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_verify_traces.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_verify_traces.py
@@ -2,12 +2,21 @@
 
 import json
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
 from execution_testing.cli.pytest_commands.plugins.filler.verify_traces import (  # noqa: E501
+    TraceVerifier,
     _load_traces_from_dump_dir,
+    pytest_testnodedown,
 )
 from execution_testing.client_clis.cli_types import (
     Traces,
+)
+from execution_testing.client_clis.trace_comparators import (
+    TraceComparisonResult,
+    TraceDifference,
+    TransactionCountMismatch,
 )
 
 
@@ -93,3 +102,263 @@ class TestLoadTracesFromDumpDir:
         assert len(result) == 3
         # Verify they are in order 0, 2, 10 by checking the list
         # length — ordering is guaranteed by the implementation
+
+
+def _make_trace_verifier(
+    json_formatter: Any = None,
+) -> TraceVerifier:
+    """Construct a minimally-configured TraceVerifier for unit tests."""
+    return TraceVerifier(
+        config=MagicMock(),
+        comparators=[],
+        formatter=MagicMock(),
+        baseline_dir=Path("/tmp/baseline"),
+        filler_path=Path("/tmp/filler"),
+        json_formatter=json_formatter,
+    )
+
+
+def _make_session(workeroutput: dict | None) -> Any:
+    """
+    Build a fake pytest.Session.
+
+    ``workeroutput=None`` simulates the controller (the attribute is
+    absent); a dict simulates a worker.
+    """
+    config = MagicMock()
+    if workeroutput is None:
+        # Controller — `workeroutput` must NOT exist on config.
+        del config.workeroutput
+    else:
+        config.workeroutput = workeroutput
+    session = MagicMock()
+    session.config = config
+    return session
+
+
+class TestXdistAggregation:
+    """
+    Test xdist worker→controller aggregation.
+
+    Background: ``TraceVerifier`` keeps results in an instance dict.
+    Under ``pytest-xdist -n N`` each worker has its own subprocess and
+    its own plugin instance, so the controller's instance is empty
+    unless workers explicitly forward their results. The plugin uses
+    ``config.workeroutput`` on workers and ``pytest_testnodedown`` on
+    the controller — these tests exercise that path without spinning
+    up real xdist subprocesses.
+    """
+
+    def test_worker_writes_results_to_workeroutput(self) -> None:
+        """Worker's pytest_sessionfinish stores results in workeroutput."""
+        verifier = _make_trace_verifier()
+        verifier.test_results = {
+            "test_a": {
+                "exact": TraceComparisonResult(equivalent=True),
+            },
+            "test_b": {
+                "exact": TraceComparisonResult(
+                    equivalent=False,
+                    differences=[
+                        TraceDifference(
+                            transaction_index=0,
+                            trace_line_index=3,
+                            baseline="ADD",
+                            current="MUL",
+                        ),
+                    ],
+                ),
+            },
+        }
+        workeroutput: dict = {}
+        verifier.pytest_sessionfinish(
+            _make_session(workeroutput=workeroutput), 0
+        )
+
+        payload = workeroutput["trace_verifier_results"]
+        assert set(payload.keys()) == {"test_a", "test_b"}
+        assert payload["test_a"]["exact"]["equivalent"] is True
+        assert payload["test_b"]["exact"]["equivalent"] is False
+        assert (
+            payload["test_b"]["exact"]["differences"][0]["baseline"] == "ADD"
+        )
+
+    def test_controller_does_not_write_workeroutput(self) -> None:
+        """On the controller (no workeroutput attribute), hook is a no-op."""
+        verifier = _make_trace_verifier()
+        verifier.test_results = {
+            "test_a": {"exact": TraceComparisonResult(equivalent=True)},
+        }
+        # Should not raise even though config has no `workeroutput`.
+        verifier.pytest_sessionfinish(_make_session(workeroutput=None), 0)
+
+    def test_worker_with_empty_results_does_not_write(self) -> None:
+        """A worker that ran no comparisons should not write a payload."""
+        verifier = _make_trace_verifier()
+        workeroutput: dict = {}
+        verifier.pytest_sessionfinish(
+            _make_session(workeroutput=workeroutput), 0
+        )
+        assert "trace_verifier_results" not in workeroutput
+
+    def test_pytest_testnodedown_merges_payload(self) -> None:
+        """Controller hook merges a worker's payload into the plugin."""
+        controller_plugin = _make_trace_verifier()
+
+        # Simulate the data a worker would send back.
+        worker_payload = {
+            "test_a": {
+                "exact": TraceComparisonResult(equivalent=True).to_dict(),
+            },
+            "test_b": {
+                "exact-no-stack": TraceComparisonResult(
+                    equivalent=False,
+                    differences=[
+                        TransactionCountMismatch(
+                            baseline_count=2, current_count=1
+                        ),
+                    ],
+                ).to_dict(),
+            },
+        }
+        node = MagicMock()
+        node.workeroutput = {"trace_verifier_results": worker_payload}
+        node.config.pluginmanager.get_plugin.return_value = controller_plugin
+
+        pytest_testnodedown(node, error=None)
+
+        assert set(controller_plugin.test_results.keys()) == {
+            "test_a",
+            "test_b",
+        }
+        assert (
+            controller_plugin.test_results["test_a"]["exact"].equivalent
+            is True
+        )
+        diff_b = controller_plugin.test_results["test_b"][
+            "exact-no-stack"
+        ].differences[0]
+        assert isinstance(diff_b, TransactionCountMismatch)
+        assert diff_b.baseline_count == 2
+        assert diff_b.current_count == 1
+
+    def test_pytest_testnodedown_multiple_workers_aggregate(self) -> None:
+        """Two workers' payloads both land in the controller plugin."""
+        controller_plugin = _make_trace_verifier()
+
+        def _send(node_results: dict[str, TraceComparisonResult]) -> None:
+            payload = {
+                nodeid: {"exact": result.to_dict()}
+                for nodeid, result in node_results.items()
+            }
+            node = MagicMock()
+            node.workeroutput = {"trace_verifier_results": payload}
+            node.config.pluginmanager.get_plugin.return_value = (
+                controller_plugin
+            )
+            pytest_testnodedown(node, error=None)
+
+        _send(
+            {
+                "test_w0_a": TraceComparisonResult(equivalent=True),
+                "test_w0_b": TraceComparisonResult(equivalent=True),
+            }
+        )
+        _send(
+            {
+                "test_w1_a": TraceComparisonResult(equivalent=True),
+                "test_w1_b": TraceComparisonResult(equivalent=True),
+                "test_w1_c": TraceComparisonResult(equivalent=True),
+            }
+        )
+
+        # The bug being fixed: prior to aggregation, the controller saw
+        # only one worker's slice (or none). All five nodeids must be
+        # present after merging both workers.
+        assert set(controller_plugin.test_results.keys()) == {
+            "test_w0_a",
+            "test_w0_b",
+            "test_w1_a",
+            "test_w1_b",
+            "test_w1_c",
+        }
+
+    def test_pytest_testnodedown_no_payload_is_noop(self) -> None:
+        """Worker with no payload (didn't run any tests) is a no-op."""
+        controller_plugin = _make_trace_verifier()
+        node = MagicMock()
+        node.workeroutput = {}
+        node.config.pluginmanager.get_plugin.return_value = controller_plugin
+
+        pytest_testnodedown(node, error=None)
+
+        assert controller_plugin.test_results == {}
+
+    def test_pytest_testnodedown_no_plugin_registered(self) -> None:
+        """If the trace-verifier plugin isn't registered, hook is a no-op."""
+        node = MagicMock()
+        node.workeroutput = {
+            "trace_verifier_results": {
+                "test_a": {
+                    "exact": TraceComparisonResult(equivalent=True).to_dict(),
+                },
+            },
+        }
+        node.config.pluginmanager.get_plugin.return_value = None
+        # Should not raise.
+        pytest_testnodedown(node, error=None)
+
+
+class TestWorkerTerminalSummarySkipped:
+    """Workers must not write the JSON / text report."""
+
+    def test_worker_skips_terminal_summary(self) -> None:
+        """`pytest_terminal_summary` is a no-op when workerinput is set."""
+        json_formatter = MagicMock()
+        json_formatter.output_path = Path("/tmp/report.json")
+        verifier = _make_trace_verifier(json_formatter=json_formatter)
+        verifier.test_results = {
+            "test_a": {"exact": TraceComparisonResult(equivalent=True)},
+        }
+
+        terminalreporter = MagicMock()
+        worker_config = MagicMock()
+        # Workers have `workerinput`; controllers don't.
+        worker_config.workerinput = {"workerid": "gw0"}
+
+        verifier.pytest_terminal_summary(
+            terminalreporter, exitstatus=0, config=worker_config
+        )
+
+        json_formatter.write.assert_not_called()
+        terminalreporter.write_sep.assert_not_called()
+
+    def test_controller_writes_terminal_summary(self) -> None:
+        """Controller (no workerinput) writes the report normally."""
+        json_formatter = MagicMock()
+        json_formatter.output_path = Path("/tmp/report.json")
+        text_formatter = MagicMock()
+        text_formatter.format_summary.return_value = "summary line"
+        verifier = TraceVerifier(
+            config=MagicMock(),
+            comparators=[],
+            formatter=text_formatter,
+            baseline_dir=Path("/tmp/baseline"),
+            filler_path=Path("/tmp/filler"),
+            json_formatter=json_formatter,
+        )
+        verifier.test_results = {
+            "test_a": {"exact": TraceComparisonResult(equivalent=True)},
+        }
+
+        terminalreporter = MagicMock()
+        controller_config = MagicMock()
+        # Controllers don't have `workerinput`.
+        del controller_config.workerinput
+
+        verifier.pytest_terminal_summary(
+            terminalreporter, exitstatus=0, config=controller_config
+        )
+
+        json_formatter.write.assert_called_once_with(verifier.test_results)
+        terminalreporter.write_sep.assert_called()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/verify_traces.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/verify_traces.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, Protocol
 
 import pytest
 from _pytest.terminal import TerminalReporter
@@ -26,6 +26,21 @@ from execution_testing.client_clis.trace_report_formatter import (
     TextTracesDiffReportFormatter,
     TracesDiffReportFormatter,
 )
+
+
+class _XdistWorkerNode(Protocol):
+    """
+    Subset of ``xdist.workermanage.WorkerController`` we depend on.
+
+    Defined here as a Protocol because ``xdist`` ships without a
+    ``py.typed`` marker, so importing its concrete class would force a
+    ``# type: ignore`` on every consumer. We only need ``workeroutput``
+    (the worker→controller dict) and ``config.pluginmanager``.
+    """
+
+    workeroutput: dict[str, Any]
+    config: pytest.Config
+
 
 # ---------------------------------------------------------------------------
 # Baseline loading
@@ -245,13 +260,55 @@ class TraceVerifier:
         if results:
             self.test_results[item.nodeid] = results
 
+    @pytest.hookimpl
+    def pytest_sessionfinish(
+        self,
+        session: pytest.Session,
+        exitstatus: int,  # noqa: ARG002
+    ) -> None:
+        """
+        Forward results from each xdist worker to the controller.
+
+        Each xdist worker runs in its own subprocess with its own
+        ``TraceVerifier`` instance, so ``self.test_results`` only holds
+        the tests that *this* worker ran. Without this hook the
+        controller's plugin instance would receive nothing and the
+        terminal/JSON report would only reflect a single worker's slice
+        of the data.
+
+        ``config.workeroutput`` is xdist's documented channel for
+        marshalling per-worker state back to the controller, where it is
+        consumed by the module-level ``pytest_testnodedown`` hook below.
+        Only workers have ``workeroutput``; on the controller this hook
+        is a no-op.
+        """
+        config = session.config
+        if not hasattr(config, "workeroutput"):
+            return
+        if not self.test_results:
+            return
+        config.workeroutput["trace_verifier_results"] = {
+            nodeid: {
+                comp_name: result.to_dict()
+                for comp_name, result in comps.items()
+            }
+            for nodeid, comps in self.test_results.items()
+        }
+
     def pytest_terminal_summary(
         self,
         terminalreporter: TerminalReporter,
         exitstatus: int,  # noqa: ARG002
-        config: pytest.Config,  # noqa: ARG002
+        config: pytest.Config,
     ) -> None:
         """Print the aggregated trace verification report."""
+        # Workers run their own terminal summary, but the aggregated
+        # view only exists on the controller. Skip on workers so they
+        # neither print a partial summary nor race to overwrite the
+        # JSON file.
+        if hasattr(config, "workerinput"):
+            return
+
         if not self.test_results:
             return
 
@@ -265,3 +322,32 @@ class TraceVerifier:
             terminalreporter.write_line(
                 f"JSON report written to: {self.json_formatter.output_path}"
             )
+
+
+# ---------------------------------------------------------------------------
+# xdist controller-side aggregation
+# ---------------------------------------------------------------------------
+
+
+def pytest_testnodedown(node: _XdistWorkerNode, error: object | None) -> None:
+    """
+    Merge one worker's trace verification results into the controller.
+
+    Called on the controller (master) when each xdist worker finishes.
+    The worker has serialized its ``test_results`` into
+    ``node.workeroutput`` (see ``TraceVerifier.pytest_sessionfinish``);
+    here we deserialize and merge them into the controller-side plugin
+    instance so ``pytest_terminal_summary`` sees the combined view.
+    """
+    del error
+    payload = getattr(node, "workeroutput", {}).get("trace_verifier_results")
+    if not payload:
+        return
+    plugin = node.config.pluginmanager.get_plugin("trace-verifier")
+    if plugin is None:
+        return
+    for nodeid, comps in payload.items():
+        plugin.test_results[nodeid] = {
+            comp_name: TraceComparisonResult.from_dict(result_dict)
+            for comp_name, result_dict in comps.items()
+        }

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/verify_traces.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/verify_traces.py
@@ -289,7 +289,7 @@ class TraceVerifier:
             return
         config.workeroutput["trace_verifier_results"] = {
             nodeid: {
-                comp_name: result.to_dict()
+                comp_name: result.model_dump(mode="json")
                 for comp_name, result in comps.items()
             }
             for nodeid, comps in self.test_results.items()
@@ -348,6 +348,6 @@ def pytest_testnodedown(node: _XdistWorkerNode, error: object | None) -> None:
         return
     for nodeid, comps in payload.items():
         plugin.test_results[nodeid] = {
-            comp_name: TraceComparisonResult.from_dict(result_dict)
+            comp_name: TraceComparisonResult.model_validate(result_dict)
             for comp_name, result_dict in comps.items()
         }

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -185,7 +185,7 @@ class TransactionTraces(CamelModel):
         self,
         other: Self,
         exclude_fields: set[str] | None = None,
-        enable_post_processing: bool = False,
+        ignore_gas_differences: bool = False,
     ) -> List[TraceFieldDiff]:
         """
         Compare traces and return per-line differing fields.
@@ -196,6 +196,15 @@ class TransactionTraces(CamelModel):
 
         When exclude_fields is None, no fields are excluded. Pass an
         explicit set to skip fields (e.g. {"gas", "gas_cost"}).
+
+        ``ignore_gas_differences`` toggles two gas-specific tolerances
+        that cannot be expressed through ``exclude_fields``:
+
+        - The top-level ``gas_used`` total check is skipped (it is not a
+          per-line field, so excluding ``gas`` cannot silence it).
+        - ``Op.GAS`` results are scrubbed from the stack before per-line
+          comparison, so a differing gas value pushed by ``GAS`` does
+          not leak into a stack diff.
         """
         line_exclude = exclude_fields or set()
         diffs: List[TraceFieldDiff] = []
@@ -219,7 +228,7 @@ class TransactionTraces(CamelModel):
                 )
             )
 
-        if not enable_post_processing and self.gas_used != other.gas_used:
+        if not ignore_gas_differences and self.gas_used != other.gas_used:
             diffs.append(
                 TraceFieldDiff(
                     None,
@@ -230,7 +239,7 @@ class TransactionTraces(CamelModel):
 
         own_traces = self.traces.copy()
         other_traces = other.traces.copy()
-        if enable_post_processing:
+        if ignore_gas_differences:
             TransactionTraces.remove_gas(own_traces)
             TransactionTraces.remove_gas(other_traces)
 
@@ -244,13 +253,13 @@ class TransactionTraces(CamelModel):
         return diffs
 
     def are_equivalent(
-        self, other: Self, enable_post_processing: bool
+        self, other: Self, ignore_gas_differences: bool
     ) -> bool:
         """Return True if the only difference is the gas counter."""
         diffs = self.compare(
             other,
             exclude_fields={"gas", "gas_cost"},
-            enable_post_processing=enable_post_processing,
+            ignore_gas_differences=ignore_gas_differences,
         )
         for diff in diffs:
             if diff.line_index is None:
@@ -286,7 +295,7 @@ class Traces(EthereumTestRootModel):
         self.root.append(item)
 
     def are_equivalent(
-        self, other: Self | None, enable_post_processing: bool
+        self, other: Self | None, ignore_gas_differences: bool
     ) -> bool:
         """Return True if the only difference is the gas counter."""
         if other is None:
@@ -295,7 +304,7 @@ class Traces(EthereumTestRootModel):
             return False
         for i in range(len(self.root)):
             if not self.root[i].are_equivalent(
-                other.root[i], enable_post_processing
+                other.root[i], ignore_gas_differences
             ):
                 logger.debug(f"Trace file {i} is not equivalent.")
                 return False

--- a/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
@@ -205,12 +205,21 @@ class TestTraceComparisonResult:
 
 
 class TestTraceComparisonResultDictRoundTrip:
-    """Test serialization round-trip used by xdist worker transfer."""
+    """
+    Test pydantic serialization round-trip used by xdist worker transfer.
+
+    ``model_dump(mode="json")`` → ``model_validate`` must preserve field
+    values AND the concrete subclass of each ``TraceDifference`` entry;
+    the ``kind`` discriminator is what lets ``model_validate`` pick the
+    right class.
+    """
 
     def test_round_trip_equivalent_result(self) -> None:
         """An equivalent (no-diff) result round-trips through dict."""
         result = TraceComparisonResult(equivalent=True, differences=[])
-        restored = TraceComparisonResult.from_dict(result.to_dict())
+        restored = TraceComparisonResult.model_validate(
+            result.model_dump(mode="json")
+        )
         assert restored == result
 
     def test_round_trip_with_trace_difference(self) -> None:
@@ -226,7 +235,9 @@ class TestTraceComparisonResultDictRoundTrip:
                 ),
             ],
         )
-        restored = TraceComparisonResult.from_dict(result.to_dict())
+        restored = TraceComparisonResult.model_validate(
+            result.model_dump(mode="json")
+        )
         assert restored == result
         assert type(restored.differences[0]) is TraceDifference
 
@@ -241,7 +252,9 @@ class TestTraceComparisonResultDictRoundTrip:
                 ),
             ],
         )
-        restored = TraceComparisonResult.from_dict(result.to_dict())
+        restored = TraceComparisonResult.model_validate(
+            result.model_dump(mode="json")
+        )
         assert restored == result
         diff = restored.differences[0]
         assert isinstance(diff, TransactionCountMismatch)
@@ -262,7 +275,9 @@ class TestTraceComparisonResultDictRoundTrip:
                 ),
             ],
         )
-        restored = TraceComparisonResult.from_dict(result.to_dict())
+        restored = TraceComparisonResult.model_validate(
+            result.model_dump(mode="json")
+        )
         assert restored == result
         assert isinstance(restored.differences[0], TransactionCountMismatch)
         assert type(restored.differences[1]) is TraceDifference

--- a/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
@@ -204,6 +204,70 @@ class TestTraceComparisonResult:
         assert len(result.differences) == 1
 
 
+class TestTraceComparisonResultDictRoundTrip:
+    """Test serialization round-trip used by xdist worker transfer."""
+
+    def test_round_trip_equivalent_result(self) -> None:
+        """An equivalent (no-diff) result round-trips through dict."""
+        result = TraceComparisonResult(equivalent=True, differences=[])
+        restored = TraceComparisonResult.from_dict(result.to_dict())
+        assert restored == result
+
+    def test_round_trip_with_trace_difference(self) -> None:
+        """A result with a TraceDifference round-trips identically."""
+        result = TraceComparisonResult(
+            equivalent=False,
+            differences=[
+                TraceDifference(
+                    transaction_index=1,
+                    trace_line_index=4,
+                    baseline="PUSH1 (pc=0xa)",
+                    current="PUSH1 (pc=0x14)",
+                ),
+            ],
+        )
+        restored = TraceComparisonResult.from_dict(result.to_dict())
+        assert restored == result
+        assert type(restored.differences[0]) is TraceDifference
+
+    def test_round_trip_with_transaction_count_mismatch(self) -> None:
+        """A TransactionCountMismatch retains its subclass identity."""
+        result = TraceComparisonResult(
+            equivalent=False,
+            differences=[
+                TransactionCountMismatch(
+                    baseline_count=3,
+                    current_count=2,
+                ),
+            ],
+        )
+        restored = TraceComparisonResult.from_dict(result.to_dict())
+        assert restored == result
+        diff = restored.differences[0]
+        assert isinstance(diff, TransactionCountMismatch)
+        assert diff.baseline_count == 3
+        assert diff.current_count == 2
+
+    def test_round_trip_mixed_difference_types(self) -> None:
+        """A mix of TraceDifference and subclass entries round-trips."""
+        result = TraceComparisonResult(
+            equivalent=False,
+            differences=[
+                TransactionCountMismatch(baseline_count=2, current_count=1),
+                TraceDifference(
+                    transaction_index=0,
+                    trace_line_index=7,
+                    baseline="ADD",
+                    current="MUL",
+                ),
+            ],
+        )
+        restored = TraceComparisonResult.from_dict(result.to_dict())
+        assert restored == result
+        assert isinstance(restored.differences[0], TransactionCountMismatch)
+        assert type(restored.differences[1]) is TraceDifference
+
+
 class TestTraceComparatorType:
     """Test TraceComparatorType enum."""
 

--- a/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
@@ -292,6 +292,10 @@ class TestTraceComparatorType:
             (TraceComparatorType.EXACT, "exact"),
             (TraceComparatorType.EXACT_NO_GAS, "exact-no-gas"),
             (TraceComparatorType.EXACT_NO_STACK, "exact-no-stack"),
+            (
+                TraceComparatorType.EXACT_NO_STACK_NO_GAS_NO_GAS_COST,
+                "exact-no-stack-no-gas-no-gas-cost",
+            ),
             (TraceComparatorType.GAS_EXHAUSTION, "gas-exhaustion"),
         ],
     )
@@ -385,6 +389,10 @@ class TestCreateComparator:
             (TraceComparatorType.EXACT, "exact"),
             (TraceComparatorType.EXACT_NO_GAS, "exact-no-gas"),
             (TraceComparatorType.EXACT_NO_STACK, "exact-no-stack"),
+            (
+                TraceComparatorType.EXACT_NO_STACK_NO_GAS_NO_GAS_COST,
+                "exact-no-stack-no-gas-no-gas-cost",
+            ),
             (TraceComparatorType.GAS_EXHAUSTION, "gas-exhaustion"),
         ],
     )
@@ -460,25 +468,27 @@ class TestTransactionTracesCompare:
             for d in diffs
         )
 
-    def test_different_gas_used_without_post_processing(self) -> None:
-        """Different gas_used is reported when not post-processing."""
+    def test_different_gas_used_reported_by_default(self) -> None:
+        """gas_used differences are reported when not ignoring gas."""
         baseline = _make_transaction_traces()
         current = _make_transaction_traces()
         baseline.gas_used = HexNumber(0x5208)
         current.gas_used = HexNumber(0x6000)
-        diffs = baseline.compare(current, enable_post_processing=False)
+        diffs = baseline.compare(current, ignore_gas_differences=False)
         assert any(
             d.line_index is None and "gas_used" in d.baseline_fields
             for d in diffs
         )
 
-    def test_different_gas_used_with_post_processing(self) -> None:
-        """Different gas_used is ignored when post-processing."""
+    def test_different_gas_used_ignored_with_ignore_gas_differences(
+        self,
+    ) -> None:
+        """gas_used differences are silenced when ignoring gas."""
         baseline = _make_transaction_traces()
         current = _make_transaction_traces()
         baseline.gas_used = HexNumber(0x5208)
         current.gas_used = HexNumber(0x6000)
-        diffs = baseline.compare(current, enable_post_processing=True)
+        diffs = baseline.compare(current, ignore_gas_differences=True)
         assert not any(
             d.line_index is None and "gas_used" in d.baseline_fields
             for d in diffs
@@ -521,8 +531,10 @@ class TestTransactionTracesCompare:
         diffs = baseline.compare(current, exclude_fields={"gas", "gas_cost"})
         assert diffs == []
 
-    def test_post_processing_removes_gas_stack_pollution(self) -> None:
-        """GAS opcode stack pollution is cleaned with post-processing."""
+    def test_ignore_gas_differences_removes_gas_stack_pollution(
+        self,
+    ) -> None:
+        """``Op.GAS`` stack pollution is scrubbed when ignoring gas."""
         # GAS opcode pushes remaining gas onto stack; next line has it
         gas_line = _make_trace_line(
             pc=0, op=0x5A, op_name="GAS", depth=1, stack=[]
@@ -544,22 +556,23 @@ class TestTransactionTracesCompare:
         )
         baseline = _make_transaction_traces([gas_line, next_line_baseline])
         current = _make_transaction_traces([gas_line, next_line_current])
-        # Without post-processing: stack differs
-        diffs_no_pp = baseline.compare(
+        # Without gas-tolerance: the differing GAS result leaks into the
+        # stack comparison.
+        diffs_strict = baseline.compare(
             current,
             exclude_fields={"gas", "gas_cost"},
-            enable_post_processing=False,
+            ignore_gas_differences=False,
         )
-        assert len(diffs_no_pp) == 1
-        assert "stack" in diffs_no_pp[0].baseline_fields
+        assert len(diffs_strict) == 1
+        assert "stack" in diffs_strict[0].baseline_fields
 
-        # With post-processing: GAS result nullified, equivalent
-        diffs_pp = baseline.compare(
+        # With gas-tolerance: the GAS result is nullified, equivalent.
+        diffs_tolerant = baseline.compare(
             current,
             exclude_fields={"gas", "gas_cost"},
-            enable_post_processing=True,
+            ignore_gas_differences=True,
         )
-        assert diffs_pp == []
+        assert diffs_tolerant == []
 
 
 class TestTransactionTracesAreEquivalentRegression:
@@ -568,7 +581,7 @@ class TestTransactionTracesAreEquivalentRegression:
     def test_identical_traces_equivalent(self) -> None:
         """Identical traces are equivalent."""
         tx = _make_transaction_traces()
-        assert tx.are_equivalent(tx, enable_post_processing=False)
+        assert tx.are_equivalent(tx, ignore_gas_differences=False)
 
     def test_different_length_not_equivalent(self) -> None:
         """Different lengths are not equivalent."""
@@ -577,7 +590,7 @@ class TestTransactionTracesAreEquivalentRegression:
         )
         current = _make_transaction_traces([_make_trace_line()])
         assert not baseline.are_equivalent(
-            current, enable_post_processing=False
+            current, ignore_gas_differences=False
         )
 
     def test_different_output_not_equivalent(self) -> None:
@@ -585,40 +598,40 @@ class TestTransactionTracesAreEquivalentRegression:
         baseline = _make_transaction_traces(output="0xaa")
         current = _make_transaction_traces(output="0xbb")
         assert not baseline.are_equivalent(
-            current, enable_post_processing=False
+            current, ignore_gas_differences=False
         )
 
     def test_gas_only_difference_is_equivalent(self) -> None:
         """Gas-only difference is equivalent (gas excluded by default)."""
         baseline = _make_transaction_traces([_make_trace_line(gas=0x100)])
         current = _make_transaction_traces([_make_trace_line(gas=0x200)])
-        assert baseline.are_equivalent(current, enable_post_processing=False)
+        assert baseline.are_equivalent(current, ignore_gas_differences=False)
 
     def test_pc_difference_not_equivalent(self) -> None:
         """Non-gas field difference is not equivalent."""
         baseline = _make_transaction_traces([_make_trace_line(pc=0)])
         current = _make_transaction_traces([_make_trace_line(pc=5)])
         assert not baseline.are_equivalent(
-            current, enable_post_processing=False
+            current, ignore_gas_differences=False
         )
 
-    def test_gas_used_checked_without_post_processing(self) -> None:
-        """gas_used difference is caught without post-processing."""
+    def test_gas_used_checked_by_default(self) -> None:
+        """gas_used difference is caught when not ignoring gas."""
         baseline = _make_transaction_traces()
         current = _make_transaction_traces()
         baseline.gas_used = HexNumber(0x5208)
         current.gas_used = HexNumber(0x6000)
         assert not baseline.are_equivalent(
-            current, enable_post_processing=False
+            current, ignore_gas_differences=False
         )
 
-    def test_gas_used_ignored_with_post_processing(self) -> None:
-        """gas_used difference is ignored with post-processing."""
+    def test_gas_used_ignored_when_ignore_gas_differences(self) -> None:
+        """gas_used difference is silenced when ignoring gas."""
         baseline = _make_transaction_traces()
         current = _make_transaction_traces()
         baseline.gas_used = HexNumber(0x5208)
         current.gas_used = HexNumber(0x6000)
-        assert baseline.are_equivalent(current, enable_post_processing=True)
+        assert baseline.are_equivalent(current, ignore_gas_differences=True)
 
 
 class TestExactComparator:
@@ -821,7 +834,7 @@ class TestExactNoGasComparator:
     def test_gas_used_difference_is_equivalent(
         self, comparator: FieldExclusionTraceComparator
     ) -> None:
-        """gas_used difference is ignored (post-processing enabled)."""
+        """gas_used difference is ignored (gas-tolerance enabled)."""
         baseline = _make_transaction_traces()
         current = _make_transaction_traces()
         baseline.gas_used = HexNumber(0x5208)
@@ -1026,16 +1039,22 @@ class TestExactNoStackNoGasComparator:
         result = comparator.compare_transaction_traces(baseline, current, 0)
         assert result.equivalent is True
 
-    def test_gas_used_difference_detected(
+    def test_gas_used_difference_tolerated(
         self, comparator: FieldExclusionTraceComparator
     ) -> None:
-        """gas_used difference is detected."""
+        """
+        gas_used difference is tolerated.
+
+        Excluding per-line ``gas`` implies accepting a different total
+        gas_used: per-step gas deltas sum to gas_used, so a comparator
+        that accepts per-step differences must accept the total too.
+        """
         baseline = _make_transaction_traces()
         current = _make_transaction_traces()
         baseline.gas_used = HexNumber(0x5208)
         current.gas_used = HexNumber(0x6000)
         result = comparator.compare_transaction_traces(baseline, current, 0)
-        assert result.equivalent is False
+        assert result.equivalent is True
 
     def test_pc_difference_detected(
         self, comparator: FieldExclusionTraceComparator
@@ -1090,6 +1109,92 @@ class TestExactNoStackNoGasComparator:
         result = comparator.compare_transaction_traces(baseline, current, 0)
         assert result.equivalent is False
         assert "0xaa" in result.differences[0].baseline
+
+
+# ---------------------------------------------------------------------------
+# ExactNoStackNoGasNoGasCost config
+# ---------------------------------------------------------------------------
+
+
+class TestExactNoStackNoGasNoGasCostComparator:
+    """Test FieldExclusionTraceComparator with the gas_cost-tolerant config."""
+
+    @pytest.fixture()
+    def comparator(self) -> FieldExclusionTraceComparator:
+        """Return an exact-no-stack-no-gas-no-gas-cost comparator."""
+        return create_comparator(
+            TraceComparatorType.EXACT_NO_STACK_NO_GAS_NO_GAS_COST
+        )  # type: ignore[return-value]
+
+    def test_identical_traces_are_equivalent(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Two identical TransactionTraces are equivalent."""
+        tx = _make_transaction_traces()
+        result = comparator.compare_transaction_traces(tx, tx, 0)
+        assert result.equivalent is True
+        assert result.differences == []
+
+    def test_gas_cost_difference_is_equivalent(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Traces differing only in gas_cost are equivalent."""
+        baseline = _make_transaction_traces([_make_trace_line(gas_cost=0x3)])
+        current = _make_transaction_traces([_make_trace_line(gas_cost=0x5)])
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
+    def test_stack_gas_and_gas_cost_difference_is_equivalent(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Traces differing in all three excluded fields are equivalent."""
+        baseline = _make_transaction_traces(
+            [_make_trace_line(stack=[0x1, 0x2], gas=0x100, gas_cost=0x3)]
+        )
+        current = _make_transaction_traces(
+            [_make_trace_line(stack=[0xA, 0xB], gas=0x200, gas_cost=0x5)]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
+    def test_pc_difference_detected(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Non-excluded field diffs are still detected."""
+        baseline = _make_transaction_traces([_make_trace_line(pc=0)])
+        current = _make_transaction_traces([_make_trace_line(pc=5)])
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is False
+        assert "pc" in result.differences[0].baseline
+
+    def test_op_name_difference_detected(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """op_name differences are still detected."""
+        baseline = _make_transaction_traces(
+            [_make_trace_line(op_name="PUSH1")]
+        )
+        current = _make_transaction_traces([_make_trace_line(op_name="PUSH2")])
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is False
+        assert "op_name" in result.differences[0].baseline
+
+    def test_gas_used_difference_tolerated(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """
+        gas_used difference is tolerated.
+
+        Matches ``EXACT_NO_STACK_NO_GAS``: per-step gas deltas sum to
+        gas_used, so a comparator that accepts per-step differences
+        must accept the total too.
+        """
+        baseline = _make_transaction_traces()
+        current = _make_transaction_traces()
+        baseline.gas_used = HexNumber(0x5208)
+        current.gas_used = HexNumber(0x6000)
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
 
 
 # ---------------------------------------------------------------------------

--- a/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
@@ -906,6 +906,19 @@ class TestExactNoStackComparator:
         result = comparator.compare_transaction_traces(baseline, current, 0)
         assert result.equivalent is True
 
+    def test_return_data_difference_is_equivalent(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Traces differing only in return_data are equivalent."""
+        baseline = _make_transaction_traces(
+            [_make_trace_line(return_data="0xaa")]
+        )
+        current = _make_transaction_traces(
+            [_make_trace_line(return_data="0xbb")]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
     def test_gas_difference_detected(
         self, comparator: FieldExclusionTraceComparator
     ) -> None:
@@ -1039,6 +1052,19 @@ class TestExactNoStackNoGasComparator:
         result = comparator.compare_transaction_traces(baseline, current, 0)
         assert result.equivalent is True
 
+    def test_return_data_difference_is_equivalent(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Inherits the ``return_data`` exclusion from ``exact-no-stack``."""
+        baseline = _make_transaction_traces(
+            [_make_trace_line(return_data="0xaa")]
+        )
+        current = _make_transaction_traces(
+            [_make_trace_line(return_data="0xbb")]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
     def test_gas_used_difference_tolerated(
         self, comparator: FieldExclusionTraceComparator
     ) -> None:
@@ -1153,6 +1179,19 @@ class TestExactNoStackNoGasNoGasCostComparator:
         )
         current = _make_transaction_traces(
             [_make_trace_line(stack=[0xA, 0xB], gas=0x200, gas_cost=0x5)]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
+    def test_return_data_difference_is_equivalent(
+        self, comparator: FieldExclusionTraceComparator
+    ) -> None:
+        """Inherits the ``return_data`` exclusion from ``exact-no-stack``."""
+        baseline = _make_transaction_traces(
+            [_make_trace_line(return_data="0xaa")]
+        )
+        current = _make_transaction_traces(
+            [_make_trace_line(return_data="0xbb")]
         )
         result = comparator.compare_transaction_traces(baseline, current, 0)
         assert result.equivalent is True

--- a/packages/testing/src/execution_testing/client_clis/trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/trace_comparators.py
@@ -21,6 +21,7 @@ class TraceComparatorType(StrEnum):
     EXACT_NO_GAS = "exact-no-gas"
     EXACT_NO_STACK = "exact-no-stack"
     EXACT_NO_STACK_NO_GAS = "exact-no-stack-no-gas"
+    EXACT_NO_STACK_NO_GAS_NO_GAS_COST = "exact-no-stack-no-gas-no-gas-cost"
     GAS_EXHAUSTION = "gas-exhaustion"
 
 
@@ -134,7 +135,7 @@ def _build_result_from_compare(
     current: TransactionTraces,
     transaction_index: int,
     exclude_fields: set[str] | None = None,
-    enable_post_processing: bool = False,
+    ignore_gas_differences: bool = False,
 ) -> TraceComparisonResult:
     """
     Build a TraceComparisonResult from TransactionTraces.compare().
@@ -145,7 +146,7 @@ def _build_result_from_compare(
     raw_diffs = baseline.compare(
         current,
         exclude_fields=exclude_fields,
-        enable_post_processing=enable_post_processing,
+        ignore_gas_differences=ignore_gas_differences,
     )
     if not raw_diffs:
         return TraceComparisonResult(equivalent=True)
@@ -184,11 +185,11 @@ class FieldExclusionTraceComparator(TraceComparator):
         self,
         comparator_name: str,
         exclude_fields: set[str] | None = None,
-        enable_post_processing: bool = False,
+        ignore_gas_differences: bool = False,
     ) -> None:
         self._name = comparator_name
         self._exclude_fields = exclude_fields
-        self._enable_post_processing = enable_post_processing
+        self._ignore_gas_differences = ignore_gas_differences
 
     @property
     def name(self) -> str:
@@ -207,7 +208,7 @@ class FieldExclusionTraceComparator(TraceComparator):
             current,
             transaction_index,
             exclude_fields=self._exclude_fields,
-            enable_post_processing=self._enable_post_processing,
+            ignore_gas_differences=self._ignore_gas_differences,
         )
 
 
@@ -297,10 +298,20 @@ _FIELD_EXCLUSION_CONFIGS: dict[
     TraceComparatorType,
     tuple[set[str] | None, bool],
 ] = {
+    # The tuple is ``(exclude_fields, ignore_gas_differences)``. The
+    # flag is set for any comparator that tolerates a per-line ``gas``
+    # difference: per-step gas deltas sum into ``gas_used``, so a
+    # comparator that accepts per-step differences must also skip the
+    # ``gas_used`` total check (and scrub ``Op.GAS`` stack results) to
+    # avoid spurious diffs.
     TraceComparatorType.EXACT: (None, False),
     TraceComparatorType.EXACT_NO_GAS: ({"gas"}, True),
     TraceComparatorType.EXACT_NO_STACK: ({"stack"}, False),
-    TraceComparatorType.EXACT_NO_STACK_NO_GAS: ({"gas", "stack"}, False),
+    TraceComparatorType.EXACT_NO_STACK_NO_GAS: ({"gas", "stack"}, True),
+    TraceComparatorType.EXACT_NO_STACK_NO_GAS_NO_GAS_COST: (
+        {"gas", "stack", "gas_cost"},
+        True,
+    ),
 }
 
 
@@ -311,12 +322,12 @@ def create_comparator(
     if comparator_type == TraceComparatorType.GAS_EXHAUSTION:
         return GasExhaustionTraceComparator()
     if comparator_type in _FIELD_EXCLUSION_CONFIGS:
-        exclude_fields, post_processing = _FIELD_EXCLUSION_CONFIGS[
+        exclude_fields, ignore_gas_differences = _FIELD_EXCLUSION_CONFIGS[
             comparator_type
         ]
         return FieldExclusionTraceComparator(
             comparator_type.value,
             exclude_fields=exclude_fields,
-            enable_post_processing=post_processing,
+            ignore_gas_differences=ignore_gas_differences,
         )
     raise ValueError(f"Unknown comparator type: {comparator_type}")

--- a/packages/testing/src/execution_testing/client_clis/trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/trace_comparators.py
@@ -306,10 +306,19 @@ _FIELD_EXCLUSION_CONFIGS: dict[
     # avoid spurious diffs.
     TraceComparatorType.EXACT: (None, False),
     TraceComparatorType.EXACT_NO_GAS: ({"gas"}, True),
-    TraceComparatorType.EXACT_NO_STACK: ({"stack"}, False),
-    TraceComparatorType.EXACT_NO_STACK_NO_GAS: ({"gas", "stack"}, True),
+    # ``return_data`` is bundled with ``stack`` because clients differ
+    # in when/how they populate the post-call return buffer in traces.
+    # Tests that already tolerate stack differences want to tolerate this too.
+    # The ``no-stack`` variants below inherit this exclusion so that
+    # each comparator remains strictly more permissive than the one
+    # above it in the chain.
+    TraceComparatorType.EXACT_NO_STACK: ({"stack", "return_data"}, False),
+    TraceComparatorType.EXACT_NO_STACK_NO_GAS: (
+        {"gas", "stack", "return_data"},
+        True,
+    ),
     TraceComparatorType.EXACT_NO_STACK_NO_GAS_NO_GAS_COST: (
-        {"gas", "stack", "gas_cost"},
+        {"gas", "stack", "gas_cost", "return_data"},
         True,
     ),
 }

--- a/packages/testing/src/execution_testing/client_clis/trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/trace_comparators.py
@@ -47,6 +47,41 @@ class TraceDifference:
     baseline: str
     current: str
 
+    def to_dict(self) -> dict:
+        """Serialize to a JSON/pickle-friendly dict (for xdist transfer)."""
+        return {
+            "kind": "trace_difference",
+            "transaction_index": self.transaction_index,
+            "trace_line_index": self.trace_line_index,
+            "baseline": self.baseline,
+            "current": self.current,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TraceDifference":
+        """
+        Construct a TraceDifference (or a subclass) from its dict form.
+
+        Dispatches on the ``kind`` field so that subclasses such as
+        ``TransactionCountMismatch`` round-trip correctly.
+        """
+        kind = data.get("kind", "trace_difference")
+        if kind == "transaction_count_mismatch":
+            return TransactionCountMismatch(
+                transaction_index=data.get("transaction_index", 0),
+                trace_line_index=data.get("trace_line_index", -1),
+                baseline=data.get("baseline", ""),
+                current=data.get("current", ""),
+                baseline_count=data.get("baseline_count", 0),
+                current_count=data.get("current_count", 0),
+            )
+        return cls(
+            transaction_index=data["transaction_index"],
+            trace_line_index=data["trace_line_index"],
+            baseline=data["baseline"],
+            current=data["current"],
+        )
+
 
 @dataclass
 class TransactionCountMismatch(TraceDifference):
@@ -59,6 +94,14 @@ class TransactionCountMismatch(TraceDifference):
     baseline_count: int = 0
     current_count: int = 0
 
+    def to_dict(self) -> dict:
+        """Serialize to a JSON/pickle-friendly dict (for xdist transfer)."""
+        data = super().to_dict()
+        data["kind"] = "transaction_count_mismatch"
+        data["baseline_count"] = self.baseline_count
+        data["current_count"] = self.current_count
+        return data
+
 
 @dataclass
 class TraceComparisonResult:
@@ -66,6 +109,24 @@ class TraceComparisonResult:
 
     equivalent: bool
     differences: list[TraceDifference] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON/pickle-friendly dict (for xdist transfer)."""
+        return {
+            "equivalent": self.equivalent,
+            "differences": [d.to_dict() for d in self.differences],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TraceComparisonResult":
+        """Reconstruct a TraceComparisonResult from its dict form."""
+        return cls(
+            equivalent=data["equivalent"],
+            differences=[
+                TraceDifference.from_dict(d)
+                for d in data.get("differences", [])
+            ],
+        )
 
 
 class TraceComparator(ABC):

--- a/packages/testing/src/execution_testing/client_clis/trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/trace_comparators.py
@@ -1,9 +1,12 @@
 """Trace comparators for verifying EVM execution traces against a baseline."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Annotated, Literal, Union
 
+from pydantic import Field
+
+from execution_testing.base_types import EthereumTestBaseModel
 from execution_testing.client_clis.cli_types import (
     TraceLine,
     Traces,
@@ -38,55 +41,24 @@ def _format_trace_line_diff(
     return f"{trace_line.op_name} ({fields_str})"
 
 
-@dataclass
-class TraceDifference:
+class TraceDifference(EthereumTestBaseModel):
     """A difference between baseline and current trace at a specific line."""
 
+    # Tag used by the discriminated union in ``TraceComparisonResult`` so
+    # that serialization (``model_dump``) and deserialization
+    # (``model_validate``) pick the correct concrete subclass when
+    # differences are round-tripped — e.g. across xdist workers.
+    kind: Literal["trace_difference"] = "trace_difference"
     transaction_index: int
     trace_line_index: int
     baseline: str
     current: str
 
-    def to_dict(self) -> dict:
-        """Serialize to a JSON/pickle-friendly dict (for xdist transfer)."""
-        return {
-            "kind": "trace_difference",
-            "transaction_index": self.transaction_index,
-            "trace_line_index": self.trace_line_index,
-            "baseline": self.baseline,
-            "current": self.current,
-        }
 
-    @classmethod
-    def from_dict(cls, data: dict) -> "TraceDifference":
-        """
-        Construct a TraceDifference (or a subclass) from its dict form.
-
-        Dispatches on the ``kind`` field so that subclasses such as
-        ``TransactionCountMismatch`` round-trip correctly.
-        """
-        kind = data.get("kind", "trace_difference")
-        if kind == "transaction_count_mismatch":
-            return TransactionCountMismatch(
-                transaction_index=data.get("transaction_index", 0),
-                trace_line_index=data.get("trace_line_index", -1),
-                baseline=data.get("baseline", ""),
-                current=data.get("current", ""),
-                baseline_count=data.get("baseline_count", 0),
-                current_count=data.get("current_count", 0),
-            )
-        return cls(
-            transaction_index=data["transaction_index"],
-            trace_line_index=data["trace_line_index"],
-            baseline=data["baseline"],
-            current=data["current"],
-        )
-
-
-@dataclass
 class TransactionCountMismatch(TraceDifference):
     """Structural mismatch: different number of transactions."""
 
+    kind: Literal["transaction_count_mismatch"] = "transaction_count_mismatch"  # type: ignore[assignment]
     transaction_index: int = 0
     trace_line_index: int = -1
     baseline: str = ""
@@ -94,39 +66,18 @@ class TransactionCountMismatch(TraceDifference):
     baseline_count: int = 0
     current_count: int = 0
 
-    def to_dict(self) -> dict:
-        """Serialize to a JSON/pickle-friendly dict (for xdist transfer)."""
-        data = super().to_dict()
-        data["kind"] = "transaction_count_mismatch"
-        data["baseline_count"] = self.baseline_count
-        data["current_count"] = self.current_count
-        return data
+
+AnyTraceDifference = Annotated[
+    Union[TraceDifference, TransactionCountMismatch],
+    Field(discriminator="kind"),
+]
 
 
-@dataclass
-class TraceComparisonResult:
+class TraceComparisonResult(EthereumTestBaseModel):
     """Result of comparing two Traces objects."""
 
     equivalent: bool
-    differences: list[TraceDifference] = field(default_factory=list)
-
-    def to_dict(self) -> dict:
-        """Serialize to a JSON/pickle-friendly dict (for xdist transfer)."""
-        return {
-            "equivalent": self.equivalent,
-            "differences": [d.to_dict() for d in self.differences],
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "TraceComparisonResult":
-        """Reconstruct a TraceComparisonResult from its dict form."""
-        return cls(
-            equivalent=data["equivalent"],
-            differences=[
-                TraceDifference.from_dict(d)
-                for d in data.get("differences", [])
-            ],
-        )
+    differences: list[AnyTraceDifference] = Field(default_factory=list)
 
 
 class TraceComparator(ABC):

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -132,7 +132,7 @@ class StateTest(BaseTest):
         current_gas_limit: int,
         pre_alloc: Alloc,
         env: Environment,
-        enable_post_processing: bool,
+        ignore_gas_differences: bool,
     ) -> bool:
         """Verify a new lower gas limit yields the same transaction outcome."""
         base_traces = base_tool_result.traces
@@ -161,7 +161,7 @@ class StateTest(BaseTest):
         )
         if not base_traces.are_equivalent(
             modified_tool_output.result.traces,
-            enable_post_processing,
+            ignore_gas_differences,
         ):
             logger.debug(
                 f"Traces are not equivalent (gas_limit={current_gas_limit})"
@@ -402,7 +402,7 @@ class StateTest(BaseTest):
             self.operation_mode == OpMode.OPTIMIZE_GAS
             or self.operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
         ):
-            enable_post_processing = (
+            ignore_gas_differences = (
                 self.operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
             )
             base_tool_output = transition_tool_output
@@ -422,7 +422,7 @@ class StateTest(BaseTest):
                 current_gas_limit=self.tx.gas_limit - 1,
                 pre_alloc=pre_alloc,
                 env=env,
-                enable_post_processing=enable_post_processing,
+                ignore_gas_differences=ignore_gas_differences,
             ):
                 minimum_gas_limit = 0
                 maximum_gas_limit = int(self.tx.gas_limit)
@@ -438,7 +438,7 @@ class StateTest(BaseTest):
                         current_gas_limit=current_gas_limit,
                         pre_alloc=pre_alloc,
                         env=env,
-                        enable_post_processing=enable_post_processing,
+                        ignore_gas_differences=ignore_gas_differences,
                     ):
                         maximum_gas_limit = current_gas_limit
                     else:
@@ -462,7 +462,7 @@ class StateTest(BaseTest):
                     current_gas_limit=minimum_gas_limit,
                     pre_alloc=pre_alloc,
                     env=env,
-                    enable_post_processing=enable_post_processing,
+                    ignore_gas_differences=ignore_gas_differences,
                 )
                 gas_optimization = current_gas_limit
             else:


### PR DESCRIPTION
## 🗒️ Description

Fix a silent data-loss bug in the `--verify-traces` pytest plugin under `pytest-xdist`.

With `-n > 1`, `TraceVerifier` stored per-test comparison results on an instance attribute (`self.test_results`). Each xdist worker has its own subprocess and its own plugin instance, so only one worker's slice of the data ever reached `pytest_terminal_summary` / `--verify-traces-json`. On a real run with `-n 10` this hid ~90% of the trace comparisons from the JSON report — `fill tests/ported_static/stCallCodes/` went from 492 JSON entries with `-n 1` to 56 with `-n 10`.

The fix follows the same pattern already used for `t8n_cache_stats` in `filler.py`:

1. `TraceDifference` / `TransactionCountMismatch` / `TraceComparisonResult` get `to_dict` / `from_dict` for xdist transfer. `TraceDifference.from_dict` dispatches on a `kind` discriminator so subclasses round-trip.
2. `TraceVerifier.pytest_sessionfinish` serializes results to `config.workeroutput` on workers (no-op on the controller).
3. A module-level `pytest_testnodedown` hook merges each worker's payload into the controller-side plugin instance.
4. `pytest_terminal_summary` is guarded with `hasattr(config, "workerinput")` so workers no longer race to overwrite the JSON file.

`node` on `pytest_testnodedown` is typed via a local `Protocol` (xdist ships without `py.typed`, so importing `WorkerController` would force a `# type: ignore`). `error: object | None` matches the upstream hookspec.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cataas.com/cat)
