### PR TITLE
fix(ci): install build deps in hive-consume dev mode

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -140,6 +140,10 @@ jobs:
         with:
           cache-dependency-glob: "execution-specs/uv.lock"
 
+      - name: Setup environment
+        if: matrix.mode == 'dev'
+        uses: ./execution-specs/.github/actions/setup-env
+
       - name: Load cached Docker images
         uses: ./execution-specs/.github/actions/load-docker-images
 


### PR DESCRIPTION
## 🗒️ Description

The `Dev Mode` job of `Hive Consume` started failing on `forks/amsterdam` with a `coincurve` source-build error. Failing run: https://github.com/ethereum/execution-specs/actions/runs/25044601254.

Root cause:

- `coincurve` 20.0.0 has no `cp313` wheel on PyPI; it must be compiled when running on Python 3.13 (which `setup-uv` defaults to).
- Until commit `c48eceaca0` (#2751), `astral-sh/setup-uv`'s GitHub Actions cache (keyed on `uv.lock`) returned a hit on every run, so a previously-built `coincurve` wheel was restored and no compile step ran.
- `#2751` added `ijson` to `packages/testing/pyproject.toml` and regenerated `uv.lock`, which flipped the cache key and produced a cache miss on the first run for `forks/amsterdam`. `uv sync --all-extras` then attempted a fresh source build of `coincurve` and failed with `Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)`.
- `hive-consume.yaml`'s `Dev Mode` job uses `setup-uv` but does not invoke `setup-env`, so `pkg-config`, `libsecp256k1-dev`, and `build-essential` were not installed on the runner. `hive-execute.yaml` already runs both setup actions, which is why it has not been affected.

Fix: invoke `setup-env` in the `dev` matrix entry of `hive-consume.yaml` so the source build can succeed when the uv cache misses. The `simulator` matrix entries do not run `uv sync` on the runner (they go through Docker via `hive --sim`), so `setup-env` stays gated on `matrix.mode == 'dev'` to match `setup-uv`.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

## Cute Animal Picture

<img width="510" height="664" alt="image" src="https://github.com/user-attachments/assets/fb9bb535-ec94-4486-8e9e-151eb2af13a4" />

