### PR TITLE
feat(zkevm): add execution witness support to other fixture formats

### DIFF
--- a/docs/running_tests/test_formats/blockchain_test_engine.md
+++ b/docs/running_tests/test_formats/blockchain_test_engine.md
@@ -104,6 +104,11 @@ They can mismatch the hashes of the versioned blobs in the execution payload, fo
 
 Hash of the parent beacon block root.
 
+#### - `executionWitness`: Optional execution witness object
+
+Optional fixture metadata for stateless validation. When present, contains
+`state`, `codes`, and `headers` byte lists associated with this payload.
+
 #### - `validationError`: [`TransactionException`](../../library/execution_testing_exceptions.md#execution_testing.exceptions.TransactionException)` | `[`BlockException`](../../library/execution_testing_exceptions.md#execution_testing.exceptions.BlockException)
 
 Validation error expected when executing the payload.

--- a/docs/running_tests/test_formats/blockchain_test_engine_x.md
+++ b/docs/running_tests/test_formats/blockchain_test_engine_x.md
@@ -134,7 +134,10 @@ Optional; present from Cancun on. Maps forks to their blob schedule configuratio
 
 ### `FixtureEngineNewPayload`
 
-Engine API payload structure identical to the one defined in [Blockchain Engine Tests](./blockchain_test_engine.md#fixtureenginenewpayload). Includes execution payload, versioned hashes, parent beacon block root, validation errors, version, and error codes.
+Engine API payload structure identical to the one defined in [Blockchain Engine
+Tests](./blockchain_test_engine.md#fixtureenginenewpayload). Includes
+execution payload, optional execution witness metadata, versioned hashes,
+parent beacon block root, validation errors, version, and error codes.
 
 ## Usage Notes
 

--- a/docs/running_tests/test_formats/blockchain_test_sync.md
+++ b/docs/running_tests/test_formats/blockchain_test_sync.md
@@ -127,6 +127,11 @@ List of hashes of the versioned blobs that are part of the execution payload.
 
 Hash of the parent beacon block root.
 
+#### - `executionWitness`: Optional execution witness object
+
+Optional fixture metadata for stateless validation. When present, contains
+`state`, `codes`, and `headers` byte lists associated with this payload.
+
 #### - `validationError`: [`Optional`](./common_types.md#optional)`[`[`TransactionException`](../../library/execution_testing_exceptions.md#execution_testing.exceptions.TransactionException)` | `[`BlockException`](../../library/execution_testing_exceptions.md#execution_testing.exceptions.BlockException)`]`
 
 For sync tests, this field should not be present as sync tests only work with valid chains. Invalid blocks cannot be synced.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -993,8 +993,8 @@ def test_execution_witness_in_blockchain_fixture(
 ) -> None:
     """
     Fill a minimal Amsterdam state_test that calls a pre-deployed contract,
-    then verify the resulting blockchain fixture contains execution witness
-    and stateless validation fields.
+    then verify the resulting blockchain and engine fixtures contain
+    execution witness data.
     """
     tests_dir = testdir.mkdir("tests")
     amsterdam_tests_dir = tests_dir.mkdir("amsterdam")
@@ -1054,6 +1054,32 @@ def test_execution_witness_in_blockchain_fixture(
         EthereumBytes(bytes.fromhex(sob[2:]))
     )
     assert stateless_output.successful_validation is True
+
+    engine_fixture_path = Path(
+        "fixtures/blockchain_tests_engine/for_amsterdam/amsterdam/"
+        "module_execution_witness/execution_witness.json"
+    )
+    assert engine_fixture_path.exists(), f"{engine_fixture_path} does not exist"
+
+    with open(engine_fixture_path, "r") as f:
+        engine_fixture_data = json.load(f)
+
+    assert len(engine_fixture_data) == 1, "Expected exactly one engine fixture"
+    engine_fixture = next(iter(engine_fixture_data.values()))
+    engine_payload = engine_fixture["engineNewPayloads"][0]
+
+    assert "executionWitness" in engine_payload
+    engine_witness = engine_payload["executionWitness"]
+    assert (
+        len(engine_witness["state"]) > 0
+    ), "engine executionWitness.state is empty"
+    assert (
+        len(engine_witness["codes"]) > 0
+    ), "engine executionWitness.codes is empty"
+    assert (
+        len(engine_witness["headers"]) > 0
+    ), "engine executionWitness.headers is empty"
+    assert engine_witness == witness
 
 
 def test_execution_witness_expected_true_reuses_canonical_stateless_result(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1059,7 +1059,9 @@ def test_execution_witness_in_blockchain_fixture(
         "fixtures/blockchain_tests_engine/for_amsterdam/amsterdam/"
         "module_execution_witness/execution_witness.json"
     )
-    assert engine_fixture_path.exists(), f"{engine_fixture_path} does not exist"
+    assert engine_fixture_path.exists(), (
+        f"{engine_fixture_path} does not exist"
+    )
 
     with open(engine_fixture_path, "r") as f:
         engine_fixture_data = json.load(f)
@@ -1070,15 +1072,15 @@ def test_execution_witness_in_blockchain_fixture(
 
     assert "executionWitness" in engine_payload
     engine_witness = engine_payload["executionWitness"]
-    assert (
-        len(engine_witness["state"]) > 0
-    ), "engine executionWitness.state is empty"
-    assert (
-        len(engine_witness["codes"]) > 0
-    ), "engine executionWitness.codes is empty"
-    assert (
-        len(engine_witness["headers"]) > 0
-    ), "engine executionWitness.headers is empty"
+    assert len(engine_witness["state"]) > 0, (
+        "engine executionWitness.state is empty"
+    )
+    assert len(engine_witness["codes"]) > 0, (
+        "engine executionWitness.codes is empty"
+    )
+    assert len(engine_witness["headers"]) > 0, (
+        "engine executionWitness.headers is empty"
+    )
     assert engine_witness == witness
 
 

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -457,6 +457,7 @@ class FixtureEngineNewPayload(CamelModel):
     params: EngineNewPayloadParameters
     new_payload_version: Number
     forkchoice_updated_version: Number
+    execution_witness: ExecutionWitness | None = None
     validation_error: ExceptionInstanceOrList | None = None
     error_code: (
         Annotated[
@@ -482,6 +483,7 @@ class FixtureEngineNewPayload(CamelModel):
         withdrawals: List[Withdrawal] | None,
         requests: List[Bytes] | None,
         block_access_list: Bytes | None = None,
+        execution_witness: ExecutionWitness | None = None,
         **kwargs: Any,
     ) -> Self:
         """Create `FixtureEngineNewPayload` from a `FixtureHeader`."""
@@ -534,6 +536,7 @@ class FixtureEngineNewPayload(CamelModel):
             params=payload_params,
             new_payload_version=new_payload_version,
             forkchoice_updated_version=forkchoice_updated_version,
+            execution_witness=execution_witness,
             **kwargs,
         )
 

--- a/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
@@ -29,6 +29,7 @@ from execution_testing.test_types import (
     AuthorizationTuple,
     ConsolidationRequest,
     DepositRequest,
+    ExecutionWitness,
     Requests,
     Transaction,
     Withdrawal,
@@ -737,6 +738,11 @@ fixture_header_ones = FixtureHeader(
                         target_pubkey=BLSPublicKey(2),
                     ),
                 ).requests_list,
+                execution_witness=ExecutionWitness(
+                    state=[Bytes(b"state")],
+                    codes=[Bytes(b"code")],
+                    headers=[Bytes(b"header")],
+                ),
                 validation_error=[
                     BlockException.INCORRECT_BLOCK_FORMAT,
                     TransactionException.INTRINSIC_GAS_TOO_LOW,
@@ -821,6 +827,11 @@ fixture_header_ones = FixtureHeader(
                         ).requests_list
                     ],
                 ],
+                "executionWitness": {
+                    "state": [Bytes(b"state").hex()],
+                    "codes": [Bytes(b"code").hex()],
+                    "headers": [Bytes(b"header").hex()],
+                },
                 "forkchoiceUpdatedVersion": "3",
                 "newPayloadVersion": "4",
                 "validationError": "BlockException.INCORRECT_BLOCK_FORMAT"

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -658,6 +658,7 @@ class BuiltBlock(CamelModel):
             block_access_list=self.block_access_list.rlp
             if self.block_access_list
             else None,
+            execution_witness=self.execution_witness,
             validation_error=self.expected_exception,
             error_code=self.engine_api_error_code,
         )


### PR DESCRIPTION
## 🗒️ Description
Currently, we only support adding the `executionWitness` to `blockchain_tests` fixture format. 

This PR adds support for other formats, in particular `blockchain_tests_engine`, since I think this will be useful for testing via Hive through EngineAPI.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
