### PR TITLE
fix(testing): remove ignored StateTest engine_api_error_code

### DIFF
--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -23,7 +23,6 @@ from execution_testing.client_clis import (
 )
 from execution_testing.exceptions import (
     BlockException,
-    EngineAPIError,
     TransactionException,
 )
 from execution_testing.execution import (
@@ -80,7 +79,6 @@ class StateTest(BaseTest):
         | BlockException
         | None
     ) = None
-    engine_api_error_code: Optional[EngineAPIError] = None
     blockchain_test_header_verify: Optional[Header] = None
     blockchain_test_rlp_modifier: Optional[Header] = None
     expected_block_access_list: Optional[BlockAccessListExpectation] = None


### PR DESCRIPTION
## 🗒️ Description

Remove `engine_api_error_code` from `StateTest`.

`StateTest` currently exposes `engine_api_error_code`, but the value is silently dropped during the `StateTest -> Block` conversion in [state.py](/ethereum/execution-specs/blob/HEAD/packages/testing/src/execution_testing/specs/state.py#L329-L333). The native state-fixture path does not consume it either, so the current API advertises a field that is effectively ignored.

This field no longer matches the current codebase's abstraction:

- `engine_api_error_code` is modeled as block/payload metadata in [blockchain.py](/ethereum/execution-specs/blob/HEAD/packages/testing/src/execution_testing/specs/blockchain.py#L276-L288) and [fixtures/blockchain.py](/ethereum/execution-specs/blob/HEAD/packages/testing/src/execution_testing/fixtures/blockchain.py#L450-L469)
- all current in-repo usages attach it to `Block(...)`, not `StateTest(...)`
- unlike `block_exception`, it is not wired through `_generate_blockchain_blocks()` and has no in-tree `StateTest(...)` call sites

Removing the field makes the API honest and avoids a footgun where a test author can specify an Engine API error expectation that is silently ignored. With [BaseTest](/ethereum/execution-specs/blob/HEAD/packages/testing/src/execution_testing/specs/base.py#L88-L88) configured as `extra="forbid"`, unsupported usage will fail fast at model construction rather than being silently ignored.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails:
  ```console
  just static
  ```
- [x] All: PR title adheres to the repo standard and starts with `type(scope):`.
- [x] All: Considered updating the online docs in [./docs/](/ethereum/execution-specs/blob/HEAD/docs/).
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Cute rabbit](https://commons.wikimedia.org/wiki/Special:Redirect/file/Arctic_Hare.jpg)
