### PR TITLE
feat(spec-specs): EIP-8037 spec changes for `bal-devnet-4`

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -98,10 +98,13 @@ from .vm.eoa_delegation import is_valid_delegation
 from .vm.gas import (
     BLOB_SCHEDULE_MAX,
     GAS_PER_BLOB,
+    STATE_BYTES_PER_NEW_ACCOUNT,
+    STATE_BYTES_PER_STORAGE_SET,
     calculate_blob_gas_price,
     calculate_data_fee,
     calculate_excess_blob_gas,
     calculate_total_blob_gas,
+    state_gas_per_byte,
 )
 from .vm.interpreter import MessageCallOutput, process_message_call
 
@@ -1053,6 +1056,30 @@ def process_transaction(
     if tx_output.error is not None:
         tx_output.state_gas_left += tx_output.state_gas_used
         tx_output.state_gas_used = Uint(0)
+
+    # Refund state gas for accounts created and destroyed in the
+    # same tx (EIP-6780). Covers account, storage, and code.
+    cost_per_state_byte = state_gas_per_byte(block_env.block_gas_limit)
+    for address in tx_output.accounts_to_delete:
+        if address in tx_state.created_accounts:
+            selfdestruct_refund = (
+                STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+            )
+            storage = tx_state.storage_writes.get(address, {})
+            created_slots = sum(1 for v in storage.values() if v != 0)
+            selfdestruct_refund += (
+                Uint(created_slots)
+                * STATE_BYTES_PER_STORAGE_SET
+                * cost_per_state_byte
+            )
+            account = get_account(tx_state, address)
+            code = get_code(tx_state, account.code_hash)
+            selfdestruct_refund += Uint(len(code)) * cost_per_state_byte
+            selfdestruct_refund = min(
+                selfdestruct_refund, tx_output.state_gas_used
+            )
+            tx_output.state_gas_left += selfdestruct_refund
+            tx_output.state_gas_used -= selfdestruct_refund
 
     tx_gas_used_before_refund = (
         tx.gas - tx_output.gas_left - tx_output.state_gas_left

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -488,6 +488,8 @@ def check_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     tx_state: TransactionState,
+    intrinsic_regular_gas: Uint,
+    intrinsic_state_gas: Uint,
 ) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
@@ -502,6 +504,10 @@ def check_transaction(
         The transaction.
     tx_state :
         The transaction state tracker.
+    intrinsic_regular_gas :
+        The transaction's intrinsic regular gas.
+    intrinsic_state_gas :
+        The transaction's intrinsic state gas.
 
     Returns
     -------
@@ -549,16 +555,24 @@ def check_transaction(
         is empty.
 
     """
-    # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
-    # State gas is not checked per-tx; block-end validation enforces
-    # max(block_regular_gas_used, block_state_gas_used) <= gas_limit.
+    # Both regular and state gas are validated before execution.
     regular_gas_available = (
         block_env.block_gas_limit - block_output.block_gas_used
     )
+    state_gas_available = (
+        block_env.block_gas_limit - block_output.block_state_gas_used
+    )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
-    if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
-        raise GasUsedExceedsLimitError("regular gas used exceeds limit")
+    regular_gas_contribution = min(
+        TX_MAX_GAS_LIMIT, tx.gas - intrinsic_state_gas
+    )
+    if regular_gas_contribution > regular_gas_available:
+        raise GasUsedExceedsLimitError("regular gas exceeds limit")
+
+    state_gas_contribution = tx.gas - intrinsic_regular_gas
+    if state_gas_contribution > state_gas_available:
+        raise GasUsedExceedsLimitError("state gas exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:
@@ -991,6 +1005,8 @@ def process_transaction(
         block_output=block_output,
         tx=tx,
         tx_state=tx_state,
+        intrinsic_regular_gas=intrinsic.regular,
+        intrinsic_state_gas=intrinsic.state,
     )
 
     sender_account = get_account(tx_state, sender)

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -163,8 +163,8 @@ def set_delegation(message: Message) -> None:
     """
     Set the delegation code for the authorities in the message.
 
-    For existing accounts, adjusts intrinsic_state_gas downward since
-    no account creation is needed (only delegation code write).
+    For existing accounts, refunds the account-creation component of
+    state gas to the reservoir (no mutation of intrinsic_state_gas).
 
     Parameters
     ----------
@@ -199,11 +199,10 @@ def set_delegation(message: Message) -> None:
             continue
 
         # For existing accounts, no account creation needed.
-        # Refund the account creation state gas to the reservoir
-        # and adjust intrinsic accounting to avoid double-counting.
+        # Refund the account creation state gas to the reservoir.
+        # intrinsic_state_gas is immutable after validation.
         if account_exists(tx_state, authority):
             refund = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
-            message.tx_env.intrinsic_state_gas -= refund
             message.state_gas_reservoir += refund
 
         if auth.address == NULL_ADDRESS:


### PR DESCRIPTION
## 🗒️ Description
Stale PR as only used for reference initially, PTAL at seperate PRs for each spec change:

1) https://github.com/ethereum/execution-specs/pull/2689
2) https://github.com/ethereum/execution-specs/pull/2698
3) https://github.com/ethereum/execution-specs/pull/2704
4) https://github.com/ethereum/execution-specs/pull/2707
5) https://github.com/ethereum/execution-specs/pull/2646
6) https://github.com/ethereum/execution-specs/pull/2711
7) https://github.com/ethereum/execution-specs/pull/2703

