### PR TITLE
fix(specs,tests): EIP-7981 - Update implementation and specs

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
@@ -22,36 +22,35 @@ class EIP7981(BaseFork):
     """EIP-7981 class."""
 
     @classmethod
-    def _access_list_token_count(
+    def _access_list_floor_tokens(
         cls, access_list: List[AccessList] | None
     ) -> int:
         """
-        Return the total number of data tokens contributed by an access list.
+        Return ``access_list_bytes * 4`` floor tokens for the access list.
 
-        Tokens are counted per EIP-7981:
-        - zero byte = 1 token
-        - non-zero byte = 4 tokens
+        Every byte of each address (20 bytes) and storage key (32 bytes)
+        contributes four floor tokens, so zero and non-zero bytes are
+        charged equally per EIP-7981.
         """
         if not access_list:
             return 0
-
-        tokens = 0
+        total_bytes = 0
         for access in access_list:
-            for b in access.address:
-                tokens += 1 if b == 0 else 4
+            total_bytes += len(access.address)
             for slot in access.storage_keys:
-                for b in slot:
-                    tokens += 1 if b == 0 else 4
-        return tokens
+                total_bytes += len(slot)
+        return total_bytes * 4
 
     @classmethod
     def transaction_data_floor_cost_calculator(
         cls,
     ) -> TransactionDataFloorCostCalculator:
         """
-        Floor cost includes calldata and access list tokens.
+        Add access list floor tokens to the inherited calldata floor cost.
         """
-        calldata_gas_calculator = cls.calldata_gas_calculator()
+        super_fn = super(
+            EIP7981, cls
+        ).transaction_data_floor_cost_calculator()
         gas_costs = cls.gas_costs()
 
         def fn(
@@ -59,11 +58,10 @@ class EIP7981(BaseFork):
             data: BytesConvertible,
             access_list: List[AccessList] | None = None,
         ) -> int:
-            access_list_tokens = cls._access_list_token_count(access_list)
             return (
-                calldata_gas_calculator(data=data, floor=True)
-                + access_list_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
-                + gas_costs.GAS_TX_BASE
+                super_fn(data=data)
+                + cls._access_list_floor_tokens(access_list)
+                * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
             )
 
         return fn
@@ -73,12 +71,12 @@ class EIP7981(BaseFork):
         cls,
     ) -> TransactionIntrinsicCostCalculator:
         """
-        Access list data is charged at the floor token cost and
-        contributes to the floor gas cost per EIP-7981.
+        Charge access list data at the floor token cost on top of the
+        inherited intrinsic cost and enforce the combined data floor.
         """
         super_fn = super(EIP7981, cls).transaction_intrinsic_cost_calculator()
         gas_costs = cls.gas_costs()
-        transaction_data_floor_cost_calculator = (
+        data_floor_cost_calculator = (
             cls.transaction_data_floor_cost_calculator()
         )
 
@@ -97,19 +95,19 @@ class EIP7981(BaseFork):
                 authorization_list_or_count=authorization_list_or_count,
                 return_cost_deducted_prior_execution=True,
             )
-            access_list_tokens = cls._access_list_token_count(access_list)
             intrinsic_cost += (
-                access_list_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+                cls._access_list_floor_tokens(access_list)
+                * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
             )
 
             if return_cost_deducted_prior_execution:
                 return intrinsic_cost
 
