### PR TITLE
test(tests-eip-8024): end-of-code stack underflow regression

### DIFF
--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_endofcode_underflow.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_endofcode_underflow.py
@@ -1,0 +1,79 @@
+"""
+EIP-8024 end-of-code stack underflow regression tests.
+
+When DUPN/SWAPN/EXCHANGE is the last byte of code, the missing immediate
+byte decodes to `0` per EIP-8024, and the opcode must still execute with
+that zero-decoded immediate. When the stack is short of the resulting
+required depth, execution must halt with stack underflow — clients must
+not treat the missing immediate as a graceful STOP.
+
+See:
+- EIP-8024: https://eips.ethereum.org/EIPS/eip-8024
+- Bounty: https://github.com/ethereum-bounty/nethermind/issues/12
+- Fix:    https://github.com/NethermindEth/nethermind/pull/11178
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_8024
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8024.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8024.version
+
+pytestmark = pytest.mark.valid_from("EIP8024")
+
+
+@pytest.mark.parametrize(
+    "eip8024_opcode,pushed_items",
+    [
+        # DUPN: decode_single(0) = 145, needs 145 items — push 144.
+        pytest.param(Op.DUPN, 144, id="dupn"),
+        # SWAPN: decode_single(0) = 145, needs 146 items — push 145.
+        pytest.param(Op.SWAPN, 145, id="swapn"),
+        # EXCHANGE: decode_pair(0) = (9, 16), needs 17 items — push 16.
+        pytest.param(Op.EXCHANGE, 16, id="exchange"),
+    ],
+)
+def test_end_of_code_stack_underflow(
+    pre: Alloc,
+    state_test: StateTestFiller,
+    eip8024_opcode: Op,
+    pushed_items: int,
+) -> None:
+    """
+    Test EIP-8024 opcodes at end of code with one fewer stack item than
+    required by the zero-decoded immediate.
+
+    Per EIP-8024, `code[pc + 1]` evaluates to `0` when beyond end of code.
+    The opcode must still execute and, with insufficient stack depth for
+    the decoded immediate, must halt with stack underflow.
+
+    A buggy implementation that treats the missing immediate as an
+    implicit STOP would incorrectly succeed and persist the marker
+    stored before the opcode.
+    """
+    sender = pre.fund_eoa()
+    marker_value = 0x42
+
+    code = (
+        # store marker that must not persist if the opcode underflows
+        Op.SSTORE(0, marker_value)
+        # one fewer item than the zero-decoded immediate requires
+        + Op.PUSH0 * pushed_items
+        # end-of-code EIP-8024 opcode, no immediate byte
+        + eip8024_opcode
+    )
+    contract_address = pre.deploy_contract(code=code)
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+
+    # Transaction must fail (stack underflow), leaving storage untouched.
+    post = {contract_address: Account(storage={})}
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

Adds a parametrized regression state test that pins down the EIP-8024 behaviour at end-of-code when the zero-decoded immediate requires more stack depth than is available.

Per EIP-8024, `code[pc + 1]` evaluates to `0` when beyond end of code and the opcode must still execute with that zero-decoded immediate — so when the stack is one item short of what the decoded immediate requires, execution must halt with stack underflow. A client that treats the missing immediate as an implicit/graceful STOP would silently succeed.

The test covers all three affected opcodes:

| opcode | `decode(0)` | required depth | pushed items |
|---|---|---|---|
| `DUPN` | 145 | 145 | 144 |
| `SWAPN` | 145 | 146 | 145 |
| `EXCHANGE` | (9, 16) | 17 | 16 |

Each case stores a marker before the opcode and asserts `storage == {}` in post-state: a buggy implementation that STOPs instead of underflowing would persist the marker, failing the test.

Existing coverage on this branch (`test_endofcode_behavior`, `test_eip_vector_end_of_code`, `test_eip_vector_exchange_end_of_code`) only exercises the EOC happy-path with sufficient stack depth, so it doesn't catch the graceful-STOP regression. Explicit-immediate underflow tests (`test_dupn_stack_underflow`, `test_eip_vector_dupn_stack_underflow`, etc.) don't reach the end-of-code decode path either.

## 🔗 Related Issues or PRs

- Issue: https://github.com/ethereum-bounty/nethermind/issues/12
- Nethermind fix: https://github.com/NethermindEth/nethermind/pull/11178

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Verification

Filled locally against the EIP-8024 reference spec:

```
uv run fill --clean -v -s tests/amsterdam/eip8024_dupn_swapn_exchange/test_endofcode_underflow.py --fork=Amsterdam
# 9 passed (3 opcodes x 3 fixture formats)
```