### PR TITLE
feat(ci, test-fill): make `--generate-all-formats` optional via `feature.yaml`

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -44,7 +44,7 @@ runs:
 
         if [ -n "$IS_SPLIT" ]; then
           OUTPUT_ARG="--output=fixtures_${{ inputs.release_name }}"
-          FORK_ARGS="--generate-all-formats --from=${{ inputs.from_fork }} --until=${{ inputs.until_fork }}"
+          FORK_ARGS="--from=${{ inputs.from_fork }} --until=${{ inputs.until_fork }}"
         else
           OUTPUT_ARG="--output=fixtures_${{ inputs.release_name }}.tar.gz"
           FORK_ARGS=""

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -5,12 +5,12 @@ mainnet:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
+  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
   feature_only: true
 
 benchmark_fast:
   evm-type: benchmark
-  fill-params: --fork=Osaka --gas-benchmark-values 100 ./tests/benchmark/compute
+  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
   feature_only: true
 
 bal:

--- a/docs/filling_tests/filling_tests_command_line.md
+++ b/docs/filling_tests/filling_tests_command_line.md
@@ -101,13 +101,9 @@ This flag automatically performs a two-phase execution:
 1. **Phase 1**: Generates pre-allocation groups for optimization.
 2. **Phase 2**: Generates all supported fixture formats (`StateFixture`, `BlockchainFixture`, `BlockchainEngineFixture`, `BlockchainEngineXFixture`, etc.).
 
-!!! tip "Automatic enabling with tarball output"
-    When using tarball output (`.tar.gz` files), the `--generate-all-formats` flag is automatically enabled:
+!!! note "Tarball output requires explicit opt-in"
+    Tarball output (`.tar.gz` files) does **not** imply `--generate-all-formats`. Pass the flag explicitly to include the pre-allocation group formats:
     ```console
-    # Automatically enables --generate-all-formats due to .tar.gz output
-    uv run fill --output=fixtures.tar.gz tests/shanghai/
-
-    # Equivalent to:
     uv run fill --generate-all-formats --output=fixtures.tar.gz tests/shanghai/
     ```
 

--- a/docs/running_tests/releases.md
+++ b/docs/running_tests/releases.md
@@ -102,13 +102,11 @@ For standard releases, two tarballs are available:
 
 I.e., `fixtures_develop` are a superset of `fixtures_stable`.
 
-!!! tip "Generating tarballs directly via `--output` includes all fixture formats"
-    When generating fixtures for release, specifying tarball output automatically enables all fixture formats:
+!!! tip "Release features opt into all fixture formats via `feature.yaml`"
+    Tarball output (`.tar.gz`) does not by itself include the pre-allocation group formats (`BlockchainEngineXFixture`, `BlockchainEngineStatefulFixture`). A release feature requests them by adding `--generate-all-formats` to its `fill-params` in `.github/configs/feature.yaml`:
     ```console
-    # Automatically enables --generate-all-formats due to .tar.gz output
-    uv run fill --output=fixtures_stable.tar.gz tests/
+    uv run fill --generate-all-formats --output=fixtures_stable.tar.gz tests/
     ```
-    This ensures that all fixture formats are included in the tarball release.
 
 ### Pre-Release and Devnet Releases
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
@@ -45,9 +45,6 @@ class FillCommand(PytestCommand):
 
         # Check if we need two-phase execution
         if self._should_use_two_phase_execution(processed_args):
-            processed_args = self._ensure_generate_all_formats_for_tarball(
-                processed_args
-            )
             return self._create_two_phase_executions(processed_args)
         elif "--use-pre-alloc-groups" in processed_args:
             # Only phase 2: using existing pre-allocation groups
@@ -203,32 +200,7 @@ class FillCommand(PytestCommand):
         return (
             "--generate-pre-alloc-groups" in args
             or "--generate-all-formats" in args
-            or self._is_tarball_output(args)
         )
