### PR TITLE
feat(doc): replace index with __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ actionlint = [
     "shellcheck-py>=0.10",
 ]
 doc = [
-    "docc>=0.5.1,<0.6.0",
+    "docc>=0.6.0,<0.7.0",
     "fladrif>=0.2.0,<0.3.0",
     "mistletoe>=1.5.0,<2",
 ]
@@ -273,6 +273,7 @@ whitelist = "ethereum_spec_tools.whitelist:main"
 [project.entry-points."docc.plugins"]
 "ethereum_spec_tools.docc.listing" = "ethereum_spec_tools.docc:EthereumListingDiscover"
 "ethereum_spec_tools.docc.discover" = "ethereum_spec_tools.docc:EthereumDiscover"
+"ethereum_spec_tools.docc.python" = "ethereum_spec_tools.docc:EthereumPythonDiscover"
 "ethereum_spec_tools.docc.build" = "ethereum_spec_tools.docc:EthereumBuilder"
 "ethereum_spec_tools.docc.fix-indexes" = "ethereum_spec_tools.docc:FixIndexTransform"
 "ethereum_spec_tools.docc.minimize-diffs" = "ethereum_spec_tools.docc:MinimizeDiffsTransform"
@@ -311,7 +312,7 @@ context = [
 discovery = [
     "docc.search.discover",
     "docc.html.discover",
-    "docc.python.discover",
+    "ethereum_spec_tools.docc.python",
     "ethereum_spec_tools.docc.discover",
     "ethereum_spec_tools.docc.listing",
     "docc.files.discover",
@@ -341,7 +342,7 @@ excluded_references = [
     "ethereum_spec_tools.lint.lints",   # This is a namespace package.
 ]
 
-[tool.docc.plugins."docc.python.discover"]
+[tool.docc.plugins."ethereum_spec_tools.docc.python"]
 paths = [
     "src",
 ]

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -21,6 +21,7 @@ import dataclasses
 import logging
 import os
 from collections import defaultdict
+from functools import total_ordering
 from itertools import tee, zip_longest
 from pathlib import PurePath
 from typing import (
@@ -51,7 +52,8 @@ from docc.plugins.listing import (
     ListingNode,
     ListingSource,
 )
-from docc.plugins.python import PythonBuilder
+from docc.plugins.python import PythonBuilder, PythonDiscover
+from docc.plugins.python.cst import PythonSource
 from docc.plugins.references import Definition, Reference
 from docc.settings import PluginSettings
 from docc.source import Source
@@ -76,6 +78,44 @@ def pairwise(iterable: Iterable[G]) -> Iterable[Tuple[G, G]]:
     return zip(a, b, strict=False)
 
 
+@total_ordering
+@dataclasses.dataclass(frozen=True)
+class _EthereumSortKey:
+    sort: int
+    path: PurePath
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, _EthereumSortKey):
+            return (self.sort, self.path) < (other.sort, other.path)
+        elif isinstance(other, PurePath):
+            return self.path < other
+        return NotImplemented
+
+
+class _EthereumPythonSource(PythonSource):
+    _sort: Final[int]
+
+    def __init__(
+        self,
+        root_path: PurePath,
+        relative_path: PurePath,
+        absolute_path: PurePath,
+        sort: int,
+    ) -> None:
+        super().__init__(root_path, relative_path, absolute_path)
+        self._sort = sort
+
+    @override
+    def listing_order_key(
+        self,
+    ) -> Tuple[bool, _EthereumSortKey, None]:
+        return (
+            self.index_dir is None,
+            _EthereumSortKey(self._sort, self.output_path),
+            None,
+        )
+
+
 class _EthereumListingSource(ListingSource):
     _sort: Final[int]
 
@@ -83,17 +123,20 @@ class _EthereumListingSource(ListingSource):
         self,
         relative_path: PurePath,
         output_path: PurePath,
-        sources: Set[Source],
         sort: int,
     ) -> None:
-        super().__init__(relative_path, output_path, sources)
+        super().__init__(relative_path, output_path)
         self._sort = sort
 
     @override
     def listing_order_key(
         self,
-    ) -> Tuple[bool, Tuple[int, PurePath], None]:
-        return (self.is_leaf, (self._sort, self.output_path), None)
+    ) -> Tuple[bool, _EthereumSortKey, None]:
+        return (
+            self.index_dir is None,
+            _EthereumSortKey(self._sort, self.output_path),
+            None,
+        )
 
 
 def _find_forks(config: PluginSettings) -> List[Hardfork]:
