### PR TITLE
refactor(test-benchmark): support 8037 for `SSTORE` benchmark

### DIFF
--- a/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
@@ -325,7 +325,8 @@ def test_tx_iterations_by_total_iteration_count_raises_on_impossible() -> None:
 
     with pytest.raises(
         ValueError,
-        match="Single iteration gas cost is greater than gas limit.",
+        match="Single iteration gas cost exceeds gas_limit "
+        "or compute_gas_limit.",
     ):
         list(
             bytecode.tx_iterations_by_total_iteration_count(

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -1002,20 +1002,19 @@ class IteratingBytecode(Bytecode):
         gas_limit: int,
         compute_gas_limit: int | None = None,
         **intrinsic_cost_kwargs: Any,
-    ) -> Tuple[bool, int]:
+    ) -> bool:
         """
         Check whether iteration_count iterations fit within the gas limits.
 
-        Returns (fits, combined_gas) where combined_gas is the
-        total regular+state gas (i.e. tx.gas) given the iteration
-        count. fits is True when both:
-          - combined_gas <= gas_limit (block-budget constraint).
+        Returns True when both:
+          - The combined regular+state gas (i.e. tx.gas) is <=
+            gas_limit (block-budget constraint).
           - The regular gas, computed as
-            combined_gas - iteration_count * iterating_state_gas,
-            respects the compute_gas_limit
+            combined - iteration_count * iterating_state_gas,
+            respects the compute_gas_limit.
         """
         if iteration_count <= 0:
-            return True, 0
+            return True
         combined = self.tx_gas_limit_by_iteration_count(
             fork=fork,
             iteration_count=iteration_count,
@@ -1023,12 +1022,12 @@ class IteratingBytecode(Bytecode):
             **intrinsic_cost_kwargs,
         )
         if combined > gas_limit:
-            return False, combined
+            return False
         if compute_gas_limit is not None:
             compute = combined - iteration_count * self.iterating_state_gas
             if compute > compute_gas_limit:
-                return False, combined
-        return True, combined
+                return False
+        return True
 
     def _binary_search_iterations(
         self,
@@ -1050,35 +1049,30 @@ class IteratingBytecode(Bytecode):
             **intrinsic_cost_kwargs,
         }
 
-        ok, _ = self._iterations_fit_within_gas_limits(
+        if not self._iterations_fit_within_gas_limits(
             iteration_count=1, **fits_kwargs
-        )
-        if not ok:
+        ):
             raise ValueError(
-                "Single iteration gas cost is greater than gas limit."
+                "Single iteration gas cost exceeds gas_limit "
+                "or compute_gas_limit."
             )
 
         low = 1
         high = 2
 
         # Exponential search to find upper bound
-        ok, _ = self._iterations_fit_within_gas_limits(
+        while self._iterations_fit_within_gas_limits(
             iteration_count=high, **fits_kwargs
-        )
-        while ok:
+        ):
             low = high
             high *= 2
-            ok, _ = self._iterations_fit_within_gas_limits(
-                iteration_count=high, **fits_kwargs
-            )
 
         # Binary search for exact fit
         while low < high:
             mid = (low + high) // 2
-            ok, _ = self._iterations_fit_within_gas_limits(
+            if not self._iterations_fit_within_gas_limits(
                 iteration_count=mid, **fits_kwargs
-            )
-            if not ok:
+            ):
                 high = mid
             else:
                 low = mid + 1
@@ -1175,6 +1169,7 @@ class IteratingBytecode(Bytecode):
                 best_iterations, _ = self._binary_search_iterations(
                     fork=fork,
                     gas_limit=gas_limit_cap,
+                    compute_gas_limit=gas_limit_cap,
                     start_iteration=start_iteration,
                     **intrinsic_cost_kwargs,
                 )

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -806,6 +806,10 @@ class IteratingBytecode(Bytecode):
     """
     cleanup: Bytecode
     """Bytecode executed once at the end after all iterations complete."""
+    iterating_state_gas: int
+    """
+    State-gas portion (EIP-8037) charged per loop iteration.
+    """
 
     def __new__(
         cls,
@@ -815,6 +819,7 @@ class IteratingBytecode(Bytecode):
         cleanup: Bytecode | None = None,
         warm_iterating: Bytecode | None = None,
         iterating_subcall: Bytecode | int | None = None,
+        iterating_state_gas: int = 0,
     ) -> Self:
         """
         Create a new iterating bytecode.
