### PR TITLE
feat(doc,test-benchmark): re-enable benchmark tests in test case reference

### DIFF
--- a/docs/scripts/gen_test_case_reference.py
+++ b/docs/scripts/gen_test_case_reference.py
@@ -29,21 +29,22 @@ GENERATE_UNTIL_FORK = DocsConfig().GENERATE_UNTIL_FORK
 logger = logging.getLogger("mkdocs")
 
 
-# If docs are generated while FAST_DOCS is true, then use "tests/frontier"
-# otherwise use "tests"
+# If docs are generated while FAST_DOCS is true, then use "tests/frontier";
+# otherwise include both "tests" and "tests/benchmark". The benchmark path
+# must be listed explicitly so its tests are picked up alongside the rest.
 #
 # USAGE 1 (use fast mode):
 #       export FAST_DOCS=true && uv run mkdocs serve
 # USAGE 2 (use fast mode + hide side-effect warnings):
 #       export FAST_DOCS=true && uv run mkdocs serve 2>&1 | sed '/is not found among documentation files/d' #noqa: E501
-test_arg = "tests"
+test_paths = ["tests", "tests/benchmark"]
 fast_mode = getenv("FAST_DOCS")
 if fast_mode is not None:
     if fast_mode.lower() == "true":
         print(
             "-" * 40, "\nWill generate docs using FAST_DOCS mode.\n" + "-" * 40
         )
