### PR TITLE
fix(test-forks): treat transition fork variants as equal to canonical

### DIFF
--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -184,7 +184,7 @@ class BaseForkMeta(ABCMeta):
         return cls.name()
 
     @staticmethod
-    def _maybe_transitioned(fork_cls: "BaseForkMeta") -> "BaseForkMeta":
+    def _maybe_transitioned(fork_cls: type) -> type:
         """
         Return the transitioned fork, if a transition fork, otherwise return
         `fork_cls`.
@@ -203,14 +203,14 @@ class BaseForkMeta(ABCMeta):
         """
         # Resolve variants to canonical identity so comparisons between
         # a variant and a canonical descendant fork work as expected.
-        a = BaseForkMeta._identity(a)
-        b = BaseForkMeta._identity(b)
-        a = BaseForkMeta._maybe_transitioned(a)
-        b = BaseForkMeta._maybe_transitioned(b)
-        return issubclass(a, b)
+        a_id: type = BaseForkMeta._identity(a)
+        b_id: type = BaseForkMeta._identity(b)
+        a_id = BaseForkMeta._maybe_transitioned(a_id)
+        b_id = BaseForkMeta._maybe_transitioned(b_id)
+        return issubclass(a_id, b_id)
 
     @staticmethod
-    def _identity(fork_cls: "BaseForkMeta") -> "BaseForkMeta":
+    def _identity(fork_cls: type) -> type:
         """Return the canonical fork class, resolving variants."""
         base = getattr(fork_cls, "_base_fork", None)
         return base if base is not None else fork_cls

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -754,3 +754,32 @@ def test_fork_variant_ordering() -> None:
     assert not (variant < London)
     assert variant >= London
     assert variant <= London
+
+
+def test_transition_fork_variant_equality() -> None:
+    """
+    Variants of a transition fork created via `with_env_gas_limit` must
+    compare equal to their canonical parent and to each other, even when
+    different gas limits are used. Distinct canonical transition forks
+    must remain unequal.
+    """
+    canonical = CancunToPragueAtTime15k
+    variant_a = canonical.with_env_gas_limit(30_000_000)
+    variant_b = canonical.with_env_gas_limit(45_000_000)
+    variant_c = canonical.with_env_gas_limit(30_000_000)
+
+    assert variant_a is not canonical
+    assert variant_a is not variant_b
+    assert variant_a is not variant_c
+
+    assert variant_a == canonical
+    assert variant_b == canonical
+    assert variant_a == variant_b
+    assert variant_a == variant_c
+
+    assert hash(variant_a) == hash(canonical)
+    assert hash(variant_b) == hash(canonical)
+    assert hash(variant_c) == hash(canonical)
+
+    assert canonical != PragueToOsakaAtTime15k
+    assert variant_a != PragueToOsakaAtTime15k

--- a/packages/testing/src/execution_testing/forks/transition_base_fork.py
+++ b/packages/testing/src/execution_testing/forks/transition_base_fork.py
@@ -1,8 +1,8 @@
 """Base objects used to define transition forks."""
 
-from typing import Any, Callable, ClassVar, Dict, Type
+from typing import Any, Callable, ClassVar, Dict, Optional, Type
 
-from .base_fork import BaseFork
+from .base_fork import BaseFork, BaseForkMeta
 
 
 class TransitionBaseMetaClass(type):
@@ -14,6 +14,19 @@ class TransitionBaseMetaClass(type):
         implemented by subclasses.
         """
         raise Exception("Not implemented")
+
+    def __eq__(cls, other: object) -> bool:
+        """
+        Compare transition fork identity, treating variants created by
+        `with_env_gas_limit` as equal to their canonical parent.
+        """
+        if not isinstance(other, type):
+            return NotImplemented
+        return BaseForkMeta._identity(cls) is BaseForkMeta._identity(other)
+
+    def __hash__(cls) -> int:
+        """Hash by canonical transition fork identity."""
+        return id(BaseForkMeta._identity(cls))
 
     def transitions_to(cls) -> Type[BaseFork]:
         """
@@ -76,6 +89,7 @@ class TransitionBaseClass(metaclass=TransitionBaseMetaClass):
     at_timestamp: ClassVar[int] = 0
     _ignore: ClassVar[bool] = False
     _env_gas_limit: ClassVar[int] = 0
+    _base_fork: ClassVar[Optional[Type["TransitionBaseClass"]]] = None
 
     @classmethod
     def fork_at(
@@ -117,6 +131,7 @@ class TransitionBaseClass(metaclass=TransitionBaseMetaClass):
         """
         new_cls = type(cls.__name__, (cls,), {})
         new_cls._env_gas_limit = env_gas_limit  # type: ignore[attr-defined]
+        new_cls._base_fork = cls._base_fork or cls  # type: ignore[attr-defined]
         return new_cls
 
 


### PR DESCRIPTION
## Description

`TransitionBaseClass.with_env_gas_limit` produced fresh class objects that compared unequal via the default `type.__eq__`, breaking pre-alloc group reuse during `fill --generate-pre-alloc-groups` and tripping the `add_test_pre` assertion (`Incompatible fork: CancunToPragueAtTime15k!=CancunToPragueAtTime15k`).

Mirror `BaseForkMeta` by adding `__eq__`/`__hash__` on `TransitionBaseMetaClass` keyed on the canonical identity, set `_base_fork` on the variant inside `with_env_gas_limit`, and widen `_identity`/`_maybe_transitioned` signatures to `type` so the metaclass can reuse them. Adds a regression test covering transition fork variant equality.

## Related Issues or PRs

Bug introduced by #2690 (`feat(test-forks): Gas-limit-aware Fork, fork-aware Environment`).

## Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).