@@ -833,6 +838,8 @@ class IteratingBytecode(Bytecode):
                 calculation. The value can also be an integer, in which case it
                 represents the gas cost of the subcall (e.g. the subcall is a
                 precompiled contract).
+            iterating_state_gas: EIP-8037 state-gas portion charged
+                per iteration, defaults to 0.
 
         Returns:
             A new IteratingBytecode instance.
@@ -860,6 +867,7 @@ class IteratingBytecode(Bytecode):
         if cleanup is None:
             cleanup = Bytecode()
         instance.cleanup = cleanup
+        instance.iterating_state_gas = iterating_state_gas
         return instance
 
     def iterating_subcall_gas_cost(
@@ -985,61 +993,92 @@ class IteratingBytecode(Bytecode):
             **intrinsic_cost_kwargs,
         ) + self.iterating_subcall_reserve(fork=fork)
 
+    def _iterations_fit_within_gas_limits(
+        self,
+        *,
+        fork: Fork,
+        iteration_count: int,
+        start_iteration: int,
+        gas_limit: int,
+        compute_gas_limit: int | None = None,
+        **intrinsic_cost_kwargs: Any,
+    ) -> Tuple[bool, int]:
+        """
+        Check whether iteration_count iterations fit within the gas limits.
+
+        Returns (fits, combined_gas) where combined_gas is the
+        total regular+state gas (i.e. tx.gas) given the iteration
+        count. fits is True when both:
+          - combined_gas <= gas_limit (block-budget constraint).
+          - The regular gas, computed as
+            combined_gas - iteration_count * iterating_state_gas,
+            respects the compute_gas_limit
+        """
+        if iteration_count <= 0:
+            return True, 0
+        combined = self.tx_gas_limit_by_iteration_count(
+            fork=fork,
+            iteration_count=iteration_count,
+            start_iteration=start_iteration,
+            **intrinsic_cost_kwargs,
+        )
+        if combined > gas_limit:
+            return False, combined
+        if compute_gas_limit is not None:
+            compute = combined - iteration_count * self.iterating_state_gas
+            if compute > compute_gas_limit:
+                return False, combined
+        return True, combined
+
     def _binary_search_iterations(
         self,
         *,
         fork: Fork,
         gas_limit: int,
         start_iteration: int,
+        compute_gas_limit: int | None = None,
         **intrinsic_cost_kwargs: Any,
     ) -> Tuple[int, int]:
         """
         Binary search for the maximum iterations that fit within a gas limit.
         """
-        single_iteration_gas = self.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=1,
-            start_iteration=start_iteration,
+        fits_kwargs: Dict[str, Any] = {
+            "fork": fork,
+            "start_iteration": start_iteration,
+            "gas_limit": gas_limit,
+            "compute_gas_limit": compute_gas_limit,
             **intrinsic_cost_kwargs,
+        }
+
+        ok, _ = self._iterations_fit_within_gas_limits(
+            iteration_count=1, **fits_kwargs
         )
-        if single_iteration_gas > gas_limit:
+        if not ok:
             raise ValueError(
                 "Single iteration gas cost is greater than gas limit."
             )
+
         low = 1
         high = 2
 
         # Exponential search to find upper bound
-        high_gas_cost = self.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=high,
-            start_iteration=start_iteration,
-            **intrinsic_cost_kwargs,
+        ok, _ = self._iterations_fit_within_gas_limits(
+            iteration_count=high, **fits_kwargs
         )
-        while high_gas_cost < gas_limit:
+        while ok:
             low = high
             high *= 2