-            transaction_floor_data_cost = (
-                transaction_data_floor_cost_calculator(
+            return max(
+                intrinsic_cost,
+                data_floor_cost_calculator(
                     data=calldata, access_list=access_list
-                )
+                ),
             )
-            return max(intrinsic_cost, transaction_floor_data_cost)
 
         return fn

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
@@ -48,9 +48,7 @@ class EIP7981(BaseFork):
         """
         Add access list floor tokens to the inherited calldata floor cost.
         """
-        super_fn = super(
-            EIP7981, cls
-        ).transaction_data_floor_cost_calculator()
+        super_fn = super(EIP7981, cls).transaction_data_floor_cost_calculator()
         gas_costs = cls.gas_costs()
 
         def fn(

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -581,8 +581,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -591,7 +591,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -611,25 +611,18 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     1. Base cost (`GAS_TX_BASE`)
     2. Cost for data (zero and non-zero bytes)
     3. Cost for contract creation (if applicable)
-    4. Cost for access list entries and their data (if applicable)
+    4. Cost for access list entries (if applicable)
     5. Cost for authorizations (if applicable)
 
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
-    transaction based on the calldata and access list size.
+    transaction based on the calldata size.
     """
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = Uint(tx.data.count(0))
-    num_non_zeros = ulen(tx.data) - num_zeros
-
-    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
-        tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE
-    )
+    tokens_in_calldata = count_tokens_in_data(tx.data)
 
     data_cost = tokens_in_calldata * GAS_TX_DATA_TOKEN_STANDARD
 
@@ -639,15 +632,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
+    tokens_in_access_list = Uint(0)
     if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
                 ulen(access.slots) * GAS_TX_ACCESS_LIST_STORAGE_KEY
             )
-
-    # Data token floor cost for access list bytes.
-    access_list_cost += tokens_in_access_list * GAS_TX_DATA_TOKEN_FLOOR
 
     # Data token floor cost for access list bytes.
     access_list_cost += tokens_in_access_list * GAS_TX_DATA_TOKEN_FLOOR

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -480,6 +480,7 @@ Transaction = (
 Union type representing any valid transaction type.
 """
 
+
 AccessListCapableTransaction = (
     AccessListTransaction
     | FeeMarketTransaction
@@ -580,8 +581,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
+    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -590,7 +591,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, data_floor_gas_cost
+    return intrinsic_gas, calldata_floor_gas_cost
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -610,18 +611,25 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     1. Base cost (`GAS_TX_BASE`)
     2. Cost for data (zero and non-zero bytes)
     3. Cost for contract creation (if applicable)
-    4. Cost for access list entries (if applicable)
+    4. Cost for access list entries and their data (if applicable)
     5. Cost for authorizations (if applicable)
 
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
-    transaction based on the calldata size.
+    transaction based on the calldata and access list size.
     """
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    tokens_in_calldata = count_tokens_in_data(tx.data)
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
+
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
+    # EIP-7623 floor price (note: no EVM costs)
+    calldata_floor_gas_cost = (
+        tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE
+    )
 
     data_cost = tokens_in_calldata * GAS_TX_DATA_TOKEN_STANDARD
 
@@ -631,7 +639,6 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    tokens_in_access_list = Uint(0)
     if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -65,6 +65,22 @@ GAS_TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
 Gas cost for including a storage key in the access list of a transaction.
 """
 
+ACCESS_LIST_ADDRESS_FLOOR_TOKENS = Uint(80)
+"""
+Floor data tokens contributed by a single access list address per
+[EIP-7981] (address byte length multiplied by four tokens per byte).
+
+[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+"""
+
+ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS = Uint(128)
+"""
+Floor data tokens contributed by a single access list storage key per
+[EIP-7981] (storage key byte length multiplied by four tokens per byte).
+
+[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+"""
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -638,6 +654,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
                 ulen(access.slots) * GAS_TX_ACCESS_LIST_STORAGE_KEY
+            )
+            tokens_in_access_list += ACCESS_LIST_ADDRESS_FLOOR_TOKENS
+            tokens_in_access_list += (
+                ulen(access.slots) * ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS
             )
 
     # Data token floor cost for access list bytes.

--- a/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
@@ -209,31 +209,6 @@ def tx_intrinsic_gas_cost_including_floor_data_cost(
 
 
 @pytest.fixture
-def tx_floor_data_cost(
-    fork: Fork,
-    tx_data: Bytes,
-    access_list: List[AccessList] | None,
-) -> int:
-    """
-    Floor data cost for the given transaction data and access list.
-
-    This includes both calldata tokens and access list tokens.
-
-    Note: This is calculated by the fork's intrinsic cost calculator,
-    so we return the same value as
-    tx_intrinsic_gas_cost_including_floor_data_cost.
-    """
-    fork_data_floor_cost_calculator = (
-        fork.transaction_data_floor_cost_calculator()
-    )
-
-    # Calculate calldata floor cost
-    return fork_data_floor_cost_calculator(
-        data=tx_data, access_list=access_list
-    )
-
-
-@pytest.fixture
 def tx_gas_limit(
     tx_intrinsic_gas_cost_including_floor_data_cost: int,
     tx_gas_delta: int,

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "be5f9861f233bfd0c0576cfa3dd027a2c4edcd4e"
+    "EIPS/eip-7981.md", "f0f874b8ed796a4e172fcaf2339c3bfaade92860"
 )
 
 
@@ -26,4 +26,3 @@ class Spec:
 
     ACCESS_LIST_ADDRESS_COST = 2400
     ACCESS_LIST_STORAGE_KEY_COST = 1900
-    TOTAL_COST_FLOOR_PER_TOKEN = 16

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -8,6 +8,7 @@ from execution_testing import (
     Address,
     Alloc,
     Bytes,
+    Fork,
     Hash,
     StateTestFiller,
     Transaction,
@@ -98,6 +99,7 @@ pytestmark = pytest.mark.valid_at("EIP7981")
 )
 def test_access_list_token_calculation(
     state_test: StateTestFiller,
+    fork: Fork,
     pre: Alloc,
     tx: Transaction,
     access_list: list,
@@ -106,18 +108,25 @@ def test_access_list_token_calculation(
     """
     Test that access list floor tokens are calculated correctly.
 
-    This test verifies the token counting mechanism:
-    - Each access list byte contributes 4 floor tokens
+    Every access list byte contributes four floor tokens regardless of
+    whether it is zero or non-zero. Verify both the reference helper and
+    the fork's floor cost calculator agree with the expected token count.
     """
-    # Verify our helper calculates floor tokens correctly
-    calculated_floor_tokens = calculate_access_list_floor_tokens(access_list)
-    assert calculated_floor_tokens == expected_floor_tokens, (
-        "Expected "
-        f"{expected_floor_tokens} tokens, got "
-        f"{calculated_floor_tokens}"
+    assert (
+        calculate_access_list_floor_tokens(access_list)
+        == expected_floor_tokens
     )
 
-    # The transaction should be valid with correct gas
+    gas_costs = fork.gas_costs()
+    expected_floor_cost = (
+        expected_floor_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+        + gas_costs.GAS_TX_BASE
+    )
+    actual_floor_cost = fork.transaction_data_floor_cost_calculator()(
+        data=b"", access_list=access_list
+    )
+    assert actual_floor_cost == expected_floor_cost
+
     state_test(
         pre=pre,
         post={},


### PR DESCRIPTION
Refactored the EIP-7981 branch to charge every access list byte as bytes × 4 × `GAS_TX_DATA_TOKEN_FLOOR`: adding the access-list floor cost via the inherited super_fn and a _access_list_floor_tokens helper instead of weighted token counting, so the branch contains only EIP-7981 logic on top of the EIP-7623 baseline (FLOOR=10) and will combine with EIP-7976 cleanly via rebase, without ever implementing 7976 itself.
