### PR TITLE
feat(spec-specs,tests): EIP-8037 nested child frame refunds

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -174,11 +174,43 @@ class Evm:
     regular_gas_used: Uint = Uint(0)
     state_gas_used: Uint = Uint(0)
     state_gas_refund: Uint = Uint(0)
+    state_gas_refund_pending: Uint = Uint(0)
+
+
+def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:
+    """
+    Credit an inline state gas refund to `evm.state_gas_left`.
+
+    Clamp the applied portion to this frame's `state_gas_used` — the
+    matching charge may sit in an ancestor sharing storage via
+    CALLCODE/DELEGATECALL.  Track it in `state_gas_refund` so
+    `incorporate_child_on_error` can undo the inflation, and defer the
+    unapplied remainder in `state_gas_refund_pending` for propagation
+    on success.
+
+    Parameters
+    ----------
+    evm :
+        The frame crediting the refund.
+    amount :
+        The refund amount to credit.
+
+    """
+    applied = min(amount, evm.state_gas_used)
+    evm.state_gas_left += applied
+    evm.state_gas_used -= applied
+    evm.state_gas_refund += applied
+    evm.state_gas_refund_pending += amount - applied
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     """
     Incorporate the state of a successful `child_evm` into the parent `evm`.
+
+    Propagate `state_gas_refund` (inline credits the child applied) so
+    an ancestor revert can undo the inflation, and apply
+    `state_gas_refund_pending` (the unapplied remainder) to the parent
+    via `credit_state_gas_refund`; any leftover propagates further up.
 
     Parameters
     ----------
@@ -198,6 +230,7 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     evm.regular_gas_used += child_evm.regular_gas_used
     evm.state_gas_used += child_evm.state_gas_used
     evm.state_gas_refund += child_evm.state_gas_refund
+    credit_state_gas_refund(evm, child_evm.state_gas_refund_pending)
 
 
 def incorporate_child_on_error(
@@ -212,11 +245,11 @@ def incorporate_child_on_error(
     that spilled into `gas_left`, is restored to the parent's reservoir and
     the child's `state_gas_used` is not accumulated.
 
-    Inline state-gas refunds (SSTORE 0 to x to 0) accumulated in the child or
-    its successful descendants are dropped: `state_gas_refund` is subtracted
-    from the amount returned to the parent's reservoir and is not propagated.
-    This matches `refund_counter`'s error-path behavior and keeps the refund
-    frame-scoped.
+    Inline state-gas refunds (SSTORE 0 to x to 0, CREATE silent failure)
+    credited by the child inflated its `state_gas_left`; subtract
+    `state_gas_refund` from the amount returned to the parent's
+    reservoir so the inflation does not leak across the error boundary.
+    `state_gas_refund_pending` is discarded with the child frame.
 
     Parameters
     ----------

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -20,7 +20,7 @@ from ...state_tracker import (
     set_storage,
     set_transient_storage,
 )
-from .. import Evm
+from .. import Evm, credit_state_gas_refund
 from ..exceptions import WriteInStaticContext
 from ..gas import (
     GAS_CALL_STIPEND,
@@ -127,28 +127,11 @@ def sstore(evm: Evm) -> None:
         if original_value == new_value:
             # Storage slot being restored to its original value
             if original_value == 0:
-                # Slot set then cleared: credit refund, clamped to this
-                # frame's state_gas_used since the 0 to N SSTORE may
-                # have charged state gas in an ancestor sharing storage
-                # via CALLCODE/DELEGATECALL.
-                state_gas_refund_applied = min(
-                    state_gas_storage_set, evm.state_gas_used
-                )
-                evm.state_gas_left += state_gas_refund_applied
-                evm.state_gas_used -= state_gas_refund_applied
-                evm.state_gas_refund += state_gas_storage_set
-                evm.refund_counter += int(
-                    GAS_STORAGE_UPDATE
-                    - GAS_COLD_STORAGE_ACCESS
-                    - GAS_WARM_ACCESS
-                )
-            else:
-                # Slot was originally non-empty and was UPDATED earlier
-                evm.refund_counter += int(
-                    GAS_STORAGE_UPDATE
-                    - GAS_COLD_STORAGE_ACCESS
-                    - GAS_WARM_ACCESS
-                )
+                # Slot set then cleared: refund the state gas charge.
+                credit_state_gas_refund(evm, state_gas_storage_set)
+            evm.refund_counter += int(
+                GAS_STORAGE_UPDATE - GAS_COLD_STORAGE_ACCESS - GAS_WARM_ACCESS
+            )
 
     # Charge regular gas before state gas so that a regular-gas OOG
     # does not consume state gas that would inflate the parent's

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -38,6 +38,7 @@ from ...vm.eoa_delegation import (
 from .. import (
     Evm,
     Message,
+    credit_state_gas_refund,
     incorporate_child_on_error,
     incorporate_child_on_success,
 )
@@ -122,9 +123,7 @@ def generic_create(
         evm.gas_left += create_message_gas
         evm.state_gas_left += create_message_state_gas_reservoir
         # No account created — refund state gas to reservoir.
-        evm.state_gas_left += create_account_state_gas
-        evm.state_gas_used -= create_account_state_gas
-        evm.state_gas_refund += create_account_state_gas
+        credit_state_gas_refund(evm, create_account_state_gas)
         push(evm.stack, U256(0))
         return
 
@@ -137,9 +136,7 @@ def generic_create(
         evm.regular_gas_used += create_message_gas
         evm.state_gas_left += create_message_state_gas_reservoir
         # Address collision — no account created, refund state gas.
-        evm.state_gas_left += create_account_state_gas
-        evm.state_gas_used -= create_account_state_gas
-        evm.state_gas_refund += create_account_state_gas
+        credit_state_gas_refund(evm, create_account_state_gas)
         push(evm.stack, U256(0))
         return
 
@@ -170,9 +167,7 @@ def generic_create(
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         # No account created, refund parent's CREATE state gas.
-        evm.state_gas_left += create_account_state_gas
-        evm.state_gas_used -= create_account_state_gas
-        evm.state_gas_refund += create_account_state_gas
+        credit_state_gas_refund(evm, create_account_state_gas)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -528,3 +528,109 @@ def test_selfdestruct_pre_existing_account_no_refund(
         blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_regular))],
         post={victim: Account(code=victim_code)},
     )
+
+
+@pytest.mark.parametrize(
+    "num_hops",
+    [
+        pytest.param(1, id="single_hop"),
+        pytest.param(2, id="two_hops"),
+    ],
+)
+@pytest.mark.with_all_call_opcodes(
+    selector=lambda call_opcode: call_opcode in (Op.DELEGATECALL, Op.CALLCODE)
+)
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_via_delegatecall_chain(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_hops: int,
+    call_opcode: Op,
+) -> None:
+    """
+    Verify SELFDESTRUCT refund when the opcode executes in a nested
+    DELEGATECALL/CALLCODE frame below a same-tx-created contract.
+
+    A factory CREATEs contract A; A delegates down `num_hops` frames
+    into a helper that runs SELFDESTRUCT(Op.ADDRESS). `current_target`
+    is preserved by DELEGATECALL/CALLCODE, so A is queued for deletion
+    and its account + code-deposit state gas is refunded at tx end.
+    Exercises `accounts_to_delete` propagation across multiple
+    `incorporate_child_on_success` hops.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+    sstore_state_gas = fork.sstore_state_gas()
+
+    # Bottom of the chain does the SELFDESTRUCT; intermediate helpers
+    # just delegate further down.
+    delegate_target = pre.deploy_contract(code=Op.SELFDESTRUCT(Op.ADDRESS))
+    for _ in range(num_hops - 1):
+        delegate_target = pre.deploy_contract(
+            code=Op.POP(call_opcode(gas=Op.GAS, address=delegate_target))
+            + Op.STOP,
+        )
+
+    # A's deployed runtime: one delegation into the top of the chain.
+    deployed = bytes(
+        Op.POP(call_opcode(gas=Op.GAS, address=delegate_target)) + Op.STOP
+    )
+    code_deposit_state_gas = fork.code_deposit_state_gas(
+        code_size=len(deployed)
+    )
+    initcode = Initcode(deploy_code=deployed)
+    initcode_len = len(initcode)
+
+    # Slots 0 and 1 guard against a vacuously-NONEXISTENT A: slot 0
+    # fails if CREATE silently returned 0, slot 1 fails if the factory
+    # OOGed before completing the nested CALL.  TSTORE caches the
+    # CREATE return so both can reuse it.
+    factory_storage = Storage()
+    factory_code = (
+        Op.CALLDATACOPY(
+            0,
+            0,
+            Op.CALLDATASIZE,
+            data_size=initcode_len,
+            new_memory_size=initcode_len,
+        )
+        + Op.TSTORE(
+            0,
+            Op.CREATE(
+                value=0,
+                offset=0,
+                size=Op.CALLDATASIZE,
+                init_code_size=initcode_len,
+            ),
+        )
+        + Op.SSTORE(
+            factory_storage.store_next(1, "create_returned_nonzero"),
+            Op.ISZERO(Op.ISZERO(Op.TLOAD(0))),
+        )
+        + Op.SSTORE(
+            factory_storage.store_next(1, "call_returned_success"),
+            Op.CALL(gas=Op.GAS, address=Op.TLOAD(0)),
+        )
+    )
+    factory = pre.deploy_contract(code=factory_code)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    # Reservoir must also cover the two fresh SSTORE markers.
+    total_state_refund = new_account_state_gas + code_deposit_state_gas
+    tx = Transaction(
+        to=factory,
+        data=bytes(initcode),
+        gas_limit=gas_limit_cap + total_state_refund + 2 * sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post={
+            created_address: Account.NONEXISTENT,
+            factory: Account(storage=factory_storage),
+        },
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -735,6 +735,88 @@ def test_sstore_restoration_cross_frame(
     )
 
 
+@pytest.mark.parametrize(
+    "num_hops",
+    [
+        pytest.param(1, id="single_hop"),
+        pytest.param(2, id="two_hops"),
+        pytest.param(3, id="three_hops"),
+    ],
+)
+@pytest.mark.with_all_call_opcodes(
+    selector=lambda call_opcode: call_opcode in (Op.DELEGATECALL, Op.CALLCODE)
+)
+@pytest.mark.valid_from("EIP8037")
+def test_sstore_restoration_charge_in_ancestor(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    call_opcode: Op,
+    num_hops: int,
+) -> None:
+    """
+    Verify 0 to x to 0 refund when the 0 to x charge is in the parent
+    and x to 0 runs `num_hops` DELEGATECALL/CALLCODE frames below,
+    each sharing storage with the parent.
+
+    Every intermediate frame has zero local `state_gas_used`, so the
+    refund must propagate up the chain to the ancestor that charged
+    the 0 to x.  A probe SSTORE sized to OOG by 1 detects any loss.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
+    sstore_state_gas = fork.sstore_state_gas()
+    probe_gas = (
+        2 * gas_costs.GAS_VERY_LOW
+        + gas_costs.GAS_COLD_STORAGE_WRITE
+        + sstore_state_gas
+        - 1
+    )
+
+    # Innermost frame does x to 0; each hop above delegates down.
+    delegate_target = pre.deploy_contract(
+        code=(
+            Op.SSTORE.with_metadata(
+                key_warm=True,
+                original_value=0,
+                current_value=1,
+                new_value=0,
+            )(0, 0)
+            + Op.STOP
+        )
+    )
+    for _ in range(num_hops - 1):
+        delegate_target = pre.deploy_contract(
+            code=Op.POP(call_opcode(gas=Op.GAS, address=delegate_target))
+            + Op.STOP,
+        )
+
+    probe = pre.deploy_contract(code=Op.SSTORE(0, 1))
+
+    parent_storage = Storage()
+    parent_code = (
+        Op.SSTORE(parent_storage.store_next(0, "cycle_restored"), 1)
+        + Op.POP(call_opcode(gas=Op.GAS, address=delegate_target))
+        + Op.SSTORE(
+            parent_storage.store_next(1, "probe_must_succeed"),
+            Op.CALL(gas=probe_gas, address=probe),
+        )
+    )
+    parent = pre.deploy_contract(code=parent_code)
+
+    # Reservoir starts at exactly sstore_state_gas; the parent's 0 to 1
+    # drains it to zero before entering the delegation chain.
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=parent,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+    )
+
+    post = {parent: Account(storage=parent_storage)}
+    state_test(pre=pre, tx=tx, post=post)
+
+
 @pytest.mark.with_all_call_opcodes(
     selector=lambda call_opcode: call_opcode != Op.STATICCALL
 )


### PR DESCRIPTION
## 🗒️ Description

- Fix `SSTORE` _0->N->0_ refund when the _0->N_ is charged in an ancestor (`DELEGATECALL`/`CALLCODE`): clamp the inline credit to the local frame's `state_gas_used` and propagate the remainder to ancestors on success. Tests cover 1/2/3-hop chains.
- Add `SELFDESTRUCT` test for `DELEGATECALL`/`CALLCODE` chain (1–2 hops) for a same-tx-created contract. `SELFDESTRUCT` refunds are computed once at tx-finalization against the aggregated `tx_output.state_gas_used` (after all frames have been incorporated), so the per-frame accounting bug that broke `SSTORE`  (refund inflating a child frame `state_gas_left` and leaking back via `incorporate_child_on_error`) doesn't apply. Still good to add this nested test for coverage though imo.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="751" height="383" alt="Screenshot 2026-04-20 at 11 54 57" src="https://github.com/user-attachments/assets/f8f6f0e3-3e8b-4075-906e-44924ddb2dc1" />
