### PR TITLE
chore(ci): generate-all-formats for mainnet fixture releases

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,7 +1,7 @@
 # Unless filling for special features, all features should fill for previous forks (starting from Frontier) too
 mainnet:
   evm-type: eels
-  fill-params: --until=BPO2
+  fill-params: --until=BPO2 --generate-all-formats
 
 benchmark:
   evm-type: benchmark


### PR DESCRIPTION
## 🗒️ Description
Small fix-up to #2702: Enable all formats for mainnet test fixture releases in CI.

## 🔗 Related Issues or PRs
#2702

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:frog: 