### PR TITLE
fix(spec): fix bad formatting indroduced by large refactor

### DIFF
--- a/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/blake2f.py
+++ b/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/blake2f.py
@@ -35,10 +35,7 @@ def blake2f(evm: Evm) -> None:
     blake2b = Blake2b()
     rounds, h, m, t_0, t_1, f = blake2b.get_blake2_parameters(data)
 
-    charge_gas(
-        evm,
-        GasCosts.PRECOMPILE_BLAKE2F_PER_ROUND * rounds,
-    )
+    charge_gas(evm, GasCosts.PRECOMPILE_BLAKE2F_PER_ROUND * rounds)
     if f not in [0, 1]:
         raise InvalidParameter
 

--- a/src/ethereum/forks/osaka/vm/precompiled_contracts/blake2f.py
+++ b/src/ethereum/forks/osaka/vm/precompiled_contracts/blake2f.py
@@ -35,10 +35,7 @@ def blake2f(evm: Evm) -> None:
     blake2b = Blake2b()
     rounds, h, m, t_0, t_1, f = blake2b.get_blake2_parameters(data)
 
-    charge_gas(
-        evm,
-        GasCosts.PRECOMPILE_BLAKE2F_PER_ROUND * rounds,
-    )
+    charge_gas(evm, GasCosts.PRECOMPILE_BLAKE2F_PER_ROUND * rounds)
     if f not in [0, 1]:
         raise InvalidParameter
 


### PR DESCRIPTION
## 🗒️ Description
Fix bad formatting introduced during the large refactor of the gas constants.

## 🔗 Related Issues or PRs
#2396 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
