### PR TITLE
fix(tooling,ci): collect filled fixtures in json-loader pytest step

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -160,7 +160,7 @@ json-loader *args:
         --skip-index \
         --clean \
         --ignore=tests/ported_static \
-        --output="{{ output_dir }}/json-loader/fixtures" \
+        --output="tests/json_loader/fixtures" \
         --cov-config=pyproject.toml \
         --cov=ethereum \
         --cov-fail-under=85
@@ -169,8 +169,7 @@ json-loader *args:
         -n auto --maxprocesses 6 --dist=loadfile \
         --basetemp="{{ output_dir }}/json-loader/tmp" \
         "$@" \
-        tests/json_loader \
-        "{{ output_dir }}/json-loader/fixtures"
+        tests/json_loader
 
 # --- Unit Tests ---
 


### PR DESCRIPTION
## 🗒️ Description
Move fill output from .just/json-loader/fixtures to tests/json_loader/fixtures so the pytest_collect_file hook in tests/json_loader/conftest.py (which is directory-scoped) actually fires for the generated JSON files. Previously the second pytest step silently skipped all fixtures and only ran the handful of Python test modules under tests/json_loader/.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.