-        test_arg = "tests/frontier"
+        test_paths = ["tests/frontier"]
 
 args = [
     "--override-ini",
@@ -60,10 +61,9 @@ args = [
     "--skip-index",
     "--ignore=tests/ported_static",
     "-m",
-    "not blockchain_test_engine and not benchmark",
+    "not blockchain_test_engine",
     "-s",
-    test_arg,
-]
+] + test_paths
 
 runner = CliRunner()
 logger.info(

--- a/docs/scripts/gen_test_case_reference.py
+++ b/docs/scripts/gen_test_case_reference.py
@@ -30,21 +30,19 @@ logger = logging.getLogger("mkdocs")
 
 
 # If docs are generated while FAST_DOCS is true, then use "tests/frontier";
-# otherwise include both "tests" and "tests/benchmark". The benchmark path
-# must be listed explicitly so its tests are picked up alongside the rest.
+# otherwise use "tests". Benchmark tests are opted in via --include-benchmark
+# in full mode only.
 #
 # USAGE 1 (use fast mode):
 #       export FAST_DOCS=true && uv run mkdocs serve
 # USAGE 2 (use fast mode + hide side-effect warnings):
 #       export FAST_DOCS=true && uv run mkdocs serve 2>&1 | sed '/is not found among documentation files/d' #noqa: E501
-test_paths = ["tests", "tests/benchmark"]
-fast_mode = getenv("FAST_DOCS")
-if fast_mode is not None:
-    if fast_mode.lower() == "true":
-        print(
-            "-" * 40, "\nWill generate docs using FAST_DOCS mode.\n" + "-" * 40
-        )
-        test_paths = ["tests/frontier"]
+fast_mode = (getenv("FAST_DOCS") or "").lower() == "true"
+if fast_mode:
+    print("-" * 40, "\nWill generate docs using FAST_DOCS mode.\n" + "-" * 40)
+    test_arg = "tests/frontier"
+else:
+    test_arg = "tests"
 
 args = [
     "--override-ini",
@@ -63,7 +61,10 @@ args = [
     "-m",
     "not blockchain_test_engine",
     "-s",
-] + test_paths
+]
+if not fast_mode:
+    args.append("--include-benchmark")
+args.append(test_arg)
 
 runner = CliRunner()
 logger.info(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/gen_test_doc/gen_test_doc.py
@@ -53,7 +53,7 @@ import pytest
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from pytest import Item
 
-from execution_testing.forks import get_forks
+from execution_testing.forks import ALL_TRANSITION_FORKS, get_forks
 from execution_testing.specs import BaseTest
 from execution_testing.tools.utility.versioning import (
     generate_github_url,
@@ -251,6 +251,17 @@ class TestDocsGenerator:
         self.deployed_forks = [
             fork.name() for fork in get_forks() if fork.is_deployed()
         ]
+        # Map each transition fork's name to the base fork it ends at so that
+        # cases parametrized as a transition fork (e.g.
+        # `BPO2ToAmsterdamAtTime15k`) count toward the fork they transition
+        # into (`Amsterdam`).
+        self._transition_to_base: Dict[str, str] = {
+            fork.name(): fork.transitions_to().name()
+            for fork in ALL_TRANSITION_FORKS
+        }
+        self._fork_newness: Dict[str, int] = {
+            fork.name(): i for i, fork in enumerate(get_forks())
+        }
         self._setup_logger()
         self.jinja2_env = Environment(
             loader=FileSystemLoader("docs/templates"),
@@ -265,6 +276,10 @@ class TestDocsGenerator:
         self.module_page_props: ModulePagePropsLookup = {}
         # the complete set of pages and their properties
         self.page_props: PagePropsLookup = {}
+
+    def _base_fork(self, fork_name: str) -> str:
+        """Return the base fork name, resolving transition forks."""
+        return self._transition_to_base.get(fork_name, fork_name)
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_collection_modifyitems(
@@ -461,26 +476,36 @@ class TestDocsGenerator:
                 # valid_from marker, separated by a comma. Take the last.
                 valid_from_fork = valid_from_marker.args[0].split(",")[-1]
 
-            target_or_valid_fork = (
-                self.target_fork
-                if valid_from_fork in self.deployed_forks
-                else valid_from_fork
-            )
-            test_type = get_test_function_test_type(items[0])
-
-            test_case_count = len(
-                [
-                    case
-                    for case in test_cases
-                    if case.fork == target_or_valid_fork
-                    and case.fixture_type == test_type
-                ]
-            )
-
             benchmark_dir = (
                 Path(items[0].config.rootpath) / "tests" / "benchmark"
             )
             is_benchmark = benchmark_dir in Path(items[0].fspath).parents
+            test_type = get_test_function_test_type(items[0])
+
+            # Pick the displayed fork from the collected cases: the latest
+            # base fork any case is parametrized for, with transition forks
+            # resolved to the fork they transition into. Fall back to
+            # `valid_from_fork` when nothing was collected.
+            base_forks = {self._base_fork(case.fork) for case in test_cases}
+            if base_forks:
+                target_or_valid_fork = max(
+                    base_forks,
+                    key=lambda f: self._fork_newness.get(f, -1),
+                )
+            else:
+                target_or_valid_fork = valid_from_fork
+
+            # Count unique parametrizations at the displayed fork.
+            # `case.params` already excludes `fork` and the fixture-type key
+            # (see `skip_params` above), so a parametrization that produces
+            # several fixture formats (e.g. benchmark -> `blockchain_test`
+            # and `blockchain_test_engine`) collapses to a single case.
+            unique_params = {
+                tuple(sorted(case.params.items()))
+                for case in test_cases
+                if self._base_fork(case.fork) == target_or_valid_fork
+            }
+            test_case_count = len(unique_params)
 
             self.function_page_props[function_id] = FunctionPageProps(
                 title=get_test_function_name(items[0]),
@@ -554,7 +579,12 @@ class TestDocsGenerator:
                 Path(*module_path_parts[: i + 1])
                 for i in range(len(module_path_parts))
             )
+        benchmark_root = self.source_dir / "benchmark"
         for directory in sub_paths:
+            is_benchmark = (
+                directory == benchmark_root
+                or benchmark_root in directory.parents
+            )
             directory_fork_name = (
                 directory.relative_to(self.source_dir).parts[0].capitalize()
                 if directory != self.source_dir
@@ -564,13 +594,6 @@ class TestDocsGenerator:
                 fork = self.target_fork
             else:
                 fork = directory_fork_name
-
-            is_benchmark = any(
-                module_page.is_benchmark
-                for module_page in self.module_page_props.values()
-                if directory in module_page.path.parents
-                or module_page.path.parent == directory
-            )
             self.page_props[str(directory)] = DirectoryPageProps(
                 title=sanitize_string_title(str(directory.name)),
                 path=directory,
@@ -654,6 +677,8 @@ class TestDocsGenerator:
             fork.name().lower(): i
             for i, fork in enumerate(reversed(get_forks()))
         }
+        # Benchmark entries sort above all fork entries.
+        fork_order["benchmark"] = -1
 
         def sort_by_fork_deployment_and_path(x: PageProps) -> Tuple[Any, ...]:
             """

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/gen_test_doc/gen_test_doc.py
@@ -42,6 +42,7 @@ uv run mkdocs serve
 import glob
 import logging
 import os
+import re
 import sys
 import textwrap
 from collections import defaultdict
@@ -673,8 +674,15 @@ class TestDocsGenerator:
         Add the generated 'Test Case Reference' entries to the mkdocs
         navigation menu.
         """
+
+        # Fork directories on disk are snake_case (e.g. `tangerine_whistle`)
+        # but `fork.name()` is CamelCase (`TangerineWhistle`).
+        def _dir_name(fork_name: str) -> str:
+            s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", fork_name)
+            return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
         fork_order = {
-            fork.name().lower(): i
+            _dir_name(fork.name()): i
             for i, fork in enumerate(reversed(get_forks()))
         }
         # Benchmark entries sort above all fork entries.

--- a/tests/benchmark/compute/eip7928_block_level_access_lists/__init__.py
+++ b/tests/benchmark/compute/eip7928_block_level_access_lists/__init__.py
@@ -1,0 +1,1 @@
+"""EIP-7928 Block-level Access List benchmark tests."""


### PR DESCRIPTION
## 🗒️ Description

Adds benchmark tests to the "Test Case Reference" in the HTML docs.

- Use `--include-benchmark` in `gen_test_case_reference.py` to allow collection of benchmark tests together alongside consensus tests (info why this is required in #2668).
- Improve test case counting: benchmark tests were counted incorrectly as they target a different fork. Now counting depends only on the collected cases, not on the target fork.
- As a bonus:
    - The count of tests that have transition forks is fixed.
    - Forks with spaces get ordered correctly, specifically "Tangerine Whistle".

Test locally via:
```
just docs-serve
```

> [!IMPORTANT]
> Requires #2665 to land first. Without that fix, this script crashes with `INTERNALERROR> AssertionError: assert None is not None` on EIP 7951, because `tests/benchmark/compute/precompile/test_p256verify.py:34` references it via the `eip=[7951]` kwarg of `eip_checklist`.

> [!IMPORTANT]
> Requires #2668 to land first. Without that fix, it is impossible to collect both consensus tests and benchmark tests in a single run. This was preferable to multiple runs to avoid the complexity of accumulating state between runs.

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/cc675492-607a-47d1-82a9-7234174fbc94" />


## 🔗 Related Issues or PRs

- Closes #1756.
- Requires #2665.
- Requires #2668.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).