### PR TITLE
feat(test-fill): add `--include-benchmark` and scan both tests + tests/benchmark in `checklist`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -90,7 +90,7 @@ def checklist(
         uv run checklist tests/prague/eip7702_set_code_tx
 
         # Limit to a specific fork
-        uv run checklist --until Prague
+        uv run checklist --fork Prague
 
         # Specify output directory
         uv run checklist --output ./my-checklists

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -34,6 +34,12 @@ def _last_development_fork() -> str | None:
 
 
 @click.command()
+@click.argument(
+    "paths",
+    nargs=-1,
+    type=click.Path(),
+    default=("tests", "tests/benchmark"),
+)
 @click.option(
     "--output",
     "-o",
@@ -56,7 +62,11 @@ def _last_development_fork() -> str | None:
     help="Include upcoming forks up to and including this fork",
 )
 def checklist(
-    output: str, eip: tuple[int, ...], until: str | None, **kwargs: Any
+    paths: tuple[str, ...],
+    output: str,
+    eip: tuple[int, ...],
+    until: str | None,
+    **kwargs: Any,
 ) -> None:
     """
     Generate EIP test checklists based on pytest.mark.eip_checklist markers.
@@ -64,18 +74,21 @@ def checklist(
     This command scans test files for eip_checklist markers and generates
     filled checklists showing which checklist items have been implemented.
 
+    By default it scans `tests` plus `tests/benchmark`; pass one or more
+    paths to limit collection to a subset.
+
     By default, includes all development forks so that checklists for
     upcoming EIPs are generated without needing --until.
 
     Examples:
-        # Generate checklists for all EIPs
+        # Generate checklists for all EIPs (default: tests + tests/benchmark)
         uv run checklist
 
         # Generate checklist for specific EIP
         uv run checklist --eip 7702
 
-        # Generate checklists for specific test path
-        uv run checklist tests/prague/eip7702*
+        # Generate checklists for a specific test path
+        uv run checklist tests/prague/eip7702_set_code_tx
 
         # Limit to a specific fork
         uv run checklist --until Prague
@@ -100,10 +113,14 @@ def checklist(
     if until:
         args.extend(["--until", until])
 
+    # The default `paths` (`tests`, `tests/benchmark`) lists `tests/benchmark`
+    # explicitly because positional paths override `testpaths = tests/` in
+    # pytest-fill.ini, otherwise checklist coverage from benchmark tests
+    # gets dropped.
+    args.extend(paths)
+
     command = ChecklistCommand(
-        plugins=[
-            "execution_testing.cli.pytest_commands.plugins.filler.eip_checklist"
-        ],
+        plugins=["execution_testing.cli.pytest_commands.plugins.filler.eip_checklist"],
     )
     command.execute(args)
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -89,7 +89,7 @@ def checklist(
         # Generate checklists for a specific test path
         uv run checklist tests/prague/eip7702_set_code_tx
 
-        # Limit to a specific fork
+        # Generate until a specific fork
         uv run checklist --fork Prague
 
         # Specify output directory

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -38,7 +38,6 @@ def _last_development_fork() -> str | None:
     "paths",
     nargs=-1,
     type=click.Path(),
-    default=("tests", "tests/benchmark"),
 )
 @click.option(
     "--output",
@@ -113,14 +112,20 @@ def checklist(
     if until:
         args.extend(["--until", until])
 
-    # The default `paths` (`tests`, `tests/benchmark`) lists `tests/benchmark`
-    # explicitly because positional paths override `testpaths = tests/` in
-    # pytest-fill.ini, otherwise checklist coverage from benchmark tests
-    # gets dropped.
+    # When no paths are provided, scan `tests/` and force inclusion of
+    # `tests/benchmark/` via `--include-benchmark`. The conftest normally
+    # hides `tests/benchmark/` from a plain `tests/` collection, and
+    # passing both as positional paths triggers pytest path deduplication
+    # which drops the broader `tests/`.
+    if not paths:
+        paths = ("tests",)
+        args.append("--include-benchmark")
     args.extend(paths)
 
     command = ChecklistCommand(
-        plugins=["execution_testing.cli.pytest_commands.plugins.filler.eip_checklist"],
+        plugins=[
+            "execution_testing.cli.pytest_commands.plugins.filler.eip_checklist"
+        ],
     )
     command.execute(args)
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -90,7 +90,7 @@ def checklist(
         uv run checklist tests/prague/eip7702_set_code_tx
 
         # Generate until a specific fork
-        uv run checklist --fork Prague
+        uv run checklist --until Prague
 
         # Specify output directory
         uv run checklist --output ./my-checklists

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_include_benchmark.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_include_benchmark.py
@@ -1,0 +1,126 @@
+"""Test the --include-benchmark flag gates tests/benchmark/ collection."""
+
+import textwrap
+
+import pytest
+
+BENCHMARK_CONFTEST = textwrap.dedent(
+    """\
+    from pathlib import Path
+    from typing import Any
+
+
+    def pytest_ignore_collect(
+        collection_path: Path, config: Any
+    ) -> bool | None:
+        if config.getoption("include_benchmark", default=False):
+            return False
+
+        benchmark_dir = Path(__file__).parent
+        args = config.invocation_params.args or ()
+        if any(
+            benchmark_dir in Path(a).resolve().parents
+            or Path(a).resolve() == benchmark_dir
+            for a in args
+        ):
+            return False
+        return True
+    """
+)
+
+BENCHMARK_TEST_MODULE = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import Environment
+
+    @pytest.mark.valid_at("Prague")
+    def test_dummy_benchmark(state_test) -> None:
+        state_test(env=Environment(), pre={}, post={}, tx=None)
+    """
+)
+
+CONSENSUS_TEST_MODULE = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import Environment
+
+    @pytest.mark.valid_at("Prague")
+    def test_dummy_consensus(state_test) -> None:
+        state_test(env=Environment(), pre={}, post={}, tx=None)
+    """
+)
+
+
+def _setup_benchmark_and_consensus_tests(
+    pytester: pytest.Pytester,
+) -> None:
+    """Seed `tests/benchmark/` and `tests/prague/` test modules."""
+    tests_dir = pytester.mkdir("tests")
+
+    benchmark_dir = tests_dir / "benchmark"
+    benchmark_dir.mkdir()
+    (benchmark_dir / "conftest.py").write_text(BENCHMARK_CONFTEST)
+    benchmark_module = benchmark_dir / "dummy_test_module"
+    benchmark_module.mkdir()
+    (benchmark_module / "test_dummy_benchmark.py").write_text(
+        BENCHMARK_TEST_MODULE
+    )
+
+    consensus_dir = tests_dir / "prague"
+    consensus_dir.mkdir()
+    consensus_module = consensus_dir / "dummy_test_module"
+    consensus_module.mkdir()
+    (consensus_module / "test_dummy_consensus.py").write_text(
+        CONSENSUS_TEST_MODULE
+    )
+
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+
+
+def test_default_excludes_benchmark(pytester: pytest.Pytester) -> None:
+    """A plain `tests/` collection hides `tests/benchmark/`."""
+    _setup_benchmark_and_consensus_tests(pytester)
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "tests/",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0, f"Collection failed:\n{result.outlines}"
+    assert any("test_dummy_consensus" in line for line in result.outlines)
+    assert not any(
+        "test_dummy_benchmark" in line for line in result.outlines
+    ), f"Benchmark should be hidden by default:\n{result.outlines}"
+
+
+def test_include_benchmark_flag_collects_both(
+    pytester: pytest.Pytester,
+) -> None:
+    """`--include-benchmark` forces `tests/benchmark/` into collection."""
+    _setup_benchmark_and_consensus_tests(pytester)
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "tests/",
+        "--include-benchmark",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0, f"Collection failed:\n{result.outlines}"
+    assert any("test_dummy_consensus" in line for line in result.outlines)
+    assert any("test_dummy_benchmark" in line for line in result.outlines), (
+        f"Benchmark should be collected with the flag:\n{result.outlines}"
+    )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_include_benchmark.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_include_benchmark.py
@@ -1,31 +1,16 @@
 """Test the --include-benchmark flag gates tests/benchmark/ collection."""
 
 import textwrap
+from pathlib import Path
 
 import pytest
 
-BENCHMARK_CONFTEST = textwrap.dedent(
-    """\
-    from pathlib import Path
-    from typing import Any
-
-
-    def pytest_ignore_collect(
-        collection_path: Path, config: Any
-    ) -> bool | None:
-        if config.getoption("include_benchmark", default=False):
-            return False
-
-        benchmark_dir = Path(__file__).parent
-        args = config.invocation_params.args or ()
-        if any(
-            benchmark_dir in Path(a).resolve().parents
-            or Path(a).resolve() == benchmark_dir
-            for a in args
-        ):
-            return False
-        return True
-    """
+REAL_BENCHMARK_CONFTEST = (
+    Path(__file__).resolve().parents[9] / "tests" / "benchmark" / "conftest.py"
+)
+assert REAL_BENCHMARK_CONFTEST.is_file(), (
+    f"Expected real benchmark conftest at {REAL_BENCHMARK_CONFTEST}; the "
+    "repo layout likely changed and the parent traversal above is stale."
 )
 
 BENCHMARK_TEST_MODULE = textwrap.dedent(
@@ -61,7 +46,9 @@ def _setup_benchmark_and_consensus_tests(
 
     benchmark_dir = tests_dir / "benchmark"
     benchmark_dir.mkdir()
-    (benchmark_dir / "conftest.py").write_text(BENCHMARK_CONFTEST)
+    (benchmark_dir / "conftest.py").write_text(
+        REAL_BENCHMARK_CONFTEST.read_text()
+    )
     benchmark_module = benchmark_dir / "dummy_test_module"
     benchmark_module.mkdir()
     (benchmark_module / "test_dummy_benchmark.py").write_text(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -71,6 +71,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Can be a JSON string or path to a JSON file."
         ),
     )
+    benchmark_group.addoption(
+        "--include-benchmark",
+        action="store_true",
+        dest="include_benchmark",
+        default=False,
+        help=(
+            "Include tests/benchmark/ during collection even when no "
+            "benchmark path is passed as a positional argument. Needed "
+            "when collecting both tests/ and tests/benchmark/ in a single "
+            "pytest invocation, since pytest's path deduplication drops "
+            "the broader tests/ arg."
+        ),
+    )
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/packages/testing/src/execution_testing/cli/tests/test_pytest_checklist_command.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_pytest_checklist_command.py
@@ -1,0 +1,48 @@
+"""Tests for the checklist command click CLI."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ..pytest_commands.checklist import checklist
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Click CliRunner for invoking command-line interfaces."""
+    return CliRunner()
+
+
+def _captured_execute_args(runner: CliRunner, *cli_args: str) -> list[str]:
+    """Invoke `checklist` and return the args passed to ChecklistCommand."""
+    with patch(
+        "execution_testing.cli.pytest_commands.checklist.ChecklistCommand"
+    ) as mock_cls:
+        result = runner.invoke(checklist, list(cli_args))
+    assert result.exit_code == 0, result.output
+    instance = mock_cls.return_value
+    instance.execute.assert_called_once()
+    (execute_args,) = instance.execute.call_args.args
+    return execute_args
+
+
+def test_checklist_default_injects_include_benchmark(
+    runner: CliRunner,
+) -> None:
+    """Default invocation passes `tests` plus `--include-benchmark`."""
+    args = _captured_execute_args(runner)
+
+    assert "--include-benchmark" in args
+    assert args[-1] == "tests"
+
+
+def test_checklist_explicit_paths_skip_include_benchmark(
+    runner: CliRunner,
+) -> None:
+    """Explicit paths scope collection and drop `--include-benchmark`."""
+    args = _captured_execute_args(runner, "tests/prague/eip7702_set_code_tx")
+
+    assert "--include-benchmark" not in args
+    assert "tests/prague/eip7702_set_code_tx" in args
+    assert "tests" not in args

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -51,8 +51,10 @@ def pytest_generate_tests(metafunc: Any) -> None:
 
 def pytest_ignore_collect(collection_path: Path, config: Any) -> bool | None:
     """Skip benchmark directory unless explicitly targeted."""
-    benchmark_dir = Path(__file__).parent
+    if config.getoption("include_benchmark", default=False):
+        return False
 
+    benchmark_dir = Path(__file__).parent
     args = config.invocation_params.args or ()
     if any(
         benchmark_dir in Path(a).resolve().parents


### PR DESCRIPTION
## 🗒️ Description

TIL that we apply checklist markers to benchmark tests. This seems very reasonable in certain situations, although we should ensure that these tests are also run regularly in a standard public dashboard to ensure coverage. @kclowes wdyt? Worth making this change?

Two problems this PR fixes:

- The `checklist` CLI rejected positional paths despite the docstring example: `uv run checklist tests/prague/eip7702*` errored with `Got unexpected extra argument`, because `@click.argument("paths", ...)` was missing.
- Benchmark tests' `eip_checklist` markers were silently dropped from generated checklists. `tests/benchmark/conftest.py` hides the benchmark directory from a plain `tests/` collection unless a benchmark path is passed explicitly.

### Why the obvious fix does not work

Defaulting `paths` to `("tests", "tests/benchmark")` looks correct, but pytest deduplicates overlapping path arguments: when both `tests/` and `tests/benchmark/...` are passed, pytest drops the broader `tests/` arg before collection starts. The benchmark `pytest_ignore_collect` hook is scoped to `tests/benchmark/` and never fires for sibling paths, so it cannot rescue `tests/prague/` etc. Net effect: only benchmark tests got collected from the default.

### The fix

Add an `--include-benchmark` flag, registered in the shared `benchmarking` plugin. When set, `tests/benchmark/conftest.py::pytest_ignore_collect` short-circuits to `return False`, including `tests/benchmark/` regardless of the positional args. The `checklist` CLI now passes a single `tests/` path plus `--include-benchmark` when no paths are supplied, sidestepping pytest's path deduplication entirely. Explicit positional paths still work and override the default.

Verified:

- `uv run fill --co tests/` still excludes benchmark (~360k tests, unchanged default behavior).
- `uv run fill --co tests/ --include-benchmark` now collects both (~366k tests).
- `uv run checklist` (default) generates checklists for benchmark-only EIPs such as EIP-7928.
- `uv run checklist tests/prague/eip7702_set_code_tx` remains scoped and excludes benchmark.

> [!IMPORTANT]
> Requires #2665. Without that fix, expanding default collection to include `tests/benchmark` trips the `assert eip.path is not None` assertion on EIP-7951 because the kwarg-referenced EIP cannot resolve its canonical doc location.

## 🔗 Related Issues or PRs

- Requires #2665.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
