### PR TITLE
feat(tests): EIP-8037 additional state gas coverage

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -22,6 +22,7 @@ from execution_testing import (
     Op,
     Storage,
     Transaction,
+    TransactionException,
 )
 
 from .spec import ref_spec_8037
@@ -465,4 +466,170 @@ def test_multi_block_dimension_flip(
             ),
         ],
         post=post_2,
+    )
+
+
+@pytest.mark.exception_test
+@pytest.mark.valid_from("EIP8037")
+def test_tx_rejected_when_regular_gas_exceeds_block_limit_small(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Reject a small-gas tx whose regular contribution overflows the block.
+
+    Complements `test_block_regular_gas_limit` which covers
+    `TX_MAX_GAS_LIMIT`-sized transactions. Here the block has a
+    tight gas_limit (2 * intrinsic) and the second tx's gas_limit
+    sits just one gas above the remaining regular budget, so the
+    pre-execution check rejects it without executing.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    block_gas_limit = intrinsic_gas * 2
+
+    filler = pre.deploy_contract(code=Op.STOP)
+    filler_tx = Transaction(
+        to=filler,
+        gas_limit=intrinsic_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    rejected_gas_limit = intrinsic_gas + 1
+    assert rejected_gas_limit < gas_limit_cap
+    rejected = pre.deploy_contract(code=Op.STOP)
+    rejected_tx = Transaction(
+        to=rejected,
+        gas_limit=rejected_gas_limit,
+        sender=pre.fund_eoa(),
+        error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[filler_tx, rejected_tx],
+                gas_limit=block_gas_limit,
+                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+            )
+        ],
+        post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "tx2_gas_limit_equals_block_gas_limit",
+    [
+        pytest.param(True, id="tx_gas_limit_equals_block_limit"),
+        pytest.param(False, id="tx_gas_limit_just_above_remaining"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_block_2d_gas_tx_gas_limit_exceeds_regular_remaining(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx2_gas_limit_equals_block_gas_limit: bool,
+) -> None:
+    """
+    Verify block validity when tx.gas_limit exceeds regular remaining.
+
+    After a preceding STOP tx consumes regular gas, the second tx
+    has `gas_limit >> TX_MAX_GAS_LIMIT`. The pre-execution inclusion
+    check must use `min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state)`
+    against the cumulative regular budget, not the raw tx.gas_limit.
+    A client that subtracts the full `tx.gas_limit` from the regular
+    pool would reject this otherwise-valid block.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    env = Environment()
+    block_gas_limit = int(env.gas_limit)
+
+    if tx2_gas_limit_equals_block_gas_limit:
+        tx2_gas_limit = block_gas_limit
+    else:
+        tx2_gas_limit = block_gas_limit - intrinsic_gas + 1
+
+    assert tx2_gas_limit > gas_limit_cap
+    assert tx2_gas_limit > block_gas_limit - intrinsic_gas
+
+    stop_contract = pre.deploy_contract(code=Op.STOP)
+
+    storage = Storage()
+    sstore_contract = pre.deploy_contract(
+        code=Op.SSTORE(storage.store_next(1), 1),
+    )
+
+    tx1_regular = intrinsic_gas
+    tx2_regular, tx2_state = sstore_tx_gas(fork)
+    expected_gas_used = max(tx1_regular + tx2_regular, tx2_state)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[
+                    Transaction(
+                        to=stop_contract,
+                        gas_limit=intrinsic_gas,
+                        sender=pre.fund_eoa(),
+                    ),
+                    Transaction(
+                        to=sstore_contract,
+                        gas_limit=tx2_gas_limit,
+                        sender=pre.fund_eoa(),
+                    ),
+                ],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={sstore_contract: Account(storage=storage)},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_receipt_cumulative_differs_from_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify receipt cumulative_gas_used can diverge from header gas_used.
+
+    Under 2D accounting, `header.gas_used = max(sum_regular, sum_state)`
+    while a receipt's `cumulative_gas_used` accumulates per-tx
+    `regular + state`. In a block dominated by state gas, the
+    header is strictly less than the receipt cumulative. A client
+    that uses either value for the other check would reject valid
+    blocks.
+    """
+    tx_regular, tx_state = sstore_tx_gas(fork)
+    num_txs = 3
+
+    txs, post = sstore_txs(pre, fork, num_txs)
+
+    block_regular = num_txs * tx_regular
+    block_state = num_txs * tx_state
+    header_gas_used = max(block_regular, block_state)
+    receipt_cumulative = num_txs * (tx_regular + tx_state)
+
+    assert block_state > block_regular
+    assert header_gas_used < receipt_cumulative
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(gas_used=header_gas_used),
+            ),
+        ],
+        post=post,
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -476,15 +476,7 @@ def test_tx_rejected_when_regular_gas_exceeds_block_limit_small(
     pre: Alloc,
     fork: Fork,
 ) -> None:
-    """
-    Reject a small-gas tx whose regular contribution overflows the block.
-
-    Complements `test_block_regular_gas_limit` which covers
-    `TX_MAX_GAS_LIMIT`-sized transactions. Here the block has a
-    tight gas_limit (2 * intrinsic) and the second tx's gas_limit
-    sits just one gas above the remaining regular budget, so the
-    pre-execution check rejects it without executing.
-    """
+    """Reject a small-gas tx whose regular gas overflows the block."""
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
@@ -537,14 +529,8 @@ def test_block_2d_gas_tx_gas_limit_exceeds_regular_remaining(
     tx2_gas_limit_equals_block_gas_limit: bool,
 ) -> None:
     """
-    Verify block validity when tx.gas_limit exceeds regular remaining.
-
-    After a preceding STOP tx consumes regular gas, the second tx
-    has `gas_limit >> TX_MAX_GAS_LIMIT`. The pre-execution inclusion
-    check must use `min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state)`
-    against the cumulative regular budget, not the raw tx.gas_limit.
-    A client that subtracts the full `tx.gas_limit` from the regular
-    pool would reject this otherwise-valid block.
+    Verify a block is valid when a later tx's gas_limit exceeds the
+    regular budget remaining but its capped regular contribution fits.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -601,14 +587,8 @@ def test_receipt_cumulative_differs_from_header_gas_used(
     fork: Fork,
 ) -> None:
     """
-    Verify receipt cumulative_gas_used can diverge from header gas_used.
-
-    Under 2D accounting, `header.gas_used = max(sum_regular, sum_state)`
-    while a receipt's `cumulative_gas_used` accumulates per-tx
-    `regular + state`. In a block dominated by state gas, the
-    header is strictly less than the receipt cumulative. A client
-    that uses either value for the other check would reject valid
-    blocks.
+    Verify receipt cumulative_gas_used can diverge from header
+    gas_used under 2D accounting when state gas dominates.
     """
     tx_regular, tx_state = sstore_tx_gas(fork)
     num_txs = 3

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -23,6 +23,7 @@ from execution_testing import (
     Storage,
     Transaction,
     TransactionException,
+    TransactionReceipt,
 )
 
 from .spec import ref_spec_8037
@@ -593,15 +594,36 @@ def test_receipt_cumulative_differs_from_header_gas_used(
     tx_regular, tx_state = sstore_tx_gas(fork)
     num_txs = 3
 
-    txs, post = sstore_txs(pre, fork, num_txs)
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    tx_gas_limit = gas_limit_cap + fork.sstore_state_gas()
+    per_tx_gas_used = tx_regular + tx_state
+
+    txs: list[Transaction] = []
+    post: dict = {}
+    for i in range(num_txs):
+        storage = Storage()
+        contract = pre.deploy_contract(
+            code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        )
+        txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=tx_gas_limit,
+                sender=pre.fund_eoa(),
+                expected_receipt=TransactionReceipt(
+                    cumulative_gas_used=(i + 1) * per_tx_gas_used,
+                ),
+            )
+        )
+        post[contract] = Account(storage=storage)
 
     block_regular = num_txs * tx_regular
     block_state = num_txs * tx_state
     header_gas_used = max(block_regular, block_state)
-    receipt_cumulative = num_txs * (tx_regular + tx_state)
 
     assert block_state > block_regular
-    assert header_gas_used < receipt_cumulative
+    assert header_gas_used < num_txs * per_tx_gas_used
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1464,3 +1464,116 @@ def test_create_oog_during_state_gas_charge(
 
     post = {parent: Account(storage=storage)}
     state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_call_new_account_no_regular_account_creation_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Regression: CALL with value to a non-existent account must NOT
+    charge the pre-Amsterdam 25,000 regular `ACCOUNT_CREATION_COST`.
+
+    Surfaced by evmone mutation testing (PR #2639 review comment):
+    keeping `25_000` regular on top of `GAS_NEW_ACCOUNT` state gas
+    passes the existing suite because no test budgets the CALL
+    tightly enough to reject the extra regular draw.
+
+    Tight-gas discriminator. `tx.gas_limit` is sized at the exact
+    regular cost of the caller code plus `GAS_NEW_ACCOUNT` (which
+    spills from `gas_left` since the reservoir is zero for
+    `tx.gas < TX_MAX_GAS_LIMIT`) plus a small slack. Under the
+    correct spec the CALL completes and transfers the value. Under
+    the mutation the extra 25,000 regular pushes the caller OOG,
+    the CALL aborts, and the target's balance stays at 0.
+    """
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    target = pre.fund_eoa(amount=0)
+
+    caller_code = Op.POP(Op.CALL(gas=0, address=target, value=1)) + Op.STOP
+    caller = pre.deploy_contract(code=caller_code, balance=1)
+
+    # Pre-Amsterdam CALL_NEW_ACCOUNT_COST was 25,000 regular. Budget
+    # 20,000 slack (< 25,000) so the correct spec fits and the
+    # mutation runs out of regular gas. `caller_code.gas_cost`
+    # already includes the cold access, so only the value-transfer
+    # extra needs adding.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    tx = Transaction(
+        to=caller,
+        gas_limit=(
+            intrinsic
+            + caller_code.gas_cost(fork)
+            + gas_costs.GAS_CALL_VALUE
+            + new_account_state_gas
+            + 20_000
+        ),
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(pre=pre, post={target: Account(balance=1)}, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Regression: on child failure, state gas must be returned to the
+    parent's state gas reservoir, not to `gas_left`.
+
+    Surfaced by evmone mutation testing (PR #2639 review comment):
+    routing `incorporate_child_on_error`'s state-gas restoration to
+    `gas_left` (regular) rather than `state_gas_left` passes the
+    existing suite because every reservoir-restoration test leaves
+    `gas_left` large enough to absorb the subsequent SSTORE spill.
+
+    Grandchild discriminator. After a failing child restores the
+    reservoir, the parent forwards a tight `gas` stipend to a
+    grandchild that attempts an SSTORE. Under the correct spec the
+    grandchild inherits the restored reservoir and the SSTORE
+    consumes from it. Under the mutation the grandchild's reservoir
+    is zero, the SSTORE's state gas has to spill into the tight
+    `gas_left`, and the grandchild OOGs.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
+    sstore_state_gas = fork.sstore_state_gas()
+
+    grandchild = pre.deploy_contract(code=Op.SSTORE(0, 1))
+
+    child = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.REVERT(0, 0))
+
+    # Tight stipend: one cold SSTORE regular plus its two stack
+    # pushes. The grandchild has no spare `gas_left` to absorb a
+    # state-gas spill; the SSTORE only completes if state gas comes
+    # from the forwarded reservoir.
+    push_cost = 2 * gas_costs.GAS_VERY_LOW
+    sstore_regular = gas_costs.GAS_COLD_STORAGE_WRITE
+    grandchild_stipend = push_cost + sstore_regular
+
+    parent = pre.deploy_contract(
+        code=(
+            Op.POP(Op.CALL(gas=Op.GAS, address=child))
+            + Op.POP(Op.CALL(gas=grandchild_stipend, address=grandchild))
+        ),
+    )
+
+    tx = Transaction(
+        to=parent,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        pre=pre,
+        post={grandchild: Account(storage={0: 1})},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -29,6 +29,7 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionReceipt,
     compute_create2_address,
     compute_create_address,
 )
@@ -1542,10 +1543,22 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
         ),
     )
 