---

### 1) Top-level failure zeros execution state gas: [57a6385](https://github.com/spencer-tb/execution-specs/commit/57a6385c90de38ee36366e3224df7311ebb44c4c)

On top-level revert or exceptional halt, all state changes are rolled back. Return consumed execution state gas to the reservoir (`state_gas_left += state_gas_used`) and zero `state_gas_used` for block accounting. Intrinsic state gas remains unchanged (immutable).

### 2) SSTORE 0 to x to 0 refunds state gas to reservoir: [3feb782](https://github.com/spencer-tb/execution-specs/commit/3feb782e5ac5403612e0948a92b722bc1344ec68)

When a storage slot is restored to its original zero value (0 to x to 0), the net state growth is zero. Refund `32 * cost_per_state_byte` directly to the reservoir instead of through the `refund_counter`. The regular gas write cost refund still goes through `refund_counter`. The refund happens immediately after the x to 0 change.

### 3) CREATE failure refunds account state gas to reservoir: [6b6f3c8](https://github.com/spencer-tb/execution-specs/commit/6b6f3c8b467b125d0ef2ca1c05f8c0be7d1a4288)

CREATE/CREATE2 charges `112 * cost_per_state_byte` upfront. On a silent failure (insufficient balance, nonce overflow, stack depth, address collision) or child revert/halt, no account is created. Refund the account creation state gas to the reservoir.

### 4) SELFDESTRUCT same-tx refunds state gas at end of tx: [9ca780d](https://github.com/spencer-tb/execution-specs/commit/9ca780d68bf7b540beab84f725ceece31b2b7e57)

When an account is created and self-destructed in the same transaction, the state doesn't persist. At the end of tx, refund all state gas for:
- Account creation: `112 * cost_per_state_byte`
- Created storage slots: `32 * cost_per_state_byte` per non-zero slot
- Code deposit: `len(code) * cost_per_state_byte`

No double refund with point 2: slots that went 0 to x to 0 have a final value of 0 and are not counted.

### 5) CALL to self-destructed account, no change: [e6beb15](https://github.com/spencer-tb/execution-specs/commit/e6beb157ac)

After a same-tx `CREATE+SELFDESTRUCT`, the account still has `nonce=1` from the CREATE, so `is_account_alive` returns true and a subsequent `CALL` with value does not charge `GAS_NEW_ACCOUNT` state gas. The account is destroyed at end of tx regardless, and any value transferred via the CALL is burned with it, so no persisted state results from the CALL. Combined with 4)'s refund, the net state gas across the CREATE+SELFDESTRUCT+CALL lifecycle is zero, matching the zero persisted state. No spec change.

### 6) Immutable `intrinsic_state_gas` for EIP-7702: [fd76b10](https://github.com/spencer-tb/execution-specs/commit/fd76b105f2)

Stop mutating `intrinsic_state_gas` during execution. The worst case charge is kept. When an authorization targets an existing account, refund `STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte` to the reservoir only. Block accounting uses the original immutable `intrinsic_state_gas`.

### 7) 2D transaction inclusion check: [928b819](https://github.com/spencer-tb/execution-specs/commit/928b819b47)

Both regular gas and state gas are validated before executing a transaction using intrinsic-aware worst-case per-dimension contributions.

```python
regular_gas_available = (
    block_env.block_gas_limit - block_output.block_gas_used
)
state_gas_available = (
    block_env.block_gas_limit - block_output.block_state_gas_used
)
regular_gas_contribution = min(
    TX_MAX_GAS_LIMIT, tx.gas - intrinsic_state_gas
)
if regular_gas_contribution > regular_gas_available:
    raise GasUsedExceedsLimitError("regular gas exceeds limit")
state_gas_contribution = tx.gas - intrinsic_regular_gas
if state_gas_contribution > state_gas_available:
    raise GasUsedExceedsLimitError("state gas exceeds limit")
```

## 🔗 Related Issues or PRs

- EIPs PR for 1): ethereum/EIPs#11476
- EIPs PR for 2) to 6): ethereum/EIPs#11532
- EIPs PR for 7): ethereum/EIPs#11536

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).