### PR TITLE
feat(tests): port stPreCompiledContracts/modexp 128-byte carry cases

### DIFF
--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -449,11 +449,40 @@ REFERENCE_SPEC_VERSION = "5c8f066acb210c704ef80c1033a941aa5374aac5"
             ),
             id="truncated_input_4",
         ),
+        # 128-byte (1024-bit) operands exercising the multi-word
+        # Montgomery/Barrett reduction carry path. Modulus is
+        # 2**1024 - 0x69, so neither operand hits any 256-bit
+        # specialization. Both cases reduce to 9^exp mod m (base=m+9 in
+        # the first case), and with this exp, 9^exp ≡ 9 mod m.
+        pytest.param(
+            ModExpInput(
+                base="ff" * 127 + "a0",
+                exponent="ff" * 127 + "97",
+                modulus="ff" * 127 + "97",
+            ),
+            ModExpOutput(returned_data="0x" + "00" * 127 + "09"),
+            id="modexp_37120_37111_37111_1000000",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="09",
+                exponent="ff" * 127 + "97",
+                modulus="ff" * 127 + "97",
+            ),
+            ModExpOutput(returned_data="0x" + "00" * 127 + "09"),
+            id="modexp_9_37111_37111_1000000",
+        ),
     ],
     ids=lambda param: param.__repr__(),  # only required to remove parameter
     # names (input/output)
 )
 @pytest.mark.eels_base_coverage
+@pytest.mark.ported_from(
+    [
+        "https://github.com/ethereum/legacytests/blob/master/src/LegacyTests/Constantinople/GeneralStateTestsFiller/stPreCompiledContracts/modexp_37120_37111_37111_1000000Filler.json",
+        "https://github.com/ethereum/legacytests/blob/master/src/LegacyTests/Constantinople/GeneralStateTestsFiller/stPreCompiledContracts/modexp_9_37111_37111_1000000Filler.json",
+    ],
+)
 def test_modexp(
     state_test: StateTestFiller,
     mod_exp_input: ModExpInput | Bytes,
@@ -504,7 +533,7 @@ def test_modexp(
         ty=0x0,
         to=account,
         data=mod_exp_input,
-        gas_limit=500_000,
+        gas_limit=2_000_000,
         protected=True,
         sender=sender,
     )


### PR DESCRIPTION
## 🗒️ Description
Add two MODEXP parametrizations with 128-byte (1024-bit) operands to test_modexp. Both use modulus 2**1024 - 0x69 and reduce to 9^exp mod m (in the first case, base = m + 9). The modulus size forces the implementation through the multi-word Montgomery/Barrett reduction path rather than any 256-bit specialization.

Also bump the test's gas_limit from 500k to 2M so the Byzantium pre-EIP-2565 cost (~682k for a 128-byte modulus) fits. The bump is a no-op for every existing case: the "out-of-gas" params OOG on modexp's own gas formula (huge declared exp/mod lengths), not on the tx cap, so they stay OOG at 2M.

Ported from two legacy fillers that the bulk static-filler import in #1442 did not pull in:

- src/LegacyTests/Constantinople/GeneralStateTestsFiller/ stPreCompiledContracts/modexp_37120_37111_37111_1000000Filler.json
- src/LegacyTests/Constantinople/GeneralStateTestsFiller/ stPreCompiledContracts/modexp_9_37111_37111_1000000Filler.json

Those fillers live in the ethereum/tests LegacyTests submodule (ethereum/legacytests), which the original port did not descend into.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

🐢
