### PR TITLE
feat(test-benchmark): accept float values for `--gas-benchmark-values` flag

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -219,7 +219,7 @@ bench-gas *args:
     @mkdir -p "{{ output_dir }}/bench-gas/tmp" "{{ output_dir }}/bench-gas/logs"
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
-        --gas-benchmark-values 1 \
+        --gas-benchmark-values 0.5 \
         --generate-pre-alloc-groups \
         --fork Osaka \
         -m "not slow" \

--- a/Justfile
+++ b/Justfile
@@ -219,7 +219,7 @@ bench-gas *args:
     @mkdir -p "{{ output_dir }}/bench-gas/tmp" "{{ output_dir }}/bench-gas/logs"
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
-        --gas-benchmark-values 0.5 \
+        --gas-benchmark-values 1 \
         --generate-pre-alloc-groups \
         --fork Osaka \
         -m "not slow" \

--- a/docs/running_tests/releases.md
+++ b/docs/running_tests/releases.md
@@ -52,8 +52,8 @@ follow the same layout.
 
 When filling with `--gas-benchmark-values`, benchmark tests additionally
 include the gas limit in the subdirectory name (`for_{fork}_at_{gas}M`,
-where `{gas}` is in millions, zero-padded to four digits), with one
-subdirectory per gas value:
+where `{gas}` is in millions, zero-padded to at least four digits), with
+one subdirectory per gas value:
 
 ```text
 fixtures/

--- a/docs/writing_tests/benchmarks.md
+++ b/docs/writing_tests/benchmarks.md
@@ -71,7 +71,7 @@ This mode is designed for gas limit testing, and gas repricing, where it enables
 
 **Note:** For both benchmark modes, users may supply multiple values in a single invocation. For example:
 
-- `--gas-benchmark-values 1,2,3` runs the test with 1M, 2M, and 3M block gas limits
+- `--gas-benchmark-values 0.5,1,10` runs the test with 0.5M, 1M, and 10M block gas limits
 - `--fixed-opcode-count 4,5` runs the test with approximately 4K and 5K opcode executions
 
 **Output layout with gas benchmark values:** When `--gas-benchmark-values` is provided and benchmark tests are filled, fixtures are written into per‑fork, per‑gas‑limit subdirectories under each format directory:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py
@@ -16,6 +16,7 @@ from execution_testing.cli.pytest_commands.plugins.shared.fixture_output import 
     FORK_SUBDIR_PREFIX,
     SUBFOLDER_LEVEL_SEPARATOR,
     format_fork_subdir,
+    format_gas_limit_prefix,
 )
 
 # EVM binary for fill tests; defaults to geth evm
@@ -198,6 +199,33 @@ def test_benchmarking_mode_configured_with_option(
     assert any("benchmark-gas-value_10M" in line for line in result.outlines)
     assert any("benchmark-gas-value_20M" in line for line in result.outlines)
     assert any("benchmark-gas-value_30M" in line for line in result.outlines)
+
+
+def test_benchmarking_mode_with_float_gas_values(
+    pytester: pytest.Pytester,
+) -> None:
+    """Test that float --gas-benchmark-values are accepted and formatted."""
+    setup_test_directory_structure(
+        pytester, test_module_dummy, "test_dummy_benchmark.py"
+    )
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "--gas-benchmark-values",
+        "0.5,1.5,10",
+        "tests/benchmark/dummy_test_module/",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0
+    assert any("6 tests collected" in line for line in result.outlines)
+    assert any("benchmark-gas-value_0.5M" in line for line in result.outlines)
+    assert any("benchmark-gas-value_1.5M" in line for line in result.outlines)
+    assert any("benchmark-gas-value_10M" in line for line in result.outlines)
 
 
 def test_benchmark_gas_values_split_into_subdirs(
@@ -1209,3 +1237,20 @@ def test_consensus_fixtures_split_by_fork(
             assert "fork_Prague" not in key, (
                 f"Unexpected fork_Prague in key {key} ({file_path})"
             )
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        ([1.0, 10.0, 60.0], ["0001M", "0010M", "0060M"]),
+        ([0.5, 1.0, 10.0], ["0000.5M", "0001.0M", "0010.0M"]),
+        ([0.25, 0.5, 1.0], ["0000.25M", "0000.50M", "0001.00M"]),
+    ],
+    ids=["integers", "mixed", "fractional"],
+)
+def test_format_gas_limit_prefix(
+    values: List[float], expected: List[str]
+) -> None:
+    """Test gas limit prefix formatting for int and float values."""
+    result = [format_gas_limit_prefix(v, values) for v in values]
+    assert result == expected

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -3,9 +3,10 @@
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import ClassVar, Dict, List, Self
+from typing import Annotated, ClassVar, Dict, List, Self
 
 import pytest
+from annotated_types import Gt
 from pydantic import BaseModel, Field, RootModel
 
 from execution_testing.test_types import Environment, EnvironmentDefaults
@@ -33,7 +34,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help=(
             "Gas limits (in millions) for benchmark tests. "
-            "Example: '100,500' runs tests with 100M and 500M gas. "
+            "Example: '0.5,1,10' runs tests with 0.5M, 1M and 10M gas. "
             "Benchmark outputs are grouped under "
             f"{FORK_SUBDIR_PREFIX}{{fork}}"
             f"{SUBFOLDER_LEVEL_SEPARATOR}XXXXM/ subdirectories. "
@@ -174,7 +175,7 @@ class BenchmarkParametrizer(ABC):
 class GasBenchmarkValues(RootModel, BenchmarkParametrizer):
     """Gas benchmark values configuration object."""
 
-    root: List[int]
+    root: List[Annotated[float, Gt(0)]]
 
     flag: ClassVar[str] = "--gas-benchmark-values"
     config_field: ClassVar[str] = "_gas_benchmark_values_config"
@@ -191,8 +192,8 @@ class GasBenchmarkValues(RootModel, BenchmarkParametrizer):
         """Get benchmark values. All tests have the same list."""
         return [
             pytest.param(
-                gas_value * 1_000_000,
-                id=f"benchmark-gas-value_{gas_value}M",
+                int(gas_value * 1_000_000),
+                id=f"benchmark-gas-value_{gas_value:g}M",
                 marks=[
                     pytest.mark.fixture_subfolder(
                         level=1,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/fixture_output.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/fixture_output.py
@@ -319,10 +319,18 @@ def format_gas_limit_prefix(
 ) -> str:
     """Return a stable, sortable gas-limit prefix for a fixture subfolder."""
     max_value = max(all_values_millions) if all_values_millions else 0
-    width = max(4, len(str(int(max_value))))
-    if gas_value_millions == int(gas_value_millions):
-        return f"{int(gas_value_millions):0{width}d}M"
-    return f"{gas_value_millions:0{width + 2}.1f}M"
+    int_width = max(4, len(str(int(max_value))))
+    # Find max decimal places across all fractional values for
+    # consistent padding (ensures lexicographic sortability).
+    max_decimals = 0
+    for v in all_values_millions:
+        label = f"{v:g}"
+        if "." in label:
+            max_decimals = max(max_decimals, len(label.split(".")[1]))
+    if gas_value_millions == int(gas_value_millions) and max_decimals == 0:
+        return f"{int(gas_value_millions):0{int_width}d}M"
+    total_width = int_width + 1 + max_decimals  # digits + dot + decimals
+    return f"{gas_value_millions:0{total_width}.{max_decimals}f}M"
 
 
 def format_fork_subdir(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/fixture_output.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/fixture_output.py
@@ -315,12 +315,14 @@ SUBFOLDER_LEVEL_SEPARATOR = "_at_"
 
 
 def format_gas_limit_prefix(
-    gas_value_millions: int, all_values_millions: list[int]
+    gas_value_millions: float, all_values_millions: list[float]
 ) -> str:
     """Return a stable, sortable gas-limit prefix for a fixture subfolder."""
     max_value = max(all_values_millions) if all_values_millions else 0
-    width = max(4, len(str(max_value)))
-    return f"{gas_value_millions:0{width}d}M"
+    width = max(4, len(str(int(max_value))))
+    if gas_value_millions == int(gas_value_millions):
+        return f"{int(gas_value_millions):0{width}d}M"
+    return f"{gas_value_millions:0{width + 2}.1f}M"
 
 
 def format_fork_subdir(


### PR DESCRIPTION
Accept fractional Mgas values in --gas-benchmark-values to speed up the bench-gas CI check. Changes GasBenchmarkValues.root from List[int] to 
  List[Annotated[float, Gt(0)]], adds int() cast at the multiplication boundary so all downstream code still receives int, updates
  format_gas_limit_prefix to handle float formatting, and reduces the Justfile default from 1 to 0.5.                                           
                                                            
  🔗 Related Issues or PRs

  Fixes #2673                                                                                                                                   
   
  ✅ Checklist                                                                                                                                  
                                                            
  - All: Ran fast static checks to avoid unnecessary CI fails, see also Code Standards and Enabling Pre-commit Checks:                          
  just static
  - All: PR title adheres to the repo standard - it will be used as the squash commit message and should start type(scope):.                    
  - All: Considered updating the online docs in the ./docs/ directory.                                                                          
  - All: Set appropriate labels for the changes (only maintainers can apply labels).                                                            
  - Tests: Ran mkdocs serve locally and verified the auto-generated docs for new tests in the Test Case Reference are correctly formatted.      
  - Tests: For PRs implementing a missed test case, update the post-mortem document to add an entry the list.                                   
  - Ported Tests: All converted JSON/YML tests from ethereum/tests or tests/static have been assigned @ported_from marker.                      
                                                                                                                                                
                                                                 
   