@@ -105,47 +148,85 @@ def _diff_path(before: Hardfork, after: Hardfork) -> PurePath:
     return PurePath("diffs") / before.short_name / after.short_name
 
 
+class _ForkOrder:
+    forks: List[PurePath]
+    diffs: List[PurePath]
+
+    def __init__(self, config: PluginSettings) -> None:
+        forks = _find_forks(config)
+        self.forks = [
+            config.unresolve_path(PurePath(f.path))
+            for f in forks
+            if f.path is not None
+        ]
+        self.diffs = [_diff_path(b, a).parent for b, a in pairwise(forks)]
+
+    def index(self, parent: PurePath) -> Optional[int]:
+        for idx, fork in enumerate(self.forks):
+            if parent.is_relative_to(fork):
+                return idx
+
+        for idx, diff in enumerate(self.diffs):
+            if parent.is_relative_to(diff):
+                return idx
+
+        return None
+
+
 class EthereumListingDiscover(ListingDiscover):
     """
     Changes the sort order of directory listings so they render in hard fork
     chronological order.
     """
 
-    fork_order: List[PurePath]
-    diff_order: List[PurePath]
+    _fork_order: _ForkOrder
 
     def __init__(self, config: PluginSettings) -> None:
         super().__init__(config)
-        forks = _find_forks(config)
-        self.fork_order = [
-            config.unresolve_path(PurePath(f.path))
-            for f in forks
-            if f.path is not None
-        ]
-        self.diff_order = [_diff_path(b, a).parent for b, a in pairwise(forks)]
-
-    def _fork_index(self, parent: PurePath) -> Optional[int]:
-        for idx, fork in enumerate(self.fork_order):
-            if parent.is_relative_to(fork):
-                return idx
-
-        for idx, diff in enumerate(self.diff_order):
-            if parent.is_relative_to(diff):
-                return idx
-
-        return None
+        self._fork_order = _ForkOrder(config)
 
     @override
     def _listing_source(
         self, source: Source, parent: PurePath
     ) -> ListingSource:
-        index = self._fork_index(parent)
+        index = self._fork_order.index(parent)
         if index is None:
             return super()._listing_source(source, parent)
         return _EthereumListingSource(
             parent,
             parent / "index",
-            set(),
+            -index,  # Reverse chronological order
+        )
+
+
+class EthereumPythonDiscover(PythonDiscover):
+    """
+    Changes the sort order of python files so they render in hard fork
+    chronological order.
+    """
+
+    _fork_order: _ForkOrder
+
+    def __init__(self, config: PluginSettings) -> None:
+        super().__init__(config)
+        self._fork_order = _ForkOrder(config)
+
+    @override
+    def _python_source(
+        self,
+        root_path: PurePath,
+        relative_path: PurePath,
+        absolute_path: PurePath,
+    ) -> PythonSource:
+        index = self._fork_order.index(relative_path)
+        if index is None:
+            return super()._python_source(
+                root_path, relative_path, absolute_path
+            )
+        return _EthereumPythonSource(
+            root_path,
+            relative_path,
+            absolute_path,
             -index,  # Reverse chronological order
         )
 
@@ -214,6 +295,9 @@ class EthereumDiscover(Discover):
 
                 assert before_source or after_source
 
