### PR TITLE
feat(tests): EIP-8073 - remove stale header verify on CALL to selfdestructed tests

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1056,12 +1056,7 @@ def test_call_value_to_self_destructed_header_gas_used(
 
     blockchain_test(
         pre=pre,
-        blocks=[
-            Block(
-                txs=[tx],
-                header_verify=Header(gas_used=new_account_state_gas),
-            ),
-        ],
+        blocks=[Block(txs=[tx])],
         post={},
     )
 
@@ -1146,17 +1141,9 @@ def test_call_value_to_self_destructed_burns_value(
         sender=pre.fund_eoa(),
     )
 
-    # Header reflects the CREATE's single new account state gas
-    # charge. A spurious charge on the value bearing CALL would
-    # double the state gas component.
     blockchain_test(
         pre=pre,
-        blocks=[
-            Block(
-                txs=[tx],
-                header_verify=Header(gas_used=new_account_state_gas),
-            ),
-        ],
+        blocks=[Block(txs=[tx])],
         post={
             created_address: Account.NONEXISTENT,
             orchestrator: Account(balance=0),
@@ -1218,12 +1205,7 @@ def test_call_zero_value_to_self_destructed_same_tx_account(
 
     blockchain_test(
         pre=pre,
-        blocks=[
-            Block(
-                txs=[tx],
-                header_verify=Header(gas_used=new_account_state_gas),
-            ),
-        ],
+        blocks=[Block(txs=[tx])],
         post={},
     )
 


### PR DESCRIPTION
## 🗒️ Description

Drop the brittle `header_verify` from the three tests in `test_state_gas_call.py`:

Affected (20 variants across `blockchain_test` and `blockchain_test_engine` fixture formats):
- `test_call_value_to_self_destructed_header_gas_used`
- `test_call_value_to_self_destructed_burns_value`
- `test_call_zero_value_to_self_destructed_same_tx_account`

## 🔗 Related Issues or PRs

- Follow-up to #2707 (EIP-11532 same-tx SELFDESTRUCT refund)
- Fixes regressions from the combination of #2707 and the tests added in #2646

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).