-
-    def _ensure_generate_all_formats_for_tarball(
-        self, args: List[str]
-    ) -> List[str]:
-        """Auto-add --generate-all-formats for tarball output."""
-        if (
-            self._is_tarball_output(args)
-            and "--generate-all-formats" not in args
-        ):
-            return args + ["--generate-all-formats"]
-        return args
-
-    def _is_tarball_output(self, args: List[str]) -> bool:
-        """Check if output argument specifies a tarball (.tar.gz) path."""
-        from pathlib import Path
-
-        for i, arg in enumerate(args):
-            if arg.startswith("--output="):
-                output_path = Path(arg.split("=", 1)[1])
-                return str(output_path).endswith(".tar.gz")
-            elif arg == "--output" and i + 1 < len(args):
-                output_path = Path(args[i + 1])
-                return str(output_path).endswith(".tar.gz")
-        return False
 
     def _is_watch_mode(self, args: List[str]) -> bool:
         """Check if any watch flag is present in arguments."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_generate_all_formats.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_generate_all_formats.py
@@ -54,22 +54,21 @@ def test_fixture_output_from_config_includes_generate_all_formats() -> None:
     assert fixture_output.output_path.name == "test"
 
 
-def test_tarball_output_auto_enables_generate_all_formats() -> None:
+def test_tarball_output_does_not_auto_enable_generate_all_formats() -> None:
     """
-    Test that tarball output (.tar.gz) automatically enables
-    should_generate_all_formats.
+    Test that tarball output (.tar.gz) alone does not enable
+    should_generate_all_formats; the flag must be set explicitly.
     """
 
-    # Mock pytest config object with tarball output
     class MockConfig:
         def getoption(self, option: str) -> Any:
             option_values = {
-                "output": "/tmp/fixtures.tar.gz",  # Tarball output
+                "output": "/tmp/fixtures.tar.gz",
                 "single_fixture_per_file": False,
                 "clean": False,
                 "generate_pre_alloc_groups": False,
                 "use_pre_alloc_groups": False,
-                "generate_all_formats": False,  # Explicitly False
+                "generate_all_formats": False,
             }
             return option_values.get(option, False)
 
@@ -78,27 +77,25 @@ def test_tarball_output_auto_enables_generate_all_formats() -> None:
         config  # type: ignore
     )
 
-    # Should auto-enable should_generate_all_formats due to tarball output
-    assert fixture_output.should_generate_all_formats is True
+    assert fixture_output.should_generate_all_formats is False
     assert fixture_output.is_tarball is True
 
 
 def test_regular_output_does_not_auto_enable_generate_all_formats() -> None:
     """
-    Test that regular directory output doesn't auto-enable
-    should_generate_all_formats.
+    Test that regular directory output doesn't enable
+    should_generate_all_formats without the explicit flag.
     """
 
-    # Mock pytest config object with regular output
     class MockConfig:
         def getoption(self, option: str) -> Any:
             option_values = {
-                "output": "/tmp/fixtures",  # Regular directory output
+                "output": "/tmp/fixtures",
                 "single_fixture_per_file": False,
                 "clean": False,
                 "generate_pre_alloc_groups": False,
                 "use_pre_alloc_groups": False,
-                "generate_all_formats": False,  # Explicitly False
+                "generate_all_formats": False,
             }
             return option_values.get(option, False)
 
@@ -107,27 +104,25 @@ def test_regular_output_does_not_auto_enable_generate_all_formats() -> None:
         config  # type: ignore
     )
 
-    # Should remain False for regular directory output
     assert fixture_output.should_generate_all_formats is False
     assert fixture_output.is_tarball is False
 
 
-def test_explicit_generate_all_formats_overrides_tarball_auto_enable() -> None:
+def test_explicit_generate_all_formats_with_tarball() -> None:
     """
     Test that explicitly setting should_generate_all_formats=True works with
     tarball output.
     """
 
-    # Mock pytest config object with tarball output and explicit flag
     class MockConfig:
         def getoption(self, option: str) -> Any:
             option_values = {
-                "output": "/tmp/fixtures.tar.gz",  # Tarball output
+                "output": "/tmp/fixtures.tar.gz",
                 "single_fixture_per_file": False,
                 "clean": False,
                 "generate_pre_alloc_groups": False,
                 "use_pre_alloc_groups": False,
-                "generate_all_formats": True,  # Explicitly True
+                "generate_all_formats": True,
             }
             return option_values.get(option, False)
 
@@ -136,6 +131,5 @@ def test_explicit_generate_all_formats_overrides_tarball_auto_enable() -> None:
         config  # type: ignore
     )
 
-    # Should be True (both explicitly set and auto-enabled)
     assert fixture_output.should_generate_all_formats is True
     assert fixture_output.is_tarball is True

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/fixture_output.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/fixture_output.py
@@ -288,14 +288,6 @@ class FixtureOutput(BaseModel):
         output_path = Path(config.getoption("output"))
         should_generate_all_formats = config.getoption("generate_all_formats")
 
-        # Auto-enable --generate-all-formats for tarball output
-        # Use same logic as is_tarball property
-        if (
-            output_path.suffix == ".gz"
-            and output_path.with_suffix("").suffix == ".tar"
-        ):
-            should_generate_all_formats = True
-
         return cls(
             output_path=output_path,
             single_fixture_per_file=config.getoption(

--- a/packages/testing/src/execution_testing/cli/tests/test_generate_all_formats.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_generate_all_formats.py
@@ -177,5 +177,3 @@ def test_regular_output_does_not_auto_trigger_two_phase() -> None:
     assert "--generate-pre-alloc-groups" not in execution.args
     assert "--use-pre-alloc-groups" not in execution.args
     assert "--generate-all-formats" not in execution.args
-
-

--- a/packages/testing/src/execution_testing/cli/tests/test_generate_all_formats.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_generate_all_formats.py
@@ -114,9 +114,10 @@ def test_single_phase_without_flags() -> None:
     assert "--generate-all-formats" not in execution.args
 
 
-def test_tarball_output_auto_enables_generate_all_formats() -> None:
+def test_tarball_output_without_flag_stays_single_phase() -> None:
     """
