### PR TITLE
chore(tests): cap `test_selfdestruct_after_create2_collision` at Osaka

### DIFF
--- a/tests/paris/eip7610_create_collision/test_collision_selfdestruct.py
+++ b/tests/paris/eip7610_create_collision/test_collision_selfdestruct.py
@@ -23,6 +23,7 @@ REFERENCE_SPEC_VERSION = "80ef48d0bbb5a4939ade51caaaac57b5df6acd4e"
 
 
 @pytest.mark.valid_from("Cancun")
+@pytest.mark.valid_until("Osaka")
 @pytest.mark.pre_alloc_mutable
 def test_selfdestruct_after_create2_collision(
     state_test: StateTestFiller,


### PR DESCRIPTION
## 🗒️ Description

Cap `test_selfdestruct_after_create2_collision` at Osaka so it doesn't run on Amsterdam under `devnets/bal/3`.

The test exposes a regression in this branch's EIP-8037 implementation: `generic_create` charges `create_account_state_gas` upfront but doesn't refund it on the address-collision path, leaving the caller short of gas for the follow-up `SELFDESTRUCT`. The same case is fixed in `devnets/bal/4` via `credit_state_gas_refund` (PR #2704). The test post-dates the last `bal-devnet-3` fixture release (`bal@v5.6.1`), so it never ran on this branch in CI.

We can't pull in the #2704 fix into `devnets/bal/3` as it'd be a breaking/none-backwards compatible 8037-spec change.

Skip here as a stop-gap; the tests will be ran with updated spec in `devnets/bal/5`.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.