### PR TITLE
feat(spec-specs, tests): EIP-8037 - per-dimension block gas limit check at tx inclusion

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -80,6 +80,7 @@ from .transactions import (
     TX_MAX_GAS_LIMIT,
     BlobTransaction,
     FeeMarketTransaction,
+    IntrinsicGasCost,
     LegacyTransaction,
     SetCodeTransaction,
     Transaction,
@@ -485,6 +486,7 @@ def check_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     tx_state: TransactionState,
+    intrinsic: IntrinsicGasCost,
 ) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
@@ -499,6 +501,9 @@ def check_transaction(
         The transaction.
     tx_state :
         The transaction state tracker.
+    intrinsic :
+        The transaction's intrinsic gas cost, split into regular and
+        state components.
 
     Returns
     -------
@@ -546,9 +551,9 @@ def check_transaction(
         is empty.
 
     """
-    # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
-    # State gas dimension is checked per-tx;
-    # block-end validation still enforces
+    # Per-tx 2D gas inclusion check: for each dimension the worst-case
+    # contribution must fit in the remaining budget.  Block-end
+    # validation still enforces
     # max(block_regular_gas_used, block_state_gas_used) <= gas_limit.
     regular_gas_available = (
         block_env.block_gas_limit - block_output.block_gas_used
@@ -558,14 +563,17 @@ def check_transaction(
     )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
-    if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
-        raise GasUsedExceedsLimitError("regular gas used exceeds limit")
+    # Worst-case regular contribution: tx.gas minus the portion that
+    # must go to intrinsic state gas, capped at TX_MAX_GAS_LIMIT.
+    if min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state) > (
+        regular_gas_available
+    ):
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
 
-    state_gas_contribution = (
-        tx.gas - TX_MAX_GAS_LIMIT if tx.gas > TX_MAX_GAS_LIMIT else Uint(0)
-    )
-    if state_gas_contribution > state_gas_available:
-        raise GasUsedExceedsLimitError("state gas exceeds limit")
+    # Worst-case state contribution: tx.gas minus the portion that
+    # must go to intrinsic regular gas.
+    if tx.gas - intrinsic.regular > state_gas_available:
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:
@@ -998,6 +1006,7 @@ def process_transaction(
         block_output=block_output,
         tx=tx,
         tx_state=tx_state,
+        intrinsic=intrinsic,
     )
 
     sender_account = get_account(tx_state, sender)

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -547,15 +547,25 @@ def check_transaction(
 
     """
     # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
-    # State gas is not checked per-tx; block-end validation enforces
+    # State gas dimension is checked per-tx;
+    # block-end validation still enforces
     # max(block_regular_gas_used, block_state_gas_used) <= gas_limit.
     regular_gas_available = (
         block_env.block_gas_limit - block_output.block_gas_used
+    )
+    state_gas_available = (
+        block_env.block_gas_limit - block_output.block_state_gas_used
     )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
     if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
         raise GasUsedExceedsLimitError("regular gas used exceeds limit")
+
+    state_gas_contribution = (
+        tx.gas - TX_MAX_GAS_LIMIT if tx.gas > TX_MAX_GAS_LIMIT else Uint(0)
+    )
+    if state_gas_contribution > state_gas_available:
+        raise GasUsedExceedsLimitError("state gas exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -288,21 +288,28 @@ def test_block_2d_gas_boundary_exact_fit(
     num_sstores: int,
 ) -> None:
     """
-    Verify a block is valid when max(regular, state) == gas_limit.
+    Verify a block is valid when state gas dominates regular gas.
 
-    Set block_gas_limit = block_state_gas (the dominant dimension).
     Clients that sum regular + state will reject this valid block.
     """
     tx_regular, tx_state = sstore_tx_gas(fork, num_sstores)
-    block_state = num_txs * tx_state
-    block_gas_limit = block_state
+    intrinsic_regular = fork.transaction_intrinsic_cost_calculator()()
 
-    # tx_limit must exceed tx_regular + tx_state so the tx is valid,
-    # but the per-tx regular reservation against block gas must still
-    # leave room for all txs.
     tx_limit = tx_regular + tx_state + tx_regular // 10
-    worst = block_gas_limit - (num_txs - 1) * tx_regular
-    assert worst >= tx_limit, "per-tx regular gas check fails"
+
+    # Per-tx worst-case state contribution: tx.gas - intrinsic_regular.
+    # The block_gas_limit must leave enough state budget for every tx.
+    worst_state_per_tx = tx_limit - intrinsic_regular
+    block_gas_limit = max(
+        # Regular dimension: last tx must fit.
+        (num_txs - 1) * tx_regular + tx_limit,
+        # State dimension: cumulative worst-case must fit.
+        num_txs * worst_state_per_tx,
+    )
+
+    block_regular = num_txs * tx_regular
+    block_state = num_txs * tx_state
+    expected_gas_used = max(block_regular, block_state)
 
     txs, post = sstore_txs(
         pre,
@@ -320,7 +327,7 @@ def test_block_2d_gas_boundary_exact_fit(
             Block(
                 txs=txs,
                 gas_limit=block_gas_limit,
-                header_verify=Header(gas_used=block_gas_limit),
+                header_verify=Header(gas_used=expected_gas_used),
             )
         ],
         post=post,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -247,19 +247,31 @@ def test_block_regular_gas_limit(
     blockchain_test(pre=pre, post={}, blocks=[block])
 
 
-def _block_state_gas_limit_setup(
+@pytest.mark.parametrize(
+    "delta",
+    [
+        pytest.param(0, id="exact_fit"),
+        pytest.param(1, id="exceeded", marks=pytest.mark.exception_test),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_block_state_gas_limit_boundary(
+    blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     delta: int,
-) -> tuple:
+) -> None:
     """
-    Build txs and block params for the per-tx state gas limit check.
+    Verify the per-tx state check at the strict-greater-than boundary.
 
-    tx1 consumes state gas via cold SSTOREs. tx2's worst-case state
-    gas contribution (tx.gas - intrinsic_regular) is set to exactly
-    match the remaining budget (delta=0) or exceed it by delta.
+    tx1 consumes `tx1_state` via cold SSTOREs. tx2 is sized so that
+    its worst-case state contribution `tx.gas - intrinsic_regular`
+    equals `state_available` (delta=0, accepted because the check is
+    strict `>`) or exceeds it by 1 (delta=1, rejected with
+    `GAS_ALLOWANCE_EXCEEDED`).
 
-    Returns (tx1, tx2, block_gas_limit, tx2_error).
+    The regular check is asserted to pass so rejection on delta=1 is
+    pinned to the state dimension.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -279,25 +291,24 @@ def _block_state_gas_limit_setup(
     state_headroom = tx1_state + 100_000
     block_gas_limit = gas_limit_cap + state_headroom
 
-    # --- tx2: worst-case state contribution at boundary ---
-    # EIP-8037 state check: tx.gas - intrinsic_regular > state_available
-    # Set tx2.gas so that tx2.gas - tx2_intrinsic_regular =
-    #   state_available + delta.
+    # tx2: worst-case state contribution = state_available + delta.
+    # Plain call, so intrinsic_state is zero.
     tx2_intrinsic_regular = intrinsic_cost()
-    state_available_after_tx1 = block_gas_limit - tx1_state
-    tx2_gas = tx2_intrinsic_regular + state_available_after_tx1 + delta
+    state_available = block_gas_limit - tx1_state
+    tx2_gas = tx2_intrinsic_regular + state_available + delta
 
-    # Verify the regular check passes for tx2: the EIP checks
-    # min(TX_MAX, tx.gas - intrinsic_state) > regular_available.
-    # tx2 has intrinsic_state = 0 (plain call, no creation/auth).
-    regular_available_after_tx1 = block_gas_limit - tx1_regular
-    assert min(gas_limit_cap, tx2_gas) < regular_available_after_tx1, (
+    # Pin the rejection (when delta > 0) to the state check: the
+    # regular check must not fire.
+    regular_available = block_gas_limit - tx1_regular
+    assert min(gas_limit_cap, tx2_gas) < regular_available, (
         "tx2 would fail the regular check instead of the state check"
     )
 
-    rejected = delta > 0
     tx2_error = (
-        TransactionException.GAS_ALLOWANCE_EXCEEDED if rejected else None
+        TransactionException.GAS_ALLOWANCE_EXCEEDED if delta > 0 else None
+    )
+    block_exception = (
+        TransactionException.GAS_ALLOWANCE_EXCEEDED if delta > 0 else None
     )
 
     tx1 = Transaction(
@@ -312,26 +323,6 @@ def _block_state_gas_limit_setup(
         error=tx2_error,
     )
 
-    return tx1, tx2, block_gas_limit, tx2_error
-
-
-@pytest.mark.valid_from("EIP8037")
-def test_block_state_gas_limit_exact_fit(
-    blockchain_test: BlockchainTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Test tx accepted when state gas contribution exactly fits budget.
-
-    tx2's state gas contribution (tx.gas - TX_MAX_GAS_LIMIT) equals
-    the remaining state gas budget. The check uses strict greater-than,
-    so the tx must be accepted.
-    """
-    tx1, tx2, block_gas_limit, tx2_error = _block_state_gas_limit_setup(
-        pre, fork, delta=0
-    )
-
     blockchain_test(
         genesis_environment=Environment(gas_limit=block_gas_limit),
         pre=pre,
@@ -339,38 +330,7 @@ def test_block_state_gas_limit_exact_fit(
             Block(
                 txs=[tx1, tx2],
                 gas_limit=block_gas_limit,
-            )
-        ],
-        post={},
-    )
-
-
-@pytest.mark.exception_test
-@pytest.mark.valid_from("EIP8037")
-def test_block_state_gas_limit_exceeded(
-    blockchain_test: BlockchainTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Test tx rejected when state gas contribution exceeds budget by 1.
-
-    tx2's state gas contribution (tx.gas - TX_MAX_GAS_LIMIT) exceeds
-    the remaining state gas budget by 1 gas. The tx must be rejected
-    at inclusion with GAS_ALLOWANCE_EXCEEDED.
-    """
-    tx1, tx2, block_gas_limit, tx2_error = _block_state_gas_limit_setup(
-        pre, fork, delta=1
-    )
-
-    blockchain_test(
-        genesis_environment=Environment(gas_limit=block_gas_limit),
-        pre=pre,
-        blocks=[
-            Block(
-                txs=[tx1, tx2],
-                gas_limit=block_gas_limit,
-                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+                exception=block_exception,
             )
         ],
         post={},
@@ -384,13 +344,15 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
     fork: Fork,
 ) -> None:
     """
-    Verify the regular check subtracts intrinsic state gas from tx.gas.
+    Verify the regular check subtracts `intrinsic.state` from tx.gas.
 
-    EIP-8037 regular check: min(TX_MAX, tx.gas - intrinsic_state).
-    For a creation tx, intrinsic_state = 112 * cpsb. A tx whose raw
-    tx.gas exceeds regular_available but tx.gas - intrinsic_state fits
-    must be ACCEPTED. Under the old formula (min(TX_MAX, tx.gas)) it
-    would be rejected.
+    The EIP regular check is
+    `min(TX_MAX, tx.gas - intrinsic.state) > regular_available`. For a
+    creation tx, `intrinsic.state = GAS_NEW_ACCOUNT`. This test sizes a
+    creation tx whose raw `tx.gas` exceeds `regular_available` but
+    `tx.gas - intrinsic.state` fits; it must be accepted. The old
+    formula `min(TX_MAX, tx.gas)` would reject the same tx, proving
+    the subtraction is honored.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -402,22 +364,29 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
     intrinsic_total = intrinsic_cost(contract_creation=True)
     intrinsic_regular = intrinsic_total - intrinsic_state
 
+    # Filler consumes the full regular cap (OOG on INVALID).
     filler = pre.deploy_contract(code=Op.INVALID)
-    filler_gas = gas_limit_cap
 
-    # After filler: remaining regular = intrinsic_regular + 1.
-    # create tx.gas = intrinsic_total > remaining (old check rejects)
-    # but tx.gas - intrinsic_state = intrinsic_regular <= remaining ✓
+    # After filler, the remaining regular budget is exactly
+    # `intrinsic_regular + 1`. The creation tx has
+    # `tx.gas = intrinsic_total = intrinsic_regular + intrinsic_state`,
+    # which exceeds the remaining budget under the old formula but
+    # equals `intrinsic_regular` after the `- intrinsic.state`
+    # subtraction — so the new formula accepts it.
     remaining_regular = intrinsic_regular + 1
     block_gas_limit = gas_limit_cap + remaining_regular
     create_tx_gas = intrinsic_total
 
-    assert create_tx_gas > remaining_regular
-    assert create_tx_gas - intrinsic_state <= remaining_regular
+    assert create_tx_gas > remaining_regular, (
+        "old formula must reject to prove new formula differs"
+    )
+    assert create_tx_gas - intrinsic_state <= remaining_regular, (
+        "new formula must accept"
+    )
 
     filler_tx = Transaction(
         to=filler,
-        gas_limit=filler_gas,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
     create_tx = Transaction(
@@ -511,9 +480,7 @@ def test_creation_tx_state_check_exceeded(
     create_intrinsic_state = fork.transaction_intrinsic_state_gas(
         contract_creation=True,
     )
-    create_intrinsic_regular = (
-        create_intrinsic_total - create_intrinsic_state
-    )
+    create_intrinsic_regular = create_intrinsic_total - create_intrinsic_state
 
     num_sstores = 50
     tx1_code = Bytecode()

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -229,18 +229,145 @@ def test_block_regular_gas_limit(
                 to=gas_spender,
                 sender=pre.fund_eoa(),
                 gas_limit=gas_limit_cap,
-                error=TransactionException.GAS_ALLOWANCE_EXCEEDED
-                if i >= tx_count
-                else None,
+                error=(
+                    TransactionException.GAS_ALLOWANCE_EXCEEDED
+                    if i >= tx_count
+                    else None
+                ),
             )
             for i in range(total_txs)
         ],
-        exception=TransactionException.GAS_ALLOWANCE_EXCEEDED
-        if exceed_block_gas_limit
-        else None,
+        exception=(
+            TransactionException.GAS_ALLOWANCE_EXCEEDED
+            if exceed_block_gas_limit
+            else None
+        ),
     )
 
     blockchain_test(pre=pre, post={}, blocks=[block])
+
+
+def _block_state_gas_limit_setup(
+    pre: Alloc,
+    fork: Fork,
+    delta: int,
+) -> tuple:
+    """
+    Build txs and block params for the per-tx state gas limit check.
+
+    tx1 consumes state gas via cold SSTOREs. tx2's state gas
+    contribution is set to exactly match the remaining budget
+    (delta=0) or exceed it by delta.
+
+    Returns (tx1, tx2, block_gas_limit, tx2_error).
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+
+    num_sstores = 50
+    tx1_code = Bytecode()
+    for i in range(num_sstores):
+        tx1_code = tx1_code + Op.SSTORE(i, 1)
+    tx1_contract = pre.deploy_contract(code=tx1_code)
+
+    tx1_state = num_sstores * sstore_state_gas
+    tx1_regular = intrinsic_cost() + tx1_code.gas_cost(fork) - tx1_state
+    tx1_gas = gas_limit_cap + tx1_state
+
+    state_headroom = tx1_state + 100_000
+    block_gas_limit = gas_limit_cap + state_headroom
+
+    state_available_after_tx1 = block_gas_limit - tx1_state
+    tx2_state_contribution = state_available_after_tx1 + delta
+    tx2_gas = gas_limit_cap + tx2_state_contribution
+
+    regular_available_after_tx1 = block_gas_limit - tx1_regular
+    assert gas_limit_cap < regular_available_after_tx1, (
+        "tx2 would fail the regular check instead of the state check"
+    )
+
+    rejected = delta > 0
+    tx2_error = (
+        TransactionException.GAS_ALLOWANCE_EXCEEDED if rejected else None
+    )
+
+    tx1 = Transaction(
+        to=tx1_contract,
+        gas_limit=tx1_gas,
+        sender=pre.fund_eoa(),
+    )
+    tx2 = Transaction(
+        to=pre.deploy_contract(code=Op.STOP),
+        gas_limit=tx2_gas,
+        sender=pre.fund_eoa(),
+        error=tx2_error,
+    )
+
+    return tx1, tx2, block_gas_limit, tx2_error
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_block_state_gas_limit_exact_fit(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test tx accepted when state gas contribution exactly fits budget.
+
+    tx2's state gas contribution (tx.gas - TX_MAX_GAS_LIMIT) equals
+    the remaining state gas budget. The check uses strict greater-than,
+    so the tx must be accepted.
+    """
+    tx1, tx2, block_gas_limit, tx2_error = _block_state_gas_limit_setup(
+        pre, fork, delta=0
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx1, tx2],
+                gas_limit=block_gas_limit,
+            )
+        ],
+        post={},
+    )
+
+
+@pytest.mark.exception_test
+@pytest.mark.valid_from("EIP8037")
+def test_block_state_gas_limit_exceeded(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test tx rejected when state gas contribution exceeds budget by 1.
+
+    tx2's state gas contribution (tx.gas - TX_MAX_GAS_LIMIT) exceeds
+    the remaining state gas budget by 1 gas. The tx must be rejected
+    at inclusion with GAS_ALLOWANCE_EXCEEDED.
+    """
+    tx1, tx2, block_gas_limit, tx2_error = _block_state_gas_limit_setup(
+        pre, fork, delta=1
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx1, tx2],
+                gas_limit=block_gas_limit,
+                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+            )
+        ],
+        post={},
+    )
 
 
 @pytest.mark.valid_from("EIP8037")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -255,9 +255,9 @@ def _block_state_gas_limit_setup(
     """
     Build txs and block params for the per-tx state gas limit check.
 
-    tx1 consumes state gas via cold SSTOREs. tx2's state gas
-    contribution is set to exactly match the remaining budget
-    (delta=0) or exceed it by delta.
+    tx1 consumes state gas via cold SSTOREs. tx2's worst-case state
+    gas contribution (tx.gas - intrinsic_regular) is set to exactly
+    match the remaining budget (delta=0) or exceed it by delta.
 
     Returns (tx1, tx2, block_gas_limit, tx2_error).
     """
@@ -279,12 +279,19 @@ def _block_state_gas_limit_setup(
     state_headroom = tx1_state + 100_000
     block_gas_limit = gas_limit_cap + state_headroom
 
+    # --- tx2: worst-case state contribution at boundary ---
+    # EIP-8037 state check: tx.gas - intrinsic_regular > state_available
+    # Set tx2.gas so that tx2.gas - tx2_intrinsic_regular =
+    #   state_available + delta.
+    tx2_intrinsic_regular = intrinsic_cost()
     state_available_after_tx1 = block_gas_limit - tx1_state
-    tx2_state_contribution = state_available_after_tx1 + delta
-    tx2_gas = gas_limit_cap + tx2_state_contribution
+    tx2_gas = tx2_intrinsic_regular + state_available_after_tx1 + delta
 
+    # Verify the regular check passes for tx2: the EIP checks
+    # min(TX_MAX, tx.gas - intrinsic_state) > regular_available.
+    # tx2 has intrinsic_state = 0 (plain call, no creation/auth).
     regular_available_after_tx1 = block_gas_limit - tx1_regular
-    assert gas_limit_cap < regular_available_after_tx1, (
+    assert min(gas_limit_cap, tx2_gas) < regular_available_after_tx1, (
         "tx2 would fail the regular check instead of the state check"
     )
 
@@ -354,6 +361,193 @@ def test_block_state_gas_limit_exceeded(
     """
     tx1, tx2, block_gas_limit, tx2_error = _block_state_gas_limit_setup(
         pre, fork, delta=1
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx1, tx2],
+                gas_limit=block_gas_limit,
+                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+            )
+        ],
+        post={},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_creation_tx_regular_check_subtracts_intrinsic_state(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify the regular check subtracts intrinsic state gas from tx.gas.
+
+    EIP-8037 regular check: min(TX_MAX, tx.gas - intrinsic_state).
+    For a creation tx, intrinsic_state = 112 * cpsb. A tx whose raw
+    tx.gas exceeds regular_available but tx.gas - intrinsic_state fits
+    must be ACCEPTED. Under the old formula (min(TX_MAX, tx.gas)) it
+    would be rejected.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+
+    intrinsic_state = fork.transaction_intrinsic_state_gas(
+        contract_creation=True,
+    )
+    intrinsic_total = intrinsic_cost(contract_creation=True)
+    intrinsic_regular = intrinsic_total - intrinsic_state
+
+    filler = pre.deploy_contract(code=Op.INVALID)
+    filler_gas = gas_limit_cap
+
+    # After filler: remaining regular = intrinsic_regular + 1.
+    # create tx.gas = intrinsic_total > remaining (old check rejects)
+    # but tx.gas - intrinsic_state = intrinsic_regular <= remaining ✓
+    remaining_regular = intrinsic_regular + 1
+    block_gas_limit = gas_limit_cap + remaining_regular
+    create_tx_gas = intrinsic_total
+
+    assert create_tx_gas > remaining_regular
+    assert create_tx_gas - intrinsic_state <= remaining_regular
+
+    filler_tx = Transaction(
+        to=filler,
+        gas_limit=filler_gas,
+        sender=pre.fund_eoa(),
+    )
+    create_tx = Transaction(
+        to=None,
+        gas_limit=create_tx_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[filler_tx, create_tx],
+                gas_limit=block_gas_limit,
+            )
+        ],
+        post={},
+    )
+
+
+@pytest.mark.exception_test
+@pytest.mark.valid_from("EIP8037")
+def test_single_tx_state_check_exceeds_block_limit(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify a single tx is rejected when its state contribution exceeds
+    the entire block gas limit.
+
+    No prior txs needed. A tx whose tx.gas - intrinsic_regular exceeds
+    block_gas_limit must be rejected at inclusion.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_regular = intrinsic_cost()
+
+    block_gas_limit = gas_limit_cap + 100
+    tx_gas = block_gas_limit + intrinsic_regular + 1
+
+    tx = Transaction(
+        to=pre.deploy_contract(code=Op.STOP),
+        gas_limit=tx_gas,
+        sender=pre.fund_eoa(),
+        error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                gas_limit=block_gas_limit,
+                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+            )
+        ],
+        post={},
+    )
+
+
+@pytest.mark.exception_test
+@pytest.mark.valid_from("EIP8037")
+def test_creation_tx_state_check_exceeded(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify a creation tx is rejected by the state check.
+
+    A creation tx has non-zero intrinsic_state (new account) AND
+    intrinsic_regular (base + CREATE cost). Both formulas are
+    exercised: the regular check subtracts intrinsic_state, the state
+    check subtracts intrinsic_regular.
+
+    A filler tx consumes state budget. The creation tx's state
+    contribution (tx.gas - intrinsic_regular) exceeds the remaining
+    state budget while its regular contribution
+    (tx.gas - intrinsic_state) fits the regular budget.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+
+    create_intrinsic_total = intrinsic_cost(contract_creation=True)
+    create_intrinsic_state = fork.transaction_intrinsic_state_gas(
+        contract_creation=True,
+    )
+    create_intrinsic_regular = (
+        create_intrinsic_total - create_intrinsic_state
+    )
+
+    num_sstores = 50
+    tx1_code = Bytecode()
+    for i in range(num_sstores):
+        tx1_code = tx1_code + Op.SSTORE(i, 1)
+    tx1_contract = pre.deploy_contract(code=tx1_code)
+
+    tx1_state = num_sstores * sstore_state_gas
+    tx1_regular = intrinsic_cost() + tx1_code.gas_cost(fork) - tx1_state
+    tx1_gas = gas_limit_cap + tx1_state
+
+    state_headroom = tx1_state + 100_000
+    block_gas_limit = gas_limit_cap + state_headroom
+    state_available = block_gas_limit - tx1_state
+
+    # tx2 state contribution = state_available + 1 → rejected
+    tx2_gas = create_intrinsic_regular + state_available + 1
+
+    # Regular check must pass so rejection is pinned to state.
+    regular_available = block_gas_limit - tx1_regular
+    assert min(gas_limit_cap, tx2_gas - create_intrinsic_state) < (
+        regular_available
+    )
+
+    tx1 = Transaction(
+        to=tx1_contract,
+        gas_limit=tx1_gas,
+        sender=pre.fund_eoa(),
+    )
+    tx2 = Transaction(
+        to=None,
+        gas_limit=tx2_gas,
+        sender=pre.fund_eoa(),
+        error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
     )
 
     blockchain_test(


### PR DESCRIPTION
## 🗒️ Description

Implements [ethereum/EIPs#11536](https://github.com/ethereum/EIPs/pull/11536) (update to EIP-8037): at transaction inclusion time, `check_transaction` enforces the block gas limit per gas dimension (regular, state) rather than only on the regular component. For each dimension the worst-case contribution must fit in the remaining budget. Block-end validation still enforces `max(block_regular, block_state) <= block.gas_limit`.

### Spec Change

Adds per-dimension checks to `check_transaction`:

```python
regular_gas_available = block.gas_limit - block_output.block_gas_used
state_gas_available   = block.gas_limit - block_output.block_state_gas_used
if min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state) > regular_gas_available:
    raise GasUsedExceedsLimitError("gas used exceeds limit")
if tx.gas - intrinsic.regular > state_gas_available:
    raise GasUsedExceedsLimitError("gas used exceeds limit")
```

`intrinsic` is now passed into `check_transaction` so both formulas have access to the split intrinsic cost. Both checks raise `GasUsedExceedsLimitError`, which maps to `TransactionException.GAS_ALLOWANCE_EXCEEDED`.

### Tests

* `test_block_state_gas_limit_boundary[exact_fit]` (accepted)
* `test_block_state_gas_limit_boundary[exceeded]` (rejected)
* `test_creation_tx_regular_check_subtracts_intrinsic_state`
* `test_single_tx_state_check_exceeds_block_limit`
* `test_creation_tx_state_check_exceeded`

## 🔗 Related Issues or PRs

* EIP text change: [ethereum/EIPs#11536](https://github.com/ethereum/EIPs/pull/11536)

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) and will be used as the squash commit message, starting with `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
