### PR TITLE
feat(zkevm): properly handle invalid txs in the guest program input bytes

### DIFF
--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -73,7 +73,13 @@ def build_stateless_input(
             tx_bytes_list.append(Bytes(rlp.encode(tx)))
         else:
             tx_bytes_list.append(Bytes(tx))
-            tx_obj = decode_transaction(tx)
+            # A typed tx may be malformed (pre-execution-rejected by
+            # t8n but still committed to by the block's transactions
+            # trie). 
+            try:
+                tx_obj = decode_transaction(tx)
+            except Exception:
+                continue
             if isinstance(tx_obj, BlobTransaction):
                 versioned_hashes.extend(tx_obj.blob_versioned_hashes)
 

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -75,7 +75,7 @@ def build_stateless_input(
             tx_bytes_list.append(Bytes(tx))
             # A typed tx may be malformed (pre-execution-rejected by
             # t8n but still committed to by the block's transactions
-            # trie). 
+            # trie).
             try:
                 tx_obj = decode_transaction(tx)
             except Exception:

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -405,16 +405,16 @@ class Result:
                 block_access_list_hash=self.block_access_list_hash,
             )
 
-            # TODO: perhaps change this for t8n.all_txs minus rejected_txs?
-            included_txs = []
-            for key in block_output.receipt_keys:
+            payload_txs = []
+            for tx_index in range(len(t8n.txs.transactions)):
+                key = rlp.encode(Uint(tx_index))
                 tx = t8n.fork.trie_get(block_output.transactions_trie, key)
                 assert tx is not None
-                included_txs.append(tx)
+                payload_txs.append(tx)
 
             block = t8n.fork.Block(
                 header=header,
-                transactions=tuple(included_txs),
+                transactions=tuple(payload_txs),
                 ommers=(),
                 withdrawals=withdrawals,
             )


### PR DESCRIPTION
## 🗒️ Description
Before this PR, invalid transactions were discarded from the `Block` when constructing the stateless program inputs. I don't recall why this was done, but it was very weird since the `statelessInputBytes` execution payload didn't contain the invalid txs.

This still worked in teh stateless runs while filling because the missing txs in the SSZ input caused a `transactionTrie` root mismatch when doing the `block_hash` validation. As in, the `ExecutionPayload.block_hash` did contain in the transaction trie _all_ the transactions. But the `ExecutionPayload.transactions` didn't have the invalid txs.

So while the `successful_validation` was still `False`, it wasn't `False` for the right reason:
- Wrong reason: `transactionTrieRoot` mismatch (before this PR).
- Right reason: the block contains an invalid txs (with this PR).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
