### PR TITLE
feat(specs): EIP-8037 state-delta counter (frame-diff alternative) [DRAFT]

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1114,8 +1114,9 @@ def process_transaction(
 
     block_output.block_logs += tx_output.logs
 
-    for address in tx_output.accounts_to_delete:
-        destroy_account(tx_state, address)
+    # SELFDESTRUCT same-tx destructions are finalized inside
+    # process_message at depth 0 so the state_delta_bytes counter
+    # captures them; no per-tx loop is needed here.
 
     incorporate_tx_into_block(tx_state, block_env.block_access_list_builder)
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -971,7 +971,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx, block_env.block_gas_limit)
+    intrinsic = validate_transaction(tx)
 
     intrinsic_gas = intrinsic.regular + intrinsic.state
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -77,6 +77,7 @@ from .state_tracker import (
     set_account_balance,
 )
 from .transactions import (
+    TX_MAX_GAS_LIMIT,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -330,10 +331,12 @@ def execute_block(
         block_output.block_access_list
     )
 
-    if block_output.block_gas_used != block.header.gas_used:
-        raise InvalidBlock(
-            f"{block_output.block_gas_used} != {block.header.gas_used}"
-        )
+    block_gas_used = max(
+        block_output.block_gas_used,
+        block_output.block_state_gas_used,
+    )
+    if block_gas_used != block.header.gas_used:
+        raise InvalidBlock(f"{block_gas_used} != {block.header.gas_used}")
     if transactions_root != block.header.transactions_root:
         raise InvalidBlock
     if block_state_root != block.header.state_root:
@@ -540,11 +543,16 @@ def check_transaction(
         is empty.
 
     """
-    gas_available = block_env.block_gas_limit - block_output.block_gas_used
+    # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
+    # State gas is not checked per-tx; block-end validation enforces
+    # max(block_regular_gas_used, block_state_gas_used) <= gas_limit.
+    regular_gas_available = (
+        block_env.block_gas_limit - block_output.block_gas_used
+    )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
-    if tx.gas > gas_available:
-        raise GasUsedExceedsLimitError("gas used exceeds limit")
+    if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
+        raise GasUsedExceedsLimitError("regular gas used exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:
@@ -763,6 +771,7 @@ def process_unchecked_system_transaction(
         origin=SYSTEM_ADDRESS,
         gas_price=block_env.base_fee_per_gas,
         gas=SYSTEM_TRANSACTION_GAS,
+        state_gas_reservoir=Uint(0),
         access_list_addresses=set(),
         access_list_storage_keys=set(),
         state=system_tx_state,
@@ -770,6 +779,8 @@ def process_unchecked_system_transaction(
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
+        intrinsic_regular_gas=Uint(0),
+        intrinsic_state_gas=Uint(0),
     )
 
     system_tx_message = Message(
@@ -778,6 +789,7 @@ def process_unchecked_system_transaction(
         caller=SYSTEM_ADDRESS,
         target=target_address,
         gas=SYSTEM_TRANSACTION_GAS,
+        state_gas_reservoir=Uint(0),
         value=U256(0),
         data=data,
         code=system_contract_code,
@@ -959,7 +971,9 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx, block_env.block_gas_limit)
+
+    intrinsic_gas = intrinsic.regular + intrinsic.state
 
     (
         sender,
@@ -982,7 +996,12 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    # Split execution gas into gas_left (capped by remaining regular gas
+    # budget) and state_gas_reservoir.
+    execution_gas = tx.gas - intrinsic_gas
+    regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic.regular
+    gas = min(regular_gas_budget, execution_gas)
+    state_gas_reservoir = Uint(execution_gas - gas)
 
     increment_nonce(tx_state, sender)
 
@@ -1008,6 +1027,7 @@ def process_transaction(
         origin=sender,
         gas_price=effective_gas_price,
         gas=gas,
+        state_gas_reservoir=state_gas_reservoir,
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
         state=tx_state,
@@ -1015,6 +1035,8 @@ def process_transaction(
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
+        intrinsic_regular_gas=intrinsic.regular,
+        intrinsic_state_gas=intrinsic.state,
     )
 
     message = prepare_message(
@@ -1025,9 +1047,14 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    # For EIP-7623 we first calculate the execution_gas_used, which includes
-    # the execution gas refund.
-    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    # With diff-at-return, state_gas_left can exceed its initial value
+    # (from negative diffs crediting the reservoir). Use saturating
+    # subtraction to prevent underflow.
+    total_remaining = tx_output.gas_left + tx_output.state_gas_left
+    if total_remaining > tx.gas:
+        tx_gas_used_before_refund = Uint(0)
+    else:
+        tx_gas_used_before_refund = tx.gas - total_remaining
     tx_gas_refund = min(
         tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
     )
@@ -1035,9 +1062,7 @@ def process_transaction(
 
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
-    tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
-    )
+    tx_gas_used = max(tx_gas_used_after_refund, intrinsic.calldata_floor)
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund
     gas_refund_amount = tx_gas_left * effective_gas_price
@@ -1065,11 +1090,17 @@ def process_transaction(
     ):
         destroy_account(tx_state, block_env.coinbase)
 
-    block_output.block_gas_used += tx_gas_used_after_refund
+    tx_regular_gas = tx_env.intrinsic_regular_gas + tx_output.regular_gas_used
+    tx_state_gas = tx_env.intrinsic_state_gas + tx_output.state_gas_used
+    block_output.block_gas_used += max(
+        tx_regular_gas, intrinsic.calldata_floor
+    )
+    block_output.block_state_gas_used += tx_state_gas
     block_output.blob_gas_used += tx_blob_gas_used
 
+    block_output.cumulative_gas_used += tx_gas_used
     receipt = make_receipt(
-        tx, tx_output.error, block_output.block_gas_used, tx_output.logs
+        tx, tx_output.error, block_output.cumulative_gas_used, tx_output.logs
     )
 
     receipt_key = rlp.encode(Uint(index))

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -38,10 +38,6 @@ from ethereum.state import (
 if TYPE_CHECKING:
     from .block_access_lists import BlockAccessListBuilder
 
-# EIP-8037 state byte costs
-STATE_BYTES_NEW_ACCOUNT = 112
-STATE_BYTES_STORAGE_SET = 32
-
 
 @dataclass
 class BlockState:
@@ -92,7 +88,6 @@ class TransactionState:
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
-    state_delta_bytes: int = 0
 
 
 def get_account_optional(
@@ -392,9 +387,6 @@ def set_account(
     deletes the account (but not its storage, see
     ``destroy_account()``).
 
-    Bump ``tx_state.state_delta_bytes`` by ±``STATE_BYTES_NEW_ACCOUNT``
-    on a ``None ↔ Some`` transition for EIP-8037 state gas accounting.
-
     Parameters
     ----------
     tx_state :
@@ -405,13 +397,6 @@ def set_account(
         Account to set at address.
 
     """
-    before = get_account_optional(tx_state, address)
-    before_existed = before is not None
-    after_exists = account is not None
-    if not before_existed and after_exists:
-        tx_state.state_delta_bytes += STATE_BYTES_NEW_ACCOUNT
-    elif before_existed and not after_exists:
-        tx_state.state_delta_bytes -= STATE_BYTES_NEW_ACCOUNT
     tx_state.account_writes[address] = account
 
 
@@ -423,9 +408,6 @@ def set_storage(
 ) -> None:
     """
     Set a value at a storage key on an account.
-
-    Bump ``tx_state.state_delta_bytes`` by ±``STATE_BYTES_STORAGE_SET``
-    on a ``0 ↔ nonzero`` transition for EIP-8037 state gas accounting.
 
     Parameters
     ----------
@@ -440,11 +422,6 @@ def set_storage(
 
     """
     assert get_account_optional(tx_state, address) is not None
-    old_value = get_storage(tx_state, address, key)
-    if old_value == U256(0) and value != U256(0):
-        tx_state.state_delta_bytes += STATE_BYTES_STORAGE_SET
-    elif old_value != U256(0) and value == U256(0):
-        tx_state.state_delta_bytes -= STATE_BYTES_STORAGE_SET
     if address not in tx_state.storage_writes:
         tx_state.storage_writes[address] = {}
     tx_state.storage_writes[address][key] = value
@@ -459,10 +436,6 @@ def destroy_account(tx_state: TransactionState, address: Address) -> None:
     future hardfork and this function will be removed. Only supports same
     transaction destruction.
 
-    Credits the deployed code's bytes to ``tx_state.state_delta_bytes``
-    here (looked up before destruction); the account and storage credits
-    flow through the inner ``set_account``/``destroy_storage`` calls.
-
     Parameters
     ----------
     tx_state :
@@ -471,10 +444,6 @@ def destroy_account(tx_state: TransactionState, address: Address) -> None:
         Address of account to destroy.
 
     """
-    account = get_account_optional(tx_state, address)
-    if account is not None:
-        code = get_code(tx_state, account.code_hash)
-        tx_state.state_delta_bytes -= len(code)
     destroy_storage(tx_state, address)
     set_account(tx_state, address, None)
 
@@ -487,9 +456,6 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     from created-then-destroyed accounts appear in the Block Access
     List. Only supports same transaction destruction.
 
-    Credits ``tx_state.state_delta_bytes`` by ``STATE_BYTES_STORAGE_SET``
-    for each non-zero slot being cleared.
-
     Parameters
     ----------
     tx_state :
@@ -499,9 +465,6 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
 
     """
     if address in tx_state.storage_writes:
-        for value in tx_state.storage_writes[address].values():
-            if value != U256(0):
-                tx_state.state_delta_bytes -= STATE_BYTES_STORAGE_SET
         for key in tx_state.storage_writes[address]:
             tx_state.storage_reads.add((address, key))
         del tx_state.storage_writes[address]
@@ -653,9 +616,6 @@ def set_code(
     """
     Set Account code.
 
-    Bumps ``tx_state.state_delta_bytes`` by ``len(code)`` if this call
-    introduces a fresh ``code_hash`` to ``tx_state.code_writes``.
-
     Parameters
     ----------
     tx_state :
@@ -668,8 +628,6 @@ def set_code(
     """
     code_hash = keccak256(code)
     if code_hash != EMPTY_CODE_HASH:
-        if code_hash not in tx_state.code_writes:
-            tx_state.state_delta_bytes += len(code)
         tx_state.code_writes[code_hash] = code
 
     def write_code_hash(sender: Account) -> None:
@@ -712,7 +670,6 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         transient_storage=dict(tx_state.transient_storage),
         storage_reads=tx_state.storage_reads,
         account_reads=tx_state.account_reads,
-        state_delta_bytes=tx_state.state_delta_bytes,
     )
 
 
@@ -734,7 +691,6 @@ def restore_tx_state(
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
     tx_state.transient_storage = snapshot.transient_storage
-    tx_state.state_delta_bytes = snapshot.state_delta_bytes
 
 
 # -- Lifecycle --------------------------------------------------------------

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -639,6 +639,92 @@ def set_code(
 # -- Snapshot / Rollback ---------------------------------------------------
 
 
+def _get_storage_at_snapshot(
+    snapshot: TransactionState, address: Address, key: Bytes32
+) -> U256:
+    """
+    Get the storage value as it was at the time of the snapshot.
+
+    Read chain: snapshot writes -> block writes -> pre_state.
+    For accounts created in the tx, return 0.
+    """
+    if address in snapshot.storage_writes:
+        if key in snapshot.storage_writes[address]:
+            return snapshot.storage_writes[address][key]
+    if address in snapshot.parent.storage_writes:
+        if key in snapshot.parent.storage_writes[address]:
+            return snapshot.parent.storage_writes[address][key]
+    if address in snapshot.created_accounts:
+        return U256(0)
+    return snapshot.parent.pre_state.get_storage(address, key)
+
+
+def _account_existed_at_snapshot(
+    snapshot: TransactionState, address: Address
+) -> bool:
+    """Check if an account existed at the time of the snapshot."""
+    if address in snapshot.account_writes:
+        return snapshot.account_writes[address] is not None
+    if address in snapshot.parent.account_writes:
+        return snapshot.parent.account_writes[address] is not None
+    return snapshot.parent.pre_state.get_account_optional(address) is not None
+
+
+def compute_state_growth_cost(
+    snapshot: TransactionState,
+    current: TransactionState,
+    cost_per_state_byte: Uint,
+) -> int:
+    """
+    Compute the net state growth cost by diffing a snapshot against
+    the current transaction state.
+
+    Positive cost = state grew (accounts created, slots set, code deployed).
+    Negative cost = state shrank (accounts removed, slots cleared).
+
+    Parameters
+    ----------
+    snapshot :
+        The transaction state at call entry.
+    current :
+        The current transaction state at call return.
+    cost_per_state_byte :
+        The cost per state byte for this block.
+
+    Returns
+    -------
+    cost : ``int``
+        Signed state growth cost in gas units.
+
+    """
+    cost = 0
+
+    # New accounts: in current account_writes but not at snapshot
+    for address, account in current.account_writes.items():
+        existed_before = _account_existed_at_snapshot(snapshot, address)
+        exists_now = account is not None
+        if exists_now and not existed_before:
+            cost += int(Uint(112) * cost_per_state_byte)
+        elif not exists_now and existed_before:
+            cost -= int(Uint(112) * cost_per_state_byte)
+
+    # New storage slots: nonzero in current, zero at snapshot
+    for address, slots in current.storage_writes.items():
+        for key, value in slots.items():
+            old_value = _get_storage_at_snapshot(snapshot, address, key)
+            if value != U256(0) and old_value == U256(0):
+                cost += int(Uint(32) * cost_per_state_byte)
+            elif value == U256(0) and old_value != U256(0):
+                cost -= int(Uint(32) * cost_per_state_byte)
+
+    # New code: in current code_writes but not in snapshot
+    for code_hash, code in current.code_writes.items():
+        if code_hash not in snapshot.code_writes:
+            cost += int(Uint(len(code)) * cost_per_state_byte)
+
+    return cost
+
+
 def copy_tx_state(tx_state: TransactionState) -> TransactionState:
     """
     Create a snapshot of the transaction state for rollback.
@@ -666,7 +752,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
             for addr, slots in tx_state.storage_writes.items()
         },
         code_writes=dict(tx_state.code_writes),
-        created_accounts=tx_state.created_accounts,
+        created_accounts=set(tx_state.created_accounts),
         transient_storage=dict(tx_state.transient_storage),
         storage_reads=tx_state.storage_reads,
         account_reads=tx_state.account_reads,

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -38,6 +38,10 @@ from ethereum.state import (
 if TYPE_CHECKING:
     from .block_access_lists import BlockAccessListBuilder
 
+# EIP-8037 state byte costs
+STATE_BYTES_NEW_ACCOUNT = 112
+STATE_BYTES_STORAGE_SET = 32
+
 
 @dataclass
 class BlockState:
@@ -88,6 +92,7 @@ class TransactionState:
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
+    state_delta_bytes: int = 0
 
 
 def get_account_optional(
@@ -387,6 +392,9 @@ def set_account(
     deletes the account (but not its storage, see
     ``destroy_account()``).
 
+    Bump ``tx_state.state_delta_bytes`` by ±``STATE_BYTES_NEW_ACCOUNT``
+    on a ``None ↔ Some`` transition for EIP-8037 state gas accounting.
+
     Parameters
     ----------
     tx_state :
@@ -397,6 +405,13 @@ def set_account(
         Account to set at address.
 
     """
+    before = get_account_optional(tx_state, address)
+    before_existed = before is not None
+    after_exists = account is not None
+    if not before_existed and after_exists:
+        tx_state.state_delta_bytes += STATE_BYTES_NEW_ACCOUNT
+    elif before_existed and not after_exists:
+        tx_state.state_delta_bytes -= STATE_BYTES_NEW_ACCOUNT
     tx_state.account_writes[address] = account
 
 
@@ -408,6 +423,9 @@ def set_storage(
 ) -> None:
     """
     Set a value at a storage key on an account.
+
+    Bump ``tx_state.state_delta_bytes`` by ±``STATE_BYTES_STORAGE_SET``
+    on a ``0 ↔ nonzero`` transition for EIP-8037 state gas accounting.
 
     Parameters
     ----------
@@ -422,6 +440,11 @@ def set_storage(
 
     """
     assert get_account_optional(tx_state, address) is not None
+    old_value = get_storage(tx_state, address, key)
+    if old_value == U256(0) and value != U256(0):
+        tx_state.state_delta_bytes += STATE_BYTES_STORAGE_SET
+    elif old_value != U256(0) and value == U256(0):
+        tx_state.state_delta_bytes -= STATE_BYTES_STORAGE_SET
     if address not in tx_state.storage_writes:
         tx_state.storage_writes[address] = {}
     tx_state.storage_writes[address][key] = value
@@ -436,6 +459,10 @@ def destroy_account(tx_state: TransactionState, address: Address) -> None:
     future hardfork and this function will be removed. Only supports same
     transaction destruction.
 
+    Credits the deployed code's bytes to ``tx_state.state_delta_bytes``
+    here (looked up before destruction); the account and storage credits
+    flow through the inner ``set_account``/``destroy_storage`` calls.
+
     Parameters
     ----------
     tx_state :
@@ -444,6 +471,10 @@ def destroy_account(tx_state: TransactionState, address: Address) -> None:
         Address of account to destroy.
 
     """
+    account = get_account_optional(tx_state, address)
+    if account is not None:
+        code = get_code(tx_state, account.code_hash)
+        tx_state.state_delta_bytes -= len(code)
     destroy_storage(tx_state, address)
     set_account(tx_state, address, None)
 
@@ -456,6 +487,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     from created-then-destroyed accounts appear in the Block Access
     List. Only supports same transaction destruction.
 
+    Credits ``tx_state.state_delta_bytes`` by ``STATE_BYTES_STORAGE_SET``
+    for each non-zero slot being cleared.
+
     Parameters
     ----------
     tx_state :
@@ -465,6 +499,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
 
     """
     if address in tx_state.storage_writes:
+        for value in tx_state.storage_writes[address].values():
+            if value != U256(0):
+                tx_state.state_delta_bytes -= STATE_BYTES_STORAGE_SET
         for key in tx_state.storage_writes[address]:
             tx_state.storage_reads.add((address, key))
         del tx_state.storage_writes[address]
@@ -616,6 +653,9 @@ def set_code(
     """
     Set Account code.
 
+    Bumps ``tx_state.state_delta_bytes`` by ``len(code)`` if this call
+    introduces a fresh ``code_hash`` to ``tx_state.code_writes``.
+
     Parameters
     ----------
     tx_state :
@@ -628,6 +668,8 @@ def set_code(
     """
     code_hash = keccak256(code)
     if code_hash != EMPTY_CODE_HASH:
+        if code_hash not in tx_state.code_writes:
+            tx_state.state_delta_bytes += len(code)
         tx_state.code_writes[code_hash] = code
 
     def write_code_hash(sender: Account) -> None:
@@ -637,92 +679,6 @@ def set_code(
 
 
 # -- Snapshot / Rollback ---------------------------------------------------
-
-
-def _get_storage_at_snapshot(
-    snapshot: TransactionState, address: Address, key: Bytes32
-) -> U256:
-    """
-    Get the storage value as it was at the time of the snapshot.
-
-    Read chain: snapshot writes -> block writes -> pre_state.
-    For accounts created in the tx, return 0.
-    """
-    if address in snapshot.storage_writes:
-        if key in snapshot.storage_writes[address]:
-            return snapshot.storage_writes[address][key]
-    if address in snapshot.parent.storage_writes:
-        if key in snapshot.parent.storage_writes[address]:
-            return snapshot.parent.storage_writes[address][key]
-    if address in snapshot.created_accounts:
-        return U256(0)
-    return snapshot.parent.pre_state.get_storage(address, key)
-
-
-def _account_existed_at_snapshot(
-    snapshot: TransactionState, address: Address
-) -> bool:
-    """Check if an account existed at the time of the snapshot."""
-    if address in snapshot.account_writes:
-        return snapshot.account_writes[address] is not None
-    if address in snapshot.parent.account_writes:
-        return snapshot.parent.account_writes[address] is not None
-    return snapshot.parent.pre_state.get_account_optional(address) is not None
-
-
-def compute_state_growth_cost(
-    snapshot: TransactionState,
-    current: TransactionState,
-    cost_per_state_byte: Uint,
-) -> int:
-    """
-    Compute the net state growth cost by diffing a snapshot against
-    the current transaction state.
-
-    Positive cost = state grew (accounts created, slots set, code deployed).
-    Negative cost = state shrank (accounts removed, slots cleared).
-
-    Parameters
-    ----------
-    snapshot :
-        The transaction state at call entry.
-    current :
-        The current transaction state at call return.
-    cost_per_state_byte :
-        The cost per state byte for this block.
-
-    Returns
-    -------
-    cost : ``int``
-        Signed state growth cost in gas units.
-
-    """
-    cost = 0
-
-    # New accounts: in current account_writes but not at snapshot
-    for address, account in current.account_writes.items():
-        existed_before = _account_existed_at_snapshot(snapshot, address)
-        exists_now = account is not None
-        if exists_now and not existed_before:
-            cost += int(Uint(112) * cost_per_state_byte)
-        elif not exists_now and existed_before:
-            cost -= int(Uint(112) * cost_per_state_byte)
-
-    # New storage slots: nonzero in current, zero at snapshot
-    for address, slots in current.storage_writes.items():
-        for key, value in slots.items():
-            old_value = _get_storage_at_snapshot(snapshot, address, key)
-            if value != U256(0) and old_value == U256(0):
-                cost += int(Uint(32) * cost_per_state_byte)
-            elif value == U256(0) and old_value != U256(0):
-                cost -= int(Uint(32) * cost_per_state_byte)
-
-    # New code: in current code_writes but not in snapshot
-    for code_hash, code in current.code_writes.items():
-        if code_hash not in snapshot.code_writes:
-            cost += int(Uint(len(code)) * cost_per_state_byte)
-
-    return cost
 
 
 def copy_tx_state(tx_state: TransactionState) -> TransactionState:
@@ -756,6 +712,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         transient_storage=dict(tx_state.transient_storage),
         storage_reads=tx_state.storage_reads,
         account_reads=tx_state.account_reads,
+        state_delta_bytes=tx_state.state_delta_bytes,
     )
 
 
@@ -777,6 +734,7 @@ def restore_tx_state(
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
     tx_state.transient_storage = snapshot.transient_storage
+    tx_state.state_delta_bytes = snapshot.state_delta_bytes
 
 
 # -- Lifecycle --------------------------------------------------------------

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -23,10 +23,28 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
-    TransactionGasLimitExceededError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+
+@dataclass
+class IntrinsicGasCost:
+    """
+    Intrinsic gas costs for a transaction, split by gas type.
+
+    `regular`: `ethereum.base_types.Uint`
+        Regular execution gas (calldata, base cost, access list, etc.)
+    `state`: `ethereum.base_types.Uint`
+        State growth gas (account creation, storage set, authorization).
+    `calldata_floor`: `ethereum.base_types.Uint`
+        Minimum gas cost based on calldata size per [EIP-7623].
+    """
+
+    regular: Uint
+    state: Uint
+    calldata_floor: Uint
+
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
@@ -513,7 +531,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -531,33 +549,39 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     Also, the code size of a contract creation transaction must be within
     limits of the protocol.
 
-    This function takes a transaction as a parameter and returns the intrinsic
-    gas cost and the minimum calldata gas cost for the transaction after
-    validation. It throws an `InsufficientTransactionGasError` exception if
-    the transaction does not provide enough gas to cover the intrinsic cost,
-    and a `NonceOverflowError` exception if the nonce is greater than
-    `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    This function takes a transaction and gas_limit as parameters and
+    returns the intrinsic gas costs for the transaction after validation.
+    It throws an `InsufficientTransactionGasError` exception if the
+    transaction does not provide enough gas to cover the intrinsic cost,
+    and a `NonceOverflowError` exception if the nonce overflows.
+    It also raises an `InitCodeTooLargeError` if the code
+    size of a contract creation transaction exceeds the maximum allowed
+    size.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx, gas_limit)
+    intrinsic_gas = intrinsic.regular + intrinsic.state
+    if max(intrinsic_gas, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
+    if max(intrinsic.regular, intrinsic.calldata_floor) > TX_MAX_GAS_LIMIT:
+        raise InsufficientTransactionGasError(
+            "Intrinsic regular gas or calldata floor exceeds TX_MAX_GAS_LIMIT"
+        )
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
-        raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, data_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(
+    tx: Transaction, gas_limit: Uint
+) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -578,37 +602,50 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     5. Cost for authorizations (if applicable)
 
 
-    This function takes a transaction as a parameter and returns the intrinsic
-    gas cost of the transaction and the minimum gas cost used by the
-    transaction based on the calldata size.
+    This function takes a transaction and gas_limit as parameters and
+    returns the intrinsic regular gas cost, intrinsic state gas cost, and the
+    minimum gas cost used by the transaction based on the calldata size.
     """
-    from .vm.gas import GasCosts, init_code_cost
+    from .vm.gas import (
+        PER_AUTH_BASE_COST,
+        STATE_BYTES_PER_AUTH_BASE,
+        STATE_BYTES_PER_NEW_ACCOUNT,
+        GasCosts,
+        init_code_cost,
+        state_gas_per_byte,
+    )
 
     tokens_in_calldata = count_tokens_in_data(tx.data)
 
     data_cost = tokens_in_calldata * GasCosts.TX_DATA_TOKEN_STANDARD
 
-    if tx.to == Bytes0(b""):
-        create_cost = GasCosts.TX_CREATE + init_code_cost(ulen(tx.data))
-    else:
-        create_cost = Uint(0)
+    cost_per_state_byte = state_gas_per_byte(gas_limit)
 
-    access_list_cost = Uint(0)
+    create_regular_gas = Uint(0)
+    create_state_gas = Uint(0)
+    if tx.to == Bytes0(b""):
+        create_state_gas = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+        create_regular_gas = (
+            GasCosts.TX_CREATE + init_code_cost(ulen(tx.data))
+        )
+
+    access_list_gas = Uint(0)
     tokens_in_access_list = Uint(0)
     if has_access_list(tx):
         for access in tx.access_list:
-            access_list_cost += GasCosts.TX_ACCESS_LIST_ADDRESS
-            access_list_cost += (
+            access_list_gas += GasCosts.TX_ACCESS_LIST_ADDRESS
+            access_list_gas += (
                 ulen(access.slots) * GasCosts.TX_ACCESS_LIST_STORAGE_KEY
             )
 
-    # Data token floor cost for access list bytes.
-    access_list_cost += tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR
-
-    auth_cost = Uint(0)
+    auth_regular_gas = Uint(0)
+    auth_state_gas = Uint(0)
     if isinstance(tx, SetCodeTransaction):
-        auth_cost += Uint(
-            GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
+        auth_regular_gas = PER_AUTH_BASE_COST * ulen(tx.authorizations)
+        auth_state_gas = (
+            (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE)
+            * cost_per_state_byte
+            * ulen(tx.authorizations)
         )
 
     # Floor tokens from calldata.
@@ -618,19 +655,24 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     total_floor_tokens = floor_tokens_in_calldata + tokens_in_access_list
 
     # Floor gas cost (EIP-7623: minimum gas for data-heavy transactions).
-    data_floor_gas_cost = (
+    calldata_floor_gas_cost = (
         total_floor_tokens * GasCosts.TX_DATA_TOKEN_FLOOR + GasCosts.TX_BASE
     )
 
-    return (
-        Uint(
-            GasCosts.TX_BASE
-            + data_cost
-            + create_cost
-            + access_list_cost
-            + auth_cost
-        ),
-        data_floor_gas_cost,
+    intrinsic_regular_gas = (
+        GasCosts.TX_BASE
+        + data_cost
+        + create_regular_gas
+        + access_list_gas
+        + auth_regular_gas
+    )
+
+    intrinsic_state_gas = create_state_gas + auth_state_gas
+
+    return IntrinsicGasCost(
+        regular=intrinsic_regular_gas,
+        state=intrinsic_state_gas,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -531,7 +531,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -549,21 +549,18 @@ def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
     Also, the code size of a contract creation transaction must be within
     limits of the protocol.
 
-    This function takes a transaction and gas_limit as parameters and
-    returns the intrinsic gas costs for the transaction after validation.
-    It throws an `InsufficientTransactionGasError` exception if the
-    transaction does not provide enough gas to cover the intrinsic cost,
-    and a `NonceOverflowError` exception if the nonce overflows.
-    It also raises an `InitCodeTooLargeError` if the code
-    size of a contract creation transaction exceeds the maximum allowed
-    size.
+    Returns the intrinsic gas costs for the transaction after validation.
+    Raises ``InsufficientTransactionGasError`` if the transaction does not
+    provide enough gas to cover the intrinsic cost, ``NonceOverflowError``
+    if the nonce overflows, and ``InitCodeTooLargeError`` if a contract
+    creation transaction's code size exceeds the maximum allowed.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic = calculate_intrinsic_cost(tx, gas_limit)
+    intrinsic = calculate_intrinsic_cost(tx)
     intrinsic_gas = intrinsic.regular + intrinsic.state
     if max(intrinsic_gas, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
@@ -579,9 +576,7 @@ def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
     return intrinsic
 
 
-def calculate_intrinsic_cost(
-    tx: Transaction, gas_limit: Uint
-) -> IntrinsicGasCost:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -602,29 +597,26 @@ def calculate_intrinsic_cost(
     5. Cost for authorizations (if applicable)
 
 
-    This function takes a transaction and gas_limit as parameters and
-    returns the intrinsic regular gas cost, intrinsic state gas cost, and the
-    minimum gas cost used by the transaction based on the calldata size.
+    Returns the intrinsic regular gas cost, intrinsic state gas cost, and
+    the minimum gas cost used by the transaction based on the calldata size.
     """
     from .vm.gas import (
+        COST_PER_STATE_BYTE,
         PER_AUTH_BASE_COST,
         STATE_BYTES_PER_AUTH_BASE,
         STATE_BYTES_PER_NEW_ACCOUNT,
         GasCosts,
         init_code_cost,
-        state_gas_per_byte,
     )
 
     tokens_in_calldata = count_tokens_in_data(tx.data)
 
     data_cost = tokens_in_calldata * GasCosts.TX_DATA_TOKEN_STANDARD
 
-    cost_per_state_byte = state_gas_per_byte(gas_limit)
-
     create_regular_gas = Uint(0)
     create_state_gas = Uint(0)
     if tx.to == Bytes0(b""):
-        create_state_gas = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+        create_state_gas = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
         create_regular_gas = (
             GasCosts.TX_CREATE + init_code_cost(ulen(tx.data))
         )
@@ -644,7 +636,7 @@ def calculate_intrinsic_cost(
         auth_regular_gas = PER_AUTH_BASE_COST * ulen(tx.authorizations)
         auth_state_gas = (
             (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE)
-            * cost_per_state_byte
+            * COST_PER_STATE_BYTE
             * ulen(tx.authorizations)
         )
 

--- a/src/ethereum/forks/amsterdam/utils/message.py
+++ b/src/ethereum/forks/amsterdam/utils/message.py
@@ -78,6 +78,7 @@ def prepare_message(
         caller=tx_env.origin,
         target=tx.to,
         gas=tx_env.gas,
+        state_gas_reservoir=tx_env.state_gas_reservoir,
         value=tx.value,
         data=msg_data,
         code=code,

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -61,6 +61,10 @@ class BlockOutput:
 
     block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
+    block_state_gas_used : `ethereum.base_types.Uint`
+        State gas used for executing all transactions.
+    cumulative_gas_used : `ethereum.base_types.Uint`
+        Cumulative gas paid by users (post-refund, post-floor).
     transactions_trie : `ethereum.fork_types.Root`
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
@@ -81,6 +85,8 @@ class BlockOutput:
     """
 
     block_gas_used: Uint = Uint(0)
+    block_state_gas_used: Uint = Uint(0)
+    cumulative_gas_used: Uint = Uint(0)
     transactions_trie: Trie[Bytes, Optional[Bytes | LegacyTransaction]] = (
         field(default_factory=lambda: Trie(secured=False, default=None))
     )
@@ -106,6 +112,7 @@ class TransactionEnvironment:
     origin: Address
     gas_price: Uint
     gas: Uint
+    state_gas_reservoir: Uint
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     state: TransactionState
@@ -113,6 +120,8 @@ class TransactionEnvironment:
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
+    intrinsic_regular_gas: Uint
+    intrinsic_state_gas: Uint
 
 
 @dataclass
@@ -127,6 +136,7 @@ class Message:
     target: Bytes0 | Address
     current_target: Address
     gas: Uint
+    state_gas_reservoir: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -149,6 +159,7 @@ class Evm:
     memory: bytearray
     code: Bytes
     gas_left: Uint
+    state_gas_left: Uint
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]
     refund_counter: int
@@ -160,6 +171,8 @@ class Evm:
     error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
+    regular_gas_used: Uint = Uint(0)
+    state_gas_used: Uint = Uint(0)
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
@@ -175,16 +188,25 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
 
     """
     evm.gas_left += child_evm.gas_left
+    evm.state_gas_left += child_evm.state_gas_left
     evm.logs += child_evm.logs
     evm.refund_counter += child_evm.refund_counter
     evm.accounts_to_delete.update(child_evm.accounts_to_delete)
     evm.accessed_addresses.update(child_evm.accessed_addresses)
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
+    evm.regular_gas_used += child_evm.regular_gas_used
+    evm.state_gas_used += child_evm.state_gas_used
 
 
-def incorporate_child_on_error(evm: Evm, child_evm: Evm) -> None:
+def incorporate_child_on_error(
+    evm: Evm,
+    child_evm: Evm,
+) -> None:
     """
     Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
+
+    With diff-at-return, the child's state was reverted so its diff is
+    zero. Only the remaining reservoir is returned.
 
     Parameters
     ----------
@@ -195,3 +217,5 @@ def incorporate_child_on_error(evm: Evm, child_evm: Evm) -> None:
 
     """
     evm.gas_left += child_evm.gas_left
+    evm.state_gas_left += child_evm.state_gas_left
+    evm.regular_gas_used += child_evm.regular_gas_used

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -173,6 +173,7 @@ class Evm:
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     regular_gas_used: Uint = Uint(0)
     state_gas_used: Uint = Uint(0)
+    state_delta_bytes: int = 0
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
@@ -196,6 +197,7 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
     evm.regular_gas_used += child_evm.regular_gas_used
     evm.state_gas_used += child_evm.state_gas_used
+    evm.state_delta_bytes += child_evm.state_delta_bytes
 
 
 def incorporate_child_on_error(

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -22,9 +22,9 @@ from ..state_tracker import (
 )
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import (
+    COST_PER_STATE_BYTE,
     STATE_BYTES_PER_NEW_ACCOUNT,
     GasCosts,
-    state_gas_per_byte,
 )
 from . import Evm, Message
 
@@ -173,7 +173,6 @@ def set_delegation(message: Message) -> None:
 
     """
     tx_state = message.tx_env.state
-    cost_per_state_byte = state_gas_per_byte(message.block_env.block_gas_limit)
     for auth in message.tx_env.authorizations:
         if auth.chain_id not in (message.block_env.chain_id, U256(0)):
             continue
@@ -199,7 +198,7 @@ def set_delegation(message: Message) -> None:
             continue
 
         if account_exists(tx_state, authority):
-            refund = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+            refund = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
             message.state_gas_reservoir += refund
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -21,14 +21,17 @@ from ..state_tracker import (
     set_code,
 )
 from ..utils.hexadecimal import hex_to_address
-from ..vm.gas import GasCosts
+from ..vm.gas import (
+    STATE_BYTES_PER_NEW_ACCOUNT,
+    GasCosts,
+    state_gas_per_byte,
+)
 from . import Evm, Message
 
 SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -155,23 +158,22 @@ def calculate_delegation_cost(
     return True, delegated_address, delegation_gas_cost
 
 
-def set_delegation(message: Message) -> U256:
+def set_delegation(message: Message) -> None:
     """
     Set the delegation code for the authorities in the message.
+
+    For existing accounts, no account creation is needed, so the worst-case
+    state gas pre-charged in `intrinsic.state` is refunded back to the
+    `state_gas_reservoir`. The intrinsic itself stays immutable.
 
     Parameters
     ----------
     message :
         Transaction specific items.
 
-    Returns
-    -------
-    refund_counter: `U256`
-        Refund from authority which already exists in state.
-
     """
     tx_state = message.tx_env.state
-    refund_counter = U256(0)
+    cost_per_state_byte = state_gas_per_byte(message.block_env.block_gas_limit)
     for auth in message.tx_env.authorizations:
         if auth.chain_id not in (message.block_env.chain_id, U256(0)):
             continue
@@ -197,10 +199,8 @@ def set_delegation(message: Message) -> U256:
             continue
 
         if account_exists(tx_state, authority):
-            refund_counter += U256(
-                GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
-            )
+            refund = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+            message.state_gas_reservoir += refund
 
         if auth.address == NULL_ADDRESS:
             code_to_set = b""
@@ -217,5 +217,3 @@ def set_delegation(message: Message) -> U256:
         tx_state,
         get_account(tx_state, message.code_address).code_hash,
     )
-
-    return refund_counter

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -43,16 +43,16 @@ class GasCosts:
     COLD_ACCOUNT_ACCESS = Uint(2600)
     COLD_STORAGE_ACCESS = Uint(2100)
 
-    # Storage (EIP-8037: regular gas reduced; state gas via diff at return)
+    # Storage
     STORAGE_SET = Uint(5000)
     COLD_STORAGE_WRITE = Uint(5000)
 
-    # Call (EIP-8037: NEW_ACCOUNT regular charge removed; state gas via diff)
+    # Call
     CALL_VALUE = Uint(9000)
     CALL_STIPEND = Uint(2300)
     NEW_ACCOUNT = Uint(0)
 
-    # Contract Creation (EIP-8037: code deposit regular charge removed)
+    # Contract Creation
     CODE_DEPOSIT_PER_BYTE = Uint(0)
     CODE_INIT_PER_WORD = Uint(2)
 
@@ -101,7 +101,7 @@ class GasCosts:
     # Block Access Lists
     BLOCK_ACCESS_LIST_ITEM = Uint(2000)
 
-    # Transactions (EIP-8037: TX_CREATE regular reduced; state gas intrinsic)
+    # Transactions
     TX_BASE = Uint(21000)
     TX_CREATE = Uint(9000)
     TX_DATA_TOKEN_STANDARD = Uint(4)
@@ -170,7 +170,7 @@ class GasCosts:
     OPCODE_DUP = VERY_LOW
     OPCODE_SWAP = VERY_LOW
 
-    # Dynamic Opcode Components (EIP-8037: CREATE regular reduced)
+    # Dynamic Opcode Components
     OPCODE_RETURNDATACOPY_BASE = VERY_LOW
     OPCODE_RETURNDATACOPY_PER_WORD = Uint(3)
     OPCODE_CALLDATACOPY_BASE = VERY_LOW
@@ -192,11 +192,7 @@ class GasCosts:
     OPCODE_SELFDESTRUCT_NEW_ACCOUNT = Uint(0)
 
 
-# EIP-8037 state gas constants
-TARGET_STATE_GROWTH_PER_YEAR = Uint(100 * 1024**3)  # noqa: F841
-BLOCKS_PER_YEAR = Uint(2_628_000)  # noqa: F841
-COST_PER_STATE_BYTE_SIGNIFICANT_BITS = Uint(5)  # noqa: F841
-COST_PER_STATE_BYTE_OFFSET = Uint(9578)  # noqa: F841
+COST_PER_STATE_BYTE = Uint(1174)
 
 STATE_BYTES_PER_NEW_ACCOUNT = Uint(112)
 STATE_BYTES_PER_STORAGE_SET = Uint(32)
@@ -236,40 +232,6 @@ class MessageCallGas:
 
     cost: Uint
     sub_call: Uint
-
-
-def state_gas_per_byte(gas_limit: Uint) -> Uint:  # noqa: ARG001
-    """
-    Calculate the state gas cost per byte based on the block gas limit.
-
-    At a gas limit of 100,000,000 this returns 1174.
-
-    Parameters
-    ----------
-    gas_limit :
-        The block gas limit.
-
-    Returns
-    -------
-    state_gas_per_byte : `Uint`
-        The state gas cost per byte.
-
-    """
-    # TODO: Remove hardcoded value and restore the formula below
-    #   once the static tests use the correct gas limit.
-    return Uint(1174)
-    # numerator = gas_limit * BLOCKS_PER_YEAR
-    # denominator = Uint(2) * TARGET_STATE_GROWTH_PER_YEAR
-    # raw = (numerator + denominator - Uint(1)) // denominator
-    # shifted = raw + COST_PER_STATE_BYTE_OFFSET
-    # shift = max(
-    #     shifted.bit_length()
-    #         - COST_PER_STATE_BYTE_SIGNIFICANT_BITS, Uint(0)
-    # )
-    # quantized = (shifted >> shift) << shift
-    # if quantized > COST_PER_STATE_BYTE_OFFSET:
-    #     return quantized - COST_PER_STATE_BYTE_OFFSET
-    # return Uint(1)
 
 
 def check_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -17,14 +17,13 @@ from typing import List, Tuple
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.forks.bpo5.blocks import Header as PreviousHeader
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund, StateGasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
 
 from ..blocks import Header
 from ..transactions import BlobTransaction, Transaction
 from . import Evm
 from .exceptions import OutOfGasError
-
 
 # These values may be patched at runtime by a future gas repricing utility
 class GasCosts:
@@ -44,17 +43,17 @@ class GasCosts:
     COLD_ACCOUNT_ACCESS = Uint(2600)
     COLD_STORAGE_ACCESS = Uint(2100)
 
-    # Storage
-    STORAGE_SET = Uint(20000)
+    # Storage (EIP-8037: regular gas reduced; state gas via diff at return)
+    STORAGE_SET = Uint(5000)
     COLD_STORAGE_WRITE = Uint(5000)
 
-    # Call
+    # Call (EIP-8037: NEW_ACCOUNT regular charge removed; state gas via diff)
     CALL_VALUE = Uint(9000)
     CALL_STIPEND = Uint(2300)
-    NEW_ACCOUNT = Uint(25000)
+    NEW_ACCOUNT = Uint(0)
 
-    # Contract Creation
-    CODE_DEPOSIT_PER_BYTE = Uint(200)
+    # Contract Creation (EIP-8037: code deposit regular charge removed)
+    CODE_DEPOSIT_PER_BYTE = Uint(0)
     CODE_INIT_PER_WORD = Uint(2)
 
     # Authorization
@@ -102,9 +101,9 @@ class GasCosts:
     # Block Access Lists
     BLOCK_ACCESS_LIST_ITEM = Uint(2000)
 
-    # Transactions
+    # Transactions (EIP-8037: TX_CREATE regular reduced; state gas intrinsic)
     TX_BASE = Uint(21000)
-    TX_CREATE = Uint(32000)
+    TX_CREATE = Uint(9000)
     TX_DATA_TOKEN_STANDARD = Uint(4)
     TX_DATA_TOKEN_FLOOR = Uint(10)
     TX_ACCESS_LIST_ADDRESS = Uint(2400)
@@ -171,7 +170,7 @@ class GasCosts:
     OPCODE_DUP = VERY_LOW
     OPCODE_SWAP = VERY_LOW
 
-    # Dynamic Opcode Components
+    # Dynamic Opcode Components (EIP-8037: CREATE regular reduced)
     OPCODE_RETURNDATACOPY_BASE = VERY_LOW
     OPCODE_RETURNDATACOPY_PER_WORD = Uint(3)
     OPCODE_CALLDATACOPY_BASE = VERY_LOW
@@ -181,7 +180,7 @@ class GasCosts:
     OPCODE_MSTORE_BASE = VERY_LOW
     OPCODE_MSTORE8_BASE = VERY_LOW
     OPCODE_COPY_PER_WORD = Uint(3)
-    OPCODE_CREATE_BASE = Uint(32000)
+    OPCODE_CREATE_BASE = Uint(9000)
     OPCODE_EXP_BASE = Uint(10)
     OPCODE_EXP_PER_BYTE = Uint(50)
     OPCODE_KECCAK256_BASE = Uint(30)
@@ -190,7 +189,20 @@ class GasCosts:
     OPCODE_LOG_DATA_PER_BYTE = Uint(8)
     OPCODE_LOG_TOPIC = Uint(375)
     OPCODE_SELFDESTRUCT_BASE = Uint(5000)
-    OPCODE_SELFDESTRUCT_NEW_ACCOUNT = Uint(25000)
+    OPCODE_SELFDESTRUCT_NEW_ACCOUNT = Uint(0)
+
+
+# EIP-8037 state gas constants
+TARGET_STATE_GROWTH_PER_YEAR = Uint(100 * 1024**3)  # noqa: F841
+BLOCKS_PER_YEAR = Uint(2_628_000)  # noqa: F841
+COST_PER_STATE_BYTE_SIGNIFICANT_BITS = Uint(5)  # noqa: F841
+COST_PER_STATE_BYTE_OFFSET = Uint(9578)  # noqa: F841
+
+STATE_BYTES_PER_NEW_ACCOUNT = Uint(112)
+STATE_BYTES_PER_STORAGE_SET = Uint(32)
+STATE_BYTES_PER_AUTH_BASE = Uint(23)
+
+PER_AUTH_BASE_COST = Uint(7500)
 
 
 @dataclass
@@ -226,6 +238,40 @@ class MessageCallGas:
     sub_call: Uint
 
 
+def state_gas_per_byte(gas_limit: Uint) -> Uint:  # noqa: ARG001
+    """
+    Calculate the state gas cost per byte based on the block gas limit.
+
+    At a gas limit of 100,000,000 this returns 1174.
+
+    Parameters
+    ----------
+    gas_limit :
+        The block gas limit.
+
+    Returns
+    -------
+    state_gas_per_byte : `Uint`
+        The state gas cost per byte.
+
+    """
+    # TODO: Remove hardcoded value and restore the formula below
+    #   once the static tests use the correct gas limit.
+    return Uint(1174)
+    # numerator = gas_limit * BLOCKS_PER_YEAR
+    # denominator = Uint(2) * TARGET_STATE_GROWTH_PER_YEAR
+    # raw = (numerator + denominator - Uint(1)) // denominator
+    # shifted = raw + COST_PER_STATE_BYTE_OFFSET
+    # shift = max(
+    #     shifted.bit_length()
+    #         - COST_PER_STATE_BYTE_SIGNIFICANT_BITS, Uint(0)
+    # )
+    # quantized = (shifted >> shift) << shift
+    # if quantized > COST_PER_STATE_BYTE_OFFSET:
+    #     return quantized - COST_PER_STATE_BYTE_OFFSET
+    # return Uint(1)
+
+
 def check_gas(evm: Evm, amount: Uint) -> None:
     """
     Checks if `amount` gas is available without charging it.
@@ -245,22 +291,50 @@ def check_gas(evm: Evm, amount: Uint) -> None:
 
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `evm.gas_left`.
+    Subtracts `amount` from `evm.gas_left` (regular gas) and records usage.
 
     Parameters
     ----------
     evm :
         The current EVM.
     amount :
-        The amount of gas the current operation requires.
+        The amount of regular gas the current operation requires.
 
     """
     evm_trace(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError
+    evm.gas_left -= amount
+
+    evm.regular_gas_used += amount
+
+
+def charge_state_gas(evm: Evm, amount: Uint) -> None:
+    """
+    Subtracts `amount` from the state gas reservoir, then from
+    `evm.gas_left` when the reservoir is empty. Records state gas usage.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM.
+    amount :
+        The amount of state gas the current operation requires.
+
+    """
+    evm_trace(evm, StateGasAndRefund(int(amount)))
+
+    if evm.state_gas_left >= amount:
+        evm.state_gas_left -= amount
+    elif evm.state_gas_left + evm.gas_left >= amount:
+        remainder = amount - evm.state_gas_left
+        evm.state_gas_left = Uint(0)
+        evm.gas_left -= remainder
     else:
-        evm.gas_left -= amount
+        raise OutOfGasError
+
+    evm.state_gas_used += amount
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -93,35 +93,30 @@ def sstore(evm: Evm) -> None:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GasCosts.COLD_STORAGE_ACCESS
 
+    # EIP-8037 diff-at-return: state gas for storage creation is
+    # computed from the state diff at call return, not charged here.
     if original_value == current_value and current_value != new_value:
-        if original_value == 0:
-            gas_cost += GasCosts.STORAGE_SET
-        else:
-            gas_cost += (
-                GasCosts.COLD_STORAGE_WRITE - GasCosts.COLD_STORAGE_ACCESS
-            )
+        gas_cost += GasCosts.COLD_STORAGE_WRITE - GasCosts.COLD_STORAGE_ACCESS
     else:
         gas_cost += GasCosts.WARM_ACCESS
 
-    # Refund Counter Calculation
+    # Refund Counter Calculation (regular gas only, no state gas)
     if current_value != new_value:
         if original_value != 0 and current_value != 0 and new_value == 0:
-            # Storage is cleared for the first time in the transaction
             evm.refund_counter += GasCosts.REFUND_STORAGE_CLEAR
 
         if original_value != 0 and current_value == 0:
-            # Gas refund issued earlier to be reversed
             evm.refund_counter -= GasCosts.REFUND_STORAGE_CLEAR
 
         if original_value == new_value:
-            # Storage slot being restored to its original value
             if original_value == 0:
-                # Slot was originally empty and was SET earlier
+                # Slot restored to zero — refund the regular write cost
                 evm.refund_counter += int(
-                    GasCosts.STORAGE_SET - GasCosts.WARM_ACCESS
+                    GasCosts.COLD_STORAGE_WRITE
+                    - GasCosts.COLD_STORAGE_ACCESS
+                    - GasCosts.WARM_ACCESS
                 )
             else:
-                # Slot was originally non-empty and was UPDATED earlier
                 evm.refund_counter += int(
                     GasCosts.COLD_STORAGE_WRITE
                     - GasCosts.COLD_STORAGE_ACCESS

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -11,7 +11,7 @@ Introduction
 Implementations of the EVM storage related instructions.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import U256, Uint
 
 from ...state_tracker import (
     get_storage,
@@ -23,6 +23,7 @@ from ...state_tracker import (
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (
+    STATE_BYTES_PER_STORAGE_SET,
     GasCosts,
     charge_gas,
     check_gas,
@@ -93,8 +94,6 @@ def sstore(evm: Evm) -> None:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GasCosts.COLD_STORAGE_ACCESS
 
-    # EIP-8037 diff-at-return: state gas for storage creation is
-    # computed from the state diff at call return, not charged here.
     if original_value == current_value and current_value != new_value:
         gas_cost += GasCosts.COLD_STORAGE_WRITE - GasCosts.COLD_STORAGE_ACCESS
     else:
@@ -125,6 +124,12 @@ def sstore(evm: Evm) -> None:
 
     charge_gas(evm, gas_cost)
     set_storage(tx_state, evm.message.current_target, key, new_value)
+
+    # EIP-8037: count state-byte delta for the slot transition.
+    if current_value == U256(0) and new_value != U256(0):
+        evm.state_delta_bytes += int(STATE_BYTES_PER_STORAGE_SET)
+    elif current_value != U256(0) and new_value == U256(0):
+        evm.state_delta_bytes -= int(STATE_BYTES_PER_STORAGE_SET)
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -23,7 +23,6 @@ from ...state_tracker import (
     get_account,
     get_code,
     increment_nonce,
-    is_account_alive,
     move_ether,
     set_account_balance,
 )
@@ -73,13 +72,12 @@ def generic_create(
         process_create_message,
     )
 
-    # Check static context first
-    if evm.message.is_static:
-        raise WriteInStaticContext
-
     # Check max init code size early before memory read
     if memory_size > U256(MAX_INIT_CODE_SIZE):
         raise OutOfGasError
+
+    # EIP-8037 diff-at-return: account creation state gas is computed
+    # from the state diff at call return, not charged here.
 
     tx_state = evm.message.tx_env.state
 
@@ -89,6 +87,11 @@ def generic_create(
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
+
+    # Pass full reservoir to child (no 63/64 rule for state gas)
+    create_message_state_gas_reservoir = evm.state_gas_left
+    evm.state_gas_left = Uint(0)
+
     evm.return_data = b""
 
     sender_address = evm.message.current_target
@@ -100,6 +103,7 @@ def generic_create(
         or evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT
     ):
         evm.gas_left += create_message_gas
+        evm.state_gas_left += create_message_state_gas_reservoir
         push(evm.stack, U256(0))
         return
 
@@ -109,6 +113,8 @@ def generic_create(
         tx_state, contract_address
     ) or account_has_storage(tx_state, contract_address):
         increment_nonce(tx_state, evm.message.current_target)
+        evm.regular_gas_used += create_message_gas
+        evm.state_gas_left += create_message_state_gas_reservoir
         push(evm.stack, U256(0))
         return
 
@@ -120,6 +126,7 @@ def generic_create(
         caller=evm.message.current_target,
         target=Bytes0(),
         gas=create_message_gas,
+        state_gas_reservoir=create_message_state_gas_reservoir,
         value=endowment,
         data=b"",
         code=call_data,
@@ -155,6 +162,9 @@ def create(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    if evm.message.is_static:
+        raise WriteInStaticContext
+
     # STACK
     endowment = pop(evm.stack)
     memory_start_position = pop(evm.stack)
@@ -204,6 +214,9 @@ def create2(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    if evm.message.is_static:
+        raise WriteInStaticContext
+
     # STACK
     endowment = pop(evm.stack)
     memory_start_position = pop(evm.stack)
@@ -280,6 +293,7 @@ def return_(evm: Evm) -> None:
 def generic_call(
     evm: Evm,
     gas: Uint,
+    state_gas_reservoir: Uint,
     value: U256,
     caller: Address,
     to: Address,
@@ -302,6 +316,7 @@ def generic_call(
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
+        evm.state_gas_left += state_gas_reservoir
         push(evm.stack, U256(0))
         return
 
@@ -315,6 +330,7 @@ def generic_call(
         caller=caller,
         target=to,
         gas=gas,
+        state_gas_reservoir=state_gas_reservoir,
         value=value,
         data=call_data,
         code=code,
@@ -346,6 +362,17 @@ def generic_call(
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
+
+
+def escrow_subcall_regular_gas(evm: Evm, sub_call_gas: Uint) -> None:
+    """
+    Remove forwarded CALL* gas from the caller's regular gas usage.
+
+    CALL* forwards `sub_call_gas` to the child frame as temporary escrow.
+    Only gas actually burned by the child should be reintroduced via
+    `incorporate_child_*` child gas accounting.
+    """
+    evm.regular_gas_used -= sub_call_gas
 
 
 def call(evm: Evm) -> None:
@@ -398,11 +425,9 @@ def call(evm: Evm) -> None:
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
-    create_gas_cost = GasCosts.NEW_ACCOUNT
-    if value == 0 or is_account_alive(tx_state, to):
-        create_gas_cost = Uint(0)
-
-    extra_gas = access_gas_cost + transfer_gas_cost + create_gas_cost
+    # EIP-8037 diff-at-return: new-account state gas is computed from
+    # the state diff at call return, not charged here.
+    extra_gas = access_gas_cost + transfer_gas_cost
     (
         is_delegated,
         code_address,
@@ -419,25 +444,37 @@ def call(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
+    # EIP-8037 diff-at-return: new-account state gas is computed from
+    # the state diff at call return, not charged here.
+    charge_gas(evm, extra_gas + extend_memory.cost)
+
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        extra_gas,
+        memory_cost=Uint(0),
+        extra_gas=Uint(0),
     )
-    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    charge_gas(evm, message_call_gas.cost)
+    escrow_subcall_regular_gas(evm, message_call_gas.sub_call)
 
     evm.memory += b"\x00" * extend_memory.expand_by
+
+    # Pass full reservoir to child (no 63/64 rule for state gas)
+    call_state_gas_reservoir = evm.state_gas_left
+    evm.state_gas_left = Uint(0)
+
     sender_balance = get_account(tx_state, evm.message.current_target).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
         evm.gas_left += message_call_gas.sub_call
+        evm.state_gas_left += call_state_gas_reservoir
     else:
         generic_call(
             evm,
             message_call_gas.sub_call,
+            call_state_gas_reservoir,
             value,
             evm.message.current_target,
             to,
@@ -530,19 +567,27 @@ def callcode(evm: Evm) -> None:
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    escrow_subcall_regular_gas(evm, message_call_gas.sub_call)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
+
+    # Pass full reservoir to child (no 63/64 rule for state gas)
+    call_state_gas_reservoir = evm.state_gas_left
+    evm.state_gas_left = Uint(0)
+
     sender_balance = get_account(tx_state, evm.message.current_target).balance
 
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
         evm.gas_left += message_call_gas.sub_call
+        evm.state_gas_left += call_state_gas_reservoir
     else:
         generic_call(
             evm,
             message_call_gas.sub_call,
+            call_state_gas_reservoir,
             value,
             evm.message.current_target,
             to,
@@ -592,12 +637,8 @@ def selfdestruct(evm: Evm) -> None:
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
-    if (
-        not is_account_alive(tx_state, beneficiary)
-        and get_account(tx_state, evm.message.current_target).balance != 0
-    ):
-        gas_cost += GasCosts.OPCODE_SELFDESTRUCT_NEW_ACCOUNT
-
+    # EIP-8037 diff-at-return: beneficiary account creation state gas
+    # is computed from the state diff at call return.
     charge_gas(evm, gas_cost)
 
     originator = evm.message.current_target
@@ -687,12 +728,19 @@ def delegatecall(evm: Evm) -> None:
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    escrow_subcall_regular_gas(evm, message_call_gas.sub_call)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
+
+    # Pass full reservoir to child (no 63/64 rule for state gas)
+    call_state_gas_reservoir = evm.state_gas_left
+    evm.state_gas_left = Uint(0)
+
     generic_call(
         evm,
         message_call_gas.sub_call,
+        call_state_gas_reservoir,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -777,12 +825,19 @@ def staticcall(evm: Evm) -> None:
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    escrow_subcall_regular_gas(evm, message_call_gas.sub_call)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
+
+    # Pass full reservoir to child (no 63/64 rule for state gas)
+    call_state_gas_reservoir = evm.state_gas_left
+    evm.state_gas_left = Uint(0)
+
     generic_call(
         evm,
         message_call_gas.sub_call,
+        call_state_gas_reservoir,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -41,6 +41,7 @@ from ..state_tracker import (
     get_account,
     get_code,
     increment_nonce,
+    is_account_alive,
     mark_account_created,
     move_ether,
     restore_tx_state,
@@ -48,7 +49,13 @@ from ..state_tracker import (
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
-from ..vm.gas import GasCosts, charge_gas, state_gas_per_byte
+from ..vm.gas import (
+    COST_PER_STATE_BYTE,
+    STATE_BYTES_PER_NEW_ACCOUNT,
+    STATE_BYTES_PER_STORAGE_SET,
+    GasCosts,
+    charge_gas,
+)
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Evm
 from .exceptions import (
@@ -226,8 +233,6 @@ def process_create_message(message: Message) -> Evm:
                 // Uint(32)
             )
             charge_gas(evm, code_hash_gas)
-            # EIP-8037 diff-at-return: code deposit state gas is
-            # computed from the state diff at call return.
         except ExceptionalHalt as error:
             restore_tx_state(tx_state, snapshot)
             evm.regular_gas_used += evm.gas_left
@@ -238,6 +243,13 @@ def process_create_message(message: Message) -> Evm:
             evm.error = error
         else:
             set_code(tx_state, message.current_target, contract_code)
+            # EIP-8037: count the new account and the deployed code on
+            # this CREATE frame's counter. Only fires on the successful
+            # deployment path; init-code OOG and invalid-code paths
+            # restore_tx_state above and discard the bump implicitly
+            # (this branch is unreached).
+            evm.state_delta_bytes += int(STATE_BYTES_PER_NEW_ACCOUNT)
+            evm.state_delta_bytes += len(contract_code)
     else:
         restore_tx_state(tx_state, snapshot)
     return evm
@@ -289,12 +301,19 @@ def process_message(message: Message) -> Evm:
     snapshot = copy_tx_state(tx_state)
 
     if message.should_transfer_value and message.value != 0:
+        # EIP-8037: a value transfer to an empty/non-existent target
+        # creates a new account; charge the new-account state bytes.
+        creates_target_account = not is_account_alive(
+            tx_state, message.current_target
+        )
         move_ether(
             tx_state,
             message.caller,
             message.current_target,
             message.value,
         )
+        if creates_target_account:
+            evm.state_delta_bytes += int(STATE_BYTES_PER_NEW_ACCOUNT)
 
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
@@ -328,22 +347,28 @@ def process_message(message: Message) -> Evm:
         evm.error = error
 
     # EIP-8037: at depth 0, finalize SELFDESTRUCT same-tx destructions
-    # before the counter charge so the destroy hooks credit
-    # tx_state.state_delta_bytes naturally (account, code, storage).
+    # before the counter charge. Debit the counter for each destroyed
+    # account's bytes (account, code, non-zero storage slots) before
+    # actually destroying.
     if message.depth == Uint(0) and not evm.error:
         for address in evm.accounts_to_delete:
             if address in tx_state.created_accounts:
+                account = get_account(tx_state, address)
+                code = get_code(tx_state, account.code_hash)
+                evm.state_delta_bytes -= int(STATE_BYTES_PER_NEW_ACCOUNT)
+                evm.state_delta_bytes -= len(code)
+                for slot_value in tx_state.storage_writes.get(
+                    address, {}
+                ).values():
+                    if slot_value != U256(0):
+                        evm.state_delta_bytes -= int(
+                            STATE_BYTES_PER_STORAGE_SET
+                        )
                 destroy_account(tx_state, address)
 
     # EIP-8037: charge state gas from the per-frame state-byte counter.
     if not evm.error:
-        cost_per_state_byte = state_gas_per_byte(
-            message.block_env.block_gas_limit
-        )
-        frame_delta_bytes = (
-            tx_state.state_delta_bytes - snapshot.state_delta_bytes
-        )
-        growth_cost = frame_delta_bytes * int(cost_per_state_byte)
+        growth_cost = evm.state_delta_bytes * int(COST_PER_STATE_BYTE)
         # Inner calls already deducted from reservoir
         already_paid = int(message.state_gas_reservoir) - int(
             evm.state_gas_left

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -35,8 +35,8 @@ from ..blocks import Log
 from ..state_tracker import (
     account_has_code_or_nonce,
     account_has_storage,
-    compute_state_growth_cost,
     copy_tx_state,
+    destroy_account,
     destroy_storage,
     get_account,
     get_code,
@@ -327,14 +327,23 @@ def process_message(message: Message) -> Evm:
         evm_trace(evm, OpException(error))
         evm.error = error
 
-    # EIP-8037: charge state gas based on actual state diff at call return
+    # EIP-8037: at depth 0, finalize SELFDESTRUCT same-tx destructions
+    # before the counter charge so the destroy hooks credit
+    # tx_state.state_delta_bytes naturally (account, code, storage).
+    if message.depth == Uint(0) and not evm.error:
+        for address in evm.accounts_to_delete:
+            if address in tx_state.created_accounts:
+                destroy_account(tx_state, address)
+
+    # EIP-8037: charge state gas from the per-frame state-byte counter.
     if not evm.error:
         cost_per_state_byte = state_gas_per_byte(
             message.block_env.block_gas_limit
         )
-        growth_cost = compute_state_growth_cost(
-            snapshot, tx_state, cost_per_state_byte
+        frame_delta_bytes = (
+            tx_state.state_delta_bytes - snapshot.state_delta_bytes
         )
+        growth_cost = frame_delta_bytes * int(cost_per_state_byte)
         # Inner calls already deducted from reservoir
         already_paid = int(message.state_gas_reservoir) - int(
             evm.state_gas_left

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -29,11 +29,13 @@ from ethereum.trace import (
     TransactionEnd,
     evm_trace,
 )
+from ethereum.utils.numeric import ceil32
 
 from ..blocks import Log
 from ..state_tracker import (
     account_has_code_or_nonce,
     account_has_storage,
+    compute_state_growth_cost,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -46,7 +48,7 @@ from ..state_tracker import (
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
-from ..vm.gas import GasCosts, charge_gas
+from ..vm.gas import GasCosts, charge_gas, state_gas_per_byte
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Evm
 from .exceptions import (
@@ -79,14 +81,19 @@ class MessageCallOutput:
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `error`: The error from the execution if any.
           6. `return_data`: The output of the execution.
+          7. `regular_gas_used`: Regular gas used during execution.
+          8. `state_gas_used`: State gas used during execution.
     """
 
     gas_left: Uint
+    state_gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     error: Optional[EthereumException]
     return_data: Bytes
+    regular_gas_used: Uint
+    state_gas_used: Uint
 
 
 def process_message_call(message: Message) -> MessageCallOutput:
@@ -113,18 +120,21 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(tx_state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                state_gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
+                regular_gas_used=Uint(0),
+                state_gas_used=Uint(0),
             )
         else:
             evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
-            refund_counter += set_delegation(message)
+            set_delegation(message)
 
         delegated_address = get_delegated_code_address(message.code)
         if delegated_address is not None:
@@ -153,11 +163,14 @@ def process_message_call(message: Message) -> MessageCallOutput:
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
+        state_gas_left=evm.state_gas_left,
         refund_counter=refund_counter,
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         error=evm.error,
         return_data=evm.output,
+        regular_gas_used=evm.regular_gas_used,
+        state_gas_used=evm.state_gas_used,
     )
 
 
@@ -200,19 +213,27 @@ def process_create_message(message: Message) -> Evm:
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output
-        contract_code_gas = (
-            ulen(contract_code) * GasCosts.CODE_DEPOSIT_PER_BYTE
-        )
         try:
             if len(contract_code) > 0:
                 if contract_code[0] == 0xEF:
                     raise InvalidContractPrefix
-            charge_gas(evm, contract_code_gas)
             if len(contract_code) > MAX_CODE_SIZE:
                 raise OutOfGasError
+            # Hash cost for computing keccak256 of deployed bytecode
+            code_hash_gas = (
+                GasCosts.OPCODE_KECCACK256_PER_WORD
+                * ceil32(Uint(len(contract_code)))
+                // Uint(32)
+            )
+            charge_gas(evm, code_hash_gas)
+            # EIP-8037 diff-at-return: code deposit state gas is
+            # computed from the state diff at call return.
         except ExceptionalHalt as error:
             restore_tx_state(tx_state, snapshot)
+            evm.regular_gas_used += evm.gas_left
             evm.gas_left = Uint(0)
+            # State gas is preserved on exceptional halt so it can be
+            # returned to the parent frame via incorporate_child_on_error.
             evm.output = b""
             evm.error = error
         else:
@@ -243,12 +264,14 @@ def process_message(message: Message) -> Evm:
 
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+
     evm = Evm(
         pc=Uint(0),
         stack=[],
         memory=bytearray(),
         code=code,
         gas_left=message.gas,
+        state_gas_left=message.state_gas_reservoir,
         valid_jump_destinations=valid_jump_destinations,
         logs=(),
         refund_counter=0,
@@ -294,12 +317,49 @@ def process_message(message: Message) -> Evm:
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
+        evm.regular_gas_used += evm.gas_left
         evm.gas_left = Uint(0)
+        # State gas is preserved on exceptional halt so it can be
+        # returned to the parent frame via incorporate_child_on_error.
         evm.output = b""
         evm.error = error
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    # EIP-8037: charge state gas based on actual state diff at call return
+    if not evm.error:
+        cost_per_state_byte = state_gas_per_byte(
+            message.block_env.block_gas_limit
+        )
+        growth_cost = compute_state_growth_cost(
+            snapshot, tx_state, cost_per_state_byte
+        )
+        # Inner calls already deducted from reservoir
+        already_paid = int(message.state_gas_reservoir) - int(
+            evm.state_gas_left
+        )
+        this_call_cost = growth_cost - already_paid
+
+        if this_call_cost > 0:
+            cost = Uint(this_call_cost)
+            if evm.state_gas_left >= cost:
+                evm.state_gas_left -= cost
+            elif evm.state_gas_left + evm.gas_left >= cost:
+                # Spillover: reservoir exhausted, take from gas_left
+                remainder = cost - evm.state_gas_left
+                evm.state_gas_left = Uint(0)
+                evm.gas_left -= remainder
+            else:
+                # Can't afford state gas — revert
+                restore_tx_state(tx_state, snapshot)
+                evm.error = OutOfGasError()
+                evm.output = b""
+            if not evm.error:
+                evm.state_gas_used += cost
+        elif this_call_cost < 0:
+            # Negative cost — state was removed, credit reservoir
+            evm.state_gas_left += Uint(-this_call_cost)
 
     if evm.error:
         restore_tx_state(tx_state, snapshot)

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -151,6 +151,18 @@ class GasAndRefund:
     """
 
 
+@dataclass
+class StateGasAndRefund:
+    """
+    Trace event that is triggered when state gas is deducted.
+    """
+
+    state_gas_cost: int
+    """
+    Amount of state gas charged.
+    """
+
+
 TraceEvent = (
     TransactionStart
     | TransactionEnd
@@ -161,6 +173,7 @@ TraceEvent = (
     | OpException
     | EvmStop
     | GasAndRefund
+    | StateGasAndRefund
 )
 """
 All possible types of events that an [`EvmTracer`] is expected to handle.

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
@@ -18,14 +18,25 @@ from ethereum.trace import (
     OpStart,
     PrecompileEnd,
     PrecompileStart,
+    StateGasAndRefund,
     TraceEvent,
     TransactionEnd,
     TransactionStart,
 )
 
-from .protocols import Evm, EvmWithReturnData, TransactionEnvironment
+from .protocols import (
+    Evm,
+    EvmWithReturnData,
+    EvmWithStateGas,
+    TransactionEnvironment,
+)
 
-EXCLUDE_FROM_OUTPUT = ["gasCostTraced", "errorTraced", "precompile"]
+EXCLUDE_FROM_OUTPUT = [
+    "gasCostTraced",
+    "stateGasCostTraced",
+    "errorTraced",
+    "precompile",
+]
 
 
 @dataclass
@@ -45,7 +56,10 @@ class Trace:
     depth: int
     refund: int
     opName: str
+    stateGas: Optional[str] = None
+    stateGasCost: Optional[str] = None
     gasCostTraced: bool = False
+    stateGasCostTraced: bool = False
     errorTraced: bool = False
     precompile: bool = False
     error: Optional[str] = None
@@ -171,11 +185,17 @@ class Eip3155Tracer(EvmTracer):
             assert isinstance(last_trace, Trace)
 
             last_trace.gasCostTraced = True
+            last_trace.stateGasCostTraced = True
             last_trace.errorTraced = True
         elif isinstance(event, OpStart):
             op = event.op.value
             if op == "InvalidOpcode":
                 op = "Invalid"
+
+            state_gas = None
+            if isinstance(evm, EvmWithStateGas):
+                state_gas = hex(evm.state_gas_left)
+
             new_trace = Trace(
                 pc=int(evm.pc),
                 op=op,
@@ -188,6 +208,7 @@ class Eip3155Tracer(EvmTracer):
                 depth=int(evm.message.depth) + 1,
                 refund=refund_counter,
                 opName=str(event.op).split(".")[-1],
+                stateGas=state_gas,
             )
 
             self.active_traces.append(new_trace)
@@ -195,6 +216,7 @@ class Eip3155Tracer(EvmTracer):
             assert isinstance(last_trace, Trace)
 
             last_trace.gasCostTraced = True
+            last_trace.stateGasCostTraced = True
             last_trace.errorTraced = True
         elif isinstance(event, OpException):
             if last_trace is not None:
@@ -264,6 +286,15 @@ class Eip3155Tracer(EvmTracer):
                 last_trace.gasCost = hex(event.gas_cost)
                 last_trace.refund = refund_counter
                 last_trace.gasCostTraced = True
+        elif isinstance(event, StateGasAndRefund):
+            if len(self.active_traces) == 0:
+                return
+
+            assert isinstance(last_trace, Trace)
+
+            if not last_trace.stateGasCostTraced:
+                last_trace.stateGasCost = hex(event.state_gas_cost)
+                last_trace.stateGasCostTraced = True
 
 
 class _TraceJsonEncoder(json.JSONEncoder):

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/protocols.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/protocols.py
@@ -52,3 +52,12 @@ class EvmWithReturnData(Evm, Protocol):
     """
 
     return_data: Bytes
+
+
+@runtime_checkable
+class EvmWithStateGas(EvmWithReturnData, Protocol):
+    """
+    The class describes the EVM interface for forks with state gas (EIP-8037).
+    """
+
+    state_gas_left: Uint

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -307,7 +307,13 @@ class Result:
         """
         Update the result after processing the inputs.
         """
-        self.gas_used = block_output.block_gas_used
+        if hasattr(block_output, "block_state_gas_used"):
+            self.gas_used = max(
+                block_output.block_gas_used,
+                block_output.block_state_gas_used,
+            )
+        else:
+            self.gas_used = block_output.block_gas_used
         self.tx_root = t8n.fork.root(block_output.transactions_trie)
         self.receipt_root = t8n.fork.root(block_output.receipts_trie)
         self.bloom = t8n.fork.logs_bloom(block_output.block_logs)


### PR DESCRIPTION
## Summary

Prototype implementation of EIP-8037 state gas charging via a per-frame **state-delta byte counter** on `TransactionState`, fresh from `forks/amsterdam`. Successor to PR #2683's diff-at-return approach.

Two commits:

1. **`feat(specs): EIP-8037 diff-at-return state gas charging`** (`735947d4`) — initial port of #2683's diff-at-return mechanism onto fresh `forks/amsterdam`. Computes a state diff at each `process_message` return.
2. **`feat(specs): EIP-8037 state-delta counter on TransactionState`** (`5f1f5fe1`) — replaces the diff with a counter on `TransactionState.state_delta_bytes`. Hooked at the five low-level state funcs (`set_account`, `set_storage`, `set_code`, `destroy_account`, `destroy_storage`).

Final state is the counter approach; the diff commit is preserved in history for reviewability.

## Why counter over diff

Two real problems with the diff approach surfaced during review:

1. **Code refund gap.** `destroy_account` doesn't clean `code_writes` (codes keyed by hash, may be shared). The diff never sees code disappear on same-tx CREATE+SELFDESTRUCT, so we had to add an explicit refund block in `fork.py` recomputing account + storage + code by hand.
2. **Distance from clients.** Clients meter via journals — every state change is recorded. fjl's framing in the [#eip-8037 Discord thread](https://discord.com/channels/1359927674746835211/1493618116809457684) was *"meter the in-progress state diff"*, i.e. running tally not call-boundary diff.

Counter solves both — `destroy_account` explicitly debits `-= len(code)` (no gap), and the abstraction matches journal semantics.

## Hook table

| Op | Δ bytes | Where |
|---|---|---|
| Account `None → Some` | +112 | `set_account` |
| Account `Some → None` | -112 | `set_account` |
| Storage `0 → nonzero` | +32 | `set_storage` |
| Storage `nonzero → 0` | -32 | `set_storage` |
| Code deployed (fresh `code_hash`) | +len(code) | `set_code` |
| Storage destroyed | -32 per non-zero slot | `destroy_storage` |
| Code on account destruction | -len(code) | `destroy_account` |

7702 auths run pre-EVM (before depth-0 snapshot), so their account creation is counted but absorbed into the snapshot — `frame_delta` doesn't see them. Intrinsic.state pre-charge + reservoir refund for existing-account auths handles this (unchanged from current behavior).

## Charge at frame return

```python
frame_delta_bytes = tx_state.state_delta_bytes - snapshot.state_delta_bytes
growth_cost = frame_delta_bytes * int(cost_per_state_byte)
already_paid = int(message.state_gas_reservoir) - int(evm.state_gas_left)
this_call_cost = growth_cost - already_paid
# (same reservoir/spillover/revert logic as diff-at-return)
```

The counter is stored on `TransactionState`, included in `copy_tx_state` and `restore_tx_state` — naturally rolls back on revert, no extra journal needed.

## SELFDESTRUCT same-tx refund

Moved into depth-0 `process_message`, before the counter charge:

```python
if message.depth == Uint(0) and not evm.error:
    for address in evm.accounts_to_delete:
        if address in tx_state.created_accounts:
            destroy_account(tx_state, address)
```

The destroy hooks (`-112` account, `-len(code)` code, `-32` per non-zero slot) credit `tx_state.state_delta_bytes` naturally. The subsequent `frame_delta * cpsb` calculation nets these credits against earlier charges. Removed:

- The explicit account+storage+code refund block in `fork.py:process_transaction` (was added in commit `735947d4`).
- The `for address in tx_output.accounts_to_delete: destroy_account(...)` loop in `fork.py` (now done in `process_message`).

## Files modified (final state, counter approach)

```
src/ethereum/forks/amsterdam/fork.py           |   removed selfdestruct refund block + destroy loop + 3 imports
src/ethereum/forks/amsterdam/state_tracker.py  |   +counter field, hooks in 5 funcs, removed 3 diff helpers
src/ethereum/forks/amsterdam/vm/interpreter.py |   replaced diff with counter, added depth-0 destroy loop
```

## Open items

- Tests not included on this branch — fixtures from #2683's branch may need updating for code-refund correctness on same-tx CREATE+SELFDESTRUCT cases.
- Lint not run yet (working in active branch); `mypy` clean on the three modified files.
- Imports + smoke import OK locally.

## Related

- PR #2683 (closed) — diff-at-return draft this evolves from
- Discord [#eip-8037](https://discord.com/channels/1359927674746835211/1493618116809457684), April 2026