### PR TITLE
feat(test-forks): Gas-limit-aware `Fork`, fork-aware `Environment`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -851,10 +851,13 @@ def pytest_collection_modifyitems(
         if isinstance(item, EIPSpecTestItem):
             continue
         params: Dict[str, Any] = item.callspec.params  # type: ignore
-        if "fork" not in params or params["fork"] is None:
+        if (
+            "parametrized_fork" not in params
+            or params["parametrized_fork"] is None
+        ):
             items_for_removal.append(i)
             continue
-        fork: Fork | TransitionFork = params["fork"]
+        fork: Fork | TransitionFork = params["parametrized_fork"]
         spec_type, execute_format = get_spec_format_for_item(params)
         assert issubclass(execute_format, BaseExecute)
         markers = list(item.iter_markers())

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1922,10 +1922,14 @@ def pytest_collection_modifyitems(
             params = item.callspec.params
         elif hasattr(item, "params"):
             params = item.params
-        if not params or "fork" not in params or params["fork"] is None:
+        if (
+            not params
+            or "parametrized_fork" not in params
+            or params["parametrized_fork"] is None
+        ):
             items_for_removal.append(i)
             continue
-        fork: Fork | TransitionFork = params["fork"]
+        fork: Fork | TransitionFork = params["parametrized_fork"]
         spec_type, fixture_format = get_spec_format_for_item(params)
         if isinstance(fixture_format, NotSetType):
             items_for_removal.append(i)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/gen_test_doc/gen_test_doc.py
@@ -430,7 +430,7 @@ class TestDocsGenerator:
                         )
                         for value in values
                     ]
-                    fork = item.callspec.params.get("fork").name()  # type: ignore
+                    fork = item.callspec.params.get("parametrized_fork").name()  # type: ignore
                     test_type = get_test_function_test_type(item)
                     test_type_value = item.callspec.params.get(test_type)
                     fixture_type = test_type_value.format_name  # type: ignore

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/static_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/static_filler.py
@@ -275,7 +275,7 @@ class FillerFile(pytest.File):
                             ps_id = fixture_format_parameter_set.id
                             test_id = f"fork_{fork.name()}-{ps_id}"
                             if "fork" in func_parameters:
-                                params["fork"] = fork
+                                params["parametrized_fork"] = fork
                             if "pre" in func_parameters:
                                 fixturenames.append("pre")
                             if "request" in func_parameters:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -118,7 +118,7 @@ class ForkParametrizer:
             marks = []
         self.fork_covariant_parameters = [
             ForkCovariantParameter(
-                names=["fork"],
+                names=["parametrized_fork"],
                 values=[
                     pytest.param(
                         fork,
@@ -671,7 +671,7 @@ def pytest_report_header(config: pytest.Config, start_path: Any) -> List[str]:
 
 
 @pytest.fixture(autouse=True)
-def fork(request: pytest.FixtureRequest) -> None:
+def parametrized_fork(request: pytest.FixtureRequest) -> None:
     """Parametrize test cases by fork."""
     pass
 
@@ -1234,7 +1234,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                     ],
                 )
             ]
-            metafunc.parametrize("fork", pytest_params, scope="function")
+            metafunc.parametrize(
+                "parametrized_fork", pytest_params, scope="function"
+            )
         return
 
     # Get the intersection between the test's validity marker and the current
@@ -1243,7 +1245,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         test_fork_set & metafunc.config.selected_fork_set  # type: ignore
     )
 
-    if "fork" not in metafunc.fixturenames:
+    if "parametrized_fork" not in metafunc.fixturenames:
         return
 
     unsupported_forks: Set[Fork | TransitionFork] = (
@@ -1266,7 +1268,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                     ],
                 )
             ]
-            metafunc.parametrize("fork", pytest_params, scope="function")
+            metafunc.parametrize(
+                "parametrized_fork", pytest_params, scope="function"
+            )
     else:
         pytest_params = []
         for fork in sorted(intersection_set):
@@ -1570,7 +1574,7 @@ def pytest_collection_modifyitems(
                 continue
 
         # --- validity markers ---
-        fork = params.get("fork")
+        fork = params.get("parametrized_fork")
         if fork is None:
             continue
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_fork_parametrizer_types.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_fork_parametrizer_types.py
@@ -19,7 +19,7 @@ from ..forks import (
     [
         pytest.param(
             [ForkParametrizer(fork=Frontier)],
-            ["fork"],
+            ["parametrized_fork"],
             [pytest.param(Frontier)],
             id="only_fork",
         ),
@@ -34,7 +34,7 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "some_value"],
+            ["parametrized_fork", "some_value"],
             [pytest.param(Frontier, 1)],
             id="fork_with_single_covariant_parameter",
         ),
@@ -50,7 +50,7 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "some_value"],
+            ["parametrized_fork", "some_value"],
             [pytest.param(Frontier, 1), pytest.param(Frontier, 2)],
             id="fork_with_single_covariant_parameter_multiple_values",
         ),
