### PR TITLE
feat(test-cli): always print full pytest command in ci & add to summary

### DIFF
--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -111,3 +111,13 @@ It's possible to specify the Docker image used by the `act` tool for a specific 
 ```
 
 This can be added to any `gh act` command.
+
+## Debugging CI Failures
+
+The pytest-based CLIs (`fill`, `execute`, ...) print the resolved `pytest ...` invocation at startup whenever the `CI` environment variable is set:
+
+```text
+Executing: pytest ...
+```
+
+Copy this line verbatim from the failing Github Actions log and run it locally to reproduce the exact command, including all plugin and marker arguments injected by the CLI.

--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -120,4 +120,4 @@ The pytest-based CLIs (`fill`, `execute`, ...) print the resolved `pytest ...` i
 Executing: pytest ...
 ```
 
-Copy this line verbatim from the failing Github Actions log and run it locally to reproduce the exact command, including all plugin and marker arguments injected by the CLI.
+When run under Github Actions, the same command is also appended to the job summary (via `$GITHUB_STEP_SUMMARY`), so it can be copied directly from the "Summary" panel of the failing run without scrolling through the log.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/base.py
@@ -88,6 +88,12 @@ class PytestRunner:
         if self._is_verbose(execution.args) or "CI" in os.environ:
             pytest_cmd = f"pytest {' '.join(pytest_args)}"
             self.error_console.print(f"Executing: [bold]{pytest_cmd}[/bold]")
+            summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+            if summary_path:
+                with Path(summary_path).open("a") as summary:
+                    summary.write(
+                        f"### Executing\n\n```bash\n{pytest_cmd}\n```\n\n"
+                    )
 
         return pytest.main(pytest_args)
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/base.py
@@ -1,5 +1,6 @@
 """Base classes and utilities for pytest-based CLI commands."""
 
+import os
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -57,6 +58,15 @@ class PytestRunner:
     console: Console = field(default_factory=lambda: Console(highlight=False))
     """Console to use for output."""
 
+    error_console: Console = field(
+        default_factory=lambda: Console(stderr=True, highlight=False)
+    )
+    """Console for diagnostic output.
+
+    Written to stderr so it doesn't pollute stdout captures such as the
+    `fill --help` subprocess in `docs/scripts/generate_fill_help.py`.
+    """
+
     def run_single(self, execution: PytestExecution) -> int:
         """Run pytest once with the given configuration and arguments."""
         root_dir_arg = ["--rootdir", "."]
@@ -75,9 +85,9 @@ class PytestRunner:
                 "execution_testing.cli."
                 "pytest_commands.plugins.fix_package_test_path",
             ]
-        if self._is_verbose(execution.args):
+        if self._is_verbose(execution.args) or "CI" in os.environ:
             pytest_cmd = f"pytest {' '.join(pytest_args)}"
-            self.console.print(f"Executing: [bold]{pytest_cmd}[/bold]")
+            self.error_console.print(f"Executing: [bold]{pytest_cmd}[/bold]")
 
         return pytest.main(pytest_args)
 


### PR DESCRIPTION
## 🗒️ Description

If pytest commands get `-v` they print the full pytest invocation (with ini file path, etc) to the console. This PR additionally enables this if the command is running in CI and also adds this command to the job's summary.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:mouse: 
