### PR TITLE
refactor(forks): pass fork overrides to clone

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -7,7 +7,6 @@ import fnmatch
 import json
 import os
 from contextlib import AbstractContextManager
-from dataclasses import astuple, dataclass
 from typing import Any, Final, TextIO, Type, TypeVar
 
 from ethereum_rlp import rlp
@@ -18,7 +17,11 @@ from ethereum import trace
 from ethereum.exceptions import EthereumException, InvalidBlock
 from ethereum.fork_criteria import ByBlockNumber, ByTimestamp, Unscheduled
 from ethereum.merkle_patricia_trie import copy_trie
-from ethereum_spec_tools.forks import Hardfork, TemporaryHardfork
+from ethereum_spec_tools.forks import (
+    ForkOverrides,
+    Hardfork,
+    TemporaryHardfork,
+)
 
 from ..loaders.fixture_loader import Load
 from ..utils import (
@@ -34,7 +37,6 @@ from .evm_trace.group import GroupTracer
 from .t8n_types import Alloc, Result, Txs
 
 T = TypeVar("T")
-ForkCriteriaArgument = ByBlockNumber | ByTimestamp | Unscheduled | None
 
 
 def t8n_arguments(subparsers: argparse._SubParsersAction) -> None:
@@ -92,95 +94,12 @@ def t8n_arguments(subparsers: argparse._SubParsersAction) -> None:
     t8n_parser.add_argument("--state-test", action="store_true")
 
 
-@dataclass(frozen=True)
-class _ForkOverrides:
-    """Store temporary hardfork override values."""
-
-    fork_criteria: ForkCriteriaArgument = None
-    blob_target_gas_per_block: U64 | None = None
-    gas_per_blob: U64 | None = None
-    blob_min_gasprice: Uint | None = None
-    blob_base_fee_update_fraction: Uint | None = None
-    max_blob_gas_per_block: U64 | None = None
-    blob_schedule_target: U64 | None = None
-    blob_schedule_max: U64 | None = None
-
-    def is_empty(self) -> bool:
-        """Return true when all override values are unset."""
-        return all(value is None for value in astuple(self))
-
-    @staticmethod
-    def _matches_field(override: object | None, on: object, name: str) -> bool:
-        if override is None:
-            return True
-
-        try:
-            default = getattr(on, name)
-        except AttributeError:
-            return False
-
-        return override == default
-
-    def matches_template(
-        self,
-        template: Hardfork,
-    ) -> bool:
-        """Return true when the requested overrides match the template."""
-        if self.is_empty():
-            return True
-
-        if (
-            self.fork_criteria is not None
-            and self.fork_criteria != template.criteria
-        ):
-            return False
-
-        fork_mod = template.module("fork")
-        gas_costs = template.module("vm.gas").GasCosts
-
-        checks = (
-            (
-                self.max_blob_gas_per_block,
-                fork_mod,
-                "MAX_BLOB_GAS_PER_BLOCK",
-            ),
-            (
-                self.blob_target_gas_per_block,
-                gas_costs,
-                "BLOB_TARGET_GAS_PER_BLOCK",
-            ),
-            (self.gas_per_blob, gas_costs, "PER_BLOB"),
-            (
-                self.blob_min_gasprice,
-                gas_costs,
-                "BLOB_MIN_GASPRICE",
-            ),
-            (
-                self.blob_base_fee_update_fraction,
-                gas_costs,
-                "BLOB_BASE_FEE_UPDATE_FRACTION",
-            ),
-            (
-                self.blob_schedule_target,
-                gas_costs,
-                "BLOB_SCHEDULE_TARGET",
-            ),
-            (
-                self.blob_schedule_max,
-                gas_costs,
-                "BLOB_SCHEDULE_MAX",
-            ),
-        )
-
-        return all(self._matches_field(*x) for x in checks)
-
-
 class ForkCache(AbstractContextManager):
     """
     Stores references to temporary hardforks and cleans them up when exited.
     """
 
-    _cache: Final[dict[tuple[str, _ForkOverrides], TemporaryHardfork]]
+    _cache: Final[dict[tuple[str, ForkOverrides], TemporaryHardfork]]
 
     def __init__(self) -> None:
         self._cache = {}
@@ -207,7 +126,7 @@ class ForkCache(AbstractContextManager):
         Search the cache for a matching hardfork, or create one if it doesn't
         exist.
         """
-        overrides = _ForkOverrides(
+        overrides = ForkOverrides(
             fork_criteria=fork_criteria,
             blob_target_gas_per_block=blob_target_gas_per_block,
             gas_per_blob=gas_per_blob,
@@ -226,19 +145,7 @@ class ForkCache(AbstractContextManager):
         except KeyError:
             pass
 
-        clone = Hardfork.clone(
-            template=template,
-            fork_criteria=overrides.fork_criteria,
-            blob_target_gas_per_block=overrides.blob_target_gas_per_block,
-            gas_per_blob=overrides.gas_per_blob,
-            blob_min_gasprice=overrides.blob_min_gasprice,
-            blob_base_fee_update_fraction=(
-                overrides.blob_base_fee_update_fraction
-            ),
-            max_blob_gas_per_block=overrides.max_blob_gas_per_block,
-            blob_schedule_target=overrides.blob_schedule_target,
-            blob_schedule_max=overrides.blob_schedule_max,
-        )
+        clone = Hardfork.clone(template=template, overrides=overrides)
         self._cache[cache_key] = clone
         return clone
 

--- a/src/ethereum_spec_tools/forks.py
+++ b/src/ethereum_spec_tools/forks.py
@@ -11,6 +11,7 @@ import pkgutil
 import random
 import sys
 from contextlib import AbstractContextManager
+from dataclasses import astuple, dataclass
 from enum import Enum, auto
 from importlib.machinery import ModuleSpec, PathFinder
 from pathlib import Path
@@ -26,20 +27,16 @@ from typing import (
     Optional,
     Type,
     TypeVar,
-    Union,
     cast,
 )
 
 from ethereum_types.numeric import U64, U256, Uint
 from typing_extensions import override
 
+from ethereum.fork_criteria import ByBlockNumber, ByTimestamp, Unscheduled
+
 if TYPE_CHECKING:
-    from ethereum.fork_criteria import (
-        ByBlockNumber,
-        ByTimestamp,
-        ForkCriteria,
-        Unscheduled,
-    )
+    from ethereum.fork_criteria import ForkCriteria
 
 
 class ConsensusType(Enum):
@@ -64,6 +61,96 @@ class ConsensusType(Enum):
 
 
 H = TypeVar("H", bound="Hardfork")
+ForkCriteriaArgument = ByBlockNumber | ByTimestamp | Unscheduled | None
+
+
+@dataclass(frozen=True)
+class ForkOverrides:
+    """
+    Temporary hardfork override values.
+    """
+
+    fork_criteria: ForkCriteriaArgument = None
+    blob_target_gas_per_block: U64 | None = None
+    gas_per_blob: U64 | None = None
+    blob_min_gasprice: Uint | None = None
+    blob_base_fee_update_fraction: Uint | None = None
+    max_blob_gas_per_block: U64 | None = None
+    blob_schedule_target: U64 | None = None
+    blob_schedule_max: U64 | None = None
+
+    def is_empty(self) -> bool:
+        """
+        Return true when all override values are unset.
+        """
+        return all(value is None for value in astuple(self))
+
+    @staticmethod
+    def _matches_field(override: object | None, on: object, name: str) -> bool:
+        if override is None:
+            return True
+
+        try:
+            default = getattr(on, name)
+        except AttributeError:
+            return False
+
+        return override == default
+
+    def matches_template(
+        self,
+        template: "Hardfork",
+    ) -> bool:
+        """
+        Return true when the requested overrides match the template.
+        """
+        if self.is_empty():
+            return True
+
+        if (
+            self.fork_criteria is not None
+            and self.fork_criteria != template.criteria
+        ):
+            return False
+
+        fork_mod = template.module("fork")
+        gas_costs = template.module("vm.gas").GasCosts
+
+        checks = (
+            (
+                self.max_blob_gas_per_block,
+                fork_mod,
+                "MAX_BLOB_GAS_PER_BLOCK",
+            ),
+            (
+                self.blob_target_gas_per_block,
+                gas_costs,
+                "BLOB_TARGET_GAS_PER_BLOCK",
+            ),
+            (self.gas_per_blob, gas_costs, "PER_BLOB"),
+            (
+                self.blob_min_gasprice,
+                gas_costs,
+                "BLOB_MIN_GASPRICE",
+            ),
+            (
+                self.blob_base_fee_update_fraction,
+                gas_costs,
+                "BLOB_BASE_FEE_UPDATE_FRACTION",
+            ),
+            (
+                self.blob_schedule_target,
+                gas_costs,
+                "BLOB_SCHEDULE_TARGET",
+            ),
+            (
+                self.blob_schedule_max,
+                gas_costs,
+                "BLOB_SCHEDULE_MAX",
+            ),
+        )
+
+        return all(self._matches_field(*x) for x in checks)
 
 
 class Hardfork:
@@ -204,22 +291,16 @@ class Hardfork:
     @staticmethod
     def clone(
         template: H | str,
-        fork_criteria: Union[
-            "ByBlockNumber", "ByTimestamp", "Unscheduled", None
-        ] = None,
-        blob_target_gas_per_block: U64 | None = None,
-        gas_per_blob: U64 | None = None,
-        blob_min_gasprice: Uint | None = None,
-        blob_base_fee_update_fraction: Uint | None = None,
-        max_blob_gas_per_block: U64 | None = None,
-        blob_schedule_target: U64 | None = None,
-        blob_schedule_max: U64 | None = None,
+        overrides: ForkOverrides | None = None,
     ) -> "TemporaryHardfork":
         """
         Create a temporary clone of an existing fork, optionally tweaking its
         parameters.
         """
         from .new_fork.builder import ForkBuilder
+
+        if overrides is None:
+            overrides = ForkOverrides()
 
         maybe_directory: TemporaryDirectory | None = TemporaryDirectory()
 
@@ -240,33 +321,37 @@ class Hardfork:
 
             builder.output = Path(directory.name)
 
-            if fork_criteria is not None:
-                builder.fork_criteria = fork_criteria
+            if overrides.fork_criteria is not None:
+                builder.fork_criteria = overrides.fork_criteria
 
-            if blob_target_gas_per_block is not None:
+            if overrides.blob_target_gas_per_block is not None:
                 builder.modify_target_blob_gas_per_block(
-                    blob_target_gas_per_block
+                    overrides.blob_target_gas_per_block
                 )
 
-            if gas_per_blob is not None:
-                builder.modify_gas_per_blob(gas_per_blob)
+            if overrides.gas_per_blob is not None:
+                builder.modify_gas_per_blob(overrides.gas_per_blob)
 
-            if blob_min_gasprice is not None:
-                builder.modify_min_blob_gasprice(blob_min_gasprice)
+            if overrides.blob_min_gasprice is not None:
+                builder.modify_min_blob_gasprice(overrides.blob_min_gasprice)
 
-            if blob_base_fee_update_fraction is not None:
+            if overrides.blob_base_fee_update_fraction is not None:
                 builder.modify_blob_base_fee_update_fraction(
-                    blob_base_fee_update_fraction
+                    overrides.blob_base_fee_update_fraction
                 )
 
-            if max_blob_gas_per_block is not None:
-                builder.modify_max_blob_gas_per_block(max_blob_gas_per_block)
+            if overrides.max_blob_gas_per_block is not None:
+                builder.modify_max_blob_gas_per_block(
+                    overrides.max_blob_gas_per_block
+                )
 
-            if blob_schedule_target is not None:
-                builder.modify_blob_schedule_target(blob_schedule_target)
+            if overrides.blob_schedule_target is not None:
+                builder.modify_blob_schedule_target(
+                    overrides.blob_schedule_target
+                )
 
-            if blob_schedule_max is not None:
-                builder.modify_blob_schedule_max(blob_schedule_max)
+            if overrides.blob_schedule_max is not None:
+                builder.modify_blob_schedule_max(overrides.blob_schedule_max)
 
             builder.build()
 

--- a/tests/evm_tools/test_fork_cache.py
+++ b/tests/evm_tools/test_fork_cache.py
@@ -13,7 +13,7 @@ from ethereum.fork_criteria import (
     Unscheduled,
 )
 from ethereum_spec_tools.evm_tools.t8n import ForkCache
-from ethereum_spec_tools.forks import Hardfork
+from ethereum_spec_tools.forks import ForkOverrides, Hardfork
 
 pytestmark = pytest.mark.evm_tools
 
@@ -38,6 +38,13 @@ class DummyTemporaryFork:
 def _template() -> Hardfork:
     """Return the Amsterdam fork template."""
     return Hardfork(importlib.import_module("ethereum.forks.amsterdam"))
+
+
+def _seen_overrides(seen: dict[str, Any]) -> ForkOverrides:
+    """Return the ForkOverrides passed to Hardfork.clone."""
+    overrides = seen["overrides"]
+    assert isinstance(overrides, ForkOverrides)
+    return overrides
 
 
 def _different_fork_criteria(
@@ -182,7 +189,7 @@ def test_fork_cache_clones_when_fork_criteria_changes_template(
 
     assert fork is cloned
     assert seen["template"] is template
-    assert seen["fork_criteria"] == changed_fork_criteria
+    assert _seen_overrides(seen).fork_criteria == changed_fork_criteria
 
 
 @pytest.mark.parametrize("field", OVERRIDE_FIELDS)
@@ -228,7 +235,7 @@ def test_fork_cache_clones_for_each_changed_blob_override(
 
     assert fork is cloned
     assert seen["template"] is template
-    assert seen[field] == changed_value
+    assert getattr(_seen_overrides(seen), field) == changed_value
 
 
 def test_fork_cache_reuses_cached_clone_for_identical_changed_request(

--- a/tests/evm_tools/test_fork_cache.py
+++ b/tests/evm_tools/test_fork_cache.py
@@ -148,7 +148,9 @@ def test_fork_cache_returns_template_for_identical_overrides(
         ByBlockNumber | ByTimestamp | Unscheduled,
     )
 
-    def clone(*args: Any, **kwargs: Any) -> DummyTemporaryFork:
+    def clone(
+        template: Hardfork, overrides: ForkOverrides
+    ) -> DummyTemporaryFork:
         pytest.fail("Hardfork.clone() should not run for identical overrides")
 
     monkeypatch.setattr(Hardfork, "clone", clone)
@@ -171,8 +173,12 @@ def test_fork_cache_clones_when_fork_criteria_changes_template(
     cloned = DummyTemporaryFork()
     seen: dict[str, Any] = {}
 
-    def clone(*args: Any, **kwargs: Any) -> DummyTemporaryFork:
-        seen.update(kwargs)
+    def clone(
+        template: Hardfork,
+        overrides: ForkOverrides,
+    ) -> DummyTemporaryFork:
+        seen["template"] = template
+        seen["overrides"] = overrides
         return cloned
 
     monkeypatch.setattr(Hardfork, "clone", clone)
@@ -201,7 +207,9 @@ def test_fork_cache_returns_template_for_each_identical_blob_override(
     template = _template()
     value = _override_defaults(template)[field]
 
-    def clone(*args: Any, **kwargs: Any) -> DummyTemporaryFork:
+    def clone(
+        template: Hardfork, overrides: ForkOverrides
+    ) -> DummyTemporaryFork:
         pytest.fail("Hardfork.clone() should not run for identical overrides")
 
     monkeypatch.setattr(Hardfork, "clone", clone)
@@ -224,8 +232,12 @@ def test_fork_cache_clones_for_each_changed_blob_override(
     cloned = DummyTemporaryFork()
     seen: dict[str, Any] = {}
 
-    def clone(*args: Any, **kwargs: Any) -> DummyTemporaryFork:
-        seen.update(kwargs)
+    def clone(
+        template: Hardfork,
+        overrides: ForkOverrides,
+    ) -> DummyTemporaryFork:
+        seen["template"] = template
+        seen["overrides"] = overrides
         return cloned
 
     monkeypatch.setattr(Hardfork, "clone", clone)


### PR DESCRIPTION
## 🗒️ Description
Move the fork override dataclass from `ethereum_spec_tools.evm_tools.t8n` into `ethereum_spec_tools.forks`, and pass it directly into `Hardfork.clone`.

This keeps the existing `ForkCache.get(...)` call surface unchanged while reducing the long `Hardfork.clone(...)` parameter list.

## 🔗 Related Issues or PRs
Follow-up to #2738.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
    `just` was not installed locally, so I ran the equivalent commands from the `static` recipe manually.
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Cute dog](https://plus.unsplash.com/premium_photo-1694819488591-a43907d1c5cc?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NXx8Y3V0ZSUyMGFuaW1hbHxlbnwwfHwwfHx8MA%3D%3D)