+    # Empirical per-tx cumulative. Pinning this catches a mutation
+    # that correctly restores the reservoir but also double-refunds
+    # to regular gas (or otherwise leaks extra gas to the sender),
+    # which the storage probe alone cannot discriminate.
+    expected_cumulative = {
+        Op.CALL: 73_831,
+        Op.DELEGATECALL: 73_825,
+    }[call_opcode]
+
     tx = Transaction(
         to=parent,
         gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
     )
 
     # DELEGATECALL executes the callee in the caller's storage

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1393,25 +1393,38 @@ def test_callcode_value_no_new_account_state_gas(
         sender=pre.fund_eoa(),
     )
 
-    post = {contract: Account(storage=storage)}
+    post = {
+        contract: Account(storage=storage),
+        target: Account.NONEXISTENT,
+    }
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.with_all_create_opcodes()
 @pytest.mark.valid_from("EIP8037")
 def test_create_oog_during_state_gas_charge(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    create_opcode: Op,
 ) -> None:
     """
     Verify the parent reservoir is refunded when a child's CREATE
-    OOGs while charging account-creation state gas.
+    OOGs while charging account-creation state gas. The grandchild
+    SSTORE is forwarded only its regular stipend, so it succeeds
+    only if the refund landed in the reservoir (not in `gas_left`).
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
     sstore_state_gas = fork.sstore_state_gas()
 
     init_code = Op.STOP
+    inner_create_call = (
+        create_opcode(value=0, offset=31, size=1, salt=0)
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=31, size=1)
+    )
 
     inner = pre.deploy_contract(
         code=(
@@ -1419,15 +1432,20 @@ def test_create_oog_during_state_gas_charge(
                 0,
                 int.from_bytes(bytes(init_code), "big") << 248,
             )
-            + Op.POP(Op.CREATE(0, 31, 1))
+            + Op.POP(inner_create_call)
         ),
     )
 
-    storage = Storage()
+    grandchild = pre.deploy_contract(code=Op.SSTORE(0, 1))
+
+    push_cost = 2 * gas_costs.GAS_VERY_LOW
+    sstore_regular = gas_costs.GAS_COLD_STORAGE_WRITE
+    grandchild_stipend = push_cost + sstore_regular
+
     parent = pre.deploy_contract(
         code=(
             Op.POP(Op.CALL(gas=20_000, address=inner))
-            + Op.SSTORE(storage.store_next(1), 1)
+            + Op.POP(Op.CALL(gas=grandchild_stipend, address=grandchild))
         ),
     )
 
@@ -1437,8 +1455,11 @@ def test_create_oog_during_state_gas_charge(
         sender=pre.fund_eoa(),
     )
 
-    post = {parent: Account(storage=storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    state_test(
+        pre=pre,
+        post={grandchild: Account(storage={0: 1})},
+        tx=tx,
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -1477,16 +1498,26 @@ def test_call_new_account_no_regular_account_creation_cost(
     state_test(pre=pre, post={target: Account(balance=1)}, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "call_opcode",
+    [
+        pytest.param(Op.CALL, id="call"),
+        pytest.param(Op.DELEGATECALL, id="delegatecall"),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    call_opcode: Op,
 ) -> None:
     """
     Verify state gas from a failing child is restored to the
     reservoir (not regular gas), so a grandchild SSTORE can draw
-    from it under a tight regular stipend.
+    from it under a tight regular stipend. Parametrized across CALL
+    (grandchild writes to its own storage) and DELEGATECALL
+    (grandchild writes to the parent's storage via shared context).
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1506,8 +1537,8 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
 
     parent = pre.deploy_contract(
         code=(
-            Op.POP(Op.CALL(gas=Op.GAS, address=child))
-            + Op.POP(Op.CALL(gas=grandchild_stipend, address=grandchild))
+            Op.POP(call_opcode(gas=Op.GAS, address=child))
+            + Op.POP(call_opcode(gas=grandchild_stipend, address=grandchild))
         ),
     )
 
@@ -1517,8 +1548,12 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
         sender=pre.fund_eoa(),
     )
 
-    state_test(
-        pre=pre,
-        post={grandchild: Account(storage={0: 1})},
-        tx=tx,
-    )
+    # DELEGATECALL executes the callee in the caller's storage
+    # context, so grandchild's SSTORE lands on `parent` instead of
+    # `grandchild`.
+    if call_opcode == Op.DELEGATECALL:
+        post: dict = {parent: Account(storage={0: 1})}
+    else:
+        post = {grandchild: Account(storage={0: 1})}
+
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1315,20 +1315,8 @@ def test_top_level_halt_preserves_restored_reservoir(
     reservoir_delta: int,
 ) -> None:
     """
-    Verify reservoir preserved on top-level halt after child restore.
-
-    The child runs an SSTORE drawing state gas from the reservoir
-    and then fails (revert or exceptional halt). All state gas is
-    restored to the parent's reservoir via
-    `incorporate_child_on_error`. The parent then hits INVALID,
-    triggering a top-level exceptional halt. Under PR #2689 the
-    top-level failure refund zeroes execution state gas and
-    credits it back to the reservoir for sender billing.
-
-    Parametrized over `reservoir_delta` in -1, 0, +1 around the
-    exact SSTORE state gas cost. Catches the bal-devnet-3 Besu
-    bug (#2644) where the reservoir was incorrectly consumed on
-    top-level halt instead of preserved for refund.
+    Verify the reservoir is refunded on a top-level halt after a
+    failing child restored state gas to the parent frame.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1351,11 +1339,9 @@ def test_top_level_halt_preserves_restored_reservoir(
         sender=pre.fund_eoa(),
     )
 
-    # On top-level halt, the reservoir (plus any spill-restore
-    # balance from the child failure path) is refunded to the
-    # sender. When `reservoir_delta < 0` the child spills
-    # `|delta|` gas from `gas_left`; the restore folds that back
-    # into the reservoir so block_regular drops by the same amount.
+    # When the reservoir is one short of the child's SSTORE, the
+    # spill from regular gas is restored on the child's failure,
+    # lowering the block regular total by the same amount.
     expected_gas_used = gas_limit_cap + min(reservoir_delta, 0)
 
     blockchain_test(
@@ -1377,12 +1363,8 @@ def test_callcode_value_no_new_account_state_gas(
     fork: Fork,
 ) -> None:
     """
-    Verify CALLCODE with value does not charge GAS_NEW_ACCOUNT.
-
-    CALLCODE transfers value to the caller (self), not to the
-    target. No new account is ever created on the target regardless
-    of whether it exists, so no state gas should be charged. A
-    subsequent SSTORE must succeed from the full reservoir.
+    Verify CALLCODE with value does not charge new-account state
+    gas, since the value stays with the caller.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1422,15 +1404,8 @@ def test_create_oog_during_state_gas_charge(
     fork: Fork,
 ) -> None:
     """
-    Verify CREATE child OOG on state gas charge refunds parent reservoir.
-
-    A parent CALLs an `inner` contract with only 20,000 gas
-    forwarded; the inner's CREATE charges GAS_NEW_ACCOUNT state
-    gas, which exceeds the forwarded budget (both reservoir and
-    gas_left) and raises OutOfGasError before the charge lands.
-    Per PR #2704 the parent's reservoir is refunded on child
-    failure and the subsequent SSTORE succeeds from the refunded
-    reservoir. Without the refund the SSTORE would OOG.
+    Verify the parent reservoir is refunded when a child's CREATE
+    OOGs while charging account-creation state gas.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1473,21 +1448,8 @@ def test_call_new_account_no_regular_account_creation_cost(
     fork: Fork,
 ) -> None:
     """
-    Regression: CALL with value to a non-existent account must NOT
-    charge the pre-Amsterdam 25,000 regular `ACCOUNT_CREATION_COST`.
-
-    Surfaced by evmone mutation testing (PR #2639 review comment):
-    keeping `25_000` regular on top of `GAS_NEW_ACCOUNT` state gas
-    passes the existing suite because no test budgets the CALL
-    tightly enough to reject the extra regular draw.
-
-    Tight-gas discriminator. `tx.gas_limit` is sized at the exact
-    regular cost of the caller code plus `GAS_NEW_ACCOUNT` (which
-    spills from `gas_left` since the reservoir is zero for
-    `tx.gas < TX_MAX_GAS_LIMIT`) plus a small slack. Under the
-    correct spec the CALL completes and transfers the value. Under
-    the mutation the extra 25,000 regular pushes the caller OOG,
-    the CALL aborts, and the target's balance stays at 0.
+    Verify CALL with value to a non-existent account does not
+    charge a regular account-creation cost on top of state gas.
     """
     gas_costs = fork.gas_costs()
     new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
@@ -1497,11 +1459,8 @@ def test_call_new_account_no_regular_account_creation_cost(
     caller_code = Op.POP(Op.CALL(gas=0, address=target, value=1)) + Op.STOP
     caller = pre.deploy_contract(code=caller_code, balance=1)
 
-    # Pre-Amsterdam CALL_NEW_ACCOUNT_COST was 25,000 regular. Budget
-    # 20,000 slack (< 25,000) so the correct spec fits and the
-    # mutation runs out of regular gas. `caller_code.gas_cost`
-    # already includes the cold access, so only the value-transfer
-    # extra needs adding.
+    # Tight budget: slack is less than the old pre-Amsterdam regular
+    # account-creation cost, so any extra regular draw would OOG.
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
     tx = Transaction(
         to=caller,
@@ -1525,22 +1484,9 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     fork: Fork,
 ) -> None:
     """
-    Regression: on child failure, state gas must be returned to the
-    parent's state gas reservoir, not to `gas_left`.
-
-    Surfaced by evmone mutation testing (PR #2639 review comment):
-    routing `incorporate_child_on_error`'s state-gas restoration to
-    `gas_left` (regular) rather than `state_gas_left` passes the
-    existing suite because every reservoir-restoration test leaves
-    `gas_left` large enough to absorb the subsequent SSTORE spill.
-
-    Grandchild discriminator. After a failing child restores the
-    reservoir, the parent forwards a tight `gas` stipend to a
-    grandchild that attempts an SSTORE. Under the correct spec the
-    grandchild inherits the restored reservoir and the SSTORE
-    consumes from it. Under the mutation the grandchild's reservoir
-    is zero, the SSTORE's state gas has to spill into the tight
-    `gas_left`, and the grandchild OOGs.
+    Verify state gas from a failing child is restored to the
+    reservoir (not regular gas), so a grandchild SSTORE can draw
+    from it under a tight regular stipend.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1551,10 +1497,9 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
 
     child = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.REVERT(0, 0))
 
-    # Tight stipend: one cold SSTORE regular plus its two stack
-    # pushes. The grandchild has no spare `gas_left` to absorb a
-    # state-gas spill; the SSTORE only completes if state gas comes
-    # from the forwarded reservoir.
+    # Tight stipend: just enough regular gas for the grandchild's
+    # SSTORE opcode plus its two stack pushes, leaving no slack to
+    # absorb a state-gas spill.
     push_cost = 2 * gas_costs.GAS_VERY_LOW
     sstore_regular = gas_costs.GAS_COLD_STORAGE_WRITE
     grandchild_stipend = push_cost + sstore_regular

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1289,3 +1289,178 @@ def test_call_value_to_pre_existing_selfdestructed_account(
         ],
         post={},
     )
