### PR TITLE
fix(test-benchmark): use named constants and labeled calldata in precompile benchmarks

### DIFF
--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -30,8 +30,20 @@ from tests.osaka.eip7951_p256verify_precompiles.spec import (
 
 
 class Precompile:
-    """Target opcode labels for precompile benchmarks."""
+    """Target opcode labels and addresses for precompile benchmarks."""
 
+    # Precompile addresses
+    ECRECOVER_ADDRESS = 0x01
+    SHA256_ADDRESS = 0x02
+    RIPEMD160_ADDRESS = 0x03
+    IDENTITY_ADDRESS = 0x04
+    MODEXP_ADDRESS = 0x05
+    BN128_ADD_ADDRESS = 0x06
+    BN128_MUL_ADDRESS = 0x07
+    BN128_PAIRING_ADDRESS = 0x08
+    BLAKE2F_ADDRESS = 0x09
+
+    # Target opcode labels
     ECRECOVER = OpcodeTarget("ECRECOVER", Op.STATICCALL)
     SHA256 = OpcodeTarget("SHA2-256", Op.STATICCALL)
     RIPEMD160 = OpcodeTarget("RIPEMD-160", Op.STATICCALL)
@@ -177,6 +189,101 @@ def concatenate_parameters(
             "or a sequence of byte-like objects (bytes, BytesConcatenation or "
             "FieldElement)."
         )
+
+
+def _hex32(value: str) -> bytes:
+    """Pad or validate a hex string to exactly 32 bytes."""
+    return bytes.fromhex(value.zfill(64))
+
+
+def bn128_add_calldata(
+    *,
+    x1: str,
+    y1: str,
+    x2: str,
+    y2: str,
+) -> bytes:
+    """
+    Build BN128_ADD (0x06) calldata with labeled fields.
+
+    Each coordinate is a 32-byte big-endian hex string.
+    """
+    return _hex32(x1) + _hex32(y1) + _hex32(x2) + _hex32(y2)
+
+
+def bn128_mul_calldata(
+    *,
+    x: str,
+    y: str,
+    scalar: str,
+) -> bytes:
+    """
+    Build BN128_MUL (0x07) calldata with labeled fields.
+
+    Point coordinates and scalar are 32-byte big-endian hex
+    strings.
+    """
+    return _hex32(x) + _hex32(y) + _hex32(scalar)
+
+
+def bn128_pairing_calldata(
+    pairs: Sequence[tuple[str, str, str, str, str, str]],
+) -> bytes:
+    """
+    Build BN128_PAIRING (0x08) calldata with labeled fields.
+
+    Each pair is (g1_x, g1_y, g2_x_im, g2_x_re, g2_y_im,
+    g2_y_re) — six 32-byte big-endian hex strings.
+    """
+    data = b""
+    for g1_x, g1_y, g2_x_im, g2_x_re, g2_y_im, g2_y_re in pairs:
+        data += (
+            _hex32(g1_x)
+            + _hex32(g1_y)
+            + _hex32(g2_x_im)
+            + _hex32(g2_x_re)
+            + _hex32(g2_y_im)
+            + _hex32(g2_y_re)
+        )
+    return data
+
+
+def ecrecover_calldata(
+    *,
+    msg_hash: str,
+    v: str,
+    r: str,
+    s: str,
+) -> bytes:
+    """
+    Build ECRECOVER (0x01) calldata with labeled fields.
+
+    Each field is a 32-byte big-endian hex string.
+    """
+    return _hex32(msg_hash) + _hex32(v) + _hex32(r) + _hex32(s)
+
+
+def point_evaluation_calldata(
+    *,
+    versioned_hash: str,
+    z: str,
+    y: str,
+    commitment: str,
+    proof: str,
+) -> bytes:
+    """
+    Build POINT_EVALUATION (0x0a) calldata with labeled fields.
+
+    versioned_hash, z, y are 32 bytes each; commitment and
+    proof are 48 bytes each.
+    """
+    return (
+        _hex32(versioned_hash)
+        + _hex32(z)
+        + _hex32(y)
+        + bytes.fromhex(commitment.zfill(96))
+        + bytes.fromhex(proof.zfill(96))
+    )
 
 
 def calculate_optimal_input_length(

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -4,6 +4,7 @@ import math
 import random
 
 import pytest
+from _pytest.mark import ParameterSet
 from execution_testing import (
     Address,
     Alloc,
@@ -20,375 +21,508 @@ from execution_testing import (
 )
 from py_ecc.bn128 import G1, G2, multiply
 
-from ..helpers import Precompile, concatenate_parameters
+from ..helpers import (
+    Precompile,
+    bn128_add_calldata,
+    bn128_mul_calldata,
+    bn128_pairing_calldata,
+    concatenate_parameters,
+)
+
+# Zero coordinates (point at infinity)
+ZERO = "0" * 64
 
 
-@pytest.mark.parametrize(
-    "precompile_address,calldata,target",
-    [
+def create_alt_bn128_test_cases() -> list[ParameterSet]:
+    """Create labeled test cases for ALT_BN128 precompiles."""
+    return [
+        # --- BN128_ADD (0x06) ---
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
-                    "07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED",
-                    "06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7",
-                ]
+            Precompile.BN128_ADD_ADDRESS,
+            bn128_add_calldata(
+                x1="18B18ACFB4C2C30276DB5411368E7185"
+                "B311DD124691610C5D3B74034E093DC9",
+                y1="063C909C4720840CB5134CB9F59FA749"
+                "755796819658D32EFC0D288198F37266",
+                x2="07C2B7F58A84BD6145F00C9C2BC0BB1A"
+                "187F20FF2C92963A88019E7C6A014EED",
+                y2="06614E20C147E940F2D70DA3F74C9A17"
+                "DF361706A4485C742BD6788478FA17D7",
             ),
             Precompile.BN128_ADD,
             id="bn128_add",
             marks=pytest.mark.repricing,
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L326
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L326
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                ]
+            Precompile.BN128_ADD_ADDRESS,
+            bn128_add_calldata(
+                x1=ZERO,
+                y1=ZERO,
+                x2=ZERO,
+                y2=ZERO,
             ),
             Precompile.BN128_ADD,
             id="bn128_add_infinities",
             marks=pytest.mark.repricing,
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L329
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L329
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
+            Precompile.BN128_ADD_ADDRESS,
+            bn128_add_calldata(
+                x1="01",
+                y1="02",
+                x2="01",
+                y2="02",
             ),
             Precompile.BN128_ADD,
             id="bn128_add_1_2",
         ),
+        # --- BN128_MUL (0x07) ---
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3",
-                    "1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6",
-                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x="1A87B0584CE92F4593D161480614F298"
+                "9035225609F08058CCFA3D0F940FEBE3",
+                y="1A2F3C951F6DADCC7EE9007DFF81504B"
+                "0FCD6D7CF59996EFDC33D92BF7F9F8F6",
+                scalar="F" * 64,
             ),
             Precompile.BN128_MUL,
             id="bn128_mul",
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L335
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L335
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x=ZERO,
+                y=ZERO,
+                scalar="02",
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_infinities_2_scalar",
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L338
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L338
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "25f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd585",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x=ZERO,
+                y=ZERO,
+                scalar="25f8c89ea3437f44f8fc8b6bfbb63120"
+                "74dc6f983809a5e809ff4e1d076dd585",
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_infinities_32_byte_scalar",
             marks=pytest.mark.repricing,
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L341
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L341
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x="01",
+                y="02",
+                scalar="02",
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_1_2_2_scalar",
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L344
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L344
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                    "25f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd585",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x="01",
+                y="02",
+                scalar="25f8c89ea3437f44f8fc8b6bfbb63120"
+                "74dc6f983809a5e809ff4e1d076dd585",
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_1_2_32_byte_scalar",
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L347
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L347
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf",
-                    "2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b36",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x="089142debb13c461f61523586a60732d"
+                "8b69c5b38a3380a74da7b2961d867dbf",
+                y="2d5fc7bbc013c16d7945f190b232eacc"
+                "25da675c0eb093fe6b9f1b4b4e107b36",
+                scalar="02",
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_32_byte_coord_and_2_scalar",
             marks=pytest.mark.repricing,
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L350
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L350
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf",
-                    "2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b36",
-                    "25f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd585",
-                ]
+            Precompile.BN128_MUL_ADDRESS,
+            bn128_mul_calldata(
+                x="089142debb13c461f61523586a60732d"
+                "8b69c5b38a3380a74da7b2961d867dbf",
+                y="2d5fc7bbc013c16d7945f190b232eacc"
+                "25da675c0eb093fe6b9f1b4b4e107b36",
+                scalar="25f8c89ea3437f44f8fc8b6bfbb63120"
+                "74dc6f983809a5e809ff4e1d076dd585",
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_32_byte_coord_and_scalar",
             marks=pytest.mark.repricing,
         ),
+        # --- BN128_PAIRING (0x08) ---
+        #   Each pair: (g1_x, g1_y, g2_x_im, g2_x_re,
+        #               g2_y_im, g2_y_re)
         pytest.param(
-            0x08,
-            concatenate_parameters(
+            Precompile.BN128_PAIRING_ADDRESS,
+            bn128_pairing_calldata(
                 [
-                    # First pairing
-                    "1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59",
-                    "3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41",
-                    "209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7",
-                    "04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678",
-                    "2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D",
-                    "120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550",
-                    # Second pairing
-                    "111E129F1CF1097710D41C4AC70FCDFA5BA2023C6FF1CBEAC322DE49D1B6DF7C",
-                    "103188585E2364128FE25C70558F1560F4F9350BAF3959E603CC91486E110936",
-                    "198E9393920D483A7260BFB731FB5D25F1AA493335A9E71297E485B7AEF312C2",
-                    "1800DEEF121F1E76426A00665E5C4479674322D4F75EDADD46DEBD5CD992F6ED",
-                    "090689D0585FF075EC9E99AD690C3395BC4B313370B38EF355ACDADCD122975B",
-                    "12C85EA5DB8C6DEB4AAB71808DCB408FE3D1E7690C43D37B4CE6CC0166FA7DAA",
+                    (  # First pairing
+                        "1C76476F4DEF4BB94541D57EBBA11933"
+                        "81FFA7AA76ADA664DD31C16024C43F59",
+                        "3034DD2920F673E204FEE2811C678745"
+                        "FC819B55D3E9D294E45C9B03A76AEF41",
+                        "209DD15EBFF5D46C4BD888E51A93CF99"
+                        "A7329636C63514396B4A452003A35BF7",
+                        "04BF11CA01483BFA8B34B43561848D28"
+                        "905960114C8AC04049AF4B6315A41678",
+                        "2BB8324AF6CFC93537A2AD1A445CFD0C"
+                        "A2A71ACD7AC41FADBF933C2A51BE344D",
+                        "120A2A4CF30C1BF9845F20C6FE39E07E"
+                        "A2CCE61F0C9BB048165FE5E4DE877550",
+                    ),
+                    (  # Second pairing
+                        "111E129F1CF1097710D41C4AC70FCDFA"
+                        "5BA2023C6FF1CBEAC322DE49D1B6DF7C",
+                        "103188585E2364128FE25C70558F1560"
+                        "F4F9350BAF3959E603CC91486E110936",
+                        "198E9393920D483A7260BFB731FB5D25"
+                        "F1AA493335A9E71297E485B7AEF312C2",
+                        "1800DEEF121F1E76426A00665E5C4479"
+                        "674322D4F75EDADD46DEBD5CD992F6ED",
+                        "090689D0585FF075EC9E99AD690C3395"
+                        "BC4B313370B38EF355ACDADCD122975B",
+                        "12C85EA5DB8C6DEB4AAB71808DCB408F"
+                        "E3D1E7690C43D37B4CE6CC0166FA7DAA",
+                    ),
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="bn128_two_pairings",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
+            Precompile.BN128_PAIRING_ADDRESS,
+            bn128_pairing_calldata(
                 [
-                    # First pairing
-                    "1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59",
-                    "3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41",
-                    "209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7",
-                    "04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678",
-                    "2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D",
-                    "120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550",
+                    (  # Single pairing
+                        "1C76476F4DEF4BB94541D57EBBA11933"
+                        "81FFA7AA76ADA664DD31C16024C43F59",
+                        "3034DD2920F673E204FEE2811C678745"
+                        "FC819B55D3E9D294E45C9B03A76AEF41",
+                        "209DD15EBFF5D46C4BD888E51A93CF99"
+                        "A7329636C63514396B4A452003A35BF7",
+                        "04BF11CA01483BFA8B34B43561848D28"
+                        "905960114C8AC04049AF4B6315A41678",
+                        "2BB8324AF6CFC93537A2AD1A445CFD0C"
+                        "A2A71ACD7AC41FADBF933C2A51BE344D",
+                        "120A2A4CF30C1BF9845F20C6FE39E07E"
+                        "A2CCE61F0C9BB048165FE5E4DE877550",
+                    ),
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="bn128_one_pairing",
         ),
         # Ported from
-        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L353
+        # https://github.com/NethermindEth/nethermind/blob/ceb8d57b/tools/EngineRequestsGenerator/TestCase.cs#L353
         pytest.param(
-            0x08,
+            Precompile.BN128_PAIRING_ADDRESS,
             [],
             Precompile.BN128_PAIRING,
             id="ec_pairing_zero_input",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
+            Precompile.BN128_PAIRING_ADDRESS,
+            bn128_pairing_calldata(
                 [
-                    # First pairing
-                    "2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da",
-                    "2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6",
-                    "1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc",
-                    "22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9",
-                    "2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90",
-                    "2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e",
-                    # Second pairing
-                    "0000000000000000000000000000000000000000000000000000000000000013",
-                    "0644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd451",
-                    "971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb40",
-                    "91058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc72",
-                    "a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea22",
-                    "3a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc0",
+                    (  # First pairing
+                        "2cf44499d5d27bb186308b7af7af02ac"
+                        "5bc9eeb6a3d147c186b21fb1b76e18da",
+                        "2c0f001f52110ccfe69108924926e45f"
+                        "0b0c868df0e7bde1fe16d3242dc715f6",
+                        "1fb19bb476f6b9e44e2a32234da8212f"
+                        "61cd63919354bc06aef31e3cfaff3ebc",
+                        "22606845ff186793914e03e21df544c3"
+                        "4ffe2f2f3504de8a79d9159eca2d98d9",
+                        "2bd368e28381e8eccb5fa81fc26cf3f0"
+                        "48eea9abfdd85d7ed3ab3698d63e4f90",
+                        "2fe02e47887507adf0ff1743cbac6ba2"
+                        "91e66f59be6bd763950bb16041a0a85e",
+                    ),
+                    (  # Second pairing
+                        "00000000000000000000000000000000"
+                        "00000000000000000000000000000013",
+                        "0644e72e131a029b85045b68181585d9"
+                        "7816a916871ca8d3c208c16d87cfd451",
+                        "971ff0471b09fa93caaf13cbf443c1ae"
+                        "de09cc4328f5a62aad45f40ec133eb40",
+                        "91058a3141822985733cbdddfed0fd8d"
+                        "6c104e9e9eff40bf5abfef9ab163bc72",
+                        "a23af9a5ce2ba2796c1f4e453a370eb0"
+                        "af8c212d9dc9acd8fc02c2e907baea22",
+                        "3a8eb0b0996252cb548a4487da97b024"
+                        "22ebc0e834613f954de6c7e0afdc1fc0",
+                    ),
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_2_sets",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters([""]),
+            Precompile.BN128_PAIRING_ADDRESS,
+            b"",
             Precompile.BN128_PAIRING,
             id="ec_pairing_1_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
+            Precompile.BN128_PAIRING_ADDRESS,
+            bn128_pairing_calldata(
                 [
-                    # First pairing
-                    "2371e7d92e9fc444d0e11526f0752b520318c80be68bf0131704b36b7976572e",
-                    "2dca8f05ed5d58e0f2e13c49ae40480c0f99dfcd9268521eea6c81c6387b66c4",
-                    "051a93d697db02afd3dcf8414ecb906a114a2bfdb6b06c95d41798d1801b3cbd",
-                    "2e275fef7a0bdb0a2aea77d8ec5817e66e199b3d55bc0fa308dcdda74e85060b",
-                    "1c7e33c2a72d6e12a31eababad3dbc388525135628102bb64742d9e325f43410",
-                    "115dc41fa10b2dbf99036f252ad6f00e8876b22f02cb4738dc4413b22ea9b2df",
-                    # Second pairing
-                    "09a760ea8f9bd87dc258a949395a03f7d2500c6e72c61f570986328a096b610a",
-                    "148027063c072345298117eb2cb980ad79601db31cc69bba6bcbe4937ada6720",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+                    (  # First pairing
+                        "2371e7d92e9fc444d0e11526f0752b52"
+                        "0318c80be68bf0131704b36b7976572e",
+                        "2dca8f05ed5d58e0f2e13c49ae40480c"
+                        "0f99dfcd9268521eea6c81c6387b66c4",
+                        "051a93d697db02afd3dcf8414ecb906a"
+                        "114a2bfdb6b06c95d41798d1801b3cbd",
+                        "2e275fef7a0bdb0a2aea77d8ec5817e6"
+                        "6e199b3d55bc0fa308dcdda74e85060b",
+                        "1c7e33c2a72d6e12a31eababad3dbc38"
+                        "8525135628102bb64742d9e325f43410",
+                        "115dc41fa10b2dbf99036f252ad6f00e"
+                        "8876b22f02cb4738dc4413b22ea9b2df",
+                    ),
+                    (  # Second pairing
+                        "09a760ea8f9bd87dc258a949395a03f7"
+                        "d2500c6e72c61f570986328a096b610a",
+                        "148027063c072345298117eb2cb980ad"
+                        "79601db31cc69bba6bcbe4937ada6720",
+                        "198e9393920d483a7260bfb731fb5d25"
+                        "f1aa493335a9e71297e485b7aef312c2",
+                        "1800deef121f1e76426a00665e5c4479"
+                        "674322d4f75edadd46debd5cd992f6ed",
+                        "090689d0585ff075ec9e99ad690c3395"
+                        "bc4b313370b38ef355acdadcd122975b",
+                        "12c85ea5db8c6deb4aab71808dcb408f"
+                        "e3d1e7690c43d37b4ce6cc0166fa7daa",
+                    ),
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_2_pair",
         ),
         pytest.param(
-            0x08,
+            Precompile.BN128_PAIRING_ADDRESS,
             concatenate_parameters(
                 [
-                    # First pairing
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0ef4aac9b7954d5fc6eafae7f4f4c2a732ab05b45f8d50d102cee4973f36eb2c",
-                    "23db7d30c99e0a2a7f3bb5cd1f04635aaea58732b58887df93d9239c28230d28",
-                    "2bd99d31a5054f2556d226f2e5ef0e075423d8604178b2e2c08006311caee54f",
-                    "0f11afb0c6073d12d21b13f4f78210e8ca9a66729206d3fcc2c1b04824c425f2",
+                    # First pairing (g1_x, g1_y, g2_x_im,
+                    #   g2_x_re, g2_y_im, g2_y_re)
+                    ZERO,  # g1_x (infinity)
+                    ZERO,  # g1_y (infinity)
+                    "0ef4aac9b7954d5fc6eafae7f4f4c2a7"
+                    "32ab05b45f8d50d102cee4973f36eb2c",
+                    "23db7d30c99e0a2a7f3bb5cd1f04635a"
+                    "aea58732b58887df93d9239c28230d28",
+                    "2bd99d31a5054f2556d226f2e5ef0e07"
+                    "5423d8604178b2e2c08006311caee54f",
+                    "0f11afb0c6073d12d21b13f4f78210e8"
+                    "ca9a66729206d3fcc2c1b04824c425f2",
                     # Second pairing
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+                    ZERO,  # g1_x (infinity)
+                    "198e9393920d483a7260bfb731fb5d25"
+                    "f1aa493335a9e71297e485b7aef312c2",
+                    "1800deef121f1e76426a00665e5c4479"
+                    "674322d4f75edadd46debd5cd992f6ed",
+                    "090689d0585ff075ec9e99ad690c3395"
+                    "bc4b313370b38ef355acdadcd122975b",
+                    "12c85ea5db8c6deb4aab71808dcb408f"
+                    "e3d1e7690c43d37b4ce6cc0166fa7daa",
                     # Third pairing
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+                    ZERO,  # g1_x (infinity)
+                    "198e9393920d483a7260bfb731fb5d25"
+                    "f1aa493335a9e71297e485b7aef312c2",
+                    "1800deef121f1e76426a00665e5c4479"
+                    "674322d4f75edadd46debd5cd992f6ed",
+                    "090689d0585ff075ec9e99ad690c3395"
+                    "bc4b313370b38ef355acdadcd122975b",
+                    "12c85ea5db8c6deb4aab71808dcb408f"
+                    "e3d1e7690c43d37b4ce6cc0166fa7daa",
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_3_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
+            Precompile.BN128_PAIRING_ADDRESS,
+            bn128_pairing_calldata(
                 [
-                    # First pairing
-                    "24ab69f46f3e3333027d67d51af71571141bd5652b9829157a3c5d1268461984",
-                    "0f0e1495665bccf97d627b714e8a49e9c77c21e8d5b383ad7dde7e50040d0f62",
-                    "2cab595b9d579f8b82e433249b83ae1d7b62d7073a4f67cb3aeb9b316988907f",
-                    "1326d1905ffde0c77e8ebd98257aa239b05ae76c8ec7723ec19bbc8282b0debe",
-                    "130502106676b537e01cc356765e91c005d6c4bd1a75f5f6d41d2556c73e56ac",
-                    "2dc4cb08068b4aa5f14b7f1096ab35d5c13d78319ec7e66e9f67a1ff20cbbf03",
-                    # Second pairing
-                    "1459f4140b271cbc8746de9dfcb477d5b72d50ef95bec5fef4a68dd69ddfdb2e",
-                    "2c589584551d16a9723b5d356d1ee2066d10381555cdc739e39efca2612fc544",
-                    "229ab0abdb0a7d1a5f0d93fb36ce41e12a31ba52fd9e3c27bebce524ab6c4e9b",
-                    "00f8756832b244377d06e2d00eeb95ec8096dcfd81f4e4931b50fea23c04a2fe",
-                    "29605352ce973ec48d1ab2c8355643c999b70ff771946078b519c556058c3d56",
-                    "059a65ae6e0189d4e04a966140aa40f781a1345824a90a91bb035e12ad29af1d",
-                    # Third pairing
-                    "1459f4140b271cbc8746de9dfcb477d5b72d50ef95bec5fef4a68dd69ddfdb2e",
-                    "2c589584551d16a9723b5d356d1ee2066d10381555cdc739e39efca2612fc544",
-                    "229ab0abdb0a7d1a5f0d93fb36ce41e12a31ba52fd9e3c27bebce524ab6c4e9b",
-                    "00f8756832b244377d06e2d00eeb95ec8096dcfd81f4e4931b50fea23c04a2fe",
-                    "29605352ce973ec48d1ab2c8355643c999b70ff771946078b519c556058c3d56",
-                    "059a65ae6e0189d4e04a966140aa40f781a1345824a90a91bb035e12ad29af1d",
-                    # Fourth pairing
-                    "24ab69f46f3e3333027d67d51af71571141bd5652b9829157a3c5d1268461984",
-                    "0f0e1495665bccf97d627b714e8a49e9c77c21e8d5b383ad7dde7e50040d0f62",
-                    "2cab595b9d579f8b82e433249b83ae1d7b62d7073a4f67cb3aeb9b316988907f",
-                    "1326d1905ffde0c77e8ebd98257aa239b05ae76c8ec7723ec19bbc8282b0debe",
-                    "130502106676b537e01cc356765e91c005d6c4bd1a75f5f6d41d2556c73e56ac",
-                    "2dc4cb08068b4aa5f14b7f1096ab35d5c13d78319ec7e66e9f67a1ff20cbbf03",
+                    (  # First pairing
+                        "24ab69f46f3e3333027d67d51af71571"
+                        "141bd5652b9829157a3c5d1268461984",
+                        "0f0e1495665bccf97d627b714e8a49e9"
+                        "c77c21e8d5b383ad7dde7e50040d0f62",
+                        "2cab595b9d579f8b82e433249b83ae1d"
+                        "7b62d7073a4f67cb3aeb9b316988907f",
+                        "1326d1905ffde0c77e8ebd98257aa239"
+                        "b05ae76c8ec7723ec19bbc8282b0debe",
+                        "130502106676b537e01cc356765e91c0"
+                        "05d6c4bd1a75f5f6d41d2556c73e56ac",
+                        "2dc4cb08068b4aa5f14b7f1096ab35d5"
+                        "c13d78319ec7e66e9f67a1ff20cbbf03",
+                    ),
+                    (  # Second pairing
+                        "1459f4140b271cbc8746de9dfcb477d5"
+                        "b72d50ef95bec5fef4a68dd69ddfdb2e",
+                        "2c589584551d16a9723b5d356d1ee206"
+                        "6d10381555cdc739e39efca2612fc544",
+                        "229ab0abdb0a7d1a5f0d93fb36ce41e1"
+                        "2a31ba52fd9e3c27bebce524ab6c4e9b",
+                        "00f8756832b244377d06e2d00eeb95ec"
+                        "8096dcfd81f4e4931b50fea23c04a2fe",
+                        "29605352ce973ec48d1ab2c8355643c9"
+                        "99b70ff771946078b519c556058c3d56",
+                        "059a65ae6e0189d4e04a966140aa40f7"
+                        "81a1345824a90a91bb035e12ad29af1d",
+                    ),
+                    (  # Third pairing (same as second)
+                        "1459f4140b271cbc8746de9dfcb477d5"
+                        "b72d50ef95bec5fef4a68dd69ddfdb2e",
+                        "2c589584551d16a9723b5d356d1ee206"
+                        "6d10381555cdc739e39efca2612fc544",
+                        "229ab0abdb0a7d1a5f0d93fb36ce41e1"
+                        "2a31ba52fd9e3c27bebce524ab6c4e9b",
+                        "00f8756832b244377d06e2d00eeb95ec"
+                        "8096dcfd81f4e4931b50fea23c04a2fe",
+                        "29605352ce973ec48d1ab2c8355643c9"
+                        "99b70ff771946078b519c556058c3d56",
+                        "059a65ae6e0189d4e04a966140aa40f7"
+                        "81a1345824a90a91bb035e12ad29af1d",
+                    ),
+                    (  # Fourth pairing (same as first)
+                        "24ab69f46f3e3333027d67d51af71571"
+                        "141bd5652b9829157a3c5d1268461984",
+                        "0f0e1495665bccf97d627b714e8a49e9"
+                        "c77c21e8d5b383ad7dde7e50040d0f62",
+                        "2cab595b9d579f8b82e433249b83ae1d"
+                        "7b62d7073a4f67cb3aeb9b316988907f",
+                        "1326d1905ffde0c77e8ebd98257aa239"
+                        "b05ae76c8ec7723ec19bbc8282b0debe",
+                        "130502106676b537e01cc356765e91c0"
+                        "05d6c4bd1a75f5f6d41d2556c73e56ac",
+                        "2dc4cb08068b4aa5f14b7f1096ab35d5"
+                        "c13d78319ec7e66e9f67a1ff20cbbf03",
+                    ),
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_4_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
+            Precompile.BN128_PAIRING_ADDRESS,
+            bn128_pairing_calldata(
                 [
-                    # First pairing
-                    "1147057b17237df94a3186435acf66924e1d382b8c935fdd493ceb38c38def73",
-                    "03cd046286139915160357ce5b29b9ea28bfb781b71734455d20ef1a64be76ca",
-                    "0daa7cc4983cf74c94607519df747f61e317307c449bafb6923f6d6a65299a7e",
-                    "1d48db8f275830859fd61370addbc5d5ef3f0ce7491d16918e065f7e3727439d",
-                    "1ca8ac2f4a0f540e5505edbe1d15d13899a2a0dfccb012d068134ac66edec625",
-                    "2162c315417d1d12c9d7028c5619015391003a9006d4d8979784c7af2c4537a3",
-                    # Second pairing
-                    "0d221a19ca86dafa8cb804daff78fd3d1bed30aa32e7d4029b1aa69afda2d750",
-                    "018628c766a98de1d0cca887a6d90303e68a7729490f25f937b76b57624ba0be",
-                    "14550ccf7139312da6fa9eb1259c6365b0bd688a27473ccb42bc5cd6f14c8abd",
-                    "165f8721ee9f614382c8c7edb103c941d3a55c1849c9787f34317777d5d9365b",
-                    "0d19da7439edb573a1b3e357faade63d5d68b6031771fd911459b7ab0bda9d3f",
-                    "25a50a44d10c99c5f107e3b3874f717873cb2d4674699a468204df27c0c50a9a",
-                    # Third pairing
-                    "0d7136c59b907615e1b45cf730fbfd6cf38b7e126e85e52be804620a23ace4fb",
-                    "03e80c29d24ed5cc407329ae093bb1be00f9e3c9332f532bc3658937110d7607",
-                    "2129813bd7247065ac58eac42c81e874044e199f48c12aa749a9fe6bb6e4bddc",
-                    "1b72b9ab4579283e62445555d5b2921424213d09a776152361c46988b82be8a7",
-                    "111bc8198f932e379b8f9825f01af0f5e5cacbf8bfe274bf674f6eaa6e338e04",
-                    "259f58d438fd6391e158c991e155966218e6a432703a84068a32543965749857",
-                    # Fourth pairing
-                    "1ba47a91d487cce77aa78390a295df54d9351637d67810c400415fb374278e3f",
-                    "24318bbc05a4e4d779b9498075841c360c6973c1c51dea254281829bbc9aef33",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
-                    # Fifth pairing
-                    "1e219772c16eee72450bbf43e9cadae7bf6b2e6ae6637cfeb1d1e8965287acfb",
-                    "0347e7bf4245debd3d00b6f51d2d50fd718e6769352f4fe1db0efe492fed2fc3",
-                    "24fdcc7d4ed0953e3dad500c7ef9836fc61ded44ba454ec76f0a6d0687f4c1b4",
-                    "282b18f7e59c1db4852e622919b2ce9aa5980ca883eac312049c19a3deb79f6d",
-                    "0c9d6ce303b7811dd7ea506c8fa124837405bd209b8731bda79a66eb7206277b",
-                    "1ac5dac62d2332faa8069faca3b0d27fcdf95d8c8bafc9074ee72b5c1f33aa70",
+                    (  # First pairing
+                        "1147057b17237df94a3186435acf6692"
+                        "4e1d382b8c935fdd493ceb38c38def73",
+                        "03cd046286139915160357ce5b29b9ea"
+                        "28bfb781b71734455d20ef1a64be76ca",
+                        "0daa7cc4983cf74c94607519df747f61"
+                        "e317307c449bafb6923f6d6a65299a7e",
+                        "1d48db8f275830859fd61370addbc5d5"
+                        "ef3f0ce7491d16918e065f7e3727439d",
+                        "1ca8ac2f4a0f540e5505edbe1d15d138"
+                        "99a2a0dfccb012d068134ac66edec625",
+                        "2162c315417d1d12c9d7028c561901539"
+                        "1003a9006d4d8979784c7af2c4537a3",
+                    ),
+                    (  # Second pairing
+                        "0d221a19ca86dafa8cb804daff78fd3d"
+                        "1bed30aa32e7d4029b1aa69afda2d750",
+                        "018628c766a98de1d0cca887a6d90303"
+                        "e68a7729490f25f937b76b57624ba0be",
+                        "14550ccf7139312da6fa9eb1259c6365"
+                        "b0bd688a27473ccb42bc5cd6f14c8abd",
+                        "165f8721ee9f614382c8c7edb103c941"
+                        "d3a55c1849c9787f34317777d5d9365b",
+                        "0d19da7439edb573a1b3e357faade63d"
+                        "5d68b6031771fd911459b7ab0bda9d3f",
+                        "25a50a44d10c99c5f107e3b3874f7178"
+                        "73cb2d4674699a468204df27c0c50a9a",
+                    ),
+                    (  # Third pairing
+                        "0d7136c59b907615e1b45cf730fbfd6c"
+                        "f38b7e126e85e52be804620a23ace4fb",
+                        "03e80c29d24ed5cc407329ae093bb1be"
+                        "00f9e3c9332f532bc3658937110d7607",
+                        "2129813bd7247065ac58eac42c81e874"
+                        "044e199f48c12aa749a9fe6bb6e4bddc",
+                        "1b72b9ab4579283e62445555d5b29214"
+                        "24213d09a776152361c46988b82be8a7",
+                        "111bc8198f932e379b8f9825f01af0f5"
+                        "e5cacbf8bfe274bf674f6eaa6e338e04",
+                        "259f58d438fd6391e158c991e1559662"
+                        "18e6a432703a84068a32543965749857",
+                    ),
+                    (  # Fourth pairing
+                        "1ba47a91d487cce77aa78390a295df54"
+                        "d9351637d67810c400415fb374278e3f",
+                        "24318bbc05a4e4d779b9498075841c36"
+                        "0c6973c1c51dea254281829bbc9aef33",
+                        "198e9393920d483a7260bfb731fb5d25"
+                        "f1aa493335a9e71297e485b7aef312c2",
+                        "1800deef121f1e76426a00665e5c4479"
+                        "674322d4f75edadd46debd5cd992f6ed",
+                        "090689d0585ff075ec9e99ad690c3395"
+                        "bc4b313370b38ef355acdadcd122975b",
+                        "12c85ea5db8c6deb4aab71808dcb408f"
+                        "e3d1e7690c43d37b4ce6cc0166fa7daa",
+                    ),
+                    (  # Fifth pairing
+                        "1e219772c16eee72450bbf43e9cadae7"
+                        "bf6b2e6ae6637cfeb1d1e8965287acfb",
+                        "0347e7bf4245debd3d00b6f51d2d50fd"
+                        "718e6769352f4fe1db0efe492fed2fc3",
+                        "24fdcc7d4ed0953e3dad500c7ef9836f"
+                        "c61ded44ba454ec76f0a6d0687f4c1b4",
+                        "282b18f7e59c1db4852e622919b2ce9a"
+                        "a5980ca883eac312049c19a3deb79f6d",
+                        "0c9d6ce303b7811dd7ea506c8fa12483"
+                        "7405bd209b8731bda79a66eb7206277b",
+                        "1ac5dac62d2332faa8069faca3b0d27f"
+                        "cdf95d8c8bafc9074ee72b5c1f33aa70",
+                    ),
                 ]
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_5_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                ]
-            ),
+            Precompile.BN128_PAIRING_ADDRESS,
+            bytes.fromhex(ZERO),
             Precompile.BN128_PAIRING,
             id="ec_pairing_1_pair_empty",
         ),
-    ],
+    ]
+
+
+@pytest.mark.parametrize(
+    "precompile_address,calldata,target",
+    create_alt_bn128_test_cases(),
 )
 def test_alt_bn128(
     benchmark_test: BenchmarkTestFiller,
@@ -399,7 +533,9 @@ def test_alt_bn128(
     """Benchmark ALT_BN128 precompile."""
     attack_block = Op.POP(
         Op.STATICCALL(
-            gas=Op.GAS, address=precompile_address, args_size=Op.CALLDATASIZE
+            gas=Op.GAS,
+            address=precompile_address,
+            args_size=Op.CALLDATASIZE,
         ),
     )
 
@@ -473,12 +609,13 @@ def test_bn128_pairings_amortized(
         address_warm=True,
     ).gas_cost(fork)
 
-    # This is a theoretical maximum number of pairings that can be done in a
-    # block. It is only used for an upper bound for calculating the optimal
-    # number of pairings below.
+    # This is a theoretical maximum number of pairings that can
+    # be done in a block.  It is only used for an upper bound
+    # for calculating the optimal number of pairings below.
     maximum_number_of_pairings = (tx_gas_limit - base_cost) // pairing_cost
 
-    # Discover the optimal number of pairings balancing two dimensions:
+    # Discover the optimal number of pairings balancing two
+    # dimensions:
     # 1. Amortize the precompile base cost as much as possible.
     # 2. The cost of the memory expansion.
     max_pairings = 0
@@ -507,8 +644,8 @@ def test_bn128_pairings_amortized(
         num_precompile_calls = (
             available_gas_after_expansion // approx_gas_cost_per_call
         )
-        num_pairings_done = num_precompile_calls * i  # Each precompile call
-        # does i pairings.
+        # Each precompile call does i pairings.
+        num_pairings_done = num_precompile_calls * i
 
         if num_pairings_done > max_pairings:
             max_pairings = num_pairings_done
@@ -516,7 +653,14 @@ def test_bn128_pairings_amortized(
 
     setup = Op.CALLDATACOPY(size=Op.CALLDATASIZE)
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x08, 0, Op.CALLDATASIZE, 0, 0)
+        Op.STATICCALL(
+            Op.GAS,
+            Precompile.BN128_PAIRING_ADDRESS,
+            0,
+            Op.CALLDATASIZE,
+            0,
+            0,
+        )
     )
 
     benchmark_test(
@@ -539,11 +683,15 @@ def test_alt_bn128_benchmark(
     benchmark_test: BenchmarkTestFiller,
     num_pairs: int,
 ) -> None:
-    """Benchmark BN128 pairings precompile with varying number of pairs."""
+    """Benchmark BN128 pairings precompile with varying pairs."""
     calldata = _generate_bn128_pairs(num_pairs, seed=42)
 
     attack_block = Op.POP(
-        Op.STATICCALL(gas=Op.GAS, address=0x08, args_size=Op.CALLDATASIZE),
+        Op.STATICCALL(
+            gas=Op.GAS,
+            address=Precompile.BN128_PAIRING_ADDRESS,
+            args_size=Op.CALLDATASIZE,
+        ),
     )
 
     benchmark_test(
@@ -576,13 +724,15 @@ def test_ec_pairing(
         + gsc.PRECOMPILE_ECPAIRING_PER_POINT * num_pairs
     )
 
-    # Each iteration: STATICCALL ecpairing at advancing calldata offset,
-    # then advance offset by pair_size at memory[CALLDATASIZE].
-    # The loop condition checks remaining gas against one body execution.
+    # Each iteration: STATICCALL ecpairing at advancing calldata
+    # offset, then advance offset by pair_size at
+    # memory[CALLDATASIZE].
+    # The loop condition checks remaining gas against one body
+    # execution.
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x08,
+            address=Precompile.BN128_PAIRING_ADDRESS,
             args_offset=Op.MLOAD(Op.CALLDATASIZE),
             args_size=pair_size,
             # gas accounting
@@ -605,9 +755,9 @@ def test_ec_pairing(
     iteration_cost = loop.gas_cost(fork)
     setup_cost = setup.gas_cost(fork)
 
-    # Conservative per-variant estimate for sizing the calldata:
-    # one loop iteration + worst-case calldata intrinsic (all non-zero)
-    # + CALLDATACOPY copy and linear memory expansion.
+    # Conservative per-variant estimate for sizing calldata:
+    # one loop iteration + worst-case calldata intrinsic (all
+    # non-zero) + CALLDATACOPY copy and linear memory expansion.
     words_per_variant = math.ceil(pair_size / 32)
     per_variant_gas = (
         iteration_cost
@@ -615,7 +765,8 @@ def test_ec_pairing(
         + words_per_variant * (gsc.OPCODE_COPY_PER_WORD + gsc.MEMORY_PER_WORD)
     )
     empty_intrinsic = intrinsic_gas_calculator(
-        calldata=[], return_cost_deducted_prior_execution=True
+        calldata=[],
+        return_cost_deducted_prior_execution=True,
     )
     fixed_overhead = empty_intrinsic + setup_cost + mem_exp(new_bytes=32)
 
@@ -627,7 +778,8 @@ def test_ec_pairing(
     while remaining_gas > 0:
         per_tx_gas = min(tx_gas_limit, remaining_gas)
         per_tx_variants = max(
-            1, (per_tx_gas - fixed_overhead) // per_variant_gas
+            1,
+            (per_tx_gas - fixed_overhead) // per_variant_gas,
         )
         calldata = Bytes(
             b"".join(
@@ -689,15 +841,20 @@ def _generate_g1_point(seed: int) -> Bytes:
 @pytest.mark.parametrize(
     "precompile_address,scalar,target",
     [
-        pytest.param(0x06, None, Precompile.BN128_ADD, id="ec_add"),
         pytest.param(
-            0x07,
+            Precompile.BN128_ADD_ADDRESS,
+            None,
+            Precompile.BN128_ADD,
+            id="ec_add",
+        ),
+        pytest.param(
+            Precompile.BN128_MUL_ADDRESS,
             2,
             Precompile.BN128_MUL,
             id="ec_mul_small_scalar",
         ),
         pytest.param(
-            0x07,
+            Precompile.BN128_MUL_ADDRESS,
             2**256 - 1,
             Precompile.BN128_MUL,
             id="ec_mul_max_scalar",
@@ -725,7 +882,7 @@ def test_alt_bn128_uncachable(
     gsc = fork.gas_costs()
     precompile_cost = (
         gsc.PRECOMPILE_ECMUL
-        if precompile_address == 0x07
+        if precompile_address == Precompile.BN128_MUL_ADDRESS
         else gsc.PRECOMPILE_ECADD
     )
     attack_block = Op.POP(
@@ -733,8 +890,9 @@ def test_alt_bn128_uncachable(
             gas=Op.GAS,
             address=precompile_address,
             args_size=Op.CALLDATASIZE,
-            # One G1 point (2 * 32 bytes), overwrites the input point
-            # so each iteration has unique precompile input.
+            # One G1 point (2 * 32 bytes), overwrites the
+            # input point so each iteration has unique
+            # precompile input.
             ret_size=64,
             # gas accounting
             address_warm=True,

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -9,7 +9,7 @@ from execution_testing import (
     Op,
 )
 
-from ..helpers import Precompile, concatenate_parameters
+from ..helpers import Precompile, ecrecover_calldata
 
 
 @pytest.mark.repricing
@@ -17,16 +17,17 @@ from ..helpers import Precompile, concatenate_parameters
     "precompile_address,calldata",
     [
         pytest.param(
-            0x01,
-            concatenate_parameters(
-                [
-                    # Inputs below are a valid signature, thus ECRECOVER call
-                    # will perform full computation, not blocked by validation.
-                    "38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E",
-                    "000000000000000000000000000000000000000000000000000000000000001B",
-                    "38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E",
-                    "789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02",
-                ]
+            Precompile.ECRECOVER_ADDRESS,
+            ecrecover_calldata(
+                # Valid signature: full computation, not
+                # blocked by validation.
+                msg_hash="38D18ACB67D25C8BB9942764B62F18E1"
+                "7054F66A817BD4295423ADF9ED98873E",
+                v="1B",
+                r="38D18ACB67D25C8BB9942764B62F18E1"
+                "7054F66A817BD4295423ADF9ED98873E",
+                s="789D1DD423D25F0772D2748D60F7E4B8"
+                "1BB14D086EBA8E8E8EFB6DCFF8A4AE02",
             ),
             id="ecrecover",
         )

--- a/tests/benchmark/compute/precompile/test_identity.py
+++ b/tests/benchmark/compute/precompile/test_identity.py
@@ -39,7 +39,12 @@ def test_identity(
 
     attack_block = Op.POP(
         Op.STATICCALL(
-            Op.GAS, 0x04, Op.PUSH0, optimal_input_length, Op.PUSH0, Op.PUSH0
+            Op.GAS,
+            Precompile.IDENTITY_ADDRESS,
+            Op.PUSH0,
+            optimal_input_length,
+            Op.PUSH0,
+            Op.PUSH0,
         )
     )
 
@@ -59,7 +64,14 @@ def test_identity_fixed_size(
 ) -> None:
     """Benchmark IDENTITY with fixed size input."""
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x04, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+        Op.STATICCALL(
+            Op.GAS,
+            Precompile.IDENTITY_ADDRESS,
+            Op.PUSH0,
+            size,
+            Op.PUSH0,
+            Op.PUSH0,
+        )
     )
 
     benchmark_test(
@@ -97,7 +109,7 @@ def test_identity_uncachable(
             Op.MLOAD(0),
             Op.STATICCALL(
                 gas=Op.GAS,
-                address=0x04,
+                address=Precompile.IDENTITY_ADDRESS,
                 args_size=size,
                 ret_size=size,
                 # gas accounting

--- a/tests/benchmark/compute/precompile/test_modexp.py
+++ b/tests/benchmark/compute/precompile/test_modexp.py
@@ -488,7 +488,7 @@ def test_modexp_uncachable(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x05,
+            address=Precompile.MODEXP_ADDRESS,
             args_size=Op.CALLDATASIZE,
             ret_offset=96,
             ret_size=base_length,

--- a/tests/benchmark/compute/precompile/test_point_evaluation.py
+++ b/tests/benchmark/compute/precompile/test_point_evaluation.py
@@ -20,7 +20,7 @@ from execution_testing.test_types.blob_types import Blob
 
 from tests.cancun.eip4844_blobs.spec import Spec as BlobsSpec
 
-from ..helpers import Precompile, concatenate_parameters
+from ..helpers import Precompile, point_evaluation_calldata
 
 INPUT_SIZE = 192
 
@@ -31,14 +31,19 @@ INPUT_SIZE = 192
     [
         pytest.param(
             BlobsSpec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-            concatenate_parameters(
-                [
-                    "01E798154708FE7789429634053CBF9F99B619F9F084048927333FCE637F549B",
-                    "564C0A11A0F704F4FC3E8ACFE0F8245F0AD1347B378FBF96E206DA11A5D36306",
-                    "24D25032E67A7E6A4910DF5834B8FE70E6BCFEEAC0352434196BDF4B2485D5A1",
-                    "8F59A8D2A1A625A17F3FEA0FE5EB8C896DB3764F3185481BC22F91B4AAFFCCA25F26936857BC3A7C2539EA8EC3A952B7",
-                    "873033E038326E87ED3E1276FD140253FA08E9FC25FB2D9A98527FC22A2C9612FBEAFDAD446CBC7BCDBDCD780AF2C16A",
-                ]
+            point_evaluation_calldata(
+                versioned_hash="01E798154708FE7789429634"
+                "053CBF9F99B619F9F084048927333FCE637F549B",
+                z="564C0A11A0F704F4FC3E8ACFE0F8245F"
+                "0AD1347B378FBF96E206DA11A5D36306",
+                y="24D25032E67A7E6A4910DF5834B8FE70"
+                "E6BCFEEAC0352434196BDF4B2485D5A1",
+                commitment="8F59A8D2A1A625A17F3FEA0FE5"
+                "EB8C896DB3764F3185481BC22F91B4AAFFCC"
+                "A25F26936857BC3A7C2539EA8EC3A952B7",
+                proof="873033E038326E87ED3E1276FD1402"
+                "53FA08E9FC25FB2D9A98527FC22A2C9612FB"
+                "EAFDAD446CBC7BCDBDCD780AF2C16A",
             ),
             id="point_evaluation",
         ),

--- a/tests/benchmark/compute/precompile/test_ripemd160.py
+++ b/tests/benchmark/compute/precompile/test_ripemd160.py
@@ -39,7 +39,12 @@ def test_ripemd160(
 
     attack_block = Op.POP(
         Op.STATICCALL(
-            Op.GAS, 0x03, Op.PUSH0, optimal_input_length, Op.PUSH0, Op.PUSH0
+            Op.GAS,
+            Precompile.RIPEMD160_ADDRESS,
+            Op.PUSH0,
+            optimal_input_length,
+            Op.PUSH0,
+            Op.PUSH0,
         )
     )
 
@@ -59,7 +64,14 @@ def test_ripemd160_fixed_size(
 ) -> None:
     """Benchmark RIPEMD160 with fixed size input."""
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x03, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+        Op.STATICCALL(
+            Op.GAS,
+            Precompile.RIPEMD160_ADDRESS,
+            Op.PUSH0,
+            size,
+            Op.PUSH0,
+            Op.PUSH0,
+        )
     )
 
     benchmark_test(
@@ -94,7 +106,7 @@ def test_ripemd160_uncachable(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x03,
+            address=Precompile.RIPEMD160_ADDRESS,
             args_size=size,
             ret_size=0x20,
             # gas accounting

--- a/tests/benchmark/compute/precompile/test_sha256.py
+++ b/tests/benchmark/compute/precompile/test_sha256.py
@@ -39,7 +39,12 @@ def test_sha256(
 
     attack_block = Op.POP(
         Op.STATICCALL(
-            Op.GAS, 0x02, Op.PUSH0, optimal_input_length, Op.PUSH0, Op.PUSH0
+            Op.GAS,
+            Precompile.SHA256_ADDRESS,
+            Op.PUSH0,
+            optimal_input_length,
+            Op.PUSH0,
+            Op.PUSH0,
         )
     )
 
@@ -59,7 +64,14 @@ def test_sha256_fixed_size(
 ) -> None:
     """Benchmark SHA256 with fixed size input."""
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x02, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+        Op.STATICCALL(
+            Op.GAS,
+            Precompile.SHA256_ADDRESS,
+            Op.PUSH0,
+            size,
+            Op.PUSH0,
+            Op.PUSH0,
+        )
     )
 
     benchmark_test(
@@ -93,7 +105,7 @@ def test_sha256_uncachable(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x02,
+            address=Precompile.SHA256_ADDRESS,
             args_size=size,
             ret_size=0x20,
             # gas accounting


### PR DESCRIPTION
## 🗒️ Description

Replace raw hex precompile addresses with named constants and opaque calldata with labeled factory functions across all precompile benchmark tests, improving readability and maintainability.

Changes:
- Add `Precompile` address constants (`ECRECOVER_ADDRESS` through `BLAKE2F_ADDRESS`) to `helpers.py`
- Add labeled calldata factory functions: `bn128_add_calldata()`, `bn128_mul_calldata()`, `bn128_pairing_calldata()`, `ecrecover_calldata()`, `point_evaluation_calldata()`
- Refactor `test_alt_bn128.py` with `create_alt_bn128_test_cases()` factory pattern
- Replace raw `0x01`–`0x09` addresses across all precompile benchmark tests
- Replace opaque `concatenate_parameters()` calls with labeled keyword-argument helpers

## 🔗 Related Issues or PRs

Fixes #2739

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

my cute mimi<img width="192" height="256" alt="2026-04-27 08 08 31" src="https://github.com/user-attachments/assets/c3ea1842-6ce6-42c3-aa77-435cae3ded95" />