### PR TITLE
feat(test-client-clis): tolerate missing trace file for rejected txs

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -266,6 +266,13 @@ class TransitionTool(EthereumCLI):
         for i, r in enumerate(receipts):
             trace_file_name = f"trace-{i}-{r.transaction_hash}.jsonl"
             trace_file_path = temp_dir_path / trace_file_name
+            if not trace_file_path.exists():
+                # Transaction was rejected mid-processing (e.g. EIP-3607
+                # collision): the receipt exists but the tracer's
+                # TransactionEnd event never fired, so no trace file was
+                # written. Record an empty trace for this tx.
+                traces.append(TransactionTraces(traces=[]))
+                continue
             if debug_output_path:
                 shutil.copy(
                     trace_file_path,


### PR DESCRIPTION
## 🗒️ Description

Fix `FileNotFoundError` in `fill --traces` when a transaction is rejected mid-processing (e.g. EIP-3607 collision).

When T8N's `run_state_test` catches an `EthereumException` from `process_transaction`, the tx is added to `rejected_txs` and state is rolled back — but a receipt entry is still produced by `Result.update` → `get_receipts_from_output`. Meanwhile the tracer's `TransactionEnd` event never fires, so no trace file is written. `collect_traces` then iterates receipts, assumes a matching trace file exists for each, and crashes on `shutil.copy` / `TransactionTraces.from_file`.

This patch makes `collect_traces` tolerant of a missing trace file: when the file isn't on disk, record an empty `TransactionTraces` and continue. This matches the implicit empty-trace case that already exists for tests with no transactions, and leaves downstream `verify-traces` comparison symmetric (both sides produce empty traces for rejected txs).

### Reproducer (before this PR)

```bash
TMPDIR=./.tmp uv run fill \
  tests/ported_static/stCreateTest/test_transaction_collision_to_empty_but_code.py \
  tests/ported_static/stCreateTest/test_transaction_collision_to_empty_but_nonce.py \
  tests/ported_static/stEIP3607/test_init_colliding_with_non_empty_account.py \
  --traces -n 4 --output .tmp/fix --clean
# → 117 failed (FileNotFoundError on .../trace-0-0x<hash>.jsonl)
```

After this PR: `117 passed`.

CI was not catching this because the `just fill` recipe does not pass `--traces`.

### Scope

One function (`TransitionTool.collect_traces` in `packages/testing/src/execution_testing/client_clis/transition_tool.py`), ~6 added lines. No changes to T8N, tracer, or receipt generation — those still warrant a follow-up correctness fix (emit `TransactionEnd` from the exception path) but are out of scope here.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Two red panda cubs in a tree](https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Two_Red_Panda_Cubs_in_the_Tree_01.jpg/500px-Two_Red_Panda_Cubs_in_the_Tree_01.jpg)

<sub>[Two Red Panda Cubs in the Tree](https://commons.wikimedia.org/wiki/File:Two_Red_Panda_Cubs_in_the_Tree_01.jpg) — Mathias Appel, CC0, via Wikimedia Commons</sub>