@@ -69,7 +69,7 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "some_value"],
+            ["parametrized_fork", "some_value"],
             [
                 pytest.param(Frontier, 1, marks=[pytest.mark.some_mark]),
                 pytest.param(Frontier, 2),
@@ -90,7 +90,7 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "some_value", "another_value"],
+            ["parametrized_fork", "some_value", "another_value"],
             [pytest.param(Frontier, 1, 2)],
             id="fork_with_multiple_covariant_parameters",
         ),
@@ -109,7 +109,7 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "some_value", "another_value"],
+            ["parametrized_fork", "some_value", "another_value"],
             [pytest.param(Frontier, 1, 2), pytest.param(Frontier, 1, 3)],
             id="fork_with_multiple_covariant_parameters_multiple_values",
         ),
@@ -128,7 +128,7 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "some_value", "another_value"],
+            ["parametrized_fork", "some_value", "another_value"],
             [pytest.param(Frontier, 1, "a"), pytest.param(Frontier, 2, "b")],
             id="fork_with_single_multi_value_covariant_parameter_multiple_values",
         ),
@@ -155,7 +155,7 @@ from ..forks import (
                 )
             ],
             [
-                "fork",
+                "parametrized_fork",
                 "some_value",
                 "another_value",
                 "yet_another_value",
@@ -191,7 +191,12 @@ from ..forks import (
                     ],
                 )
             ],
