### PR TITLE
fix(test-benchmark): disable cache strats except NO_CACHE for now

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -207,7 +207,7 @@ def run_bloated_eoa_benchmark(
 @pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("existing_slots", [False, True])
-@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
+@pytest.mark.parametrize("cache_strategy", [CacheStrategy.NO_CACHE])
 def test_sload_bloated(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -592,7 +592,7 @@ def test_sload_bloated_multi_contract(
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("write_new_value", [False, True])
 @pytest.mark.parametrize("existing_slots", [True, False])
-@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
+@pytest.mark.parametrize("cache_strategy", [CacheStrategy.NO_CACHE])
 def test_sstore_bloated(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -1702,7 +1702,7 @@ class AccountMode(Enum):
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
+@pytest.mark.parametrize("cache_strategy", [CacheStrategy.NO_CACHE])
 @pytest.mark.parametrize(
     "opcode,value_sent,account_mode", account_access_params()
 )


### PR DESCRIPTION
## 🗒️ Description
This PR disables the cache strategies for stateful benchmarks such that we reduce the benchmarkoor run times during Interop as well as remove them since the data isn't really useful as they seem a bit broken after 8037. 

This pends a fix.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
