### PR TITLE
feat(test-forks): enable multiple EIP to be specified in `fork.is_eip_enabled`

### DIFF
--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -1057,7 +1057,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         return int(cls.__name__[3:])
 
     @classmethod
-    def is_eip_enabled(cls, *, eip_number: int) -> bool:
+    def is_eip_enabled(cls, eip_number: int) -> bool:
         """Return whether this class has an EIP enabled."""
         return eip_number in cls._enabled_eips
 

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -1057,9 +1057,11 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         return int(cls.__name__[3:])
 
     @classmethod
-    def is_eip_enabled(cls, eip_number: int) -> bool:
-        """Return whether this class has an EIP enabled."""
-        return eip_number in cls._enabled_eips
+    def is_eip_enabled(cls, *eip_numbers: int) -> bool:
+        """Return whether this class has all specified EIPs enabled."""
+        return all(
+            eip_number in cls._enabled_eips for eip_number in eip_numbers
+        )
 
     @classmethod
     def enabling_forks(cls) -> Set[Type["BaseFork"]]:

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -724,7 +724,7 @@ def test_method_versions() -> None:  # noqa: D103
 
 def test_eips() -> None:  # noqa: D103
     assert EIP3675.enabling_forks() == {Paris}
-    assert Paris.is_eip_enabled(eip_number=3675)
-    assert Shanghai.is_eip_enabled(eip_number=3675)
-    assert not Paris.is_eip_enabled(eip_number=3855)
-    assert Shanghai.is_eip_enabled(eip_number=3855)
+    assert Paris.is_eip_enabled(3675)
+    assert Shanghai.is_eip_enabled(3675)
+    assert not Paris.is_eip_enabled(3855)
+    assert Shanghai.is_eip_enabled(3855)

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -725,6 +725,9 @@ def test_method_versions() -> None:  # noqa: D103
 def test_eips() -> None:  # noqa: D103
     assert EIP3675.enabling_forks() == {Paris}
     assert Paris.is_eip_enabled(3675)
+    assert Paris.is_eip_enabled(3675, 1559)
     assert Shanghai.is_eip_enabled(3675)
     assert not Paris.is_eip_enabled(3855)
+    assert not Paris.is_eip_enabled(3675, 3855)
+    assert not Paris.is_eip_enabled(3855, 3675)
     assert Shanghai.is_eip_enabled(3855)


### PR DESCRIPTION
## 🗒️ Description
Modify `fork.is_eip_enabled` so that `eip_number` is not a keyword argument and can be passed as a simple number.

Also the method now accepts multiple EIPs and returns `True` only if all EIPs are enabled.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/586714878/photo/cute-baby-piglet.jpg?s=612x612&w=0&k=20&c=eR79RWnj_hKVY7XAfPcwnlx4eO1k8LXb5JVnmA3BD3w=)
