### PR TITLE
feat(test-benchmark): storage initialization helper with 7702 authorization

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -86,9 +86,9 @@ def _sender_generator(
     benchmarks so the BAL builder can group nonce changes by sender
     uniformly regardless of mode.
     """
-    sender = pre.fund_eoa()
+    shared_sender = None if distinct_senders else pre.fund_eoa()
     while True:
-        yield sender if not distinct_senders else pre.fund_eoa()
+        yield pre.fund_eoa() if distinct_senders else shared_sender
 
 
 def delegate_with_calldata(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -45,6 +45,9 @@ from tests.benchmark.stateful.helpers import (
     BALANCEOF_SELECTOR,
     CacheStrategy,
     build_cache_strategy_blocks,
+    build_delegated_storage_setup,
+    create_sstore_initializer,
+    initializer_calldata_generator,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -1086,140 +1089,6 @@ def executor_calldata_generator(
     if write_value is not None:
         result += Hash(write_value)
     return result
-
-
-def initializer_calldata_generator(
-    iteration_count: int, start_iteration: int
-) -> bytes:
-    """Calldata generator for the storage: Hash(start) + Hash(count)."""
-    return Hash(start_iteration) + Hash(iteration_count)
-
-
-def pack_transactions_into_blocks(
-    transactions: List[Transaction],
-    gas_limit: int,
-) -> List[Block]:
-    """
-    Pack transactions into blocks without exceeding gas_limit per block.
-
-    Greedily adds transactions to the current block until adding another
-    would exceed the gas limit, then starts a new block.
-    """
-    if not transactions:
-        return []
-
-    blocks: List[Block] = []
-    current_txs: List[Transaction] = []
-    current_gas = 0
-
-    for tx in transactions:
-        if current_gas + tx.gas_limit > gas_limit and current_txs:
-            blocks.append(Block(txs=current_txs))
-            current_txs = []
-            current_gas = 0
-
-        current_txs.append(tx)
-        current_gas += tx.gas_limit
-
-    if current_txs:
-        blocks.append(Block(txs=current_txs))
-
-    return blocks
-
-
-def build_delegated_storage_setup(
-    *,
-    pre: Alloc,
-    fork: Fork,
-    tx_gas_limit: int,
-    needs_init: bool,
-    num_target_slots: int,
-    initializer_code: IteratingBytecode,
-    initializer_addr: Address,
-    executor_addr: Address,
-    authority: EOA,
-    authority_nonce: int,
-    delegation_sender: EOA,
-    initializer_calldata_generator: Callable[[int, int], bytes],
-) -> List[Block]:
-    """
-    Build setup blocks for delegated storage benchmarks.
-
-    Returns:
-        List of blocks for the setup phase.
-
-    """
-    blocks: List[Block] = []
-
-    if needs_init:
-        # Block 1: Authorize to initializer
-        blocks.append(
-            Block(
-                txs=[
-                    Transaction(
-                        to=delegation_sender,
-                        gas_limit=tx_gas_limit,
-                        sender=delegation_sender,
-                        authorization_list=[
-                            AuthorizationTuple(
-                                address=initializer_addr,
-                                nonce=authority_nonce,
-                                signer=authority,
-                            ),
-                        ],
-                    )
-                ]
-            )
-        )
-        authority_nonce += 1
-
-        # Calculate max slots per transaction based on gas cost
-        iteration_cost = initializer_code.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=1,
-            start_iteration=1,
-            calldata=initializer_calldata_generator,
-        )
-        iteration_count = max(1, tx_gas_limit // iteration_cost)
-
-        init_txs: List[Transaction] = []
-        for start in range(1, num_target_slots + 1, iteration_count):
-            chunk_size = min(iteration_count, num_target_slots - start + 1)
-            init_txs.extend(
-                initializer_code.transactions_by_total_iteration_count(
-                    fork=fork,
-                    total_iterations=chunk_size,
-                    sender=pre.fund_eoa(),
-                    to=authority,
-                    start_iteration=start,
-                    calldata=initializer_calldata_generator,
-                )
-            )
-
-        # Pack init transactions into blocks
-        blocks.extend(pack_transactions_into_blocks(init_txs, tx_gas_limit))
-
-    # Final block: Authorize to executor
-    blocks.append(
-        Block(
-            txs=[
-                Transaction(
-                    to=delegation_sender,
-                    gas_limit=tx_gas_limit,
-                    sender=delegation_sender,
-                    authorization_list=[
-                        AuthorizationTuple(
-                            address=executor_addr,
-                            nonce=authority_nonce,
-                            signer=authority,
-                        ),
-                    ],
-                )
-            ]
-        )
-    )
-
-    return blocks
 
 
 @pytest.mark.parametrize("access_warm", [True, False])

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -9,7 +9,7 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
 
 from enum import Enum, auto
 from functools import partial
-from typing import Callable, Generator, List
+from typing import Generator, List
 
 import pytest
 from execution_testing import (
@@ -884,50 +884,6 @@ def test_sstore_erc20_generic(
         skip_gas_used_validation=True,
         expected_receipt_status=True,
     )
-
-
-def create_sstore_initializer(init_val: int) -> IteratingBytecode:
-    """
-    Create a contract that initializes storage slots from calldata parameters.
-
-    - CALLDATA[0..32] start slot (index)
-    - CALLDATA[32..64] slot count (num)
-
-    storage[i] = init_val for i in [index, index + num).
-
-    Returns: IteratingBytecode representing the storage initializer.
-    """
-    # Setup: [index, index + num]
-    prefix = (
-        Op.CALLDATALOAD(0)  # [index]
-        + Op.DUP1  # [index, index]
-        + Op.CALLDATALOAD(32)  # [index, index, num]
-        + Op.ADD  # [index, index + num]
-    )
-
-    # Loop: decrement counter and store at current position
-    # Stack after subtraction: [index, current]
-    # where current goes from index+num-1 down to index
-    loop = (
-        Op.JUMPDEST
-        + Op.PUSH1(1)  # [index, current, 1]
-        + Op.SWAP1  # [index, 1, current]
-        + Op.SUB  # [index, current - 1]
-        + Op.SSTORE(  # STORAGE[current-1] = initial_value
-            Op.DUP2,
-            init_val,
-            key_warm=False,
-            # gas accounting
-            original_value=0,
-            current_value=0,
-            new_value=init_val,
-        )
-        # After SSTORE: [index, current - 1]
-        # Continue while current - 1 > index
-        + Op.JUMPI(len(prefix), Op.GT(Op.DUP2, Op.DUP2))
-    )
-
-    return IteratingBytecode(setup=prefix, iterating=loop)
 
 
 def create_sstore_executor(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -86,9 +86,9 @@ def _sender_generator(
     benchmarks so the BAL builder can group nonce changes by sender
     uniformly regardless of mode.
     """
-    shared_sender = None if distinct_senders else pre.fund_eoa()
+    shared_sender = pre.fund_eoa() if not distinct_senders else None
     while True:
-        yield pre.fund_eoa() if distinct_senders else shared_sender
+        yield pre.fund_eoa() if shared_sender is None else shared_sender
 
 
 def delegate_with_calldata(

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from execution_testing import (
+    EOA,
     Account,
     Address,
     Alloc,
+    AuthorizationTuple,
     BalAccountExpectation,
     BalNonceChange,
     BalStorageSlot,
@@ -24,9 +26,14 @@ from execution_testing import (
     Bytecode,
     Fork,
     Op,
-    Storage,
     TestPhaseManager,
     Transaction,
+)
+from execution_testing.base_types.base_types import Number
+
+from tests.benchmark.stateful.helpers import (
+    StorageInitRange,
+    build_sequential_storage_init,
 )
 
 CURSOR_SLOT = 0
@@ -207,38 +214,83 @@ def plan_benchmark(
 
 def run_bal_benchmark(
     pre: Alloc,
+    fork: Fork,
     benchmark_test: BenchmarkTestFiller,
     contract_code: Bytecode,
-    contract_storage: Storage,
     plan: BenchmarkPlan,
+    tx_gas_limit: int,
+    authority: EOA,
+    storage_init_ranges: list[StorageInitRange] | None = None,
     data_slot_reads: list[int] | None = None,
     extra_expectations: (dict[Address, BalAccountExpectation] | None) = None,
 ) -> None:
-    """Deploy contract, create txs, BAL expectations, and run."""
-    contract = pre.deploy_contract(
-        code=contract_code, storage=contract_storage
-    )
+    """
+    Run a BAL benchmark using EIP-7702 delegated storage initialization.
 
+    Deploy the executor contract, optionally initialize the
+    *authority*'s storage via delegation, then delegate to the
+    executor and run the benchmark transactions.  The authority's
+    nonce is incremented in-place.
+    """
+    executor_addr = pre.deploy_contract(code=contract_code)
+
+    blocks: list[Block] = []
+
+    with TestPhaseManager.setup():
+        if storage_init_ranges:
+            blocks.extend(
+                build_sequential_storage_init(
+                    pre=pre,
+                    fork=fork,
+                    tx_gas_limit=tx_gas_limit,
+                    authority=authority,
+                    storage_init_ranges=storage_init_ranges,
+                )
+            )
+
+        # Delegate authority to executor
+        delegation_sender = pre.fund_eoa()
+        blocks.append(
+            Block(
+                txs=[
+                    Transaction(
+                        to=delegation_sender,
+                        gas_limit=tx_gas_limit,
+                        sender=delegation_sender,
+                        authorization_list=[
+                            AuthorizationTuple(
+                                address=executor_addr,
+                                nonce=authority.nonce,
+                                signer=authority,
+                            ),
+                        ],
+                    )
+                ]
+            )
+        )
+        authority.nonce = Number(authority.nonce + 1)
+
+    # Execution phase
     num_txs = len(plan.gas_limits)
     with TestPhaseManager.execution():
         sender = pre.fund_eoa()
         transactions = [
             Transaction(
                 sender=sender,
-                to=contract,
+                to=authority,
                 gas_limit=plan.gas_limits[i],
                 data=b"",
             )
             for i in range(num_txs)
         ]
 
-    # BAL expectations: contract slots + sender nonces.
+    # BAL expectations: authority slots + sender nonces.
     # Use validate_any_change for cursor — exact values depend
     # on gas dynamics and are verified by consensus test suites.
     # All txs share a single sender to prevent trivial per-sender
     # optimizations in BAL implementations.
     expectations: dict[Address, BalAccountExpectation] = {
-        contract: BalAccountExpectation(
+        authority: BalAccountExpectation(
             storage_reads=sorted(set(data_slot_reads or [])),
             storage_changes=[
                 BalStorageSlot(
@@ -260,12 +312,14 @@ def run_bal_benchmark(
     if extra_expectations:
         expectations.update(extra_expectations)
 
-    block = Block(
+    exec_block = Block(
         txs=transactions,
         expected_block_access_list=BlockAccessListExpectation(
             account_expectations=expectations
         ),
     )
+
+    blocks.append(exec_block)
 
     # Post-state: only check sender nonce (sanity).
     # Exact storage values depend on gas dynamics and may be
@@ -275,5 +329,8 @@ def run_bal_benchmark(
     }
 
     benchmark_test(
-        pre=pre, post=post, blocks=[block], skip_gas_used_validation=True
+        pre=pre,
+        post=post,
+        blocks=blocks,
+        skip_gas_used_validation=True,
     )

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
@@ -333,4 +333,5 @@ def run_bal_benchmark(
         post=post,
         blocks=blocks,
         skip_gas_used_validation=True,
+        expected_receipt_status=1,
     )

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_compute_then_sload.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_compute_then_sload.py
@@ -14,10 +14,10 @@ from execution_testing import (
     Bytecode,
     Fork,
     Op,
-    Storage,
 )
 
 from .helpers import (
+    StorageInitRange,
     cursor_read,
     gas_check_loop_contract,
     plan_benchmark,
@@ -72,6 +72,7 @@ def test_bal_compute_then_sload(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     compute_percent: int,
 ) -> None:
     """Test BAL with mixed computation and SLOAD per iteration."""
@@ -84,18 +85,19 @@ def test_bal_compute_then_sload(
         gas_benchmark_value=gas_benchmark_value,
     )
     total = plan.total_iterations
-    storage = Storage(
-        {i: i + 1 for i in range(total + 1)}  # type: ignore
-    )
+    authority = pre.fund_eoa(amount=0)
     run_bal_benchmark(
         pre=pre,
+        fork=fork,
         benchmark_test=benchmark_test,
         contract_code=gas_check_loop_contract(
             setup=cursor_read(),
             body=body,
             gas_threshold=plan.gas_threshold,
         ),
-        contract_storage=storage,
         plan=plan,
+        tx_gas_limit=tx_gas_limit,
+        authority=authority,
+        storage_init_ranges=[StorageInitRange(0, total + 1, 1)],
         data_slot_reads=list(range(1, total + 1)),
     )

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_max_accounts.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_max_accounts.py
@@ -16,13 +16,11 @@ from execution_testing import (
     Bytecode,
     Fork,
     Op,
-    Storage,
 )
-from execution_testing.base_types.base_types import HashInt
 
 from .helpers import (
     CURSOR_INIT,
-    CURSOR_SLOT,
+    StorageInitRange,
     cursor_read,
     cursor_write,
     gas_check_loop_contract,
@@ -87,6 +85,7 @@ def test_bal_max_account_access(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """Test BAL with maximum unique account accesses via BALANCE."""
     setup = cursor_read() + Op.PUSH3(BASE_ADDR) + Op.ADD
@@ -103,11 +102,15 @@ def test_bal_max_account_access(
         Address(BASE_ADDR + i): BalAccountExpectation.empty()
         for i in range(CURSOR_INIT, total + CURSOR_INIT)
     }
+    authority = pre.fund_eoa(amount=0)
     run_bal_benchmark(
         pre=pre,
+        fork=fork,
         benchmark_test=benchmark_test,
         contract_code=create_balance_loop_contract(plan.gas_threshold),
-        contract_storage=Storage({HashInt(CURSOR_SLOT): HashInt(CURSOR_INIT)}),
         plan=plan,
+        tx_gas_limit=tx_gas_limit,
+        authority=authority,
+        storage_init_ranges=[StorageInitRange(0, 1, CURSOR_INIT)],
         extra_expectations=extra,
     )

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_max_sloads.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_max_sloads.py
@@ -17,10 +17,10 @@ from execution_testing import (
     BenchmarkTestFiller,
     Bytecode,
     Fork,
-    Storage,
 )
 
 from .helpers import (
+    StorageInitRange,
     cursor_read,
     gas_check_loop_contract,
     plan_benchmark,
@@ -66,6 +66,7 @@ def test_bal_max_sloads(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     reverse: bool,
 ) -> None:
     """Test BAL with maximum sequential SLOADs via cursor."""
@@ -81,16 +82,20 @@ def test_bal_max_sloads(
     # Cursor starts at slot 0; forward reads slots 1..total,
     # reverse reads slots total..1.
     cursor_start = total if reverse else 1
-    storage = Storage(
-        {0: cursor_start} | {i: i for i in range(1, total + 1)}  # type: ignore
-    )
+    authority = pre.fund_eoa(amount=0)
     run_bal_benchmark(
         pre=pre,
+        fork=fork,
         benchmark_test=benchmark_test,
         contract_code=create_sload_loop_contract(
             plan.gas_threshold, reverse=reverse
         ),
-        contract_storage=storage,
         plan=plan,
+        tx_gas_limit=tx_gas_limit,
+        authority=authority,
+        storage_init_ranges=[
+            StorageInitRange(1, total, 0),
+            StorageInitRange(0, 1, cursor_start),
+        ],
         data_slot_reads=list(range(1, total + 1)),
     )

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_pointer_chase.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/test_block_access_lists_pointer_chase.py
@@ -15,10 +15,10 @@ from execution_testing import (
     Bytecode,
     Fork,
     Op,
-    Storage,
 )
 
 from .helpers import (
+    StorageInitRange,
     cursor_read,
     gas_check_loop_contract,
     plan_benchmark,
@@ -64,6 +64,7 @@ def test_bal_max_pointer_chase(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """Test BAL with maximum dependent pointer-chasing SLOADs."""
     body_gas = _chase_body().gas_cost(fork)
@@ -74,14 +75,15 @@ def test_bal_max_pointer_chase(
         gas_benchmark_value=gas_benchmark_value,
     )
     total = plan.total_iterations
-    storage = Storage(
-        {i: i + 1 for i in range(total + 1)}  # type: ignore
-    )
+    authority = pre.fund_eoa(amount=0)
     run_bal_benchmark(
         pre=pre,
+        fork=fork,
         benchmark_test=benchmark_test,
         contract_code=create_pointer_chase_contract(plan.gas_threshold),
-        contract_storage=storage,
         plan=plan,
+        tx_gas_limit=tx_gas_limit,
+        authority=authority,
+        storage_init_ranges=[StorageInitRange(0, total + 1, 1)],
         data_slot_reads=list(range(1, total + 1)),
     )

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -4,12 +4,15 @@ from collections.abc import Callable
 from enum import Enum
 
 from execution_testing import (
+    EOA,
     AccessList,
     Address,
     Alloc,
+    AuthorizationTuple,
     Block,
     Fork,
     Hash,
+    IteratingBytecode,
     Op,
     Transaction,
 )
@@ -132,3 +135,180 @@ def build_cache_strategy_blocks(
     if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK:
         return [Block(txs=txs)]
     return [Block(txs=cache_txs), Block(txs=txs)]
+
+
+def pack_transactions_into_blocks(
+    transactions: list[Transaction],
+    gas_limit: int,
+) -> list[Block]:
+    """
+    Pack transactions into blocks without exceeding gas_limit per block.
+
+    Greedily add transactions to the current block until adding another
+    would exceed the gas limit, then start a new block.
+    """
+    if not transactions:
+        return []
+
+    blocks: list[Block] = []
+    current_txs: list[Transaction] = []
+    current_gas = 0
+
+    for tx in transactions:
+        if current_gas + tx.gas_limit > gas_limit and current_txs:
+            blocks.append(Block(txs=current_txs))
+            current_txs = []
+            current_gas = 0
+
+        current_txs.append(tx)
+        current_gas += tx.gas_limit
+
+    if current_txs:
+        blocks.append(Block(txs=current_txs))
+
+    return blocks
+
+
+def build_delegated_storage_setup(
+    *,
+    pre: Alloc,
+    fork: Fork,
+    tx_gas_limit: int,
+    needs_init: bool,
+    num_target_slots: int,
+    initializer_code: IteratingBytecode,
+    initializer_addr: Address,
+    executor_addr: Address,
+    authority: EOA,
+    authority_nonce: int,
+    delegation_sender: EOA,
+    initializer_calldata_generator: Callable[[int, int], bytes],
+) -> list[Block]:
+    """
+    Build setup blocks for delegated storage benchmarks.
+
+    Use EIP-7702 authorization to delegate an authority EOA first to
+    a storage-initializer contract (if *needs_init*), then to the
+    benchmark executor contract.  Return the list of setup blocks.
+    """
+    blocks: list[Block] = []
+
+    if needs_init:
+        # Block 1: Authorize to initializer
+        blocks.append(
+            Block(
+                txs=[
+                    Transaction(
+                        to=delegation_sender,
+                        gas_limit=tx_gas_limit,
+                        sender=delegation_sender,
+                        authorization_list=[
+                            AuthorizationTuple(
+                                address=initializer_addr,
+                                nonce=authority_nonce,
+                                signer=authority,
+                            ),
+                        ],
+                    )
+                ]
+            )
+        )
+        authority_nonce += 1
+
+        # Calculate max slots per transaction based on gas cost
+        iteration_cost = initializer_code.tx_gas_limit_by_iteration_count(
+            fork=fork,
+            iteration_count=1,
+            start_iteration=1,
+            calldata=initializer_calldata_generator,
+        )
+        iteration_count = max(1, tx_gas_limit // iteration_cost)
+
+        init_txs: list[Transaction] = []
+        for start in range(1, num_target_slots + 1, iteration_count):
+            chunk_size = min(iteration_count, num_target_slots - start + 1)
+            init_txs.extend(
+                initializer_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=chunk_size,
+                    sender=pre.fund_eoa(),
+                    to=authority,
+                    start_iteration=start,
+                    calldata=initializer_calldata_generator,
+                )
+            )
+
+        # Pack init transactions into blocks
+        blocks.extend(pack_transactions_into_blocks(init_txs, tx_gas_limit))
+
+    # Final block: Authorize to executor
+    blocks.append(
+        Block(
+            txs=[
+                Transaction(
+                    to=delegation_sender,
+                    gas_limit=tx_gas_limit,
+                    sender=delegation_sender,
+                    authorization_list=[
+                        AuthorizationTuple(
+                            address=executor_addr,
+                            nonce=authority_nonce,
+                            signer=authority,
+                        ),
+                    ],
+                )
+            ]
+        )
+    )
+
+    return blocks
+
+
+def create_sstore_initializer(init_val: int) -> IteratingBytecode:
+    """
+    Create a contract that initializes storage slots from calldata.
+
+    - CALLDATA[0..32] start slot (index)
+    - CALLDATA[32..64] slot count (num)
+
+    storage[i] = init_val for i in [index, index + num).
+    """
+    # Setup: [index, index + num]
+    prefix = (
+        Op.CALLDATALOAD(0)  # [index]
+        + Op.DUP1  # [index, index]
+        + Op.CALLDATALOAD(32)  # [index, index, num]
+        + Op.ADD  # [index, index + num]
+    )
+
+    # Loop: decrement counter and store at current position
+    # Stack after subtraction: [index, current]
+    # where current goes from index+num-1 down to index
+    loop = (
+        Op.JUMPDEST
+        + Op.PUSH1(1)  # [index, current, 1]
+        + Op.SWAP1  # [index, 1, current]
+        + Op.SUB  # [index, current - 1]
+        + Op.SSTORE(  # STORAGE[current-1] = initial_value
+            Op.DUP2,
+            init_val,
+            key_warm=False,
+            # gas accounting
+            original_value=0,
+            current_value=0,
+            new_value=init_val,
+        )
+        # After SSTORE: [index, current - 1]
+        # Continue while current - 1 > index
+        + Op.JUMPI(len(prefix), Op.GT(Op.DUP2, Op.DUP2))
+    )
+
+    return IteratingBytecode(setup=prefix, iterating=loop)
+
+
+def initializer_calldata_generator(
+    iteration_count: int, start_iteration: int
+) -> bytes:
+    """Generate calldata for the storage initializer."""
+    return Hash(start_iteration) + Hash(iteration_count)
+

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from math import ceil
 
 from execution_testing import (
     EOA,
@@ -226,7 +225,7 @@ def build_delegated_storage_setup(
             start_iteration=1,
             calldata=initializer_calldata_generator,
         )
-        iteration_count = ceil(tx_gas_limit // iteration_cost)
+        iteration_count = max(1, tx_gas_limit // iteration_cost)
 
         init_txs: list[Transaction] = []
         for start in range(1, num_target_slots + 1, iteration_count):

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -1,7 +1,9 @@
 """Shared constants and helpers for stateful benchmark tests."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
+from functools import partial
 
 from execution_testing import (
     EOA,
@@ -16,6 +18,7 @@ from execution_testing import (
     Op,
     Transaction,
 )
+from execution_testing.base_types.base_types import Number
 
 # ERC20 function selectors
 BALANCEOF_SELECTOR = 0x70A08231  # balanceOf(address)
@@ -312,3 +315,136 @@ def initializer_calldata_generator(
     """Generate calldata for the storage initializer."""
     return Hash(start_iteration) + Hash(iteration_count)
 
+
+def create_sequential_sstore_initializer() -> IteratingBytecode:
+    """
+    Create a contract that initializes storage with slot-dependent values.
+
+    - CALLDATA[0..32]  start slot (index)
+    - CALLDATA[32..64] slot count (num)
+    - CALLDATA[64..96] value offset
+
+    storage[i] = i + offset for i in [index, index + num).
+    """
+    # Setup: [offset, index, index + num]
+    prefix = (
+        Op.CALLDATALOAD(64)  # [offset]
+        + Op.CALLDATALOAD(0)  # [index, offset]
+        + Op.DUP1  # [index, index, offset]
+        + Op.CALLDATALOAD(32)  # [num, index, index, offset]
+        + Op.ADD  # [num + index, index, offset]
+    )
+
+    # Loop: decrement current and store slot-dependent value
+    # Stack: [current, index, offset]
+    # current goes from index+num down; stores at current-1
+    loop = (
+        Op.JUMPDEST
+        + Op.PUSH1(1)  # [1, current, index, offset]
+        + Op.SWAP1  # [current, 1, index, offset]
+        + Op.SUB  # [current-1, index, offset]
+        + Op.DUP1  # [current-1, current-1, index, offset]
+        + Op.DUP1  # [current-1, current-1, current-1, index, offset]
+        + Op.DUP5  # [offset, current-1, current-1, current-1, index, offset]
+        + Op.ADD  # [current-1 + offset, current-1, current-1, index, offset]
+        + Op.SWAP1  # [current-1, current-1 + offset, current-1, index, offset]
+        + Op.SSTORE(  # SSTORE(current-1, current-1 + offset)
+            key_warm=False,
+            original_value=0,
+            current_value=0,
+            new_value=1,
+        )
+        # Stack: [current-1, index, offset]
+        # Continue while current-1 > index
+        + Op.JUMPI(len(prefix), Op.GT(Op.DUP2, Op.DUP2))
+    )
+
+    return IteratingBytecode(setup=prefix, iterating=loop)
+
+
+def sequential_initializer_calldata_generator(
+    iteration_count: int,
+    start_iteration: int,
+    *,
+    offset: int = 0,
+) -> bytes:
+    """Generate calldata for the sequential storage initializer."""
+    return Hash(start_iteration) + Hash(iteration_count) + Hash(offset)
+
+
+@dataclass(frozen=True)
+class StorageInitRange:
+    """One contiguous range of storage to initialize."""
+
+    start_slot: int
+    num_slots: int
+    offset: int
+
+
+def build_sequential_storage_init(
+    *,
+    pre: Alloc,
+    fork: Fork,
+    tx_gas_limit: int,
+    authority: EOA,
+    storage_init_ranges: list[StorageInitRange],
+) -> list[Block]:
+    """
+    Build blocks that initialize storage with slot-dependent values.
+
+    Deploy a sequential-SSTORE initializer, delegate *authority* to it,
+    and emit transactions that write
+    ``storage[i] = i + range.offset`` for every range.  The authority's
+    nonce is incremented in-place.
+    """
+    initializer_code = create_sequential_sstore_initializer()
+    initializer_addr = pre.deploy_contract(code=initializer_code)
+
+    delegation_sender = pre.fund_eoa()
+    auth_tx = Transaction(
+        to=delegation_sender,
+        gas_limit=tx_gas_limit,
+        sender=delegation_sender,
+        authorization_list=[
+            AuthorizationTuple(
+                address=initializer_addr,
+                nonce=authority.nonce,
+                signer=authority,
+            ),
+        ],
+    )
+    authority.nonce = Number(authority.nonce + 1)
+
+    init_txs: list[Transaction] = []
+    for r in storage_init_ranges:
+        if r.num_slots == 0:
+            continue
+        calldata_gen = partial(
+            sequential_initializer_calldata_generator,
+            offset=r.offset,
+        )
+        iteration_cost = initializer_code.tx_gas_limit_by_iteration_count(
+            fork=fork,
+            iteration_count=1,
+            start_iteration=max(1, r.start_slot),
+            calldata=calldata_gen,
+        )
+        iteration_count = max(1, tx_gas_limit // iteration_cost)
+
+        end_slot = r.start_slot + r.num_slots
+        for start in range(r.start_slot, end_slot, iteration_count):
+            chunk = min(iteration_count, end_slot - start)
+            init_txs.extend(
+                initializer_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=chunk,
+                    sender=pre.fund_eoa(),
+                    to=authority,
+                    start_iteration=start,
+                    calldata=calldata_gen,
+                )
+            )
+
+    blocks: list[Block] = [Block(txs=[auth_tx])]
+    blocks.extend(pack_transactions_into_blocks(init_txs, tx_gas_limit))
+    return blocks

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
+from math import ceil
 
 from execution_testing import (
     EOA,
@@ -225,7 +226,7 @@ def build_delegated_storage_setup(
             start_iteration=1,
             calldata=initializer_calldata_generator,
         )
-        iteration_count = max(1, tx_gas_limit // iteration_cost)
+        iteration_count = ceil(tx_gas_limit // iteration_cost)
 
         init_txs: list[Transaction] = []
         for start in range(1, num_target_slots + 1, iteration_count):


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

In the pre-allocation phase that deploys a contract, the framework supports passing in a dictionary that represents the storage to be initialized, and then embeds the logic inside the `initcode`. When the contract is created, it executes the initcode and performs the storage update.

However, in most of the benchmark cases, this is too inefficient, since the initialization phase requires a huge range of storage initialization, it leads to an `initcode prefix too long` issue.

### Solution

To resolve this issue, we create a helper for the stateful benchmark scenario. Users can define a storage init range like this:

```python
@dataclass(frozen=True)
class StorageInitRange:
    """One contiguous range of storage to initialize."""

    start_slot: int
    num_slots: int
    offset: int
```

Which means the storage would be initialized to `STORAGE[i] = i + offset`, where `i` starts from `start_slot` to `start_slot + num_slots`.

We leverage the EIP-7702 authorization approach for testing. The workflow now becomes:

1. Delegate the authority to the storage initialization contract (`create_sequential_sstore_initializer`).
2. Initialize the specified range — this leverages `IteratingBytecode` with `transactions_by_iteration_counts`.
3. Pack the initialization transactions into blocks under the setup phase.
4. Re-delegate the authority to the real benchmarking execution code.
5. Start the BAL benchmarking phase.

### Design decisions

- The authority EOA is created in the BAL benchmark test, not inside the helper function. This provides the flexibility to use a stub account if needed.
- Nonces use `authority.nonce` (incremented in-place) rather than hardcoded constants, ensuring compatibility with execute-remote where nonces are fetched from the live network.
- Shared helpers (`build_sequential_storage_init`, `StorageInitRange`, etc.) live in `tests/benchmark/stateful/helpers.py` so they are reusable beyond the BAL tests.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
