### PR TITLE
feat(zkevm): Fix Withdrawal.amount type to comply to the consensus specs

### DIFF
--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -65,7 +65,7 @@ class SszWithdrawal(Container):
     index: uint64
     validator_index: uint64
     address: ByteVector[20]
-    amount: uint256
+    amount: uint64
 
 
 class SszExecutionPayload(Container):
@@ -180,7 +180,7 @@ def _withdrawal_to_ssz(w: Withdrawal) -> SszWithdrawal:
         index=uint64(int(w.index)),
         validator_index=uint64(int(w.validator_index)),
         address=ByteVector[20](bytes(w.address)),
-        amount=uint256(int(w.amount)),
+        amount=uint64(int(w.amount)),
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
The types of `Withdrawal.amount` was previously `u256` which isn't correct as defined in the consensus specs (see [here uses Gwei type](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#withdrawal) and [here is Gwei definition](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#types)).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
