### PR TITLE
refactor(test-execute): include EIP-8037 state-gas in contract deployment

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -352,6 +352,13 @@ class Alloc(SharedAlloc):
             )
         deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
         deploy_gas_limit += len(deploy_code) * gas_costs.CODE_DEPOSIT_PER_BYTE
+        # EIP-8037: code deposit also pays state gas (`code_size * cpsb`).
+        # Returns 0 on pre-Amsterdam forks. Without this, the doubled-safety
+        # buffer below is too small for larger contracts and the deploy tx
+        # runs out of gas, leaving the contract empty (e.g. swapn_stack_235).
+        deploy_gas_limit += fork.code_deposit_state_gas(
+            code_size=len(deploy_code)
+        )
         deploy_gas_limit += memory_expansion_gas_calculator(
             new_bytes=len(initcode)
         )
@@ -463,6 +470,11 @@ class Alloc(SharedAlloc):
             raise ValueError(f"code too large: {len(code)} > {max_code_size}")
 
         deploy_gas_limit += len(code) * gas_costs.CODE_DEPOSIT_PER_BYTE
+        # EIP-8037: code deposit also pays state gas (`code_size * cpsb`).
+        # Returns 0 on pre-Amsterdam forks. Without this, the doubled-safety
+        # buffer below is too small for larger contracts and the deploy tx
+        # runs out of gas, leaving the contract empty (e.g. swapn_stack_235).
+        deploy_gas_limit += fork.code_deposit_state_gas(code_size=len(code))
 
         prepared_initcode = Initcode(
             deploy_code=code, initcode_prefix=initcode_prefix

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -221,6 +221,39 @@ class _DeferredFundAddress:
     minimum_balance: bool
 
 
+def _compute_deploy_gas_limit(
+    fork: Fork,
+    *,
+    deploy_code_size: int,
+    initcode: Bytes | Initcode,
+    storage_slots: int = 0,
+) -> int:
+    """
+    Compute the gas_limit for a contract-deploy transaction.
+
+    Sums TX_BASE + TX_CREATE, the legacy code-deposit cost, the
+    EIP-8037 state-gas surcharge (zero on pre-Amsterdam forks),
+    memory expansion over the initcode, calldata cost, and the SSTORE
+    cost from an injected storage-init prefix, then doubles the total
+    as a safety buffer. Without the EIP-8037 component the buffer is
+    too small for larger contracts under Amsterdam and the deploy tx
+    runs out of gas mid-construction.
+    """
+    gas_costs = fork.gas_costs()
+    memory_expansion_gas_calculator = fork.memory_expansion_gas_calculator()
+    calldata_gas_calculator = fork.calldata_gas_calculator()
+
+    deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
+    deploy_gas_limit += storage_slots * 22_600
+    deploy_gas_limit += deploy_code_size * gas_costs.CODE_DEPOSIT_PER_BYTE
+    deploy_gas_limit += fork.code_deposit_state_gas(code_size=deploy_code_size)
+    deploy_gas_limit += memory_expansion_gas_calculator(
+        new_bytes=len(bytes(initcode))
+    )
+    deploy_gas_limit += calldata_gas_calculator(data=initcode)
+    return deploy_gas_limit * 2
+
+
 class Alloc(SharedAlloc):
     """A custom class that inherits from the original Alloc class."""
 
@@ -323,11 +356,6 @@ class Alloc(SharedAlloc):
         fork = self._fork.fork_at(
             block_number=self._block_number, timestamp=self._timestamp
         )
-        gas_costs = fork.gas_costs()
-        memory_expansion_gas_calculator = (
-            fork.memory_expansion_gas_calculator()
-        )
-        calldata_gas_calculator = fork.calldata_gas_calculator()
         if not isinstance(deploy_code, Bytes):
             deploy_code = Bytes(deploy_code)
         if initcode is None:
@@ -350,20 +378,11 @@ class Alloc(SharedAlloc):
             raise ValueError(
                 f"initcode too large {len(initcode)} > {max_initcode_size}"
             )
-        deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
-        deploy_gas_limit += len(deploy_code) * gas_costs.CODE_DEPOSIT_PER_BYTE
-        # EIP-8037: code deposit also pays state gas (`code_size * cpsb`).
-        # Returns 0 on pre-Amsterdam forks. Without this, the doubled-safety
-        # buffer below is too small for larger contracts and the deploy tx
-        # runs out of gas, leaving the contract empty (e.g. swapn_stack_235).
-        deploy_gas_limit += fork.code_deposit_state_gas(
-            code_size=len(deploy_code)
+        deploy_gas_limit = _compute_deploy_gas_limit(
+            fork,
+            deploy_code_size=len(deploy_code),
+            initcode=initcode,
         )
-        deploy_gas_limit += memory_expansion_gas_calculator(
-            new_bytes=len(initcode)
-        )
-        deploy_gas_limit += calldata_gas_calculator(data=initcode)
-        deploy_gas_limit = deploy_gas_limit * 2
         tx_gas_limit_cap = fork.transaction_gas_limit_cap()
         if tx_gas_limit_cap and deploy_gas_limit > tx_gas_limit_cap:
             raise ValueError(
@@ -412,11 +431,6 @@ class Alloc(SharedAlloc):
         fork = self._fork.fork_at(
             block_number=self._block_number, timestamp=self._timestamp
         )
-        gas_costs = fork.gas_costs()
-        memory_expansion_gas_calculator = (
-            fork.memory_expansion_gas_calculator()
-        )
-        calldata_gas_calculator = fork.calldata_gas_calculator()
 
         if not isinstance(storage, Storage):
             storage = Storage(storage)  # type: ignore
@@ -452,13 +466,10 @@ class Alloc(SharedAlloc):
 
         initcode_prefix = Bytecode()
 
-        deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
-
         if len(storage.root) > 0:
             initcode_prefix += sum(
                 Op.SSTORE(key, value) for key, value in storage.root.items()
             )
-            deploy_gas_limit += len(storage.root) * 22_600
 
         assert isinstance(code, Bytecode), (
             f"incompatible code type: {type(code)}"
@@ -469,18 +480,8 @@ class Alloc(SharedAlloc):
         if len(code) > max_code_size:
             raise ValueError(f"code too large: {len(code)} > {max_code_size}")
 
-        deploy_gas_limit += len(code) * gas_costs.CODE_DEPOSIT_PER_BYTE
-        # EIP-8037: code deposit also pays state gas (`code_size * cpsb`).
-        # Returns 0 on pre-Amsterdam forks. Without this, the doubled-safety
-        # buffer below is too small for larger contracts and the deploy tx
-        # runs out of gas, leaving the contract empty (e.g. swapn_stack_235).
-        deploy_gas_limit += fork.code_deposit_state_gas(code_size=len(code))
-
         prepared_initcode = Initcode(
             deploy_code=code, initcode_prefix=initcode_prefix
-        )
-        deploy_gas_limit += memory_expansion_gas_calculator(
-            new_bytes=len(bytes(prepared_initcode))
         )
 
         max_initcode_size = fork.max_initcode_size()
@@ -490,9 +491,12 @@ class Alloc(SharedAlloc):
                 f"initcode too large {initcode_len} > {max_initcode_size}"
             )
 
-        deploy_gas_limit += calldata_gas_calculator(data=prepared_initcode)
-
-        deploy_gas_limit = deploy_gas_limit * 2
+        deploy_gas_limit = _compute_deploy_gas_limit(
+            fork,
+            deploy_code_size=len(code),
+            initcode=prepared_initcode,
+            storage_slots=len(storage.root),
+        )
         tx_gas_limit_cap = fork.transaction_gas_limit_cap()
         if tx_gas_limit_cap and deploy_gas_limit > tx_gas_limit_cap:
             raise ValueError(


### PR DESCRIPTION
## Summary

In `cli/pytest_commands/plugins/execute/pre_alloc.py`, both `_deterministic_deploy_contract` and `_deploy_contract` size the deploy transaction's `gas_limit` as

```python
deploy_gas_limit  = gas_costs.TX_BASE + gas_costs.TX_CREATE
deploy_gas_limit += len(code) * gas_costs.CODE_DEPOSIT_PER_BYTE
deploy_gas_limit += memory_expansion + calldata
deploy_gas_limit *= 2  # safety
```

The `CODE_DEPOSIT_PER_BYTE` term only covers the legacy 200 gas/byte. Under [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) (Amsterdam), code deposit additionally pays state gas equal to `code_size * cost_per_state_byte`. With cpsb in the ~700–1200 range at typical devnet gas limits, the surcharge is hundreds of kilo-gas per kilobyte of code — well past what the `* 2` safety buffer can absorb.

## Symptom

Under Amsterdam, deploying a sufficiently large contract via `pre.deploy_contract(...)` succeeds for short bytecode but the deploy tx runs out of gas for longer bytecode. The actual contract code stays empty (`0x`) and EEST raises:

```
Exception: Deployed test contract didn't match expected code at address 0x...
(not enough gas_limit?).
Expected: ...
Actual: 0x
```

Concrete repro on bal-devnet-4 (100M block gas limit → cpsb=1174):

```
tests/amsterdam/eip8024_dupn_swapn_exchange/test_swapn.py
  ::test_swapn_basic[fork_Amsterdam-state_test-swapn_stack_235]
```

The 951-byte contract here needs ~1.12M extra state-gas (`951 * 1174`) on top of the legacy `951 * 200 = 190K` deposit, which the existing formula doesn't budget for. Smaller stack-index variants of the same test (`swapn_stack_{17..200}`, ~80–300 bytes) pass because the `* 2` margin happens to cover their smaller cpsb surcharge.

## Fix

Add `fork.code_deposit_state_gas(code_size=...)` to `deploy_gas_limit` in both call sites. The helper is already defined on `BaseFork` (default returns 0 via the `Genesis` implementation) and overridden by `EIP8037` to return `code_size * cls.cost_per_state_byte()`, so this change is a no-op on every fork outside Amsterdam.

## Test plan
- [x] Repro the failure on bal-devnet-4 against a besu node at 100M block gas: 192/193 pass, only `swapn_stack_235` fails with "Actual: 0x".
- [ ] Verify the fix: re-run `tests/amsterdam/eip8024_dupn_swapn_exchange/test_swapn.py::test_swapn_basic[fork_Amsterdam-state_test-swapn_stack_235]` against the same besu node with this branch installed → all 8 stack-index variants pass.
- [ ] CI on `forks/amsterdam`.