### PR TITLE
fix(bls12_381): added raise for all InvalidParameter exceptions in decode_g1_scalar_pair / decode_g2_scalar_pair

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/bpo1/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/bpo1/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/bpo2/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/bpo2/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/bpo3/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/bpo3/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/bpo4/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/bpo4/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/bpo5/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/bpo5/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/osaka/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/osaka/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")

--- a/src/ethereum/forks/prague/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/forks/prague/vm/precompiled_contracts/bls12_381/__init__.py
@@ -414,7 +414,7 @@ def decode_g1_scalar_pair(
 
     """
     if len(data) != 160:
-        InvalidParameter("Input should be 160 bytes long")
+        raise InvalidParameter("Input should be 160 bytes long")
 
     point = bytes_to_g1(data[:128], subgroup_check=True)
 
@@ -614,7 +614,7 @@ def decode_g2_scalar_pair(
 
     """
     if len(data) != 288:
-        InvalidParameter("Input should be 288 bytes long")
+        raise InvalidParameter("Input should be 288 bytes long")
 
     point = bytes_to_g2(data[:256], subgroup_check=True)
     n = int.from_bytes(data[256 : 256 + 32], "big")


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Fix missing `raise` statements in BLS12-381 scalar pair decoders.

Both `decode_g1_scalar_pair` and `decode_g2_scalar_pair` were constructing an `InvalidParameter` exception when input length checks failed, but not raising it. This resulted in the validation being a no-op, allowing execution to continue with invalid inputs.

While current callers (`bls12_g1_msm`, `bls12_g2_msm`) enforce correct input lengths and pass properly sized slices, thus making the bug effectively unreachable in existing flows, this behavior breaks the function’s contract and could lead to silent failures if these utilities are used elsewhere (e.g., tests, tooling, or future refactors).

This PR adds the missing `raise` statements to ensure proper error handling and defensive validation.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #2734

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/99/39/a1/9939a189d65d453151bc8fa77a177198.jpg)