### PR TITLE
refactor(test-benchmark): remove unused bloatnet factory entries from mainnet stubs

### DIFF
--- a/tests/benchmark/stateful/stubs/stubs_mainnet.json
+++ b/tests/benchmark/stateful/stubs/stubs_mainnet.json
@@ -34,23 +34,5 @@
   },
   "test_mixed_sload_sstore_HST": {
     "addr": "0x2e2a539285ce690e4c6bddd42deb7e37bdde9500"
-  },
-  "bloatnet_factory_0_5kb": {
-    "addr": "0xDf9da7E8660d38654C8aA267635222c9f5Ac0530"
-  },
-  "bloatnet_factory_1kb": {
-    "addr": "0xA52178573dc859741499946148CA1Fc3822Af600"
-  },
-  "bloatnet_factory_2kb": {
-    "addr": "0x88c159584059308C4B466bafC82c45d52De9951D"
-  },
-  "bloatnet_factory_5kb": {
-    "addr": "0x3f59809dac4b33e251e518acDadf923184151334"
-  },
-  "bloatnet_factory_10kb": {
-    "addr": "0xf90E8a6Ce32A949Ce5F58803BBa07476404cD89F"
-  },
-  "bloatnet_factory_24kb": {
-    "addr": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef"
   }
 }


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Remove unused bloatnet factory entries from mainnet stubs

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