+                if path.name == "__init__.py":
+                    path = path.with_name("index")
+
                 output_path = _diff_path(before, after) / path
 
                 yield DiffSource(
@@ -281,6 +365,19 @@ class DiffSource(Generic[S], Source, Listable):
         Where to write the output from this Source relative to the output path.
         """
         return self._output_path
+
+    @property
+    def index_dir(self) -> Optional[PurePath]:
+        """
+        For index sources, the directory the source indexes. For other sources,
+        `None`.
+
+        For example, for an output path of `./foo/index`, this should return
+        `./foo`.
+        """
+        if self.output_path.name == "index":
+            return self.output_path.parent
+        return None
 
 
 class AfterNode(Node):

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ wheels = [
 
 [[package]]
 name = "docc"
-version = "0.5.1"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-resources" },
@@ -749,9 +749,9 @@ dependencies = [
     { name = "tomli" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/cd/2843f0f6cb0a3bc2d4cf070477aab8779fdde7a07c83d91b7827a67d45bb/docc-0.5.1.tar.gz", hash = "sha256:b58f7cf8fb4010afb3828b034393244be899820b1bbf7661d7982f697ec78bdb", size = 71959, upload-time = "2026-04-25T01:07:01.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/37/cd2e718c92e26da0e1129700467f62efd8bd1f53dc1dae59b3e0e0402574/docc-0.6.0.tar.gz", hash = "sha256:d335be8f509884fefb507e75a184a3c9824e50e511dd5464be9089d1ad744912", size = 72398, upload-time = "2026-04-29T02:02:30.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/82/8c21566c89fd1b76b4ee18e0ef86ded549a3aa7cb63d77c4aaccd00d64e1/docc-0.5.1-py3-none-any.whl", hash = "sha256:5d82e7b0c654ee7de6e6988ee677ff4ac93b427f19d82546941eda96d2f546c7", size = 98650, upload-time = "2026-04-25T01:07:00.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/66/b81c58e0514531a26201f3d6b437b24375b996db5a8105d3e21420ccfc08/docc-0.6.0-py3-none-any.whl", hash = "sha256:bb4ed18f23926f1cea649a407c67d6794a92361826593e6ba374e80892fe98d1", size = 99176, upload-time = "2026-04-29T02:02:28.829Z" },
 ]
 
 [[package]]
@@ -965,7 +965,7 @@ dev = [
     { name = "cairosvg", specifier = ">=2.7.0,<3" },
     { name = "codespell", specifier = "==2.4.1" },
     { name = "codespell", specifier = ">=2.4.1,<3" },
-    { name = "docc", specifier = ">=0.5.1,<0.6.0" },
+    { name = "docc", specifier = ">=0.6.0,<0.7.0" },
     { name = "ethereum-execution", extras = ["optimized"] },
     { name = "ethereum-execution-testing", editable = "packages/testing" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
@@ -1003,7 +1003,7 @@ dev = [
     { name = "vulture", specifier = "==2.14.0" },
 ]
 doc = [
-    { name = "docc", specifier = ">=0.5.1,<0.6.0" },
+    { name = "docc", specifier = ">=0.6.0,<0.7.0" },
     { name = "fladrif", specifier = ">=0.2.0,<0.3.0" },
     { name = "mistletoe", specifier = ">=1.5.0,<2" },
 ]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -56,6 +56,7 @@ State.rollback_db_transaction
 # src/ethereum_spec_tools/docc.py
 docc.EthereumDiscover
 docc.EthereumBuilder
+docc.EthereumPythonDiscover
 docc.EthereumListingDiscover
 docc.DiffSource.show_in_listing
 docc.FixIndexTransform


### PR DESCRIPTION
## 🗒️ Description

Pulls in docc 0.6, which replaces the old `index.html` with the content of `__init__.py`, making for much smoother navigation.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/c19b76c1-9d51-4163-80cc-fc8b2614e33c.jpeg)
