### PR TITLE
refactor(tests): parametrize `max_code_size` for EIP-3860 & 1153

### DIFF
--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -18,6 +18,7 @@ from execution_testing import (
     compute_create_address,
 )
 from execution_testing import Macros as Om
+from execution_testing.forks.helpers import Fork
 
 from . import CreateOpcodeParams, PytestParameterEnum
 from .spec import ref_spec_1153
@@ -271,6 +272,7 @@ def test_tstore_rollback_on_failed_create(
     state_test: StateTestFiller,
     pre: Alloc,
     create_opcode: Op,
+    fork: Fork,
 ) -> None:
     """
     Test TSTORE is rolled back after failed CREATE/CREATE2 initcode.
@@ -296,11 +298,13 @@ def test_tstore_rollback_on_failed_create(
     #
     # TLOAD(1)==0:     return_size = 0x600a > max code size -> fail
     # TLOAD(1)==0x6000: return_size = 0x0a <= max code size -> succeed
+    max_code_size = fork.max_code_size()
+
     initcode = (
         Op.TLOAD(1)
-        + Op.PUSH2(0x600A)
+        + Op.PUSH4(max_code_size + 0x0A)
         + Op.SUB
-        + Op.TSTORE(1, 0x6000)
+        + Op.TSTORE(1, max_code_size)
         + Op.PUSH1(0)
         + Op.RETURN
     )

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -605,6 +605,7 @@ def test_create2_oversized_initcode_with_insufficient_balance(
     pre: Alloc,
     initcode_oversize: bool,
     expected_storage_1: int,
+    fork: Fork,
 ) -> None:
     """
     Test CREATE2 with oversized initcode and insufficient balance.
@@ -621,7 +622,9 @@ def test_create2_oversized_initcode_with_insufficient_balance(
     - Initcode within limit: insufficient balance pushes 0, execution
       continues, SSTORE(1, 1) executes, so storage slot 1 becomes 1.
     """
-    initcode_size = 0x20000 if initcode_oversize else 0x100
+    initcode_size = (
+        fork.max_initcode_size() * 2 if initcode_oversize else 0x100
+    )
     caller_code = (
         Op.CREATE2(1123123123, 0, initcode_size, 0) + Op.POP + Op.SSTORE(1, 1)
     )


### PR DESCRIPTION
## 🗒️ Description

As title - avoid hardcoding max code/initcode size in two tests

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
