### PR TITLE
fix(test-fill): resolve checklist path for EIPs referenced via `eip=[N]` kwarg

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/eip_checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/eip_checklist.py
@@ -392,6 +392,21 @@ class EIP:
         return output_dir
 
 
+def _find_eip_dir(tests_root: Path, eip_number: int) -> Path | None:
+    """
+    Return the first `eip<N>_*` directory under `tests_root`, if any.
+
+    Used as a fallback when an EIP is referenced from a test outside its
+    own `eipNNNN/` directory via the `eip=[N]` kwarg of `eip_checklist`,
+    so the checklist doc can still be attached to the EIP's canonical
+    location even when none of its primary tests were collected.
+    """
+    for match in tests_root.rglob(f"eip{eip_number}_*"):
+        if match.is_dir():
+            return match
+    return None
+
+
 class EIPChecklistCollector:
     """Collects and manages EIP checklist items from test markers."""
 
@@ -497,6 +512,14 @@ class EIPChecklistCollector:
                 continue
             self.collect_from_item(item, eip)
 
+        # Back-fill the canonical `eipNNNN_*` directory for any EIP added
+        # via the `eip=[N]` kwarg of `eip_checklist` whose primary tests
+        # weren't collected (e.g. because of a `-m` filter or `--until`).
+        tests_root = Path(config.rootpath) / "tests"
+        for eip in self.eips.values():
+            if eip.path is None:
+                eip.path = _find_eip_dir(tests_root, eip.number)
+
         # Check which mode we are in
         checklist_doc_gen = config.getoption("checklist_doc_gen", False)
         checklist_output = config.getoption(
@@ -512,7 +535,14 @@ class EIPChecklistCollector:
                 continue
 
             if checklist_doc_gen:
-                assert eip.path is not None
+                if eip.path is None:
+                    logger.warning(
+                        f"EIP-{eip.number} was referenced via the `eip` "
+                        "kwarg of `eip_checklist` but no `eip"
+                        f"{eip.number}_*` directory was found under "
+                        "tests/; skipping checklist doc generation for it."
+                    )
+                    continue
                 checklist_path = eip.path / "checklist.md"
                 checklist_props[checklist_path] = EipChecklistPageProps(
                     title=f"EIP-{eip.number} Test Checklist",


### PR DESCRIPTION
## 🗒️ Description

`@pytest.mark.eip_checklist(..., eip=[N])` is the documented escape hatch for a test that covers EIP `N` but lives outside a `tests/**/eip<N>_*/` directory (introduced in ethereum/execution-spec-tests#2088). The collector's `get_eip(N)` stores such EIPs with `path=None`, relying on a later pass over items inside the EIP's own directory to back-fill the path. When those primary tests aren't collected (e.g. deselected by a `-m` filter or `--until`), the path stays `None` and `--checklist-doc-gen` aborts at `assert eip.path is not None`:

```text
INFO    -  INTERNALERROR>   File "/home/dtopz/code/github/execution-specs.specify-docs/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/eip_checklist.py", line 515,
           in pytest_collection_modifyitems
INFO    -  INTERNALERROR>     assert eip.path is not None
INFO    -  INTERNALERROR> AssertionError: assert None is not None
INFO    -  INTERNALERROR>  +  where None = EIP(number=7951, items={'general/code_coverage/eels': EIPItem(id='general/code_coverage/eels', line_number=20, descrip...when the new constraint
           is not met. ', tests=set(), not_applicable_reason='', external_coverage_reason='')}, path=None).path
INFO    -
INFO    -  ======================================================== 10 warnings in 1.16s ========================================================
ERROR   -  Documentation generation failed (exit: 3, INTERNAL_ERROR).
ERROR   -  Script '/home/dtopz/code/github/execution-specs.specify-docs/docs/scripts/gen_test_case_reference.py' caused SystemExit(<ExitCode.INTERNAL_ERROR: 3>)
```

This PR:

- Adds a filesystem fallback `_find_eip_dir(tests_root, n)` that scans `tests/` for the canonical `eip<n>_*` directory after item collection, so the checklist doc can still attach to the EIP's natural location when its primary tests weren't collected.
- Downgrades the `assert eip.path is not None` to a `logger.warning(...)` plus `continue`, so a genuinely missing `eip<n>_*` directory no longer crashes checklist doc generation.

The fix is exercised by running `docs/scripts/gen_test_case_reference.py` with `tests/benchmark` included, where `tests/benchmark/compute/precompile/test_p256verify.py:34` references EIP 7951 via the `eip=[7951]` kwarg. Before the fix, that run crashes with the trace above; after, it completes and `tests/osaka/eip7951_p256verify_precompiles/checklist.md` gets written.

## 🔗 Related Issues or PRs

- Follow-up to ethereum/execution-spec-tests#2088 which introduced the `eip=[N]` kwarg with the stated intent "Use eip kwarg to allow checklist to find tests".
- A separate PR will update `docs/scripts/gen_test_case_reference.py` to actually collect `tests/benchmark`; that change depends on this fix.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

### Cute Animal Picture

<img width="509" height="195" alt="image" src="https://github.com/user-attachments/assets/dd53aea5-0c9f-456d-b58a-2e560d009c5a" />
