### PR TITLE
fix(benchmarks): fix `test_sload_bloated_prefetch_miss` and `test_sload_bloated_multi_contract` in execute remote filler

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -330,7 +330,7 @@ def test_sload_bloated_prefetch_miss(
     # distinct mode, a single shared sender otherwise). The senders
     # list collects one entry per tx so the BAL builder below can
     # group nonce changes by sender uniformly.
-    senders_iter = _sender_generator(pre, distinct_senders)
+    #senders_iter = _sender_generator(pre, distinct_senders)
     senders: list[EOA] = []
 
     gas_available = gas_benchmark_value
@@ -344,7 +344,8 @@ def test_sload_bloated_prefetch_miss(
     # reads an offset the prefetcher's pre-block snapshot does
     # not see, achieving a 100% prefetch miss rate on max-gas txs.
     first_tx_gas = min(gas_available, intrinsic_gas + 30_000)
-    sender = next(senders_iter)
+    sender = pre.fund_eoa()
+    nondistinct=sender
     senders.append(sender)
     txs.append(
         Transaction(
@@ -362,7 +363,7 @@ def test_sload_bloated_prefetch_miss(
     while gas_available >= intrinsic_gas:
         tx_gas = min(gas_available, tx_gas_limit)
         new_offset = base_offset + tx_index * max_sloads_per_tx
-        sender = next(senders_iter)
+        sender = pre.fund_eoa() if distinct_senders else nondistinct
         senders.append(sender)
         txs.append(
             Transaction(
@@ -370,6 +371,7 @@ def test_sload_bloated_prefetch_miss(
                 to=authority,
                 data=Hash(new_offset),
                 sender=sender,
+                #value=1
             )
         )
         gas_available -= tx_gas
@@ -498,7 +500,7 @@ def test_sload_bloated_multi_contract(
     # distinct mode, a single shared sender otherwise). The senders
     # list collects one entry per tx so the BAL builder below can
     # group nonce changes by sender uniformly.
-    senders_iter = _sender_generator(pre, distinct_senders)
+    #senders_iter = _sender_generator(pre, distinct_senders)
     senders: list[EOA] = []
 
     gas_available = gas_benchmark_value
@@ -507,6 +509,7 @@ def test_sload_bloated_multi_contract(
 
     # Each tx targets a freshly-deployed contract with identical code
     # and storage layout.
+    nondistinct = pre.fund_eoa()
     while gas_available >= min_tx_gas:
         tx_gas = min(gas_available, tx_gas_limit)
         target = pre.deploy_contract(
@@ -514,7 +517,7 @@ def test_sload_bloated_multi_contract(
             storage=Storage(storage_data),
         )
         targets.append(target)
-        sender = next(senders_iter)
+        sender = pre.fund_eoa() if distinct_senders else nondistinct
         senders.append(sender)
         txs.append(
             Transaction(

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
@@ -28,6 +28,7 @@ from execution_testing import (
     TestPhaseManager,
     Transaction,
 )
+from execution_testing.test_types.transaction_types import AuthorizationTuple
 
 CURSOR_SLOT = 0
 CURSOR_INIT = 1
@@ -216,8 +217,29 @@ def run_bal_benchmark(
 ) -> None:
     """Deploy contract, create txs, BAL expectations, and run."""
     contract = pre.deploy_contract(
-        code=contract_code, storage=contract_storage
+        code=contract_code
     )
+
+    blocks = []
+    authority = pre.stub_eoa("bloated_eoa_20GB")
+    with TestPhaseManager.setup():
+        sender = pre.fund_eoa()
+        tx = Transaction(
+            gas_limit=100_000,
+            to=sender,
+            value=0,
+            sender=sender,
+            authorization_list=[
+                AuthorizationTuple(
+                    chain_id=0,
+                    address=contract,
+                    nonce=authority.nonce,
+                    signer=authority,
+                ),
+            ],
+        )
+        blocks.append(Block(txs=[tx]))
+
 
     num_txs = len(plan.gas_limits)
     with TestPhaseManager.execution():
@@ -225,7 +247,7 @@ def run_bal_benchmark(
         transactions = [
             Transaction(
                 sender=sender,
-                to=contract,
+                to=authority,
                 gas_limit=plan.gas_limits[i],
                 data=b"",
             )
@@ -266,6 +288,8 @@ def run_bal_benchmark(
             account_expectations=expectations
         ),
     )
+    
+    blocks.append(block)
 
     # Post-state: only check sender nonce (sanity).
     # Exact storage values depend on gas dynamics and may be
@@ -275,5 +299,5 @@ def run_bal_benchmark(
     }
 
     benchmark_test(
-        pre=pre, post=post, blocks=[block], skip_gas_used_validation=True
+        pre=pre, post=post, blocks=blocks, skip_gas_used_validation=True
     )


### PR DESCRIPTION
## 🗒️ Description
This PR resolves problems filling the tests and hacks in a EIP-7702 deployer to target 20GB bloated contract instead of empty contract. `test_sload_bloated_prefetch_miss or test_sload_bloated_multi_contract` have to be solved, multi_contract not yet solved this has initcode too large for the storage set.

The EOA generator seems to cause an issue where "Sender balance must be set before sending" is thrown, seems to have to do with EOA screated which do not send txs.

These are not problems in fill mode, but these are in execute remote world, which stresses at some point we should get CI to check these.

Note: For test_sload_bloated_prefetch_miss there were certain gas limits which have failures, like 60M, this fails `FAILED tests/benchmark/stateful/bloatnet/test_single_opcode.py::test_sload_bloated_prefetch_miss[1GB-fork_Amsterdam-benchmark_test-existing_slots_True-distinct_senders_False-benchmark-gas-value_60M]` and then eest_stateful_generator.py OR EEST just hangs :thinking: 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
