### PR TITLE
feat(spec-specs, tests): EIP-8037 - apply calldata floor to sender refund

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1114,7 +1114,9 @@ def process_transaction(
 
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
-    tx_gas_used = max(tx_gas_used_after_refund, intrinsic.calldata_floor)
+    tx_gas_used_after_refund = max(
+        tx_gas_used_after_refund, intrinsic.calldata_floor
+    )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund
     gas_refund_amount = tx_gas_left * effective_gas_price
@@ -1150,7 +1152,7 @@ def process_transaction(
     block_output.block_state_gas_used += tx_state_gas
     block_output.blob_gas_used += tx_blob_gas_used
 
-    block_output.cumulative_gas_used += tx_gas_used
+    block_output.cumulative_gas_used += tx_gas_used_after_refund
     receipt = make_receipt(
         tx, tx_output.error, block_output.cumulative_gas_used, tx_output.logs
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -14,6 +14,8 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
+    Block,
+    BlockchainTestFiller,
     Environment,
     Fork,
     Op,
@@ -195,3 +197,44 @@ def test_calldata_floor_exceeding_tx_gas_limit_cap(
 
     post = {contract: Account(code=Op.STOP)} if not exceeds_cap else {}
     state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_calldata_floor_applied_to_sender_refund(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify the calldata floor is applied to the sender gas refund.
+
+    With a STOP callee and large all-nonzero calldata, execution gas
+    falls below the calldata floor. The sender must be charged
+    `calldata_floor * gas_price`, so the final balance reflects the
+    floor-applied value, not the pre-floor execution cost.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    calldata = b"\xff" * 1024
+    calldata_floor = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata,
+    )
+    gas_price = 10**9
+    initial = gas_limit_cap * gas_price
+
+    contract = pre.deploy_contract(code=Op.STOP)
+    sender = pre.fund_eoa(amount=initial)
+
+    tx = Transaction(
+        to=contract,
+        data=calldata,
+        gas_limit=gas_limit_cap,
+        gas_price=gas_price,
+        sender=sender,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post={sender: Account(balance=initial - calldata_floor * gas_price)},
+    )


### PR DESCRIPTION
## 🗒️ Description

The EIP-7623 calldata floor was applied to `block_gas_used` and `cumulative_gas_used` but not to the sender gas refund. When the floor binds (execution gas < `calldata_floor`), the sender was over-refunded by `(calldata_floor − pre_floor_execution_gas) × effective_gas_price`, so the sender's post-tx balance disagreed with the receipt's `cumulative_gas_used`.

Prague applies the floor by reassigning `tx_gas_used_after_refund = max(tx_gas_used_after_refund, calldata_floor_gas_cost)` so every downstream calculation uses the floor-applied value. Amsterdam introduced a separate `tx_gas_used` variable for `cumulative_gas_used` but left `tx_gas_left` (and the coinbase `transaction_fee`) reading the pre-floor `tx_gas_used_after_refund`. This PR mirrors Prague.

### Spec change

`src/ethereum/forks/amsterdam/fork.py`: reassign `tx_gas_used_after_refund` to the floor-applied max, drop the now-redundant `tx_gas_used` variable. Both `tx_gas_left` (sender refund) and `transaction_fee` (coinbase priority fee) now correctly pick up the floor.

### Test coverage

`test_calldata_floor_applied_to_sender_refund` in `test_state_gas_calldata_floor.py`: a tx with 1024 all-nonzero calldata bytes and a STOP callee exercises the floor-binding path. The sender's post-tx balance is pinned to `initial − calldata_floor × gas_price`. Verified the test fails on the pre-fix spec and passes on the post-fix spec.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

* [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
* [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) and will be used as the squash commit message, starting with `type(scope):`.
* [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
* [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
