### PR TITLE
fix(testing): record converged gas optimization limit

### DIFF
--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -464,7 +464,7 @@ class StateTest(BaseTest):
                     env=env,
                     enable_post_processing=enable_post_processing,
                 )
-                gas_optimization = current_gas_limit
+                gas_optimization = minimum_gas_limit
             else:
                 raise Exception("Impossible to compare.")
 

--- a/packages/testing/src/execution_testing/specs/tests/test_expect.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_expect.py
@@ -13,7 +13,10 @@ from execution_testing.base_types import (
     TestAddress,
     TestPrivateKey,
 )
-from execution_testing.client_clis import TransitionTool
+from execution_testing.client_clis import (
+    ExecutionSpecsTransitionTool,
+    TransitionTool,
+)
 from execution_testing.exceptions import TransactionException
 from execution_testing.fixtures import (
     BlockchainFixture,
@@ -30,6 +33,7 @@ from execution_testing.test_types import (
     TransactionReceipt,
 )
 
+from ..base import OpMode
 from ..blockchain import BlockchainEngineFixture, BlockchainTest
 from ..helpers import (
     ExecutionExceptionMismatchError,
@@ -94,6 +98,47 @@ def state_test(  # noqa: D103
         fork=fork,
         is_exception_test=is_exception_test,
     )
+
+
+def test_gas_optimization_records_converged_minimum(
+    state_test: StateTest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Record the converged gas limit after the binary search finishes."""
+    minimum_equivalent_gas_limit = 7
+    state_test.operation_mode = OpMode.OPTIMIZE_GAS
+
+    def fake_verify_modified_gas_limit(
+        self: StateTest,
+        *,
+        current_gas_limit: int,
+        **_: Any,
+    ) -> bool:
+        del self
+        return current_gas_limit >= minimum_equivalent_gas_limit
+
+    monkeypatch.setattr(
+        StateTest,
+        "verify_modified_gas_limit",
+        fake_verify_modified_gas_limit,
+    )
+
+    t8n = ExecutionSpecsTransitionTool(trace=True)
+    t8n.reset_traces()
+    evaluate = t8n.evaluate
+
+    def evaluate_with_traces(**kwargs: Any) -> Any:
+        output = evaluate(**kwargs)
+        traces = t8n.get_traces()
+        if output.result.traces is None and traces:
+            output.result.traces = traces[-1]
+        return output
+
+    monkeypatch.setattr(t8n, "evaluate", evaluate_with_traces)
+
+    fill_result = state_test.generate(t8n=t8n, fixture_format=StateFixture)
+
+    assert fill_result.gas_optimization == minimum_equivalent_gas_limit
 
 
 # Storage value mismatch tests


### PR DESCRIPTION
## 🗒️ Description

The gas optimization binary search already verifies the converged value with `minimum_gas_limit`, but the recorded `gas_optimization` field still used the last loop-local `current_gas_limit`.

When the final probe is a failing candidate, this stores a value that is one step below the actual minimum gas limit and propagates the wrong optimization result to the JSON output used by follow-up analysis.

This PR records `minimum_gas_limit` after convergence and adds a regression test to lock in the expected bookkeeping behavior.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img width="916" height="1146" alt="image" src="https://github.com/user-attachments/assets/66b93300-a0fc-4e13-9a4d-1e4ae781410f" />
