### PR TITLE
feat(specs,tests): EIP-7928 - Update BAL index to uint64

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Set, Tuple, TypeAlias
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U16, U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
@@ -46,7 +46,7 @@ CodeData: TypeAlias = Bytes
 Bytecode associated with an [`Account`](ref:ethereum.state.Account).
 """
 
-BlockAccessIndex: TypeAlias = U16
+BlockAccessIndex: TypeAlias = U64
 """
 Position within the set of all changes in a [`Block`].
 

--- a/tests/amsterdam/eip7928_block_level_access_lists/spec.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/spec.py
@@ -39,6 +39,6 @@ class Spec:
     HASH_SIZE: int = 32  # Hash size in bytes
 
     # Numeric type limits
-    MAX_TX_INDEX: int = 2**16 - 1  # uint16 max value
+    MAX_TX_INDEX: int = 2**64 - 1  # uint64 max value
     MAX_BALANCE: int = 2**128 - 1  # uint128 max value
     MAX_NONCE: int = 2**64 - 1  # uint64 max value


### PR DESCRIPTION
As discussed in discord, we should update the BAL index to use `uint64` instead of `uint16` to be future proof, having a large enough range to support a 300 million gas limit + EIP-2780 to be shipped.