-            high_gas_cost = self.tx_gas_limit_by_iteration_count(
-                fork=fork,
-                iteration_count=high,
-                start_iteration=start_iteration,
-                **intrinsic_cost_kwargs,
+            ok, _ = self._iterations_fit_within_gas_limits(
+                iteration_count=high, **fits_kwargs
             )
 
         # Binary search for exact fit
-        best_iterations = 0
         while low < high:
             mid = (low + high) // 2
-
-            if (
-                self.tx_gas_limit_by_iteration_count(
-                    fork=fork,
-                    iteration_count=mid,
-                    start_iteration=start_iteration,
-                    **intrinsic_cost_kwargs,
-                )
-                > gas_limit
-            ):
+            ok, _ = self._iterations_fit_within_gas_limits(
+                iteration_count=mid, **fits_kwargs
+            )
+            if not ok:
                 high = mid
             else:
                 low = mid + 1
@@ -1082,17 +1121,11 @@ class IteratingBytecode(Bytecode):
             start_iteration=start_iteration,
             **intrinsic_cost_kwargs,
         ):
-            # Binary search for the maximum number of iterations that fits
-            # within remaining_gas
-            max_gas_limit = (
-                min(remaining_gas, gas_limit_cap)
-                if gas_limit_cap is not None
-                else remaining_gas
-            )
             best_iterations, best_iterations_gas = (
                 self._binary_search_iterations(
                     fork=fork,
-                    gas_limit=max_gas_limit,
+                    gas_limit=remaining_gas,
+                    compute_gas_limit=gas_limit_cap,
                     start_iteration=start_iteration,
                     **intrinsic_cost_kwargs,
                 )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -9,7 +9,7 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
 
 from enum import Enum, auto
 from functools import partial
-from typing import Callable, Generator, List
+from typing import Any, Callable, Generator, List
 
 import pytest
 from execution_testing import (
@@ -135,12 +135,10 @@ def run_bloated_eoa_benchmark(
     existing_slots: bool,
     runtime_code: Bytecode,
     cache_strategy: CacheStrategy,
+    tx_generator: Callable[[EOA], list[Transaction]] | None = None,
 ) -> None:
     """
     Run a bloated-EOA benchmark with the given runtime delegation code.
-
-    Handles authority setup, slot 0 initialization, delegation to
-    runtime code, benchmark tx generation, and test invocation.
     """
     slot_0_value = Hash(1) if existing_slots else Hash(START_SLOT)
 
@@ -164,22 +162,25 @@ def run_bloated_eoa_benchmark(
 
     blocks: list[Block] = [Block(txs=[init_tx, runtime_tx])]
 
-    gas_available = gas_benchmark_value
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     sender = pre.fund_eoa()
 
     txs: list[Transaction] = []
     with TestPhaseManager.execution():
-        while gas_available >= intrinsic_gas:
-            tx_gas = min(gas_available, tx_gas_limit)
-            txs.append(
-                Transaction(
-                    gas_limit=tx_gas,
-                    to=authority,
-                    sender=sender,
+        if tx_generator is not None:
+            txs = tx_generator(sender)
+        else:
+            gas_available = gas_benchmark_value
+            intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+            while gas_available >= intrinsic_gas:
+                tx_gas = min(gas_available, tx_gas_limit)
+                txs.append(
+                    Transaction(
+                        gas_limit=tx_gas,
+                        to=authority,
+                        sender=sender,
+                    )
                 )
-            )
-            gas_available -= tx_gas
+                gas_available -= tx_gas
 
     cache_txs: list[Transaction] = []
     if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
@@ -189,6 +190,7 @@ def run_bloated_eoa_benchmark(
                 cache_txs.append(
                     Transaction(
                         gas_limit=tx.gas_limit,
+                        data=tx.data,
                         to=authority,
                         sender=cache_sender,
                     )
@@ -606,62 +608,106 @@ def test_sstore_bloated(
 ) -> None:
     """
     Benchmark SSTORE opcodes targeting an EOA with storage bloated.
-
-    The storage is assumed to be filled from 0-N linearly, where
-    each slot has the value of the key. Except slot 0, this is the
-    pointer to the next free (empty) storage slot.
-
-    For this test to work correctly under all parameters then above
-    has to be true. If this is not the case then some tests will not
-    test what they claim to do. For instance, for `write_new_value`
-    set to False we need to know the current value of the slots.
     """
+    sstore_metadata: dict[str, Any] = {}
+    # If CACHE_TX, there would be one cold SLOAD before SSTORE
+    sstore_metadata["key_warm"] = cache_strategy == CacheStrategy.CACHE_TX
+
+    # SSTORE metadata matrix:
+    #
+    # existing_slots | write_new_value | original | current | new
+    # ---------------+-----------------+----------+---------+-----
+    # True           | True            | 1        | 1       | 2
+    # True           | False           | 1        | 1       | 1
+    # False          | True            | 0        | 0       | 1
+    # False          | False           | 0        | 0       | 0
+
+    # When existing_slots is False, the initial value is always 0
+    # Otherwise, the initial value starts at 1 instead.
+    sstore_metadata["original_value"] = existing_slots
+    sstore_metadata["current_value"] = existing_slots
+
+    # If not writing a new value, the new value is the same as the current one
+    # If writing a new value, the new value is current value + 1
+    sstore_metadata["new_value"] = (
+        existing_slots if not write_new_value else existing_slots + 1
+    )
+
+    sstore_metadata["key_warm"] = cache_strategy == CacheStrategy.CACHE_TX
+
     setup = (
-        Op.PUSH0  # [0]
-        + Op.SLOAD  # [key], s[0] = key
-        + Op.DUP1  # [key, key]
+        Op.CALLDATALOAD(32)  # [end_slot]
+        + Op.CALLDATALOAD(0)  # [counter, end_slot]
     )
 
-    if write_new_value:
-        setup += (
-            Op.PUSH1(1)  # [1, key, key]
-            + Op.ADD  # [key+1, key]
-            + Op.SWAP1  # [key, key+1]
-        )
+    # stack element: [counter, end_slot]
 
-    # After setup phase, the stack element represents
-    # [slot, value], slot to write and value to write
+    loop = Op.JUMPDEST  # jump target
 
-    cache_op = Bytecode()
+    # If CACHE_TX, warm the slot with a cold SLOAD before the SSTORE loop
     if cache_strategy == CacheStrategy.CACHE_TX:
-        cache_op = (
-            Op.DUP1  # [slot, slot, value]
-            + Op.SLOAD  # [s[slot], slot, value]
-            + Op.POP  # [slot, value]
+        loop += Op.POP(Op.SLOAD(Op.DUP1, key_warm=False))
+
+    sstore_op: Bytecode = Bytecode()
+    if write_new_value:
+        # s[counter] = counter + 1
+        sstore_op = (
+            Op.DUP1  # [counter, counter, end_slot]
+            + Op.DUP1  # [counter, counter, counter, end_slot]
+            + Op.PUSH1(1)  # [1, counter, counter, counter, end_slot]
+            + Op.ADD  # [counter+1, counter, counter, end_slot]
+            + Op.SWAP1  # [counter, counter+1, counter, end_slot]
+            + Op.SSTORE(**sstore_metadata)  # [counter, end_slot]
+        )
+    else:
+        # s[counter] = counter (existing slot) or 0 (non existing slot)
+        push_value = Op.DUP1 if existing_slots else Op.PUSH1(0)
+        sstore_op = (
+            push_value  # [value, counter, end_slot]
+            + Op.DUP2  # [counter, value, counter, end_slot]
+            + Op.SSTORE(**sstore_metadata)  # [counter, end_slot]
         )
 
-    # The cache mechanism touches the slot before SSTORE
+    loop += sstore_op
 
-    runtime_code = (
-        setup
-        + While(
-            body=(
-                cache_op  # [slot, value]
-                + Op.DUP2  # [value, slot, value]
-                + Op.DUP2  # [slot, value, slot, value]
-                + Op.SSTORE  # [slot, value], s[slot] = value
-                + Op.PUSH1(1)  # [1, slot, value]
-                + Op.ADD  # [slot+1, value]
-                + Op.SWAP1  # [value, slot+1]
-                + Op.PUSH1(1)  # [1, value, slot+1]
-                + Op.ADD  # [value+1, slot+1]
-                + Op.SWAP1  # [slot+1, value+1]
-            ),
-            condition=Op.GT(Op.GAS, 0xFFFF),
-        )
-        + Op.PUSH0  # [0, slot+1, value+1]
-        + Op.SSTORE  # s[0] = slot+1
+    # stack element: [counter, end_slot]
+
+    loop += (
+        Op.PUSH1(1)  # [1, counter, end_slot]
+        + Op.ADD  # [counter+1, end_slot]
+        + Op.DUP2  # [end_slot, counter+1, end_slot]
+        + Op.DUP2  # [counter+1, end_slot, counter+1, end_slot]
+        + Op.LT  # [counter+1<end_slot, counter+1, end_slot]
+        + Op.PUSH1(len(setup))  # [dest, condition, counter+1, end_slot]
+        + Op.JUMPI  # [counter+1, end_slot]
     )
+
+    runtime_code = IteratingBytecode(
+        setup=setup,
+        iterating=loop,
+        cleanup=Op.STOP,
+        iterating_state_gas=fork.sstore_state_gas()
+        if (not existing_slots and write_new_value)
+        else 0,
+    )
+
+    authority = pre.stub_eoa(token_name)
+    start_slot = 1 if existing_slots else START_SLOT
+
+    def calldata_gen(iteration_count: int, start_iteration: int) -> bytes:
+        return Hash(start_iteration) + Hash(start_iteration + iteration_count)
+
+    def tx_generator(sender: EOA) -> list[Transaction]:
+        return list(
+            runtime_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                sender=sender,
+                to=authority,
+                start_iteration=start_slot,
+                calldata=calldata_gen,
+            )
+        )
 
     run_bloated_eoa_benchmark(
         benchmark_test=benchmark_test,
@@ -669,10 +715,11 @@ def test_sstore_bloated(
         fork=fork,
         gas_benchmark_value=gas_benchmark_value,
         tx_gas_limit=tx_gas_limit,
-        authority=pre.stub_eoa(token_name),
+        authority=authority,
         existing_slots=existing_slots,
         runtime_code=runtime_code,
         cache_strategy=cache_strategy,
+        tx_generator=tx_generator,
     )
 
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -622,18 +622,18 @@ def test_sstore_bloated(
     # False          | True            | 0        | 0       | 1
     # False          | False           | 0        | 0       | 0
 
+    initial_value = int(existing_slots)
+
     # When existing_slots is False, the initial value is always 0
     # Otherwise, the initial value starts at 1 instead.
-    sstore_metadata["original_value"] = existing_slots
-    sstore_metadata["current_value"] = existing_slots
+    sstore_metadata["original_value"] = initial_value
+    sstore_metadata["current_value"] = initial_value
 
     # If not writing a new value, the new value is the same as the current one
     # If writing a new value, the new value is current value + 1
     sstore_metadata["new_value"] = (
-        existing_slots if not write_new_value else existing_slots + 1
+        initial_value if not write_new_value else initial_value + 1
     )
-
-    sstore_metadata["key_warm"] = cache_strategy == CacheStrategy.CACHE_TX
 
     setup = (
         Op.CALLDATALOAD(32)  # [end_slot]
@@ -642,7 +642,8 @@ def test_sstore_bloated(
 
     # stack element: [counter, end_slot]
 
-    loop = Op.JUMPDEST  # jump target
+    loop = Bytecode()
+    loop += Op.JUMPDEST  # jump target
 
     # If CACHE_TX, warm the slot with a cold SLOAD before the SSTORE loop
     if cache_strategy == CacheStrategy.CACHE_TX:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Under eip-8037, `SSTORE` on a zero to nonzero transition incurs an additional state-gas cost (`32 * cost_per_state_byte`) that was not being accounted for when sizing the per-tx iteration count. This PR updates the `IteratingBytecode` to support the eip-8037 helper and refactor the `SSTORE` benchmark.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
