### PR TITLE
fix(cli): add pytest EIP markers for valid_from tests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -1494,7 +1494,9 @@ def blob_params_changed_at_transition(fork: Fork | TransitionFork) -> bool:
     return False
 
 
-def get_valid_from_eip_marker_names(markers: Iterator[pytest.Mark]) -> Set[str]:
+def get_valid_from_eip_marker_names(
+    markers: Iterator[pytest.Mark],
+) -> Set[str]:
     """
     Return explicit EIP names from ``valid_from`` markers.
 
@@ -1577,13 +1579,7 @@ def pytest_collection_modifyitems(
     filter_stats: Dict[str, Tuple[str, int, int]] = {}
 
     for i, item in enumerate(items):
-        try:
-            add_explicit_eip_markers(item)
-        except Exception as e:
-            pytest.exit(
-                f"Error in test '{item.name}': {e}",
-                returncode=pytest.ExitCode.USAGE_ERROR,
-            )
+        add_explicit_eip_markers(item)
 
         params = _get_item_params(item)
         if not params:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -38,6 +38,7 @@ from execution_testing.forks import (
     get_transition_forks,
     transition_fork_to,
 )
+from execution_testing.forks.forks.eips import ALL_EIPS
 from execution_testing.logging import (
     get_logger,
 )
@@ -513,6 +514,14 @@ def pytest_configure(config: pytest.Config) -> None:
             "shown in verbose collection output."
         ),
     )
+    for eip in sorted(ALL_EIPS):
+        config.addinivalue_line(
+            "markers",
+            (
+                f"{eip.name()}: tests explicitly enabled by "
+                f"{eip.name()} via valid_from(...)"
+            ),
+        )
     for d in fork_covariant_decorators:
         config.addinivalue_line("markers", f"{d.marker_name}: {d.description}")
 
@@ -1485,6 +1494,31 @@ def blob_params_changed_at_transition(fork: Fork | TransitionFork) -> bool:
     return False
 
 
+def get_valid_from_eip_marker_names(markers: Iterator[pytest.Mark]) -> Set[str]:
+    """
+    Return explicit EIP names from ``valid_from`` markers.
+
+    Only positive EIP-based selectors are promoted to plain pytest markers so
+    ``-m EIP1234`` matches tests explicitly enabled by that EIP.
+    """
+    eip_marker_names: Set[str] = set()
+    for marker in markers:
+        if not marker.args:
+            continue
+        for fork_or_eip in ForkEIPSetAdapter.validate_python(marker.args):
+            if not fork_or_eip.is_transition_fork and fork_or_eip.is_eip():
+                eip_marker_names.add(fork_or_eip.name())
+    return eip_marker_names
+
+
+def add_explicit_eip_markers(item: pytest.Item) -> None:
+    """Attach plain pytest EIP markers derived from ``valid_from``."""
+    for eip_marker_name in sorted(
+        get_valid_from_eip_marker_names(item.iter_markers("valid_from"))
+    ):
+        item.add_marker(getattr(pytest.mark, eip_marker_name))
+
+
 def _get_item_params(
     item: pytest.Item,
 ) -> Dict[str, Any] | None:
@@ -1543,6 +1577,14 @@ def pytest_collection_modifyitems(
     filter_stats: Dict[str, Tuple[str, int, int]] = {}
 
     for i, item in enumerate(items):
+        try:
+            add_explicit_eip_markers(item)
+        except Exception as e:
+            pytest.exit(
+                f"Error in test '{item.name}': {e}",
+                returncode=pytest.ExitCode.USAGE_ERROR,
+            )
+
         params = _get_item_params(item)
         if not params:
             continue

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -521,3 +521,128 @@ def test_param_level_validity_markers(
         *pytest_args,
     )
     result.assert_outcomes(**outcomes)
+
+
+def generate_function_level_eip_marker_test() -> str:
+    """Generate a test with a function-level EIP validity marker."""
+    return """
+import pytest
+
+@pytest.mark.valid_from("EIP3675")
+@pytest.mark.state_test_only
+def test_function_level_eip_marker(state_test):
+    pass
+"""
+
+
+def generate_param_level_eip_marker_test() -> str:
+    """Generate a test with mixed param-level EIP and fork markers."""
+    return """
+import pytest
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(
+            True,
+            id="post_eip",
+            marks=pytest.mark.valid_from("EIP7928"),
+        ),
+        pytest.param(
+            False,
+            id="post_paris",
+            marks=pytest.mark.valid_from("Paris"),
+        ),
+    ],
+)
+@pytest.mark.state_test_only
+def test_param_level_eip_marker(state_test, value):
+    pass
+"""
+
+
+def generate_negative_eip_marker_test() -> str:
+    """Generate a test that mentions an EIP only in a negative selector."""
+    return """
+import pytest
+
+@pytest.mark.valid_before("EIP7928")
+@pytest.mark.state_test_only
+def test_negative_eip_marker(state_test):
+    pass
+"""
+
+
+def test_function_level_valid_from_eip_is_selectable_by_mark(
+    pytester: pytest.Pytester,
+) -> None:
+    """``-m EIP####`` should select tests enabled via function-level valid_from."""
+    pytester.makepyfile(generate_function_level_eip_marker_test())
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--until=Prague",
+        "--collect-only",
+        "-q",
+        "-m",
+        "EIP3675",
+    )
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.fnmatch_lines(
+        [
+            "*test_function_level_eip_marker[fork_Paris]",
+            "*test_function_level_eip_marker[fork_Shanghai]",
+            "*test_function_level_eip_marker[fork_Cancun]",
+            "*test_function_level_eip_marker[fork_Prague]",
+        ]
+    )
+
+
+def test_param_level_valid_from_eip_is_selectable_by_mark(
+    pytester: pytest.Pytester,
+) -> None:
+    """``-m EIP####`` should select only matching param-level variants."""
+    pytester.makepyfile(generate_param_level_eip_marker_test())
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--until=Amsterdam",
+        "--collect-only",
+        "-q",
+        "-m",
+        "EIP7928",
+    )
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.fnmatch_lines(
+        ["*test_param_level_eip_marker[fork_Amsterdam-post_eip]"]
+    )
+    result.stdout.no_fnmatch_line(
+        "*test_param_level_eip_marker[fork_Amsterdam-post_paris]"
+    )
+
+
+def test_negative_eip_selectors_do_not_add_eip_markers(
+    pytester: pytest.Pytester,
+) -> None:
+    """``valid_before(EIP####)`` should not make a test selectable by that EIP."""
+    pytester.makepyfile(generate_negative_eip_marker_test())
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--until=Amsterdam",
+        "--collect-only",
+        "-q",
+        "-m",
+        "EIP7928",
+    )
+    assert result.ret == pytest.ExitCode.NO_TESTS_COLLECTED
+    result.stdout.no_fnmatch_line("*test_negative_eip_marker*")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -523,61 +523,22 @@ def test_param_level_validity_markers(
     result.assert_outcomes(**outcomes)
 
 
-def generate_function_level_eip_marker_test() -> str:
-    """Generate a test with a function-level EIP validity marker."""
-    return """
-import pytest
-
-@pytest.mark.valid_from("EIP3675")
-@pytest.mark.state_test_only
-def test_function_level_eip_marker(state_test):
-    pass
-"""
-
-
-def generate_param_level_eip_marker_test() -> str:
-    """Generate a test with mixed param-level EIP and fork markers."""
-    return """
-import pytest
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        pytest.param(
-            True,
-            id="post_eip",
-            marks=pytest.mark.valid_from("EIP7928"),
-        ),
-        pytest.param(
-            False,
-            id="post_paris",
-            marks=pytest.mark.valid_from("Paris"),
-        ),
-    ],
-)
-@pytest.mark.state_test_only
-def test_param_level_eip_marker(state_test, value):
-    pass
-"""
-
-
-def generate_negative_eip_marker_test() -> str:
-    """Generate a test that mentions an EIP only in a negative selector."""
-    return """
-import pytest
-
-@pytest.mark.valid_before("EIP7928")
-@pytest.mark.state_test_only
-def test_negative_eip_marker(state_test):
-    pass
-"""
-
-
 def test_function_level_valid_from_eip_is_selectable_by_mark(
     pytester: pytest.Pytester,
 ) -> None:
-    """``-m EIP####`` should select tests enabled via function-level valid_from."""
-    pytester.makepyfile(generate_function_level_eip_marker_test())
+    """
+    ``-m EIP####`` should select tests enabled via function-level valid_from.
+    """
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.valid_from("EIP3675")
+        @pytest.mark.state_test_only
+        def test_function_level_eip_marker(state_test):
+            pass
+        """
+    )
     pytester.copy_example(
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
     )
@@ -593,9 +554,7 @@ def test_function_level_valid_from_eip_is_selectable_by_mark(
     assert result.ret == pytest.ExitCode.OK
     stdout = "\n".join(result.stdout.lines)
     assert "test_function_level_eip_marker[fork_Paris-state_test]" in stdout
-    assert (
-        "test_function_level_eip_marker[fork_Shanghai-state_test]" in stdout
-    )
+    assert "test_function_level_eip_marker[fork_Shanghai-state_test]" in stdout
     assert "test_function_level_eip_marker[fork_Cancun-state_test]" in stdout
     assert "test_function_level_eip_marker[fork_Prague-state_test]" in stdout
 
@@ -604,7 +563,30 @@ def test_param_level_valid_from_eip_is_selectable_by_mark(
     pytester: pytest.Pytester,
 ) -> None:
     """``-m EIP####`` should select only matching param-level variants."""
-    pytester.makepyfile(generate_param_level_eip_marker_test())
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize(
+            "value",
+            [
+                pytest.param(
+                    True,
+                    id="post_eip",
+                    marks=pytest.mark.valid_from("EIP7928"),
+                ),
+                pytest.param(
+                    False,
+                    id="post_paris",
+                    marks=pytest.mark.valid_from("Paris"),
+                ),
+            ],
+        )
+        @pytest.mark.state_test_only
+        def test_param_level_eip_marker(state_test, value):
+            pass
+        """
+    )
     pytester.copy_example(
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
     )
@@ -619,7 +601,10 @@ def test_param_level_valid_from_eip_is_selectable_by_mark(
     )
     assert result.ret == pytest.ExitCode.OK
     stdout = "\n".join(result.stdout.lines)
-    assert "test_param_level_eip_marker[fork_Amsterdam-state_test-post_eip]" in stdout
+    assert (
+        "test_param_level_eip_marker[fork_Amsterdam-state_test-post_eip]"
+        in stdout
+    )
     assert (
         "test_param_level_eip_marker[fork_Amsterdam-state_test-post_paris]"
         not in stdout
@@ -629,8 +614,19 @@ def test_param_level_valid_from_eip_is_selectable_by_mark(
 def test_negative_eip_selectors_do_not_add_eip_markers(
     pytester: pytest.Pytester,
 ) -> None:
-    """``valid_before(EIP####)`` should not make a test selectable by that EIP."""
-    pytester.makepyfile(generate_negative_eip_marker_test())
+    """
+    ``valid_before(EIP####)`` should not make a test selectable by that EIP.
+    """
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.valid_before("EIP7928")
+        @pytest.mark.state_test_only
+        def test_negative_eip_marker(state_test):
+            pass
+        """
+    )
     pytester.copy_example(
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -591,14 +591,13 @@ def test_function_level_valid_from_eip_is_selectable_by_mark(
         "EIP3675",
     )
     assert result.ret == pytest.ExitCode.OK
-    result.stdout.fnmatch_lines(
-        [
-            "*test_function_level_eip_marker[fork_Paris]",
-            "*test_function_level_eip_marker[fork_Shanghai]",
-            "*test_function_level_eip_marker[fork_Cancun]",
-            "*test_function_level_eip_marker[fork_Prague]",
-        ]
+    stdout = "\n".join(result.stdout.lines)
+    assert "test_function_level_eip_marker[fork_Paris-state_test]" in stdout
+    assert (
+        "test_function_level_eip_marker[fork_Shanghai-state_test]" in stdout
     )
+    assert "test_function_level_eip_marker[fork_Cancun-state_test]" in stdout
+    assert "test_function_level_eip_marker[fork_Prague-state_test]" in stdout
 
 
 def test_param_level_valid_from_eip_is_selectable_by_mark(
@@ -619,11 +618,11 @@ def test_param_level_valid_from_eip_is_selectable_by_mark(
         "EIP7928",
     )
     assert result.ret == pytest.ExitCode.OK
-    result.stdout.fnmatch_lines(
-        ["*test_param_level_eip_marker[fork_Amsterdam-post_eip]"]
-    )
-    result.stdout.no_fnmatch_line(
-        "*test_param_level_eip_marker[fork_Amsterdam-post_paris]"
+    stdout = "\n".join(result.stdout.lines)
+    assert "test_param_level_eip_marker[fork_Amsterdam-state_test-post_eip]" in stdout
+    assert (
+        "test_param_level_eip_marker[fork_Amsterdam-state_test-post_paris]"
+        not in stdout
     )
 
 
@@ -645,4 +644,5 @@ def test_negative_eip_selectors_do_not_add_eip_markers(
         "EIP7928",
     )
     assert result.ret == pytest.ExitCode.NO_TESTS_COLLECTED
-    result.stdout.no_fnmatch_line("*test_negative_eip_marker*")
+    stdout = "\n".join(result.stdout.lines)
+    assert "test_negative_eip_marker" not in stdout


### PR DESCRIPTION
## 🗒️ Description

  Auto-add plain pytest `EIP####` markers for tests that are explicitly enabled by `valid_from("EIP####")`.

  This makes EIP-scoped selection work as requested in #2675, so commands like:

  ```console
  uv run fill --clean --fork=Amsterdam -m EIP7928
```
  can select tests that are marked valid from a given EIP without relying on ad hoc -k expressions.

  This change is intentionally narrow:

  - It promotes explicit valid_from("EIP####") markers into plain pytest markers during collection.
  - It does not treat negative selectors such as valid_before("EIP####") as matching -m EIP####.
  - It registers known EIP#### markers so they are valid pytest markers.

  It also adds targeted regression tests covering:

  - function-level valid_from("EIP####")
  - param-level valid_from("EIP####")
  - the negative case where valid_before("EIP####") must not match -m EIP####

  ## 🔗 Related Issues or PRs

  Fixes #2675.

  ## ✅ Checklist

  - [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also Code Standards (https://eest.ethereum.org/main/getting_started/code_standards/) and Enabling Pre-commit Checks
    (https://eest.ethereum.org/main/dev/precommit/):

    just static
  - [x] All: PR title adheres to the repo standard (https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit mes
    sage and should start type(scope):.
  - [ ] All: Considered updating the online docs in the /ethereum/execution-specs/blob/HEAD/docs/ directory.
  - [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
  - [ ] Tests: Ran mkdocs serve locally and verified the auto-generated docs for new tests in the Test Case Reference (https://eest.ethereum.org/main/tests/) are correctly formatted.
  - [ ] Tests: For PRs implementing a missed test case, update the /ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md to add an entry the list.
  - [ ] Ported Tests: All converted JSON/YML tests from /ethereum/tests or /ethereum/execution-specs/blob/HEAD/tests/static have been assigned @ported_from marker.

  ### Verification

  Manual behavior check against a real test file:
```
  uv run pytest \
    -c packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini \
    tests/frontier/validation/test_header.py \
    --until=Amsterdam \
    --collect-only -q -m EIP7928
```
  Observed result:

  - collected test_gas_limit_below_minimum[...,gas_limit_5000_1]
  - did not collect ...,gas_limit_5000_0

  This confirms -m EIP7928 selects the valid_from("EIP7928") case and not the valid_before("EIP7928") case.

  Targeted regression tests:
```
  uv run pytest \
    packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py \
    -q \
    -k 'function_level_valid_from_eip_is_selectable_by_mark or param_level_valid_from_eip_is_selectable_by_mark or negative_eip_selectors_do_not_add_eip_markers'
```
  Observed result:

  3 passed

  #### Cute Animal Picture

  <img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/8f288e6c-9dc5-4796-bc93-ecb29d2f5306" />