-            ["fork", "shared_value", "different_value_1", "different_value_2"],
+            [
+                "parametrized_fork",
+                "shared_value",
+                "different_value_1",
+                "different_value_2",
+            ],
             [
                 pytest.param(Frontier, 1, "a", "x"),
                 pytest.param(Frontier, 2, "b", "y"),

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -553,16 +553,26 @@ def _is_benchmark_test(request: pytest.FixtureRequest) -> bool:
 
 
 @pytest.fixture
-def genesis_environment(request: pytest.FixtureRequest) -> Environment:
+def env_gas_limit(request: pytest.FixtureRequest) -> int:
     """Return an Environment with appropriate gas limit."""
     if _is_benchmark_test(request):
-        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
+        return BENCHMARKING_MAX_GAS
+    return EnvironmentDefaults.gas_limit
+
+
+@pytest.fixture
+def genesis_environment(
+    request: pytest.FixtureRequest, env_gas_limit: int
+) -> Environment:
+    """Return an Environment with appropriate gas limit."""
+    if _is_benchmark_test(request):
+        return Environment(gas_limit=env_gas_limit)
     return Environment()
 
 
 @pytest.fixture
-def env(request: pytest.FixtureRequest) -> Environment:
+def env(request: pytest.FixtureRequest, env_gas_limit: int) -> Environment:
     """Return an Environment with appropriate gas limit."""
     if _is_benchmark_test(request):
-        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
+        return Environment(gas_limit=env_gas_limit)
     return Environment()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -20,6 +20,8 @@ from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
 
 if TYPE_CHECKING:
     from execution_testing.forks import Fork, TransitionFork
+import sys
+
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.specs import BaseTest
@@ -28,7 +30,6 @@ from execution_testing.test_types import (
     EOA,
     Alloc,
     ChainConfig,
-    EnvironmentDefaults,
 )
 
 from ..shared.address_stubs import AddressStubs, StubEOA
@@ -328,9 +329,48 @@ def pytest_make_parametrize_id(
 @pytest.fixture(scope="function")
 def fork(
     parametrized_fork: Fork | TransitionFork,
+    monkeypatch: pytest.MonkeyPatch,
+    env_gas_limit: int,
 ) -> Fork | TransitionFork:
-    """Return the fork for the current test."""
-    return parametrized_fork.with_env_gas_limit(EnvironmentDefaults.gas_limit)
+    """
+    Return a per-test fork variant whose ``_env_gas_limit`` tracks the
+    ``Environment.gas_limit`` used by the test.
+    """
+    fork_variant = parametrized_fork.with_env_gas_limit(env_gas_limit)
+
+    # Now we monkey-patch the `Environment` class with one that is aware of
+    # the fork that the test is using, and will update its `_env_gas_limit`
+    # automatically.
+    # TODO: This should not be necessary, we should treat the `env` object the
+    #  same way we do `pre` and force it to be a singleton in the test's
+    #  context.
+    from execution_testing.test_types.block_types import (
+        Environment as OriginalEnvironment,
+    )
+
+    class _ForkAwareEnvironment(OriginalEnvironment):
+        """Transparently syncs ``gas_limit`` back to the fork variant."""
+
+        def model_post_init(self, __context: object) -> None:
+            super().model_post_init(__context)
+            fork_variant._env_gas_limit = int(self.gas_limit)
+
+        def __setattr__(self, name: str, value: object) -> None:
+            super().__setattr__(name, value)
+            if name == "gas_limit":
+                fork_variant._env_gas_limit = int(self.gas_limit)
+
+    # Replace Environment in every module that imported the original class
+    # so that both `Environment(...)` in test code and in conftest fixtures
+    # create _ForkAwareEnvironment instances.
+    for mod in list(sys.modules.values()):
+        try:
+            if getattr(mod, "Environment", None) is OriginalEnvironment:
+                monkeypatch.setattr(mod, "Environment", _ForkAwareEnvironment)
+        except Exception:
+            continue
+
+    return fork_variant
 
 
 SPEC_TYPES_PARAMETERS: List[str] = list(BaseTest.spec_types.keys())

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -15,6 +15,7 @@ from execution_testing.execution import (
     LabeledExecuteFormat,
 )
 from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
+from execution_testing.forks import Fork, TransitionFork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.specs import BaseTest
@@ -310,7 +311,17 @@ def pytest_make_parametrize_id(
     readable test ids for the generated tests.
     """
     del config
+    if argname == "parametrized_fork":
+        return f"fork_{val}"
     return f"{argname}_{val}"
+
+
+@pytest.fixture(scope="function")
+def fork(
+    parametrized_fork: Fork | TransitionFork,
+) -> Fork | TransitionFork:
+    """Return the fork for the current test."""
+    return parametrized_fork
 
 
 SPEC_TYPES_PARAMETERS: List[str] = list(BaseTest.spec_types.keys())

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -2,8 +2,10 @@
 Shared pytest fixtures and hooks for EEST generation modes (fill and execute).
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 import pytest
 from pytest import StashKey
@@ -15,12 +17,19 @@ from execution_testing.execution import (
     LabeledExecuteFormat,
 )
 from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
-from execution_testing.forks import Fork, TransitionFork
+
+if TYPE_CHECKING:
+    from execution_testing.forks import Fork, TransitionFork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.specs import BaseTest
 from execution_testing.specs.base import OpMode
-from execution_testing.test_types import EOA, Alloc, ChainConfig
+from execution_testing.test_types import (
+    EOA,
+    Alloc,
+    ChainConfig,
+    EnvironmentDefaults,
+)
 
 from ..shared.address_stubs import AddressStubs, StubEOA
 from ..shared.helpers import get_rpc_endpoint
@@ -321,7 +330,7 @@ def fork(
     parametrized_fork: Fork | TransitionFork,
 ) -> Fork | TransitionFork:
     """Return the fork for the current test."""
-    return parametrized_fork
+    return parametrized_fork.with_env_gas_limit(EnvironmentDefaults.gas_limit)
 
 
 SPEC_TYPES_PARAMETERS: List[str] = list(BaseTest.spec_types.keys())

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -198,9 +198,13 @@ class BaseForkMeta(ABCMeta):
     @staticmethod
     def _is_subclass_of(a: "BaseForkMeta", b: "BaseForkMeta") -> bool:
         """
-        Check if `a` is a subclass of `b`, taking fork transitions into
-        account.
+        Check if `a` is a subclass of `b`, taking fork transitions and
+        variants (created by `with_env_gas_limit`) into account.
         """
+        # Resolve variants to canonical identity so comparisons between
+        # a variant and a canonical descendant fork work as expected.
+        a = BaseForkMeta._identity(a)
+        b = BaseForkMeta._identity(b)
         a = BaseForkMeta._maybe_transitioned(a)
         b = BaseForkMeta._maybe_transitioned(b)
         return issubclass(a, b)

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -1129,19 +1129,19 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         return set(cls._children)
 
     @classmethod
-    def with_env_gas_limit(
-        cls, env_gas_limit: int
-    ) -> Type["BaseFork"]:
+    def with_env_gas_limit(cls, env_gas_limit: int) -> Type["BaseFork"]:
         """Return a new fork class with the specified environment gas limit."""
         new_cls = type(cls.__name__, (cls,), {})
         # __init_subclass__ resets per-class overrides; restore from parent.
-        new_cls._env_gas_limit = env_gas_limit
-        new_cls._base_fork = cls._base_fork or cls
-        new_cls._transition_tool_name = cls._transition_tool_name
-        new_cls._solc_name = cls._solc_name
-        new_cls._ignore = cls._ignore
-        new_cls._bpo_fork = cls._bpo_fork
-        new_cls._ruleset_name = cls._ruleset_name
+        new_cls._env_gas_limit = env_gas_limit  # type: ignore[attr-defined]
+        new_cls._base_fork = cls._base_fork or cls  # type: ignore[attr-defined]
+        new_cls._transition_tool_name = (  # type: ignore[attr-defined]
+            cls._transition_tool_name
+        )
+        new_cls._solc_name = cls._solc_name  # type: ignore[attr-defined]
+        new_cls._ignore = cls._ignore  # type: ignore[attr-defined]
+        new_cls._bpo_fork = cls._bpo_fork  # type: ignore[attr-defined]
+        new_cls._ruleset_name = cls._ruleset_name  # type: ignore[attr-defined]
         # Prevent the variant from appearing in fork traversals.
         cls._children.discard(new_cls)
         return new_cls

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -205,28 +205,43 @@ class BaseForkMeta(ABCMeta):
         b = BaseForkMeta._maybe_transitioned(b)
         return issubclass(a, b)
 
+    @staticmethod
+    def _identity(fork_cls: "BaseForkMeta") -> "BaseForkMeta":
+        """Return the canonical fork class, resolving variants."""
+        base = getattr(fork_cls, "_base_fork", None)
+        return base if base is not None else fork_cls
+
+    def __eq__(cls, other: object) -> bool:
+        """Compare fork identity, treating variants as equal to parents."""
+        if not isinstance(other, BaseForkMeta):
+            return NotImplemented
+        return BaseForkMeta._identity(cls) is BaseForkMeta._identity(other)
+
+    def __hash__(cls) -> int:
+        """Hash by canonical fork identity."""
+        return id(BaseForkMeta._identity(cls))
+
     def __gt__(cls, other: "BaseForkMeta") -> bool:
         """Compare if a fork is newer than some other fork (cls > other)."""
-        return cls is not other and BaseForkMeta._is_subclass_of(cls, other)
+        return cls != other and BaseForkMeta._is_subclass_of(cls, other)
 
     def __ge__(cls, other: "BaseForkMeta") -> bool:
         """
         Compare if a fork is newer than or equal to some other fork (cls >=
         other).
         """
-        return cls is other or BaseForkMeta._is_subclass_of(cls, other)
+        return cls == other or BaseForkMeta._is_subclass_of(cls, other)
 
     def __lt__(cls, other: "BaseForkMeta") -> bool:
         """Compare if a fork is older than some other fork (cls < other)."""
-        # "Older" means other is a subclass of cls, but not the same.
-        return cls is not other and BaseForkMeta._is_subclass_of(other, cls)
+        return cls != other and BaseForkMeta._is_subclass_of(other, cls)
 
     def __le__(cls, other: "BaseForkMeta") -> bool:
         """
         Compare if a fork is older than or equal to some other fork (cls <=
         other).
         """
-        return cls is other or BaseForkMeta._is_subclass_of(other, cls)
+        return cls == other or BaseForkMeta._is_subclass_of(other, cls)
 
 
 class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
@@ -246,6 +261,10 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     _ruleset_name: ClassVar[Optional[str]] = None
     _fork_by_timestamp: ClassVar[bool] = False
     _blob_constants: ClassVar[Dict[str, int]] = {}
+
+    # Environment overrides (set on variants created by with_env_gas_limit)
+    _base_fork: ClassVar[Optional[Type["BaseFork"]]] = None
+    _env_gas_limit: ClassVar[int] = 0
     _deployed: ClassVar[bool] = True
     _enabled_eips: ClassVar[Set[int]] = set()
     _enabling_forks: ClassVar[Set[Type["BaseFork"]]] = set()
@@ -1108,6 +1127,24 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     def children(cls) -> Set[Type["BaseFork"]]:
         """Return the children forks."""
         return set(cls._children)
+
+    @classmethod
+    def with_env_gas_limit(
+        cls, env_gas_limit: int
+    ) -> Type["BaseFork"]:
+        """Return a new fork class with the specified environment gas limit."""
+        new_cls = type(cls.__name__, (cls,), {})
+        # __init_subclass__ resets per-class overrides; restore from parent.
+        new_cls._env_gas_limit = env_gas_limit
+        new_cls._base_fork = cls._base_fork or cls
+        new_cls._transition_tool_name = cls._transition_tool_name
+        new_cls._solc_name = cls._solc_name
+        new_cls._ignore = cls._ignore
+        new_cls._bpo_fork = cls._bpo_fork
+        new_cls._ruleset_name = cls._ruleset_name
+        # Prevent the variant from appearing in fork traversals.
+        cls._children.discard(new_cls)
+        return new_cls
 
     @classmethod
     @abstractmethod

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -24,6 +24,7 @@ from ..forks.forks import (
     Paris,
     Prague,
     Shanghai,
+    SpuriousDragon,
 )
 from ..forks.transition import (
     BerlinToLondonAt5,
@@ -731,3 +732,25 @@ def test_eips() -> None:  # noqa: D103
     assert not Paris.is_eip_enabled(3675, 3855)
     assert not Paris.is_eip_enabled(3855, 3675)
     assert Shanghai.is_eip_enabled(3855)
+
+
+def test_fork_variant_ordering() -> None:
+    """
+    Variants from `with_env_gas_limit` must compare consistently with
+    their canonical parent: equal to the parent, ordered identically
+    against other canonical forks.
+    """
+    variant = London.with_env_gas_limit(30_000_000)
+
+    assert variant == London
+    assert hash(variant) == hash(London)
+
+    assert variant > SpuriousDragon
+    assert variant >= SpuriousDragon
+    assert variant < Cancun
+    assert variant <= Cancun
+
+    assert not (variant > London)
+    assert not (variant < London)
+    assert variant >= London
+    assert variant <= London

--- a/packages/testing/src/execution_testing/forks/transition_base_fork.py
+++ b/packages/testing/src/execution_testing/forks/transition_base_fork.py
@@ -116,7 +116,7 @@ class TransitionBaseClass(metaclass=TransitionBaseMetaClass):
         gas limit.
         """
         new_cls = type(cls.__name__, (cls,), {})
-        new_cls._env_gas_limit = env_gas_limit
+        new_cls._env_gas_limit = env_gas_limit  # type: ignore[attr-defined]
         return new_cls
 
 

--- a/packages/testing/src/execution_testing/forks/transition_base_fork.py
+++ b/packages/testing/src/execution_testing/forks/transition_base_fork.py
@@ -75,6 +75,7 @@ class TransitionBaseClass(metaclass=TransitionBaseMetaClass):
     at_block: ClassVar[int] = 0
     at_timestamp: ClassVar[int] = 0
     _ignore: ClassVar[bool] = False
+    _env_gas_limit: ClassVar[int] = 0
 
     @classmethod
     def fork_at(
@@ -106,6 +107,18 @@ class TransitionBaseClass(metaclass=TransitionBaseMetaClass):
         """
         raise Exception("Not implemented")
 
+    @classmethod
+    def with_env_gas_limit(
+        cls, env_gas_limit: int
+    ) -> Type["TransitionBaseClass"]:
+        """
+        Return a new transition fork class with the specified environment
+        gas limit.
+        """
+        new_cls = type(cls.__name__, (cls,), {})
+        new_cls._env_gas_limit = env_gas_limit
+        return new_cls
+
 
 def transition_fork(
     to_fork: Type[BaseFork],
@@ -135,22 +148,29 @@ def transition_fork(
             _ignore = ignore
 
             @classmethod
+            def _propagate_env(cls, fork: Type[BaseFork]) -> Type[BaseFork]:
+                if cls._env_gas_limit:
+                    return fork.with_env_gas_limit(cls._env_gas_limit)
+                return fork
+
+            @classmethod
             def transitions_to(cls) -> Type[BaseFork]:
-                return to_fork
+                return cls._propagate_env(to_fork)
 
             @classmethod
             def transitions_from(cls) -> Type[BaseFork]:
-                return from_fork
+                return cls._propagate_env(from_fork)
 
             @classmethod
             def fork_at(
                 cls, *, block_number: int = 0, timestamp: int = 0
             ) -> Type[BaseFork]:
-                return (
+                fork = (
                     to_fork
                     if block_number >= at_block and timestamp >= at_timestamp
                     else from_fork
                 )
+                return cls._propagate_env(fork)
 
             @classmethod
             def name(cls) -> str:


### PR DESCRIPTION
## 🗒️ Description

Implements idea from https://github.com/ethereum/execution-specs/pull/2687#discussion_r3089863188 to facilitate EIP-8037 testing.

cc @spencer-tb I have not verified that the fixtures produced before and after this PR are an exact match, but I think they should, could you please verify if this PR looks ok and you want to merge to rebase EIP-8037?

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

