### PR TITLE
feat(spec-specs, tests): EIP-8037 - SELFDESTRUCT same-tx refunds state gas at end of tx

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -98,10 +98,13 @@ from .vm.eoa_delegation import is_valid_delegation
 from .vm.gas import (
     BLOB_SCHEDULE_MAX,
     GAS_PER_BLOB,
+    STATE_BYTES_PER_NEW_ACCOUNT,
+    STATE_BYTES_PER_STORAGE_SET,
     calculate_blob_gas_price,
     calculate_data_fee,
     calculate_excess_blob_gas,
     calculate_total_blob_gas,
+    state_gas_per_byte,
 )
 from .vm.interpreter import MessageCallOutput, process_message_call
 
@@ -1053,6 +1056,34 @@ def process_transaction(
     if tx_output.error is not None:
         tx_output.state_gas_left += tx_output.state_gas_used
         tx_output.state_gas_used = Uint(0)
+    else:
+        # Refund state gas for accounts created and destroyed in the
+        # same tx (EIP-6780). Covers account, storage, and code.
+        cost_per_state_byte = state_gas_per_byte(block_env.block_gas_limit)
+        for address in tx_output.accounts_to_delete:
+            if address in tx_state.created_accounts:
+                selfdestruct_refund = (
+                    STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+                )
+                storage = tx_state.storage_writes.get(address, {})
+                created_slots = sum(1 for v in storage.values() if v != 0)
+                selfdestruct_refund += (
+                    Uint(created_slots)
+                    * STATE_BYTES_PER_STORAGE_SET
+                    * cost_per_state_byte
+                )
+                # EIP-6780 defers account/storage/code removal to
+                # tx-end, so `account.code_hash` still points at the
+                # deployed code here and `get_code` returns it
+                # pre-deletion.
+                account = get_account(tx_state, address)
+                code = get_code(tx_state, account.code_hash)
+                selfdestruct_refund += Uint(len(code)) * cost_per_state_byte
+                selfdestruct_refund = min(
+                    selfdestruct_refund, tx_output.state_gas_used
+                )
+                tx_output.state_gas_left += selfdestruct_refund
+                tx_output.state_gas_used -= selfdestruct_refund
 
     tx_gas_used_before_refund = (
         tx.gas - tx_output.gas_left - tx_output.state_gas_left

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -16,15 +16,19 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     Environment,
     Fork,
+    Header,
+    Initcode,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
+    compute_create_address,
 )
 
-from .spec import ref_spec_8037
+from .spec import init_code_at_high_bytes, ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -247,4 +251,280 @@ def test_selfdestruct_new_beneficiary_header_gas_used(
             Block(txs=[tx]),
         ],
         post={caller: Account(storage=storage)},
+    )
+
+
+@pytest.mark.parametrize(
+    "num_slots",
+    [
+        pytest.param(0, id="no_storage"),
+        pytest.param(1, id="one_slot"),
+        pytest.param(5, id="five_slots"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_create_selfdestruct_refunds_account_and_storage(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    num_slots: int,
+) -> None:
+    """
+    Verify same tx CREATE+SELFDESTRUCT refunds account and storage.
+
+    Factory CREATE/CREATE2 initcode does N cold SSTOREs then
+    SELFDESTRUCTs. Refund covers `GAS_NEW_ACCOUNT` plus each
+    created slot's state gas. Under OLD behavior the state charges
+    remain in `block_state_gas_used`. Under NEW they are refunded.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    init_code = Bytecode()
+    for i in range(num_slots):
+        init_code += Op.SSTORE.with_metadata(
+            key_warm=False,
+            original_value=0,
+            current_value=0,
+            new_value=1,
+        )(i, 1)
+    init_code += Op.SELFDESTRUCT.with_metadata(address_warm=True)(Op.ADDRESS)
+    mstore_value, size = init_code_at_high_bytes(init_code)
+
+    # Metadata so `.gas_cost(fork)` matches runtime charges.
+    mstore = Op.MSTORE.with_metadata(new_memory_size=32, old_memory_size=0)(
+        0, mstore_value
+    )
+    create_metadata = create_opcode.with_metadata(init_code_size=size)
+    create_call = (
+        create_metadata(value=0, offset=0, size=size, salt=0)
+        if create_opcode == Op.CREATE2
+        else create_metadata(value=0, offset=0, size=size)
+    )
+    factory_code = mstore + Op.POP(create_call)
+    factory = pre.deploy_contract(code=factory_code)
+
+    total_state_refund = new_account_state_gas + num_slots * sstore_state_gas
+    # Subtract the state portion so tx_regular matches the header.
+    tx_regular = (
+        intrinsic_gas
+        + factory_code.gas_cost(fork)
+        + init_code.gas_cost(fork)
+        - total_state_refund
+    )
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit_cap + total_state_refund,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_regular))],
+        post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "beneficiary_type,code_size",
+    [
+        pytest.param("self", 2, id="self_tiny"),
+        pytest.param("self", 100, id="self_medium"),
+        pytest.param("external", 100, id="external_medium"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_create_selfdestruct_refunds_code_deposit_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    code_size: int,
+    beneficiary_type: str,
+) -> None:
+    """
+    Verify same tx CREATE+SELFDESTRUCT refunds code deposit state gas.
+
+    Factory CREATEs a contract deploying `code_size` bytes of code
+    then CALLs it to trigger SELFDESTRUCT. Refund is account plus
+    `code_size * cost_per_state_byte`. `external` beneficiary tests
+    that the refund applies to the created account, not the
+    destination of the ETH transfer.
+    """
+    assert code_size >= 2
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+    code_deposit_state_gas = fork.code_deposit_state_gas(code_size=code_size)
+
+    if beneficiary_type == "self":
+        selfdestruct = Op.SELFDESTRUCT(Op.ADDRESS)
+    else:
+        beneficiary = pre.deploy_contract(code=Op.STOP)
+        selfdestruct = Op.SELFDESTRUCT(beneficiary)
+    sd_len = len(bytes(selfdestruct))
+    assert code_size >= sd_len
+    deployed = bytes(selfdestruct) + b"\x00" * (code_size - sd_len)
+    initcode = Initcode(deploy_code=deployed)
+    initcode_len = len(initcode)
+
+    # Nest CREATE directly as the address argument to CALL so the
+    # deployed contract's address flows via the stack, avoiding a
+    # magic memory slot for address storage and an arbitrary gas
+    # budget.
+    factory_code = Op.CALLDATACOPY(
+        0,
+        0,
+        Op.CALLDATASIZE,
+        data_size=initcode_len,
+        new_memory_size=initcode_len,
+    ) + Op.POP(
+        Op.CALL(
+            gas=Op.GAS,
+            address=Op.CREATE(
+                value=0,
+                offset=0,
+                size=Op.CALLDATASIZE,
+                init_code_size=initcode_len,
+            ),
+        )
+    )
+    factory = pre.deploy_contract(code=factory_code)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    total_state_refund = new_account_state_gas + code_deposit_state_gas
+    tx = Transaction(
+        to=factory,
+        data=bytes(initcode),
+        gas_limit=gas_limit_cap + total_state_refund,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post={created_address: Account.NONEXISTENT},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_create_selfdestruct_no_double_refund_with_sstore_restoration(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify SSTORE restoration and SELFDESTRUCT refunds do not stack.
+
+    Initcode does SSTORE(0, 1) then SSTORE(0, 0) then SELFDESTRUCT.
+    The 0 to x to 0 restoration refunds the slot inline. The end of
+    tx selfdestruct refund scans `storage_writes[B]` and only counts
+    non zero final values, so the restored slot is excluded and the
+    end of tx refund is account only.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    init_code = (
+        Op.SSTORE.with_metadata(
+            key_warm=False,
+            original_value=0,
+            current_value=0,
+            new_value=1,
+        )(0, 1)
+        + Op.SSTORE.with_metadata(
+            key_warm=True,
+            original_value=0,
+            current_value=1,
+            new_value=0,
+        )(0, 0)
+        + Op.SELFDESTRUCT.with_metadata(address_warm=True)(Op.ADDRESS)
+    )
+    mstore_value, size = init_code_at_high_bytes(init_code)
+
+    mstore = Op.MSTORE.with_metadata(new_memory_size=32, old_memory_size=0)(
+        0, mstore_value
+    )
+    create_call = Op.CREATE.with_metadata(init_code_size=size)(0, 0, size)
+    factory_code = mstore + Op.POP(create_call)
+    factory = pre.deploy_contract(code=factory_code)
+
+    # Subtract both state charges (CREATE account + cold SSTORE) to
+    # isolate the regular total.
+    tx_regular = (
+        intrinsic_gas
+        + factory_code.gas_cost(fork)
+        + init_code.gas_cost(fork)
+        - new_account_state_gas
+        - sstore_state_gas
+    )
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit_cap + new_account_state_gas + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_regular))],
+        post={},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_pre_existing_account_no_refund(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify SELFDESTRUCT of a pre-existing account earns no refund.
+
+    The same-tx-create guard (`address in tx_state.created_accounts`)
+    is load-bearing: without it, destroying any account would leak
+    state gas back into the reservoir.  A contract deployed in `pre`
+    is destroyed by the tx; `accounts_to_delete` contains it but
+    `created_accounts` does not, so no refund is applied.  The block
+    header `gas_used` reflects the full regular-gas tx cost (no
+    state-gas refund offset).
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    # Victim deployed in `pre` (NOT same-tx-created).  SELFDESTRUCTs
+    # to self so no new-account state gas is charged to the tx.
+    victim_code = Op.SELFDESTRUCT.with_metadata(address_warm=True)(Op.ADDRESS)
+    victim = pre.deploy_contract(code=victim_code)
+
+    caller_code = Op.POP(Op.CALL(gas=Op.GAS, address=victim))
+    caller = pre.deploy_contract(code=caller_code)
+
+    # No refund offset: both caller_code and victim_code are pure
+    # regular gas (SELFDESTRUCT to self, no value-to-new-account).
+    tx_regular = (
+        intrinsic_gas + caller_code.gas_cost(fork) + victim_code.gas_cost(fork)
+    )
+
+    tx = Transaction(
+        to=caller,
+        gas_limit=gas_limit_cap,
+        sender=pre.fund_eoa(),
+    )
+
+    # Per EIP-6780, SELFDESTRUCT on a not-same-tx-created account
+    # does not delete it — the account still exists after the tx.
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_regular))],
+        post={victim: Account(code=victim_code)},
     )


### PR DESCRIPTION
## 🗒️ Description

Implements SELFDESTRUCT same tx state gas refund: when an account is created AND self-destructed in the same transaction (EIP-6780), refund its state gas to `state_gas_reservoir` at the end of the transaction.

EIP text change: ethereum/EIPs#11532

### Spec change: [0e1c131](https://github.com/spencer-tb/execution-specs/commit/0e1c131b3e)

After `process_message_call` returns, iterate `tx_output.accounts_to_delete`. For each address also in `tx_state.created_accounts`, refund:

* `STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte` (account)
* `STATE_BYTES_PER_STORAGE_SET * cost_per_state_byte` per non-zero final storage slot
* `len(code) * cost_per_state_byte` (code deposit)

Clamped to `state_gas_used` (cumulative across multiple accounts because `state_gas_used -= refund` each iteration). Applied before `tx_gas_used_before_refund` is computed so `block_state_gas_used` reflects the refund.

The refund loop runs only when `tx_output.error is None` — composes cleanly with the top-level failure refund path from ethereum/execution-specs#2689 which zeros `state_gas_used` on top-level revert/halt (and where `accounts_to_delete` is already empty per `interpreter.py:157`).

`account.code_hash` still points at deployed code here because EIP-6780 defers actual account/storage/code removal to tx-end; a comment in the spec calls this out so readers don't wonder why `get_code` doesn't return empty for a selfdestructed account.

### Tests: [1495372](https://github.com/spencer-tb/execution-specs/commit/1495372b33)

Four tests in `test_state_gas_selfdestruct.py`, each isolating one term of the refund formula or one guard condition. All strict `header_verify` discriminators — reverting the spec change fails every variant.

* `test_create_selfdestruct_refunds_account_and_storage`, parametrized `num_slots` in {0, 1, 5} and `create_opcode` in {CREATE, CREATE2}. Initcode writes N cold SSTOREs then SELFDESTRUCTs. Asserts refund covers `GAS_NEW_ACCOUNT + N * sstore_state_gas`.
* `test_create_selfdestruct_refunds_code_deposit_state_gas`, parametrized `(beneficiary_type, code_size)` across {(self, 2), (self, 100), (external, 100)}. Factory CREATEs a contract deploying `code_size` bytes then CALLs it to trigger SELFDESTRUCT. Uses `Op.CALL(gas=Op.GAS, address=Op.CREATE(...))` so the created address flows via the stack — no hard-coded gas or magic memory slot. `external` variant verifies the refund targets the created account, not the ETH destination.
* `test_create_selfdestruct_no_double_refund_with_sstore_restoration`. Initcode does `SSTORE(0, 1)` then `SSTORE(0, 0)` then SELFDESTRUCT. The 0 to x to 0 restoration refunds the slot inline (via the mechanism from ethereum/execution-specs#2698); the end-of-tx refund then skips it because the final value is zero. Asserts the end-of-tx refund is account-only.
* `test_selfdestruct_pre_existing_account_no_refund`. A contract deployed in `pre` (NOT same-tx-created) is destroyed by the tx. `accounts_to_delete` contains it but `created_accounts` does not, so the `if address in tx_state.created_accounts` guard skips the refund. Block `gas_used` reflects full regular tx cost. Per EIP-6780, the victim account persists post-tx (SELFDESTRUCT only deletes same-tx-created accounts), which the post-state asserts.

Shared `init_code_at_high_bytes` helper is moved to `spec.py` so it can also be used by ethereum/execution-specs#2704 / future PRs.

## 🔗 Related Issues or PRs

* EIP text change: ethereum/EIPs#11532

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).