### PR TITLE
refactor(specs): move `REFUND_AUTH_PER_EXISTING_ACCOUNT` and `TX_MAX_GAS_LIMIT` to gas modules

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -542,6 +540,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -551,7 +550,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, data_floor_gas_cost

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -28,7 +28,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -109,6 +110,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -535,6 +533,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -544,7 +543,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/forks/bpo1/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo1/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -105,6 +106,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -535,6 +533,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -544,7 +543,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/forks/bpo2/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo2/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -105,6 +106,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -535,6 +533,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -544,7 +543,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/forks/bpo3/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo3/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -105,6 +106,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -535,6 +533,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -544,7 +543,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/forks/bpo4/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo4/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -105,6 +106,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -535,6 +533,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -544,7 +543,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/forks/bpo5/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo5/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -105,6 +106,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -28,8 +28,6 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 
 @slotted_freezable
 @dataclass
@@ -535,6 +533,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
@@ -544,7 +543,7 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/forks/osaka/vm/eoa_delegation.py
+++ b/src/ethereum/forks/osaka/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -200,7 +199,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)
@@ -105,6 +106,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
+    TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR = Uint(1024)

--- a/src/ethereum/forks/prague/vm/eoa_delegation.py
+++ b/src/ethereum/forks/prague/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -66,6 +66,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER = Uint(3000)


### PR DESCRIPTION
Fixes #2680

Moves these two gas-related constants to their respective gas modules to be consistent with the refactoring done in #2396