+
+
+@pytest.mark.parametrize(
+    "reservoir_delta",
+    [
+        pytest.param(-1, id="reservoir_one_short"),
+        pytest.param(0, id="reservoir_exact"),
+        pytest.param(1, id="reservoir_one_over"),
+    ],
+)
+@pytest.mark.parametrize(
+    "child_termination",
+    [
+        pytest.param("revert", id="child_revert"),
+        pytest.param("halt", id="child_halt"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_top_level_halt_preserves_restored_reservoir(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    child_termination: str,
+    reservoir_delta: int,
+) -> None:
+    """
+    Verify reservoir preserved on top-level halt after child restore.
+
+    The child runs an SSTORE drawing state gas from the reservoir
+    and then fails (revert or exceptional halt). All state gas is
+    restored to the parent's reservoir via
+    `incorporate_child_on_error`. The parent then hits INVALID,
+    triggering a top-level exceptional halt. Under PR #2689 the
+    top-level failure refund zeroes execution state gas and
+    credits it back to the reservoir for sender billing.
+
+    Parametrized over `reservoir_delta` in -1, 0, +1 around the
+    exact SSTORE state gas cost. Catches the bal-devnet-3 Besu
+    bug (#2644) where the reservoir was incorrectly consumed on
+    top-level halt instead of preserved for refund.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    if child_termination == "revert":
+        child_code: Bytecode = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
+    else:
+        child_code = Op.SSTORE(0, 1) + Op.INVALID
+
+    child = pre.deploy_contract(code=child_code)
+
+    parent = pre.deploy_contract(
+        code=(Op.POP(Op.CALL(gas=500_000, address=child)) + Op.INVALID),
+    )
+
+    tx = Transaction(
+        to=parent,
+        gas_limit=gas_limit_cap + sstore_state_gas + reservoir_delta,
+        sender=pre.fund_eoa(),
+    )
+
+    # On top-level halt, the reservoir (plus any spill-restore
+    # balance from the child failure path) is refunded to the
+    # sender. When `reservoir_delta < 0` the child spills
+    # `|delta|` gas from `gas_left`; the restore folds that back
+    # into the reservoir so block_regular drops by the same amount.
+    expected_gas_used = gas_limit_cap + min(reservoir_delta, 0)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={child: Account(storage={0: 0})},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_callcode_value_no_new_account_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify CALLCODE with value does not charge GAS_NEW_ACCOUNT.
+
+    CALLCODE transfers value to the caller (self), not to the
+    target. No new account is ever created on the target regardless
+    of whether it exists, so no state gas should be charged. A
+    subsequent SSTORE must succeed from the full reservoir.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    target = pre.fund_eoa(amount=0)
+
+    storage = Storage()
+    contract = pre.deploy_contract(
+        code=(
+            Op.POP(
+                Op.CALLCODE(
+                    gas=Op.GAS,
+                    address=target,
+                    value=1,
+                )
+            )
+            + Op.SSTORE(storage.store_next(1, "reservoir_ok"), 1)
+        ),
+        balance=10**18,
+    )
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {contract: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_create_oog_during_state_gas_charge(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify CREATE child OOG on state gas charge refunds parent reservoir.
+
+    A parent CALLs an `inner` contract with only 20,000 gas
+    forwarded; the inner's CREATE charges GAS_NEW_ACCOUNT state
+    gas, which exceeds the forwarded budget (both reservoir and
+    gas_left) and raises OutOfGasError before the charge lands.
+    Per PR #2704 the parent's reservoir is refunded on child
+    failure and the subsequent SSTORE succeeds from the refunded
+    reservoir. Without the refund the SSTORE would OOG.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    init_code = Op.STOP
+
+    inner = pre.deploy_contract(
+        code=(
+            Op.MSTORE(
+                0,
+                int.from_bytes(bytes(init_code), "big") << 248,
+            )
+            + Op.POP(Op.CREATE(0, 31, 1))
+        ),
+    )
+
+    storage = Storage()
+    parent = pre.deploy_contract(
+        code=(
+            Op.POP(Op.CALL(gas=20_000, address=inner))
+            + Op.SSTORE(storage.store_next(1), 1)
+        ),
+    )
+
+    tx = Transaction(
+        to=parent,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {parent: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2212,3 +2212,82 @@ def test_inner_create_fail_refunds_in_creation_tx(
         ],
         post=post,
     )
+
+
+@pytest.mark.pre_alloc_mutable
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_create_collision_burned_gas_counted_in_block_regular(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+) -> None:
+    """
+    Regression: on CREATE/CREATE2 address collision the forwarded
+    `create_message_gas` is burned and must count toward
+    `block_regular_gas_used`, not vanish from the block formula.
+
+    Surfaced by evmone mutation testing (PR #2639 review comment):
+    skipping the `evm.regular_gas_used += create_message_gas`
+    accounting on the collision branch passes the existing suite
+    because the only collision test uses `state_test` (no
+    block-level header check) and state-gas accounting is unchanged.
+
+    Block-level `Header(gas_used)` discriminator. `block_state_gas`
+    is zero (non-creation tx, collision refunds the state charge),
+    so `header.gas_used == block_regular`. The burned
+    `create_message_gas` dominates the regular dimension and its
+    removal under the mutation reduces `header.gas_used` by that
+    exact amount.
+    """
+    init_code = Op.STOP
+    mstore_value, size = init_code_at_high_bytes(init_code)
+    salt = 0
+
+    create_call = (
+        create_opcode(value=0, offset=0, size=size, salt=salt)
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=0, size=size)
+    )
+    factory_code = Op.MSTORE(0, mstore_value) + Op.POP(create_call) + Op.STOP
+    factory = pre.deploy_contract(code=factory_code)
+
+    collision_target = compute_create_address(
+        address=factory,
+        nonce=1,
+        salt=salt,
+        initcode=bytes(init_code),
+        opcode=create_opcode,
+    )
+    pre.deploy_contract(code=Op.STOP, address=collision_target)
+
+    # Fixed-size budget so `gas_left` at the CREATE/CREATE2 opcode
+    # (and hence `create_message_gas`) is deterministic and the
+    # `Header(gas_used)` baseline below is reproducible.
+    gas_limit = 250_000
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    # Empirical baseline. `block_state_gas` is zero for this tx, so
+    # the header just reports `intrinsic.regular + factory_regular +
+    # create_message_gas + POP + STOP`. Removing the collision's
+    # `regular_gas_used += create_message_gas` accounting subtracts
+    # `create_message_gas` from this baseline, so the test catches
+    # the mutation on both CREATE and CREATE2 paths.
+    baseline_gas_used = 0x01C98C  # 117,132 empirical header.gas_used
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=baseline_gas_used),
+            ),
+        ],
+        post={},
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1594,3 +1594,155 @@ def test_failed_create_tx_state_gas_dominates(
         ],
         post={},
     )
+
+
+@pytest.mark.parametrize(
+    "initcode_size_delta",
+    [
+        pytest.param(0, id="at_max"),
+        pytest.param(1, id="over_max", marks=pytest.mark.exception_test),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_oversized_initcode_tx_no_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    initcode_size_delta: int,
+) -> None:
+    """
+    Verify CREATE tx with oversized initcode charges no state gas.
+
+    EIP-8037 moves the initcode size validation to run before
+    account-creation state gas is charged (see PR #2608). A CREATE
+    tx whose initcode exceeds MAX_INITCODE_SIZE must be rejected
+    with no state gas consumed; otherwise block_state_gas_used
+    would include a spurious GAS_NEW_ACCOUNT charge for an account
+    that is never created.
+
+    The at_max variant succeeds and charges state gas normally.
+    The over_max variant is rejected with no state gas.
+    """
+    max_size = fork.max_initcode_size()
+    size = max_size + initcode_size_delta
+    initcode = Initcode(deploy_code=Op.STOP, initcode_length=size)
+
+    sender = pre.fund_eoa()
+    create_address = compute_create_address(address=sender, nonce=0)
+
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    create_state_gas = fork.create_state_gas(code_size=len(Op.STOP))
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode,
+        gas_limit=gas_limit_cap + create_state_gas,
+    )
+
+    if initcode_size_delta > 0:
+        tx.error = TransactionException.INITCODE_SIZE_EXCEEDED
+        post: dict = {create_address: Account.NONEXISTENT}
+    else:
+        post = {create_address: Account(code=Op.STOP)}
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                exception=(
+                    TransactionException.INITCODE_SIZE_EXCEEDED
+                    if initcode_size_delta > 0
+                    else None
+                ),
+            ),
+        ],
+        post=post,
+    )
+
+
+@pytest.mark.parametrize(
+    "initcode_size_delta",
+    [
+        pytest.param(0, id="at_max"),
+        pytest.param(1, id="over_max"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_oversized_initcode_opcode_no_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    initcode_size_delta: int,
+) -> None:
+    """
+    Verify CREATE/CREATE2 with oversized initcode charges no state gas.
+
+    A factory calls CREATE/CREATE2 with initcode exceeding
+    MAX_INITCODE_SIZE. The opcode must fail the size check before
+    charging account-creation state gas (PR #2608 ordering). If
+    state gas were charged first, block_state_gas_used would be
+    inflated by GAS_NEW_ACCOUNT for an account never created.
+
+    The at_max variant succeeds. The over_max variant returns 0
+    from CREATE and charges no state gas.
+    """
+    max_size = fork.max_initcode_size()
+    size = max_size + initcode_size_delta
+    initcode = Initcode(deploy_code=Op.STOP, initcode_length=size)
+    initcode_bytes = bytes(initcode)
+
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
+    create_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    create_call = (
+        create_opcode(
+            value=0,
+            offset=0,
+            size=Op.CALLDATASIZE,
+            salt=0,
+            init_code_size=len(initcode_bytes),
+        )
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=0, size=Op.CALLDATASIZE)
+    )
+
+    factory = pre.deploy_contract(
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.SSTORE(0, create_call)
+    )
+
+    create_address = compute_create_address(
+        address=factory,
+        nonce=1,
+        salt=0,
+        initcode=initcode,
+        opcode=create_opcode,
+    )
+
+    storage = Storage()
+    storage[0] = create_address if initcode_size_delta == 0 else 0
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=factory,
+        data=initcode_bytes,
+        gas_limit=gas_limit_cap + create_state_gas,
+    )
+
+    post: dict = {factory: Account(storage=storage)}
+    if initcode_size_delta == 0:
+        post[create_address] = Account(code=Op.STOP)
+    else:
+        post[create_address] = Account.NONEXISTENT
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post=post,
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1746,3 +1746,185 @@ def test_oversized_initcode_opcode_no_state_gas(
         blocks=[Block(txs=[tx])],
         post=post,
     )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_in_create_tx_initcode(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify state gas for a creation tx whose initcode SELFDESTRUCTs.
+
+    A creation tx (to=None) with value=1 whose initcode immediately
+    SELFDESTRUCTs to a new beneficiary. Under EIP-6780 the outer
+    contract is marked for deletion (created in the same tx). The
+    SELFDESTRUCT charges `GAS_NEW_ACCOUNT` for the beneficiary.
+
+    Post-PR #2707: the outer account is in `created_accounts` AND
+    `accounts_to_delete`, so its `GAS_NEW_ACCOUNT` is refunded
+    end-of-tx. The beneficiary charge (new, live) is NOT refunded
+    because the beneficiary itself is not in `created_accounts`.
+    After the refund, `state_gas_used = 0` (refund == beneficiary
+    charge amount). Intrinsic state gas for the outer account is
+    preserved (tracked separately from execution state gas).
+
+    Expected block state gas = intrinsic_state = `GAS_NEW_ACCOUNT`.
+    A client that skips the end-of-tx refund for the creation-tx
+    path would report `2 * GAS_NEW_ACCOUNT`.
+    """
+    gas_costs = fork.gas_costs()
+    create_state_gas = fork.create_state_gas(code_size=0)
+
+    beneficiary = 0xDEAD
+    initcode = Op.SELFDESTRUCT(beneficiary)
+
+    sender = pre.fund_eoa()
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_total = intrinsic_calc(
+        calldata=bytes(initcode), contract_creation=True
+    )
+
+    # Refund zeroes state_gas_used from the beneficiary charge;
+    # only intrinsic state (outer account) remains in the header.
+    expected_state = create_state_gas
+
+    # Gas budget: enough for initcode + beneficiary state charge
+    # so the SELFDESTRUCT reaches completion.
+    initcode_gas = initcode.gas_cost(fork)
+    gas_limit = (
+        intrinsic_total + initcode_gas + gas_costs.GAS_NEW_ACCOUNT + 1000
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode,
+        value=1,
+        gas_limit=gas_limit,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_state),
+            ),
+        ],
+        post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "outer_outcome",
+    [
+        pytest.param("succeeds", id="outer_succeeds"),
+        pytest.param("reverts", id="outer_reverts"),
+        pytest.param("halts", id="outer_halts"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_inner_create_succeeds_code_deposit_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    outer_outcome: str,
+) -> None:
+    """
+    Verify state gas for creation tx with a successful inner CREATE.
+
+    A creation tx (to=None) whose initcode runs an inner
+    CREATE/CREATE2 that succeeds and deploys 1 byte of code. The
+    outer initcode then terminates via RETURN, REVERT, or INVALID.
+
+    Post-PR #2704/#2689:
+    * outer_succeeds: the inner's `GAS_NEW_ACCOUNT` plus 1-byte
+      code deposit accumulate into the outer's `state_gas_used`
+      (via `incorporate_child_on_success`). No refund applies.
+      Block state = outer intrinsic + inner account + inner code
+      deposit.
+    * outer_reverts / outer_halts: top-level failure refund zeroes
+      `state_gas_used` (PR #2689). Only the outer's intrinsic
+      state gas remains. Block state = outer intrinsic only.
+
+    A client that fails to accumulate inner state gas on success,
+    or fails to refund on top-level failure, will produce the wrong
+    header.
+    """
+    gas_costs = fork.gas_costs()
+    outer_state_gas = fork.create_state_gas(code_size=0)
+    inner_code_deposit = fork.code_deposit_state_gas(code_size=1)
+    inner_state_gas = gas_costs.GAS_NEW_ACCOUNT + inner_code_deposit
+
+    # Inner initcode: MSTORE one byte of 0x00, RETURN(31, 1).
+    deploy_code = Op.STOP
+    inner_initcode = Op.MSTORE(
+        0,
+        int.from_bytes(bytes(deploy_code), "big") << 248,
+    ) + Op.RETURN(31, 1)
+    inner_bytes = bytes(inner_initcode)
+
+    setup = Op.MSTORE(
+        0,
+        int.from_bytes(inner_bytes, "big") << (256 - 8 * len(inner_bytes)),
+    )
+    if create_opcode == Op.CREATE2:
+        inner_create = Op.POP(Op.CREATE2(0, 0, len(inner_bytes), 0))
+    else:
+        inner_create = Op.POP(Op.CREATE(0, 0, len(inner_bytes)))
+
+    if outer_outcome == "succeeds":
+        termination = Op.RETURN(0, 0)
+    elif outer_outcome == "reverts":
+        termination = Op.REVERT(0, 0)
+    else:
+        termination = Op.INVALID
+
+    initcode = setup + inner_create + termination
+
+    sender = pre.fund_eoa()
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_total = intrinsic_calc(
+        calldata=bytes(initcode), contract_creation=True
+    )
+
+    # Static cost excludes inner code-deposit, so add it to give
+    # the initcode enough to reach RETURN in the child frame.
+    initcode_gas = initcode.gas_cost(fork)
+    gas_limit = intrinsic_total + initcode_gas + inner_code_deposit + 1000
+
+    if outer_outcome == "succeeds":
+        expected_state = outer_state_gas + inner_state_gas
+    else:
+        # Top-level failure refund (PR #2689) zeroes execution
+        # state gas, so only the outer intrinsic charge remains.
+        expected_state = outer_state_gas
+
+    create_address = compute_create_address(address=sender, nonce=0)
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode,
+        gas_limit=gas_limit,
+    )
+
+    if outer_outcome == "succeeds":
+        post: dict = {create_address: Account(code=b"")}
+    else:
+        post = {create_address: Account.NONEXISTENT}
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_state),
+            ),
+        ],
+        post=post,
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1887,8 +1887,8 @@ def test_nested_create_fail_parent_revert_state_gas(
     create_opcode: Op,
 ) -> None:
     """
-    Verify factory nonce across the compound caller to factory to
-    child-create failure flow when the parent reverts or succeeds.
+    Verify factory nonce is rolled back when the factory reverts after
+    a failed inner CREATE, and preserved when the factory returns.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1533,3 +1533,64 @@ def test_create_code_deposit_oog_refunds_state_gas(
     )
 
     state_test(pre=pre, post={factory: Account(storage=storage)}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "init_code",
+    [
+        pytest.param(Op.REVERT(0, 0), id="revert"),
+        pytest.param(Op.INVALID, id="halt"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_failed_create_tx_state_gas_dominates(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    init_code: Bytecode,
+) -> None:
+    """
+    Verify 2D header gas_used when a failed creation tx's state dominates.
+
+    A creation tx (to=None) with a tight gas limit whose initcode
+    fails via REVERT or INVALID. The intrinsic state gas for the
+    new account is preserved across the top-level failure refund
+    (only execution state gas is zeroed). With a tight regular
+    budget the state dimension dominates and the header must
+    equal `create_state_gas`. A client using 1D sum-based
+    accounting would produce a different header value.
+
+    Complements PR #2689's
+    `test_creation_tx_failure_preserves_intrinsic_state_gas` by
+    exercising the REVERT path and the tight-gas scenario.
+    """
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    create_state_gas = fork.create_state_gas(code_size=0)
+
+    intrinsic_total = intrinsic_calc(
+        calldata=bytes(init_code), contract_creation=True
+    )
+    intrinsic_regular = intrinsic_total - create_state_gas
+    gas_limit = intrinsic_total + 1000
+
+    assert intrinsic_regular + 1000 < create_state_gas, (
+        "tight gas budget must keep block_regular below create_state_gas"
+    )
+
+    tx = Transaction(
+        to=None,
+        data=init_code,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=create_state_gas),
+            ),
+        ],
+        post={},
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1550,19 +1550,8 @@ def test_failed_create_tx_state_gas_dominates(
     init_code: Bytecode,
 ) -> None:
     """
-    Verify 2D header gas_used when a failed creation tx's state dominates.
-
-    A creation tx (to=None) with a tight gas limit whose initcode
-    fails via REVERT or INVALID. The intrinsic state gas for the
-    new account is preserved across the top-level failure refund
-    (only execution state gas is zeroed). With a tight regular
-    budget the state dimension dominates and the header must
-    equal `create_state_gas`. A client using 1D sum-based
-    accounting would produce a different header value.
-
-    Complements PR #2689's
-    `test_creation_tx_failure_preserves_intrinsic_state_gas` by
-    exercising the REVERT path and the tight-gas scenario.
+    Verify the header gas is set by intrinsic state gas when a
+    creation tx fails with a tight regular budget.
     """
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     create_state_gas = fork.create_state_gas(code_size=0)
@@ -1611,17 +1600,8 @@ def test_oversized_initcode_tx_no_state_gas(
     initcode_size_delta: int,
 ) -> None:
     """
-    Verify CREATE tx with oversized initcode charges no state gas.
-
-    EIP-8037 moves the initcode size validation to run before
-    account-creation state gas is charged (see PR #2608). A CREATE
-    tx whose initcode exceeds MAX_INITCODE_SIZE must be rejected
-    with no state gas consumed; otherwise block_state_gas_used
-    would include a spurious GAS_NEW_ACCOUNT charge for an account
-    that is never created.
-
-    The at_max variant succeeds and charges state gas normally.
-    The over_max variant is rejected with no state gas.
+    Verify a creation tx with oversized initcode is rejected before
+    any state gas is charged.
     """
     max_size = fork.max_initcode_size()
     size = max_size + initcode_size_delta
@@ -1680,16 +1660,8 @@ def test_oversized_initcode_opcode_no_state_gas(
     initcode_size_delta: int,
 ) -> None:
     """
-    Verify CREATE/CREATE2 with oversized initcode charges no state gas.
-
-    A factory calls CREATE/CREATE2 with initcode exceeding
-    MAX_INITCODE_SIZE. The opcode must fail the size check before
-    charging account-creation state gas (PR #2608 ordering). If
-    state gas were charged first, block_state_gas_used would be
-    inflated by GAS_NEW_ACCOUNT for an account never created.
-
-    The at_max variant succeeds. The over_max variant returns 0
-    from CREATE and charges no state gas.
+    Verify CREATE/CREATE2 with oversized initcode fails the size
+    check before any state gas is charged.
     """
     max_size = fork.max_initcode_size()
     size = max_size + initcode_size_delta
@@ -1755,24 +1727,8 @@ def test_selfdestruct_in_create_tx_initcode(
     fork: Fork,
 ) -> None:
     """
-    Verify state gas for a creation tx whose initcode SELFDESTRUCTs.
-
-    A creation tx (to=None) with value=1 whose initcode immediately
-    SELFDESTRUCTs to a new beneficiary. Under EIP-6780 the outer
-    contract is marked for deletion (created in the same tx). The
-    SELFDESTRUCT charges `GAS_NEW_ACCOUNT` for the beneficiary.
-
-    Post-PR #2707: the outer account is in `created_accounts` AND
-    `accounts_to_delete`, so its `GAS_NEW_ACCOUNT` is refunded
-    end-of-tx. The beneficiary charge (new, live) is NOT refunded
-    because the beneficiary itself is not in `created_accounts`.
-    After the refund, `state_gas_used = 0` (refund == beneficiary
-    charge amount). Intrinsic state gas for the outer account is
-    preserved (tracked separately from execution state gas).
-
-    Expected block state gas = intrinsic_state = `GAS_NEW_ACCOUNT`.
-    A client that skips the end-of-tx refund for the creation-tx
-    path would report `2 * GAS_NEW_ACCOUNT`.
+    Verify state gas accounting when a creation tx's initcode
+    immediately SELFDESTRUCTs to a new beneficiary.
     """
     gas_costs = fork.gas_costs()
     create_state_gas = fork.create_state_gas(code_size=0)
@@ -1786,12 +1742,8 @@ def test_selfdestruct_in_create_tx_initcode(
         calldata=bytes(initcode), contract_creation=True
     )
 
-    # Refund zeroes state_gas_used from the beneficiary charge;
-    # only intrinsic state (outer account) remains in the header.
     expected_state = create_state_gas
 
-    # Gas budget: enough for initcode + beneficiary state charge
-    # so the SELFDESTRUCT reaches completion.
     initcode_gas = initcode.gas_cost(fork)
     gas_limit = (
         intrinsic_total + initcode_gas + gas_costs.GAS_NEW_ACCOUNT + 1000
@@ -1835,32 +1787,14 @@ def test_inner_create_succeeds_code_deposit_state_gas(
     outer_outcome: str,
 ) -> None:
     """
-    Verify state gas for creation tx with a successful inner CREATE.
-
-    A creation tx (to=None) whose initcode runs an inner
-    CREATE/CREATE2 that succeeds and deploys 1 byte of code. The
-    outer initcode then terminates via RETURN, REVERT, or INVALID.
-
-    Post-PR #2704/#2689:
-    * outer_succeeds: the inner's `GAS_NEW_ACCOUNT` plus 1-byte
-      code deposit accumulate into the outer's `state_gas_used`
-      (via `incorporate_child_on_success`). No refund applies.
-      Block state = outer intrinsic + inner account + inner code
-      deposit.
-    * outer_reverts / outer_halts: top-level failure refund zeroes
-      `state_gas_used` (PR #2689). Only the outer's intrinsic
-      state gas remains. Block state = outer intrinsic only.
-
-    A client that fails to accumulate inner state gas on success,
-    or fails to refund on top-level failure, will produce the wrong
-    header.
+    Verify state gas accumulation and top-level failure refund in a
+    creation tx whose initcode runs a successful inner CREATE.
     """
     gas_costs = fork.gas_costs()
     outer_state_gas = fork.create_state_gas(code_size=0)
     inner_code_deposit = fork.code_deposit_state_gas(code_size=1)
     inner_state_gas = gas_costs.GAS_NEW_ACCOUNT + inner_code_deposit
 
-    # Inner initcode: MSTORE one byte of 0x00, RETURN(31, 1).
     deploy_code = Op.STOP
     inner_initcode = Op.MSTORE(
         0,
@@ -1900,8 +1834,6 @@ def test_inner_create_succeeds_code_deposit_state_gas(
     if outer_outcome == "succeeds":
         expected_state = outer_state_gas + inner_state_gas
     else:
-        # Top-level failure refund (PR #2689) zeroes execution
-        # state gas, so only the outer intrinsic charge remains.
         expected_state = outer_state_gas
 
     create_address = compute_create_address(address=sender, nonce=0)
@@ -1955,24 +1887,8 @@ def test_nested_create_fail_parent_revert_state_gas(
     create_opcode: Op,
 ) -> None:
     """
-    Verify 2-layer refund composition: child CREATE fail + parent revert.
-
-    A caller CALLs a factory that performs CREATE/CREATE2 whose
-    initcode fails via REVERT or INVALID. Under PR #2704 the
-    factory's `GAS_NEW_ACCOUNT` for the inner CREATE is refunded
-    end-of-frame via `incorporate_child_on_error` in the caller.
-    The factory then either REVERTs (caller sees factory as an
-    error frame too) or STOPs (caller sees factory as success).
-
-    Verifies the nonce-mutation side effect:
-    * `parent_succeeds`: factory's CREATE attempted, nonce
-      incremented to 2 (CREATE always bumps nonce on its frame).
-    * `parent_reverts`: factory's state is rolled back, so nonce
-      stays at 1.
-
-    Distinct from single-layer tests added by PR #2704 which verify
-    the refund within a single failing frame; this test covers the
-    compound caller → factory → child failure flow.
+    Verify factory nonce across the compound caller to factory to
+    child-create failure flow when the parent reverts or succeeds.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -2002,8 +1918,8 @@ def test_nested_create_fail_parent_revert_state_gas(
         ),
     )
 
-    # Nested CALL required: `incorporate_child_on_error` only
-    # restores state gas when there is a parent frame to receive it.
+    # Nested CALL required so the child-error path has a parent
+    # frame to receive the restored state gas.
     caller = pre.deploy_contract(
         code=Op.POP(Op.CALL(gas=500_000, address=factory)),
     )
@@ -2015,10 +1931,8 @@ def test_nested_create_fail_parent_revert_state_gas(
     )
 
     if parent_reverts:
-        # Factory reverted: state rolled back, nonce unchanged.
         post = {factory: Account(nonce=1)}
     else:
-        # Factory succeeded: CREATE bumped the factory nonce to 2.
         post = {factory: Account(nonce=2)}
 
     blockchain_test(
@@ -2035,25 +1949,8 @@ def test_create_stack_depth_state_gas_consumed(
     fork: Fork,
 ) -> None:
     """
-    Deep-recursion robustness for state gas reservoir handling.
-
-    A contract CALLs itself recursively until gas is exhausted
-    (the EIP-150 63/64 rule caps effective recursion depth far
-    below `STACK_DEPTH_LIMIT`; reaching depth 1024 with
-    `gas_limit_cap = 16.7M` is physically infeasible since the
-    cumulative survival factor is `(63/64)**1024` ≈ 1e-7). As the
-    recursion unwinds, each frame attempts an SSTORE. The
-    outermost frame's SSTORE must succeed, proving the reservoir
-    threads through nested CALLs and survives the deepest child's
-    silent failure (CALL returns 0 when depth+1 > STACK_DEPTH_LIMIT
-    or when gas runs out, preserving `state_gas_reservoir`).
-
-    Despite the name (retained for continuity with the closed
-    PR #2639), this does NOT exercise `generic_create`'s
-    depth-1024 silent-failure branch directly, because that branch
-    is unreachable at the current gas limit. It instead exercises
-    CALL's depth/gas silent-failure branch and the reservoir
-    preservation that threads through many levels.
+    Verify the state gas reservoir survives a deep recursion of
+    nested CALLs that silently fail on gas or depth exhaustion.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -2062,16 +1959,7 @@ def test_create_stack_depth_state_gas_consumed(
     storage = Storage()
     recursive = pre.deploy_contract(
         code=(
-            # Recursive CALL until gas / depth is exhausted. The
-            # child's CALL silently fails either at depth+1 > 1024
-            # or when forwarded gas can't afford the next frame's
-            # overhead; in either case the reservoir is returned
-            # to the caller intact.
             Op.POP(Op.CALL(Op.GAS, Op.ADDRESS, 0, 0, 0, 0, 0))
-            # Probe: the outermost (and any frame with enough
-            # remaining gas) sets slot 0. Storage check ensures
-            # the probe succeeded, i.e. the reservoir remained
-            # available after the nested CALLs unwound.
             + Op.SSTORE(storage.store_next(1, "reservoir_ok"), 1)
         ),
     )
@@ -2111,35 +1999,8 @@ def test_inner_create_fail_refunds_in_creation_tx(
     num_inner_ops: int,
 ) -> None:
     """
-    Cross-over: PR #2704 CREATE failure refund in a creation-tx context.
-
-    The original closed PR #2639 test asserted inner CREATE's
-    `GAS_NEW_ACCOUNT` PERSISTS on child failure (targeting a
-    bal-devnet-3 geth behavior where geth incorrectly refunded).
-    PR #2704 later changed the spec to refund the charge, which
-    codifies what geth was already doing and inverts the original
-    test's premise. This test covers the CURRENT spec behavior in
-    a scenario not exercised by PR #2704's own tests (which all
-    use non-creation factories):
-
-    A creation tx (to=None) whose initcode performs `num_inner_ops`
-    inner CREATE/CREATE2 calls with REVERT initcode. Each inner
-    CREATE charges `GAS_NEW_ACCOUNT` state then refunds it via the
-    child-error branch (PR #2704). The outer initcode then
-    terminates via RETURN (succeeds) or REVERT.
-
-    Both outcomes yield `block_state = outer intrinsic` because inner
-    refunds net the state gas back to zero; PR #2689's top-level
-    refund (applied on revert) is a no-op over an already-zeroed
-    `state_gas_used`. A client regressing to the pre-#2704 "persist"
-    behavior would inflate `block_state` by
-    `num_inner_ops * GAS_NEW_ACCOUNT` and fail both variants.
-
-    The `outer_halts` variant is omitted: INVALID absorbs remaining
-    gas into `regular_gas_used`, making `block_regular` dominate the
-    header and dilute the state-dimension signal. PR #2689's
-    `test_creation_tx_failure_preserves_intrinsic_state_gas` already
-    covers the creation-tx + top-level halt interaction.
+    Verify failed inner CREATEs inside a creation tx refund state
+    gas so only the outer intrinsic state gas remains.
     """
     gas_costs = fork.gas_costs()
     outer_state_gas = fork.create_state_gas(code_size=0)
@@ -2172,9 +2033,6 @@ def test_inner_create_fail_refunds_in_creation_tx(
         calldata=bytes(initcode), contract_creation=True
     )
 
-    # Gas budget: enough for each inner CREATE to charge
-    # GAS_NEW_ACCOUNT (spill into gas_left, then get refunded on
-    # child failure) and for the outer termination to run.
     initcode_gas = initcode.gas_cost(fork)
     per_inner_slack = 2_000
     gas_limit = (
@@ -2183,9 +2041,6 @@ def test_inner_create_fail_refunds_in_creation_tx(
         + num_inner_ops * (gas_costs.GAS_NEW_ACCOUNT + per_inner_slack)
     )
 
-    # Expected: only outer intrinsic remains in block_state. Each
-    # inner CREATE's charge is refunded by PR #2704; any residue
-    # left in state_gas_used is zeroed on outer failure by PR #2689.
     expected_state = outer_state_gas
 
     create_address = compute_create_address(address=sender, nonce=0)
@@ -2224,22 +2079,8 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     create_opcode: Op,
 ) -> None:
     """
-    Regression: on CREATE/CREATE2 address collision the forwarded
-    `create_message_gas` is burned and must count toward
-    `block_regular_gas_used`, not vanish from the block formula.
-
-    Surfaced by evmone mutation testing (PR #2639 review comment):
-    skipping the `evm.regular_gas_used += create_message_gas`
-    accounting on the collision branch passes the existing suite
-    because the only collision test uses `state_test` (no
-    block-level header check) and state-gas accounting is unchanged.
-
-    Block-level `Header(gas_used)` discriminator. `block_state_gas`
-    is zero (non-creation tx, collision refunds the state charge),
-    so `header.gas_used == block_regular`. The burned
-    `create_message_gas` dominates the regular dimension and its
-    removal under the mutation reduces `header.gas_used` by that
-    exact amount.
+    Verify gas burned by a CREATE/CREATE2 address collision counts
+    toward block regular gas used in the header.
     """
     init_code = Op.STOP
     mstore_value, size = init_code_at_high_bytes(init_code)
@@ -2262,9 +2103,8 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     )
     pre.deploy_contract(code=Op.STOP, address=collision_target)
 
-    # Fixed-size budget so `gas_left` at the CREATE/CREATE2 opcode
-    # (and hence `create_message_gas`) is deterministic and the
-    # `Header(gas_used)` baseline below is reproducible.
+    # Fixed-size budget so the forwarded create_message_gas is
+    # deterministic and the empirical baseline below is reproducible.
     gas_limit = 250_000
 
     tx = Transaction(
@@ -2273,13 +2113,11 @@ def test_create_collision_burned_gas_counted_in_block_regular(
         sender=pre.fund_eoa(),
     )
 
-    # Empirical baseline. `block_state_gas` is zero for this tx, so
-    # the header just reports `intrinsic.regular + factory_regular +
-    # create_message_gas + POP + STOP`. Removing the collision's
-    # `regular_gas_used += create_message_gas` accounting subtracts
-    # `create_message_gas` from this baseline, so the test catches
-    # the mutation on both CREATE and CREATE2 paths.
-    baseline_gas_used = 0x01C98C  # 117,132 empirical header.gas_used
+    # Empirical baseline: block_state_gas is zero for this tx, so
+    # header.gas_used equals the regular-gas total. A mutation that
+    # drops the burned create_message_gas from regular accounting
+    # would reduce this value.
+    baseline_gas_used = 0x01C98C
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1928,3 +1928,287 @@ def test_inner_create_succeeds_code_deposit_state_gas(
         ],
         post=post,
     )
+
+
+@pytest.mark.parametrize(
+    "parent_reverts",
+    [
+        pytest.param(True, id="parent_reverts"),
+        pytest.param(False, id="parent_succeeds"),
+    ],
+)
+@pytest.mark.parametrize(
+    "child_failure",
+    [
+        pytest.param("revert", id="child_revert"),
+        pytest.param("halt", id="child_halt"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_nested_create_fail_parent_revert_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    parent_reverts: bool,
+    child_failure: str,
+    create_opcode: Op,
+) -> None:
+    """
+    Verify 2-layer refund composition: child CREATE fail + parent revert.
+
+    A caller CALLs a factory that performs CREATE/CREATE2 whose
+    initcode fails via REVERT or INVALID. Under PR #2704 the
+    factory's `GAS_NEW_ACCOUNT` for the inner CREATE is refunded
+    end-of-frame via `incorporate_child_on_error` in the caller.
+    The factory then either REVERTs (caller sees factory as an
+    error frame too) or STOPs (caller sees factory as success).
+
+    Verifies the nonce-mutation side effect:
+    * `parent_succeeds`: factory's CREATE attempted, nonce
+      incremented to 2 (CREATE always bumps nonce on its frame).
+    * `parent_reverts`: factory's state is rolled back, so nonce
+      stays at 1.
+
+    Distinct from single-layer tests added by PR #2704 which verify
+    the refund within a single failing frame; this test covers the
+    compound caller → factory → child failure flow.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
+    create_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    if child_failure == "revert":
+        init_code = Op.REVERT(0, 0)
+    else:
+        init_code = Op.INVALID
+
+    create_call = (
+        create_opcode(value=0, offset=0, size=len(init_code), salt=0)
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=0, size=len(init_code))
+    )
+
+    factory = pre.deploy_contract(
+        code=(
+            Op.MSTORE(
+                0,
+                int.from_bytes(bytes(init_code), "big")
+                << (256 - 8 * len(init_code)),
+            )
+            + Op.POP(create_call)
+            + (Op.REVERT(0, 0) if parent_reverts else Op.STOP)
+        ),
+    )
+
+    # Nested CALL required: `incorporate_child_on_error` only
+    # restores state gas when there is a parent frame to receive it.
+    caller = pre.deploy_contract(
+        code=Op.POP(Op.CALL(gas=500_000, address=factory)),
+    )
+
+    tx = Transaction(
+        to=caller,
+        gas_limit=gas_limit_cap + create_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    if parent_reverts:
+        # Factory reverted: state rolled back, nonce unchanged.
+        post = {factory: Account(nonce=1)}
+    else:
+        # Factory succeeded: CREATE bumped the factory nonce to 2.
+        post = {factory: Account(nonce=2)}
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post=post,
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_create_stack_depth_state_gas_consumed(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Deep-recursion robustness for state gas reservoir handling.
+
+    A contract CALLs itself recursively until gas is exhausted
+    (the EIP-150 63/64 rule caps effective recursion depth far
+    below `STACK_DEPTH_LIMIT`; reaching depth 1024 with
+    `gas_limit_cap = 16.7M` is physically infeasible since the
+    cumulative survival factor is `(63/64)**1024` ≈ 1e-7). As the
+    recursion unwinds, each frame attempts an SSTORE. The
+    outermost frame's SSTORE must succeed, proving the reservoir
+    threads through nested CALLs and survives the deepest child's
+    silent failure (CALL returns 0 when depth+1 > STACK_DEPTH_LIMIT
+    or when gas runs out, preserving `state_gas_reservoir`).
+
+    Despite the name (retained for continuity with the closed
+    PR #2639), this does NOT exercise `generic_create`'s
+    depth-1024 silent-failure branch directly, because that branch
+    is unreachable at the current gas limit. It instead exercises
+    CALL's depth/gas silent-failure branch and the reservoir
+    preservation that threads through many levels.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    storage = Storage()
+    recursive = pre.deploy_contract(
+        code=(
+            # Recursive CALL until gas / depth is exhausted. The
+            # child's CALL silently fails either at depth+1 > 1024
+            # or when forwarded gas can't afford the next frame's
+            # overhead; in either case the reservoir is returned
+            # to the caller intact.
+            Op.POP(Op.CALL(Op.GAS, Op.ADDRESS, 0, 0, 0, 0, 0))
+            # Probe: the outermost (and any frame with enough
+            # remaining gas) sets slot 0. Storage check ensures
+            # the probe succeeded, i.e. the reservoir remained
+            # available after the nested CALLs unwound.
+            + Op.SSTORE(storage.store_next(1, "reservoir_ok"), 1)
+        ),
+    )
+
+    tx = Transaction(
+        to=recursive,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {recursive: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "num_inner_ops",
+    [
+        pytest.param(1, id="single"),
+        pytest.param(3, id="accumulate"),
+    ],
+)
+@pytest.mark.parametrize(
+    "outer_outcome",
+    [
+        pytest.param("succeeds", id="outer_succeeds"),
+        pytest.param("reverts", id="outer_reverts"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_inner_create_fail_refunds_in_creation_tx(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    outer_outcome: str,
+    num_inner_ops: int,
+) -> None:
+    """
+    Cross-over: PR #2704 CREATE failure refund in a creation-tx context.
+
+    The original closed PR #2639 test asserted inner CREATE's
+    `GAS_NEW_ACCOUNT` PERSISTS on child failure (targeting a
+    bal-devnet-3 geth behavior where geth incorrectly refunded).
+    PR #2704 later changed the spec to refund the charge, which
+    codifies what geth was already doing and inverts the original
+    test's premise. This test covers the CURRENT spec behavior in
+    a scenario not exercised by PR #2704's own tests (which all
+    use non-creation factories):
+
+    A creation tx (to=None) whose initcode performs `num_inner_ops`
+    inner CREATE/CREATE2 calls with REVERT initcode. Each inner
+    CREATE charges `GAS_NEW_ACCOUNT` state then refunds it via the
+    child-error branch (PR #2704). The outer initcode then
+    terminates via RETURN (succeeds) or REVERT.
+
+    Both outcomes yield `block_state = outer intrinsic` because inner
+    refunds net the state gas back to zero; PR #2689's top-level
+    refund (applied on revert) is a no-op over an already-zeroed
+    `state_gas_used`. A client regressing to the pre-#2704 "persist"
+    behavior would inflate `block_state` by
+    `num_inner_ops * GAS_NEW_ACCOUNT` and fail both variants.
+
+    The `outer_halts` variant is omitted: INVALID absorbs remaining
+    gas into `regular_gas_used`, making `block_regular` dominate the
+    header and dilute the state-dimension signal. PR #2689's
+    `test_creation_tx_failure_preserves_intrinsic_state_gas` already
+    covers the creation-tx + top-level halt interaction.
+    """
+    gas_costs = fork.gas_costs()
+    outer_state_gas = fork.create_state_gas(code_size=0)
+
+    inner_initcode = bytes(Op.REVERT(0, 0))
+
+    setup = Op.MSTORE(
+        0,
+        int.from_bytes(inner_initcode, "big")
+        << (256 - 8 * len(inner_initcode)),
+    )
+
+    inner_ops = Bytecode()
+    for i in range(num_inner_ops):
+        if create_opcode == Op.CREATE2:
+            inner_ops += Op.POP(Op.CREATE2(0, 0, len(inner_initcode), i))
+        else:
+            inner_ops += Op.POP(Op.CREATE(0, 0, len(inner_initcode)))
+
+    if outer_outcome == "succeeds":
+        termination = Op.RETURN(0, 0)
+    else:
+        termination = Op.REVERT(0, 0)
+
+    initcode = setup + inner_ops + termination
+
+    sender = pre.fund_eoa()
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_total = intrinsic_calc(
+        calldata=bytes(initcode), contract_creation=True
+    )
+
+    # Gas budget: enough for each inner CREATE to charge
+    # GAS_NEW_ACCOUNT (spill into gas_left, then get refunded on
+    # child failure) and for the outer termination to run.
+    initcode_gas = initcode.gas_cost(fork)
+    per_inner_slack = 2_000
+    gas_limit = (
+        intrinsic_total
+        + initcode_gas
+        + num_inner_ops * (gas_costs.GAS_NEW_ACCOUNT + per_inner_slack)
+    )
+
+    # Expected: only outer intrinsic remains in block_state. Each
+    # inner CREATE's charge is refunded by PR #2704; any residue
+    # left in state_gas_used is zeroed on outer failure by PR #2689.
+    expected_state = outer_state_gas
+
+    create_address = compute_create_address(address=sender, nonce=0)
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode,
+        gas_limit=gas_limit,
+    )
+
+    if outer_outcome == "succeeds":
+        post: dict = {create_address: Account(code=b"")}
+    else:
+        post = {create_address: Account.NONEXISTENT}
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_state),
+            ),
+        ],
+        post=post,
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1930,10 +1930,24 @@ def test_nested_create_fail_parent_revert_state_gas(
         sender=pre.fund_eoa(),
     )
 
+    inner_address = compute_create_address(
+        address=factory,
+        nonce=1,
+        salt=0,
+        initcode=bytes(init_code),
+        opcode=create_opcode,
+    )
+
     if parent_reverts:
-        post = {factory: Account(nonce=1)}
+        post = {
+            factory: Account(nonce=1),
+            inner_address: Account.NONEXISTENT,
+        }
     else:
-        post = {factory: Account(nonce=2)}
+        post = {
+            factory: Account(nonce=2),
+            inner_address: Account.NONEXISTENT,
+        }
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -1045,15 +1045,7 @@ def test_access_list_gas_is_regular_not_state(
     num_access_list_entries: int,
     slots_per_entry: int,
 ) -> None:
-    """
-    Verify EIP-2930 access list gas is classified as regular intrinsic.
-
-    A tx with an access list and no state operations must have
-    `block_state_gas_used == 0`, so the header `gas_used` equals
-    the regular intrinsic total. A client that incorrectly classified
-    access list gas into the state dimension would produce a
-    different `max(regular, state)` in the header.
-    """
+    """Verify EIP-2930 access list gas counts as regular, not state."""
     contract = pre.deploy_contract(code=Op.STOP)
 
     access_list = []
@@ -1074,9 +1066,6 @@ def test_access_list_gas_is_regular_not_state(
         access_list=access_list,
     )
 
-    # No state ops, so block_state_gas = 0. header gas_used = regular.
-    # A client routing access list gas to the state dimension would
-    # produce a different header gas_used.
     blockchain_test(
         pre=pre,
         blocks=[
@@ -1095,15 +1084,7 @@ def test_access_list_warm_savings_stay_regular(
     pre: Alloc,
     fork: Fork,
 ) -> None:
-    """
-    Verify warm-access savings from an access list stay in regular gas.
-
-    A tx pre-warms a storage slot via its access list. The contract
-    then SLOADs (warm) and SSTOREs (warm, nonzero-to-nonzero) that
-    slot. All execution costs are regular gas; state gas is zero.
-    A client that credited the cold-to-warm difference to the state
-    dimension would produce a different `header.gas_used`.
-    """
+    """Verify access-list warm savings stay in regular gas."""
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     sstore_state_gas = fork.sstore_state_gas()
@@ -1118,8 +1099,6 @@ def test_access_list_warm_savings_stay_regular(
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     intrinsic_gas = intrinsic_calc(access_list=access_list)
 
-    # Warm SLOAD + warm nonzero-to-nonzero SSTORE = all regular.
-    # No state gas (not zero-to-nonzero).
     contract_code = Op.SSTORE.with_metadata(
         key_warm=True,
         original_value=1,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -15,6 +15,7 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Alloc,
     Block,
@@ -1020,3 +1021,130 @@ def test_top_level_failure_refunds_state_gas_propagated_from_child(
     )
 
     state_test(pre=pre, post={child: Account(storage={})}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "num_access_list_entries",
+    [
+        pytest.param(1, id="one_entry"),
+        pytest.param(10, id="ten_entries"),
+    ],
+)
+@pytest.mark.parametrize(
+    "slots_per_entry",
+    [
+        pytest.param(0, id="addresses_only"),
+        pytest.param(3, id="with_storage_keys"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_access_list_gas_is_regular_not_state(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_access_list_entries: int,
+    slots_per_entry: int,
+) -> None:
+    """
+    Verify EIP-2930 access list gas is classified as regular intrinsic.
+
+    A tx with an access list and no state operations must have
+    `block_state_gas_used == 0`, so the header `gas_used` equals
+    the regular intrinsic total. A client that incorrectly classified
+    access list gas into the state dimension would produce a
+    different `max(regular, state)` in the header.
+    """
+    contract = pre.deploy_contract(code=Op.STOP)
+
+    access_list = []
+    for _ in range(num_access_list_entries):
+        target = pre.fund_eoa(amount=0)
+        storage_keys = list(range(slots_per_entry))
+        access_list.append(
+            AccessList(address=target, storage_keys=storage_keys)
+        )
+
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    gas_needed = intrinsic_calc(access_list=access_list)
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_needed,
+        sender=pre.fund_eoa(),
+        access_list=access_list,
+    )
+
+    # No state ops, so block_state_gas = 0. header gas_used = regular.
+    # A client routing access list gas to the state dimension would
+    # produce a different header gas_used.
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=gas_needed),
+            ),
+        ],
+        post={},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_access_list_warm_savings_stay_regular(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify warm-access savings from an access list stay in regular gas.
+
+    A tx pre-warms a storage slot via its access list. The contract
+    then SLOADs (warm) and SSTOREs (warm, nonzero-to-nonzero) that
+    slot. All execution costs are regular gas; state gas is zero.
+    A client that credited the cold-to-warm difference to the state
+    dimension would produce a different `header.gas_used`.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    contract = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.SLOAD(0)),
+        storage={0: 1},
+    )
+
+    access_list = [AccessList(address=contract, storage_keys=[0])]
+
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas = intrinsic_calc(access_list=access_list)
+
+    # Warm SLOAD + warm nonzero-to-nonzero SSTORE = all regular.
+    # No state gas (not zero-to-nonzero).
+    contract_code = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=1,
+        current_value=1,
+        new_value=1,
+    )(0, Op.SLOAD.with_metadata(key_warm=True)(0))
+    evm_gas = contract_code.gas_cost(fork)
+
+    expected_gas_used = intrinsic_gas + evm_gas
+    gas_limit = gas_limit_cap + sstore_state_gas
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        access_list=access_list,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={contract: Account(storage={0: 1})},
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -413,6 +413,97 @@ def test_create_selfdestruct_refunds_code_deposit_state_gas(
 
 
 @pytest.mark.valid_from("EIP8037")
+def test_create_selfdestruct_code_deposit_refund_header_check(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Regression: block_state_gas_used must drop by the deployed
+    code's byte cost on a same-tx CREATE+SELFDESTRUCT refund.
+
+    Surfaced via targeted mutation testing: dropping the
+    `selfdestruct_refund += len(code) * cost_per_state_byte` line
+    in `fork.py` passes the existing suite because
+    `test_create_selfdestruct_refunds_code_deposit_state_gas` only
+    provisions enough gas for the refund to land and asserts the
+    destroyed account is gone — it never checks the refund
+    actually reduced `block_state_gas_used`.
+
+    Header discriminator: deploy a large enough contract that the
+    code-deposit state gas dominates the regular dimension. Under
+    the correct spec the refund zeros `state_gas_used` and the
+    header reports `block_regular`. Under the mutation `state_gas`
+    keeps the code-deposit charge and dominates the header.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    # 256-byte deployed code so code_deposit_state_gas (≈ 300,544)
+    # would dominate `block_regular` if not refunded.
+    selfdestruct = Op.SELFDESTRUCT(Op.ADDRESS)
+    sd_len = len(bytes(selfdestruct))
+    code_size = 256
+    assert code_size >= sd_len
+    deployed = bytes(selfdestruct) + b"\x00" * (code_size - sd_len)
+    initcode = Initcode(deploy_code=deployed)
+    initcode_len = len(initcode)
+    code_deposit_state_gas = fork.code_deposit_state_gas(code_size=code_size)
+
+    factory_code = Op.CALLDATACOPY(
+        0,
+        0,
+        Op.CALLDATASIZE,
+        data_size=initcode_len,
+        new_memory_size=initcode_len,
+    ) + Op.POP(
+        Op.CALL(
+            gas=Op.GAS,
+            address=Op.CREATE(
+                value=0,
+                offset=0,
+                size=Op.CALLDATASIZE,
+                init_code_size=initcode_len,
+            ),
+        )
+    )
+    factory = pre.deploy_contract(code=factory_code)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    total_state_refund = new_account_state_gas + code_deposit_state_gas
+    tx = Transaction(
+        to=factory,
+        data=bytes(initcode),
+        gas_limit=gas_limit_cap + total_state_refund,
+        sender=pre.fund_eoa(),
+    )
+
+    # Empirical baseline: `block_state_gas` refunds to zero, so
+    # `header.gas_used == block_regular`. Dropping the
+    # code-deposit portion of the refund leaves `block_state_gas`
+    # at `code_deposit_state_gas (~300,544)`, which dominates and
+    # pushes `header.gas_used` above this baseline.
+    baseline_block_regular = 0x8EAE  # 36_526 empirical
+    assert baseline_block_regular < code_deposit_state_gas, (
+        "Baseline regular must be below code_deposit_state_gas so "
+        "the mutation's un-refunded state_gas dominates the header."
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=baseline_block_regular),
+            ),
+        ],
+        post={created_address: Account.NONEXISTENT},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
 def test_create_selfdestruct_no_double_refund_with_sstore_restoration(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -634,3 +725,52 @@ def test_selfdestruct_via_delegatecall_chain(
             factory: Account(storage=factory_storage),
         },
     )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_new_beneficiary_no_regular_account_creation_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Regression: SELFDESTRUCT to a non-existent beneficiary with a
+    nonzero contract balance must NOT charge the pre-Amsterdam
+    25,000 regular `SELF_DESTRUCT_NEW_ACCOUNT` cost.
+
+    Surfaced by evmone mutation testing (PR #2639 review comment):
+    keeping the `25_000` regular on top of the `GAS_NEW_ACCOUNT`
+    state gas passes the existing suite because no test budgets
+    SELFDESTRUCT tightly enough to reject the extra regular draw.
+
+    Tight-gas discriminator. `tx.gas_limit` allows for the correct
+    spec plus 20,000 slack (< 25,000). Under the correct spec the
+    SELFDESTRUCT completes and transfers the balance to the new
+    beneficiary. Under the mutation the extra 25,000 regular
+    pushes the SELFDESTRUCT OOG, the state and balance transfer
+    roll back, and the beneficiary's balance stays at 0.
+    """
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    beneficiary = pre.fund_eoa(amount=0)
+
+    victim_code = Op.SELFDESTRUCT(beneficiary)
+    victim = pre.deploy_contract(code=victim_code, balance=1)
+
+    # `victim_code.gas_cost` already accounts for the SELFDESTRUCT
+    # opcode and the cold beneficiary access; no extra regular
+    # charge is needed beyond the intrinsic and the state gas.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    tx = Transaction(
+        to=victim,
+        gas_limit=(
+            intrinsic
+            + victim_code.gas_cost(fork)
+            + new_account_state_gas
+            + 20_000
+        ),
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(pre=pre, post={beneficiary: Account(balance=1)}, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -419,30 +419,16 @@ def test_create_selfdestruct_code_deposit_refund_header_check(
     fork: Fork,
 ) -> None:
     """
-    Regression: block_state_gas_used must drop by the deployed
-    code's byte cost on a same-tx CREATE+SELFDESTRUCT refund.
-
-    Surfaced via targeted mutation testing: dropping the
-    `selfdestruct_refund += len(code) * cost_per_state_byte` line
-    in `fork.py` passes the existing suite because
-    `test_create_selfdestruct_refunds_code_deposit_state_gas` only
-    provisions enough gas for the refund to land and asserts the
-    destroyed account is gone — it never checks the refund
-    actually reduced `block_state_gas_used`.
-
-    Header discriminator: deploy a large enough contract that the
-    code-deposit state gas dominates the regular dimension. Under
-    the correct spec the refund zeros `state_gas_used` and the
-    header reports `block_regular`. Under the mutation `state_gas`
-    keeps the code-deposit charge and dominates the header.
+    Verify block header gas reflects the code-deposit state-gas
+    refund on a same-tx CREATE plus SELFDESTRUCT.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     gas_costs = fork.gas_costs()
     new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
-    # 256-byte deployed code so code_deposit_state_gas (≈ 300,544)
-    # would dominate `block_regular` if not refunded.
+    # Deployed code is sized so the code-deposit state gas would
+    # dominate block regular gas if the refund did not land.
     selfdestruct = Op.SELFDESTRUCT(Op.ADDRESS)
     sd_len = len(bytes(selfdestruct))
     code_size = 256
@@ -480,12 +466,11 @@ def test_create_selfdestruct_code_deposit_refund_header_check(
         sender=pre.fund_eoa(),
     )
 
-    # Empirical baseline: `block_state_gas` refunds to zero, so
-    # `header.gas_used == block_regular`. Dropping the
-    # code-deposit portion of the refund leaves `block_state_gas`
-    # at `code_deposit_state_gas (~300,544)`, which dominates and
-    # pushes `header.gas_used` above this baseline.
-    baseline_block_regular = 0x8EAE  # 36_526 empirical
+    # Empirical baseline: block_state_gas refunds to zero so the
+    # header reports block regular only. Baseline regular must stay
+    # below the code-deposit state gas so a missing refund would
+    # push the header above this value.
+    baseline_block_regular = 0x8EAE
     assert baseline_block_regular < code_deposit_state_gas, (
         "Baseline regular must be below code_deposit_state_gas so "
         "the mutation's un-refunded state_gas dominates the header."
@@ -734,21 +719,8 @@ def test_selfdestruct_new_beneficiary_no_regular_account_creation_cost(
     fork: Fork,
 ) -> None:
     """
-    Regression: SELFDESTRUCT to a non-existent beneficiary with a
-    nonzero contract balance must NOT charge the pre-Amsterdam
-    25,000 regular `SELF_DESTRUCT_NEW_ACCOUNT` cost.
-
-    Surfaced by evmone mutation testing (PR #2639 review comment):
-    keeping the `25_000` regular on top of the `GAS_NEW_ACCOUNT`
-    state gas passes the existing suite because no test budgets
-    SELFDESTRUCT tightly enough to reject the extra regular draw.
-
-    Tight-gas discriminator. `tx.gas_limit` allows for the correct
-    spec plus 20,000 slack (< 25,000). Under the correct spec the
-    SELFDESTRUCT completes and transfers the balance to the new
-    beneficiary. Under the mutation the extra 25,000 regular
-    pushes the SELFDESTRUCT OOG, the state and balance transfer
-    roll back, and the beneficiary's balance stays at 0.
+    Verify SELFDESTRUCT to a new beneficiary does not charge a
+    regular account-creation cost on top of state gas.
     """
     gas_costs = fork.gas_costs()
     new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
@@ -758,9 +730,8 @@ def test_selfdestruct_new_beneficiary_no_regular_account_creation_cost(
     victim_code = Op.SELFDESTRUCT(beneficiary)
     victim = pre.deploy_contract(code=victim_code, balance=1)
 
-    # `victim_code.gas_cost` already accounts for the SELFDESTRUCT
-    # opcode and the cold beneficiary access; no extra regular
-    # charge is needed beyond the intrinsic and the state gas.
+    # Tight budget: slack is less than the old pre-Amsterdam regular
+    # account-creation cost, so any extra regular draw would OOG.
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
     tx = Transaction(
         to=victim,


### PR DESCRIPTION
## 🗒️ Description

Revives the state gas test coverage from the closed [PR #2639](https://github.com/ethereum/execution-specs/pull/2639) and closes gaps surfaced by the evmone mutation testing report on that same PR from @chfast.

Most of the tests originated during bal-devnet-3 client testing, Maria's state gas accounting review, and spec reviews. They live on `feat/eip-8037-tests-devnet3` and `feat/eip-8037-additional-tests` and were bundled into [#2639](https://github.com/ethereum/execution-specs/pull/2639) but never landed. The seven spec PRs that did merge since (#2689, #2698, #2703, #2704, #2707, #2711, plus PR #2646 and PR #2725) invalidated some of the originals (inverted premises, duplicates) and left a coverage gap for the rest, which this PR closes.

### Devnet-3 client bug regressions

Two client bugs were discovered during bal-devnet-3 testing. Regression tests:

- **Besu: reservoir consumed on top level halt after child spill restore** (Besu fix `f4c8b36`, cc @daniellehrner @jochem-brouwer). When a child frame spilled state gas into `gas_left`, then failed, then the parent hit an exception halt at the top level, Besu was incorrectly consuming the restored reservoir instead of refunding it to the sender. `test_top_level_halt_preserves_restored_reservoir` ports the regression with `child_termination * reservoir_delta` parametrization.
- **Geth: nested CREATE refund applied too eagerly** (cc @MariusVanDerWijden). The closed PR's original `test_inner_create_state_gas_persists_on_failure` asserted the parents `GAS_NEW_ACCOUNT` charge for an inner CREATE must NOT be refunded on child failure. PR #2704 subsequently changed the spec to do exactly what geth was doing (refund on failure), inverting the original test's premise. PR #2704's own refund tests cover the non-creation-factory case, `test_inner_create_fail_refunds_in_creation_tx` fills the creation tx gap.

### Access list gas classification

- `test_access_list_gas_is_regular_not_state` (EIP-2930 access list intrinsic must stay on the regular dimension, parametrized over list size and keys per entry), and `test_access_list_warm_savings_stay_regular` (warm-access savings must stay on regular, catches clients crediting the cold to warm delta to state gas). cc @MariusVanDerWijden

### Block 2D gas accounting edge cases

- `test_tx_rejected_when_regular_gas_exceeds_block_limit_small` (tight boundary case complementing PR #2703 tests, cc @kclowes), `test_block_2d_gas_tx_gas_limit_exceeds_regular_remaining` (the inclusion check uses `min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state)` not the raw `tx.gas_limit`, cc @jwasinger), `test_receipt_cumulative_differs_from_header_gas_used` (2D `header.gas_used` can diverge from 1D receipt `cumulative_gas_used` when state dominates), `test_failed_create_tx_state_gas_dominates` (creation tx with tight gas and REVERT/halt initcode where state dominates the header).

### Initcode size validation ordering

Ports the initcode size before state gas ordering regression. cc @chfast

- `test_oversized_initcode_tx_no_state_gas` (creation tx path)
- `test_oversized_initcode_opcode_no_state_gas` (CREATE/CREATE2 opcode path)

### Reservoir preservation and CALLCODE edge cases

- `test_top_level_halt_preserves_restored_reservoir` (the Besu bug regression above), `test_callcode_value_no_new_account_state_gas` (CALLCODE transfers value to self, never creates a new account), `test_create_oog_during_state_gas_charge` (inner CREATE OOGs on the state gas charge itself; parent reservoir is restored and subsequent SSTORE still succeeds).

### Creation-tx compositions

- `test_selfdestruct_in_create_tx_initcode` (creation-tx initcode SELFDESTRUCTs to a new beneficiary; the same-tx refund cancels its `GAS_NEW_ACCOUNT` charge), `test_inner_create_succeeds_code_deposit_state_gas` (creation tx with an inner CREATE that succeeds and deploys code; parametrized over `outer_outcome × create_opcode`).

### Nested CREATE fail and deep-recursion

- `test_nested_create_fail_parent_revert_state_gas` (two-layer refund: caller to factory to inner CREATE failure to factory REVERTs or STOPs, parametrized over `child_failure * parent_reverts * create_opcode`), `test_create_stack_depth_state_gas_consumed` (deep-recursion robustness; CALLs self until gas exhausts, EIP-150 63/64 caps effective depth well below the stack limit; outermost SSTORE probe verifies the reservoir threaded through), `test_inner_create_fail_refunds_in_creation_tx` (geth bug regression, rewritten for the post PR #2704 spec change).

### Mutation testing regression tests

Four from @chfast's evmone mutation testing report on the closed PR, plus one from a local mutation scan against the current spec:

- `test_call_new_account_no_regular_account_creation_cost` (pre-Amsterdam `25_000` regular `ACCOUNT_CREATION_COST` removal for CALL-to-new-account)
- `test_selfdestruct_new_beneficiary_no_regular_account_creation_cost` (same 25k regular charge removal, SELFDESTRUCT variant)
- `test_child_failure_refunds_state_gas_to_reservoir_not_gas_left` (`incorporate_child_on_error` restores to `state_gas_left`, not `gas_left`)
- `test_create_collision_burned_gas_counted_in_block_regular` (collision-burned `create_message_gas` must count toward `block_regular_gas_used`)
- `test_create_selfdestruct_code_deposit_refund_header_check` (same-tx CREATE+SELFDESTRUCT refund includes the code-length term; the existing test only asserts the account is gone, not that the refund landed at the block level)

Each was validated by injecting the target mutation into the spec and confirming the test fails under the bug.

## Closed PR tests not ported and why

Six tests from the closed PRs original set are intentionally dropped:

| Test | Why dropped |
|---|---|
| `test_failed_create_opcode_state_gas_dominates` | Duplicated by PR #2704's `test_create_child_{revert,halt}_refunds_state_gas` + `test_create_code_deposit_oog_refunds_state_gas`. Premise also inverted by PR #2704's refund. |
| `test_inner_create_state_gas_persists_on_failure` | Premise inverted by PR #2704 (see Geth bug section above). The spec now refunds on child failure; the original test asserted the opposite. Rewritten as `test_inner_create_fail_refunds_in_creation_tx`. |
| `test_create_nonce_overflow_state_gas_consumed` | Duplicated by PR #2704's `test_create_silent_failure_refunds_state_gas[nonce_overflow]`. Premise also inverted. |
| `test_create2_collision_state_gas_block_accounting` | Duplicated by PR #2704's `test_create_collision_refunds_state_gas`. Premise inverted. |
| `test_create_selfdestruct_same_tx_no_state_gas_refund` | Premise fully inverted by PR #2707. |
| `test_call_value_to_selfdestructed_same_tx_account` (`test_state_gas_selfdestruct.py` variant) | Duplicated by PR #2646's three tests already on upstream (and separately updated by PR #2725). |

## 🔗 Related Issues or PRs

Closed PR whose test set that this PR revives: [#2639](https://github.com/ethereum/execution-specs/pull/2639).

## ✅ Checklist

* [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
* [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) and will be used as the squash commit message, starting with `type(scope):`.
* [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
* [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
