### PR TITLE
refactor(spec): use uint32 instead of uint64 for block access index

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Set, Tuple, TypeAlias
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U32, U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
@@ -46,7 +46,7 @@ CodeData: TypeAlias = Bytes
 Bytecode associated with an [`Account`](ref:ethereum.state.Account).
 """
 
-BlockAccessIndex: TypeAlias = U64
+BlockAccessIndex: TypeAlias = U32
 """
 Position within the set of all changes in a [`Block`].
 

--- a/tests/amsterdam/eip7928_block_level_access_lists/spec.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/spec.py
@@ -39,6 +39,6 @@ class Spec:
     HASH_SIZE: int = 32  # Hash size in bytes
 
     # Numeric type limits
-    MAX_TX_INDEX: int = 2**64 - 1  # uint64 max value
+    MAX_TX_INDEX: int = 2**32 - 1  # uint32 max value
     MAX_BALANCE: int = 2**128 - 1  # uint128 max value
     MAX_NONCE: int = 2**64 - 1  # uint64 max value


### PR DESCRIPTION
## 🗒️ Description

As discussed in [ACDT #78](https://github.com/ethereum/pm/issues/2019), move to using `uint32` for block access index. Spec change for this is also coming.

compare to: https://github.com/ethereum/execution-specs/pull/2713

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

🐻‍❄️ 
