### PR TITLE
fix(ci): redirect Go caches to a per-job temp dir

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -18,6 +18,15 @@ runs:
         ref: master
         path: hive
 
+    # Redirect Go's module/build caches to a per-job temp dir so the
+    # actions/setup-go cache restore extracts into an empty target. On
+    # self-hosted runners $GOMODCACHE persists across jobs and would
+    # otherwise collide with the cache tarball ("File exists" from tar).
+    - name: Use ephemeral Go cache dirs
+      shell: bash
+      run: |
+        echo "GOMODCACHE=${{ runner.temp }}/go/mod" >> "$GITHUB_ENV"
+        echo "GOCACHE=${{ runner.temp }}/go/build" >> "$GITHUB_ENV"
     - name: Setup Go for Hive
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:

--- a/.github/actions/build-evm-client/geth/action.yaml
+++ b/.github/actions/build-evm-client/geth/action.yaml
@@ -42,6 +42,15 @@ runs:
         repository: ${{ inputs.repo }}
         ref: ${{ steps.geth-sha.outputs.sha }}
         path: go-ethereum
+    # See note in build-benchmark-genesis/action.yaml: redirect Go caches
+    # to a per-job temp dir so setup-go's cache restore doesn't collide
+    # with a persistent $GOMODCACHE on self-hosted runners.
+    - name: Use ephemeral Go cache dirs
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "GOMODCACHE=${{ runner.temp }}/go/mod" >> "$GITHUB_ENV"
+        echo "GOCACHE=${{ runner.temp }}/go/build" >> "$GITHUB_ENV"
     - name: Setup golang
       if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -128,6 +128,14 @@ jobs:
           ref: master
           path: hive
 
+      # Redirect Go's caches to a per-job temp dir so the setup-go cache
+      # restore doesn't collide with a persistent $GOMODCACHE on
+      # self-hosted runners (see build-benchmark-genesis/action.yaml).
+      - name: Use ephemeral Go cache dirs
+        shell: bash
+        run: |
+          echo "GOMODCACHE=${{ runner.temp }}/go/mod" >> "$GITHUB_ENV"
+          echo "GOCACHE=${{ runner.temp }}/go/build" >> "$GITHUB_ENV"
       - name: Setup go env and cache
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -52,6 +52,14 @@ jobs:
           ref: master
           path: hive
 
+      # Redirect Go's caches to a per-job temp dir so the setup-go cache
+      # restore doesn't collide with a persistent $GOMODCACHE on
+      # self-hosted runners (see build-benchmark-genesis/action.yaml).
+      - name: Use ephemeral Go cache dirs
+        shell: bash
+        run: |
+          echo "GOMODCACHE=${{ runner.temp }}/go/mod" >> "$GITHUB_ENV"
+          echo "GOCACHE=${{ runner.temp }}/go/build" >> "$GITHUB_ENV"
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:


### PR DESCRIPTION
## 🗒️ Description

The `fill (benchmark)` job in the `release_fixture_feature` workflow (and any other CI step that runs `actions/setup-go` on a `self-hosted-ghr` runner) emits hundreds of error lines like:

```
##[error]/usr/bin/tar: ../../../../../data/gh-home/go/pkg/mod/go.opentelemetry.io/otel/trace@v1.40.0/tracestate_benchkmark_test.go: Cannot open: File exists
...
/usr/bin/tar: Exiting with failure status due to previous errors
##[warning]Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
```

Example: https://github.com/ethereum/execution-specs/actions/runs/25045144626/job/73358194540#step:5:2143

The self-hosted runner pool persists `$GOMODCACHE` (`/data/gh-home/go/pkg/mod`) across jobs, so when `actions/setup-go` extracts the GHA module-cache tarball it lands on top of files that already exist. `tar` aborts each one with `File exists`, the cache restore is skipped, and the job continues using the on-disk modules. The build still succeeds, but the log noise is alarming and the ~500 MB cache download is wasted.

The same job ran cleanly in `tests-benchmark@v0.0.7` (Feb 2026) on the same runner labels, confirming the persistent `$GOMODCACHE` only began colliding recently. `tests-benchmark@v0.0.8` happened to run `build-benchmark-genesis` in the hosted `combine` job under the split-mode release path, so it didn't hit this either.

This change exports `GOMODCACHE` and `GOCACHE` to `\${{ runner.temp }}/go/...` immediately before every `setup-go` invocation in the affected workflows / composite actions:

- `.github/actions/build-benchmark-genesis/action.yaml`
- `.github/actions/build-evm-client/geth/action.yaml`
- `.github/workflows/hive-execute.yaml`
- `.github/workflows/hive-consume.yaml`

`runner.temp` is wiped at the end of each job, so the cache always lands in an empty, job-scoped directory. Behaviour on GitHub-hosted runners is unchanged; self-hosted runners stop colliding without losing the GHA cache.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    \`\`\`console
    just static
    \`\`\`
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start \`type(scope):\`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

<img width="512" alt="image" src="https://github.com/user-attachments/assets/39cf3770-a0d9-49a2-a0d1-b3c6c9f03fc8" />