-    Test that tarball output automatically enables --generate-all-formats.
+    Test that tarball output without --generate-all-formats is single-phase
+    and does not inject the flag.
     """
     command = FillCommand()
 
@@ -124,19 +125,13 @@ def test_tarball_output_auto_enables_generate_all_formats() -> None:
         pytest_args = ["--output=fixtures.tar.gz", "tests/somedir/"]
         executions = command.create_executions(pytest_args)
 
-    # Should trigger two-phase execution due to tarball output
-    assert len(executions) == 2
+    assert len(executions) == 1
+    execution = executions[0]
 
-    # Phase 1: Should have --generate-pre-alloc-groups
-    phase1_args = executions[0].args
-    assert "--generate-pre-alloc-groups" in phase1_args
-
-    # Phase 2: Should have --generate-all-formats (auto-added) and --use-pre-
-    # alloc-groups
-    phase2_args = executions[1].args
-    assert "--generate-all-formats" in phase2_args
-    assert "--use-pre-alloc-groups" in phase2_args
-    assert "--output=fixtures.tar.gz" in phase2_args
+    assert "--generate-pre-alloc-groups" not in execution.args
+    assert "--use-pre-alloc-groups" not in execution.args
+    assert "--generate-all-formats" not in execution.args
+    assert "--output=fixtures.tar.gz" in execution.args
 
 
 def test_tarball_output_with_explicit_generate_all_formats() -> None:
@@ -184,22 +179,3 @@ def test_regular_output_does_not_auto_trigger_two_phase() -> None:
     assert "--generate-all-formats" not in execution.args
 
 
-def test_tarball_output_detection_various_formats() -> None:
-    """Test tarball output detection with various argument formats."""
-    command = FillCommand()
-
-    # Test --output=file.tar.gz format
-    args1 = ["--output=test.tar.gz", "tests/somedir/"]
-    assert command._is_tarball_output(args1) is True
-
-    # Test --output file.tar.gz format
-    args2 = ["--output", "test.tar.gz", "tests/somedir/"]
-    assert command._is_tarball_output(args2) is True
-
-    # Test regular directory
-    args3 = ["--output=test/", "tests/somedir/"]
-    assert command._is_tarball_output(args3) is False
-
-    # Test no output argument
-    args4 = ["tests/somedir/"]
-    assert command._is_tarball_output(args4) is False


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Tarball output (`.tar.gz`) no longer auto applies `--generate-all-formats`. Release features declare the flag explicitly in the `fill-params` for only `benchmark` and `benchmark_fast`  features.

### Why?

TLDR; faster devnet releases during the interop.

This means both `mainnet` and `bal` releases will no run the `--generate-all-formats` flag, speeding up releases. We don't use any formats other than state, block and engine fixtures currently. Forcing us add enginex formats currently just add more time onto releases given that we don't use `consume enginex` yet. I propose that we add this flag back once 1) we are actively using `consume enginex` and 2) release with the `--generate-all-formats` flag is significantly faster.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).