### PR TITLE
feat(spec-specs, tests): EIP-8037 SSTORE refund clamp and initcode fixture guard

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -127,13 +127,15 @@ def sstore(evm: Evm) -> None:
         if original_value == new_value:
             # Storage slot being restored to its original value
             if original_value == 0:
-                # Slot set then cleared: refund state gas to the
-                # reservoir and regular cost via refund_counter. The
-                # state-gas credit is tracked in state_gas_refund so it
-                # can be unwound on revert or exceptional halt of this
-                # frame or any ancestor that inherits it.
-                evm.state_gas_left += state_gas_storage_set
-                evm.state_gas_used -= state_gas_storage_set
+                # Slot set then cleared: credit refund, clamped to this
+                # frame's state_gas_used since the 0 to N SSTORE may
+                # have charged state gas in an ancestor sharing storage
+                # via CALLCODE/DELEGATECALL.
+                state_gas_refund_applied = min(
+                    state_gas_storage_set, evm.state_gas_used
+                )
+                evm.state_gas_left += state_gas_refund_applied
+                evm.state_gas_used -= state_gas_refund_applied
                 evm.state_gas_refund += state_gas_storage_set
                 evm.refund_counter += int(
                     GAS_STORAGE_UPDATE

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -296,7 +296,7 @@ class TestContractCreationGasUsage:
         cost_per_state_byte and a code hash cost is added.
         """
         code_size = len(bytes(initcode.deploy_code))
-        if hasattr(fork, "cost_per_state_byte"):
+        if fork.is_eip_enabled(8037):
             gas_costs = fork.gas_costs()
             cpsb = fork.cost_per_state_byte()
             return (
@@ -597,7 +597,7 @@ class TestCreateInitcode:
         cost_per_state_byte and a code hash cost is added.
         """
         code_size = len(bytes(initcode.deploy_code))
-        if hasattr(fork, "cost_per_state_byte"):
+        if fork.is_eip_enabled(8037):
             gas_costs = fork.gas_costs()
             cpsb = fork.cost_per_state_byte()
             return (


### PR DESCRIPTION
## 🗒️ Description

Two small EIP-8037 fixes for bugs exposed by running the full test suite on the latest `eips/amsterdam/eip-8037`.

### 1. EELS spec: clamp SSTORE 0 to N to 0 refund to frame's `state_gas_used`

`src/ethereum/forks/amsterdam/vm/instructions/storage.py` currently unconditionally subtracts `state_gas_storage_set` from `evm.state_gas_used` when a slot is set then cleared in the same transaction. In `CALLCODE`/`DELEGATECALL` scenarios, where the parent frame charges the state gas for the 0 to N SSTORE and a child frame (sharing storage) performs the N to 0 SSTORE, the childs `state_gas_used` is 0, so the subtraction underflows and raises `OverflowError`.

The stop gap solution is to clamp the with `min(state_gas_storage_set, evm.state_gas_used)`, mirroring the existing selfdestruct refund clamp: https://github.com/ethereum/execution-specs/pull/2707/changes#diff-74fa24b5baaff0111dce07e4c323945a3fb5869a3dd24b72857179eae91fbe97R1082-R1084

Added in #2707!

**Note: this will require an change to the EIPs repo.**

### 2. Test Fix (Unrelated to point 1)

`tests/shanghai/eip3860_initcode/test_initcode.py` uses `hasattr(fork, "cost_per_state_byte")` to detect EIP-8037. Since `cost_per_state_byte` is declared on `BaseFork`, `hasattr` returns True for every fork, so pre-Amsterdam forks wrongly take the EIP-8037 code path and fail gas equality checks. Replace with `fork.is_eip_enabled(8037)`.

Resolves the 48 `test_create_opcode_initcode` parametrizations failing across Shanghai/Cancun/Prague/Osaka.

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).