### PR TITLE
feat(tests): prepare `test_scenarios` and `test_all_opcodes` for EIP-8037

### DIFF
--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -218,6 +218,11 @@ def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
         # SSTORE - untestable due to 2300 gas stipend rule
         if opcode == Op.SSTORE:
             continue
+        # EIP-8037: CREATE/CREATE2 have a state gas component charged from
+        # the state reservoir that cannot be measured via the GAS opcode
+        # delta used by gas_test. Excluded to keep the test meaningful.
+        if fork.is_eip_enabled(8037) and opcode in (Op.CREATE, Op.CREATE2):
+            continue
         if opcode.gas_cost(fork) == 0:
             # zero constant gas opcodes - untestable
             continue

--- a/tests/frontier/scenarios/test_scenarios.py
+++ b/tests/frontier/scenarios/test_scenarios.py
@@ -221,11 +221,9 @@ def test_scenarios(
             1, hint=f"runner result {scenario.name}"
         )
 
-        tx_max_gas = (
-            7_000_000
-            if test_program.id == ProgramInvalidOpcode().id
-            else 1_000_000
-        )
+        tx_max_gas = 1_000_000
+        if test_program.id == ProgramInvalidOpcode().id:
+            tx_max_gas = 10_000_000 if fork.is_eip_enabled(8037) else 7_000_000
         if scenario.category == "double_call_combinations":
             tx_max_gas *= 2
 


### PR DESCRIPTION
## 🗒️ Description

Apply two EIP-8037-aware test fixes to `forks/amsterdam` ahead of future rebases from `eips/amsterdam/eip-8037`, so the rebase no longer introduces merge conflicts in these files. Both changes are no-ops on `forks/amsterdam` — the guards only activate when `fork.is_eip_enabled(8037)`.

- `tests/frontier/scenarios/test_scenarios.py`, bump `tx_max_gas` to 10M for `ProgramInvalidOpcode` scenarios under EIP-8037.
- `tests/frontier/opcodes/test_all_opcodes.py::test_constant_gas`, skip `CREATE` / `CREATE2` under EIP-8037. Their state-gas component is charged from the state reservoir and cannot be observed via the `GAS`-opcode delta `gas_test` uses; attempts to pass explicit regular-only expected gas shrink the harness's tx gas and cause state gas to spill into `gas_left`, so measurement becomes circular. Coverage for CREATE/CREATE2 on EIP-8037 is handled comprehensively by `tests/amsterdam/eip8037_state_creation_gas_cost_increase/`.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).