### PR TITLE
refactor(test-benchmark): add cache strategy to sstore benchmark

### DIFF
--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -806,6 +806,10 @@ class IteratingBytecode(Bytecode):
     """
     cleanup: Bytecode
     """Bytecode executed once at the end after all iterations complete."""
+    iterating_state_gas: int
+    """
+    State-gas portion (EIP-8037) charged per loop iteration.
+    """
 
     def __new__(
         cls,
@@ -815,6 +819,7 @@ class IteratingBytecode(Bytecode):
         cleanup: Bytecode | None = None,
         warm_iterating: Bytecode | None = None,
         iterating_subcall: Bytecode | int | None = None,
+        iterating_state_gas: int = 0,
     ) -> Self:
         """
         Create a new iterating bytecode.
@@ -833,6 +838,9 @@ class IteratingBytecode(Bytecode):
                 calculation. The value can also be an integer, in which case it
                 represents the gas cost of the subcall (e.g. the subcall is a
                 precompiled contract).
+            iterating_state_gas: EIP-8037 state-gas portion charged
+                per iteration (see field docstring). Defaults to 0,
+                preserving pre-EIP-8037 allocator behavior.
 
         Returns:
             A new IteratingBytecode instance.
@@ -860,6 +868,7 @@ class IteratingBytecode(Bytecode):
         if cleanup is None:
             cleanup = Bytecode()
         instance.cleanup = cleanup
+        instance.iterating_state_gas = iterating_state_gas
         return instance
 
     def iterating_subcall_gas_cost(
@@ -985,61 +994,106 @@ class IteratingBytecode(Bytecode):
             **intrinsic_cost_kwargs,
         ) + self.iterating_subcall_reserve(fork=fork)
 
+    def _iterations_fit_within_gas_limits(
+        self,
+        *,
+        fork: Fork,
+        iteration_count: int,
+        start_iteration: int,
+        gas_limit: int,
+        compute_gas_limit: int | None = None,
+        **intrinsic_cost_kwargs: Any,
+    ) -> Tuple[bool, int]:
+        """
+        Check whether iteration_count iterations fit within the gas limits.
+
+        Returns (fits, combined_gas) where combined_gas is the
+        total regular+state gas (i.e. tx.gas) given the iteration
+        count. fits is True when both:
+          - combined_gas <= gas_limit (block-budget constraint).
+          - When compute_gas_limit is set, the compute portion
+            combined - iteration_count * iterating_state_gas
+            does not exceed `compute_gas_limit` (EIP-8037 per-tx
+            compute cap). With `self.iterating_state_gas == 0`
+            this reduces to `combined <= compute_gas_limit`.
+        """
+        if iteration_count <= 0:
+            return True, 0
+        combined = self.tx_gas_limit_by_iteration_count(
+            fork=fork,
+            iteration_count=iteration_count,
+            start_iteration=start_iteration,
+            **intrinsic_cost_kwargs,
+        )
+        if combined > gas_limit:
+            return False, combined
+        if compute_gas_limit is not None:
+            compute = combined - iteration_count * self.iterating_state_gas
+            if compute > compute_gas_limit:
+                return False, combined
+        return True, combined
+
     def _binary_search_iterations(
         self,
         *,
         fork: Fork,
         gas_limit: int,
         start_iteration: int,
+        compute_gas_limit: int | None = None,
         **intrinsic_cost_kwargs: Any,
     ) -> Tuple[int, int]:
         """
         Binary search for the maximum iterations that fit within a gas limit.
+
+        `gas_limit` bounds the combined (regular+state) gas, i.e., the
+        emitted `tx.gas`.
+
+        When `compute_gas_limit` is supplied alongside a non-zero
+        `self.iterating_state_gas`, the search additionally
+        requires that the regular (compute) portion fits within
+        `compute_gas_limit`. This models EIP-8037: state gas rides in
+        the per-tx reservoir on top of the compute gas cap rather than
+        eating into it. With `self.iterating_state_gas == 0` the
+        second constraint reduces to `combined ≤ compute_gas_limit`,
+        which matches today's `min(remaining, cap)` behavior.
         """
-        single_iteration_gas = self.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=1,
-            start_iteration=start_iteration,
+        fits_kwargs: Dict[str, Any] = {
+            "fork": fork,
+            "start_iteration": start_iteration,
+            "gas_limit": gas_limit,
+            "compute_gas_limit": compute_gas_limit,
             **intrinsic_cost_kwargs,
+        }
+
+        ok, _ = self._iterations_fit_within_gas_limits(
+            iteration_count=1, **fits_kwargs
         )
-        if single_iteration_gas > gas_limit:
+        if not ok:
             raise ValueError(
                 "Single iteration gas cost is greater than gas limit."
             )
+
         low = 1
         high = 2
 
         # Exponential search to find upper bound
-        high_gas_cost = self.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=high,
-            start_iteration=start_iteration,
-            **intrinsic_cost_kwargs,
+        ok, _ = self._iterations_fit_within_gas_limits(
+            iteration_count=high, **fits_kwargs
         )
-        while high_gas_cost < gas_limit:
+        while ok:
             low = high
             high *= 2
-            high_gas_cost = self.tx_gas_limit_by_iteration_count(
-                fork=fork,
-                iteration_count=high,
-                start_iteration=start_iteration,
-                **intrinsic_cost_kwargs,
+            ok, _ = self._iterations_fit_within_gas_limits(
+                iteration_count=high, **fits_kwargs
             )
 
         # Binary search for exact fit
-        best_iterations = 0
         while low < high:
             mid = (low + high) // 2
-
-            if (
-                self.tx_gas_limit_by_iteration_count(
-                    fork=fork,
-                    iteration_count=mid,
-                    start_iteration=start_iteration,
-                    **intrinsic_cost_kwargs,
-                )
-                > gas_limit
-            ):
+            ok, _ = self._iterations_fit_within_gas_limits(
+                iteration_count=mid, **fits_kwargs
+            )
+            if not ok:
                 high = mid
             else:
                 low = mid + 1
@@ -1072,6 +1126,14 @@ class IteratingBytecode(Bytecode):
         list will contain one item per transaction that represents the
         iteration count for that transaction, and no transaction will exceed
         the gas limit cap.
+
+        When `self.iterating_state_gas > 0` (EIP-8037), the per-tx
+        cap is applied to the *compute* portion only — state gas rides
+        in the tx-level reservoir on top. Each emitted tx then carries
+        `tx.gas = compute + state`, which is also what the block budget
+        (`gas_limit`) accounts against. With
+        `self.iterating_state_gas == 0` the function behaves
+        identically to today's logic.
         """
         gas_limit_cap = fork.transaction_gas_limit_cap()
         remaining_gas = gas_limit
@@ -1082,17 +1144,11 @@ class IteratingBytecode(Bytecode):
             start_iteration=start_iteration,
             **intrinsic_cost_kwargs,
         ):
-            # Binary search for the maximum number of iterations that fits
-            # within remaining_gas
-            max_gas_limit = (
-                min(remaining_gas, gas_limit_cap)
-                if gas_limit_cap is not None
-                else remaining_gas
-            )
             best_iterations, best_iterations_gas = (
                 self._binary_search_iterations(
                     fork=fork,
-                    gas_limit=max_gas_limit,
+                    gas_limit=remaining_gas,
+                    compute_gas_limit=gas_limit_cap,
                     start_iteration=start_iteration,
                     **intrinsic_cost_kwargs,
                 )
@@ -1179,6 +1235,12 @@ class IteratingBytecode(Bytecode):
         E.g. when the calldata that needs to be passed to the iterating
         bytecode changes with each iteration, the calldata can be generated
         dynamically by passing a callable to the calldata keyword argument.
+
+        EIP-8037-aware worst-case allocation engages automatically when
+        the bytecode has a non-zero ``iterating_state_gas``: the
+        per-tx cap then constrains the regular (compute) portion only,
+        and each emitted tx carries ``tx.gas = compute + state`` so
+        that the EVM-side reservoir sizes correctly.
 
         The returned object also contains an extra field with the expected
         gas cost of the transaction by the end of execution.

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -9,7 +9,7 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
 
 from enum import Enum, auto
 from functools import partial
-from typing import Callable, Generator, List
+from typing import Any, Callable, Generator, List
 
 import pytest
 from execution_testing import (
@@ -135,12 +135,10 @@ def run_bloated_eoa_benchmark(
     existing_slots: bool,
     runtime_code: Bytecode,
     cache_strategy: CacheStrategy,
+    tx_generator: Callable[[EOA], list[Transaction]] | None = None,
 ) -> None:
     """
     Run a bloated-EOA benchmark with the given runtime delegation code.
-
-    Handles authority setup, slot 0 initialization, delegation to
-    runtime code, benchmark tx generation, and test invocation.
     """
     slot_0_value = Hash(1) if existing_slots else Hash(START_SLOT)
 
@@ -164,22 +162,25 @@ def run_bloated_eoa_benchmark(
 
     blocks: list[Block] = [Block(txs=[init_tx, runtime_tx])]
 
-    gas_available = gas_benchmark_value
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     sender = pre.fund_eoa()
 
     txs: list[Transaction] = []
     with TestPhaseManager.execution():
-        while gas_available >= intrinsic_gas:
-            tx_gas = min(gas_available, tx_gas_limit)
-            txs.append(
-                Transaction(
-                    gas_limit=tx_gas,
-                    to=authority,
-                    sender=sender,
+        if tx_generator is not None:
+            txs = tx_generator(sender)
+        else:
+            gas_available = gas_benchmark_value
+            intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+            while gas_available >= intrinsic_gas:
+                tx_gas = min(gas_available, tx_gas_limit)
+                txs.append(
+                    Transaction(
+                        gas_limit=tx_gas,
+                        to=authority,
+                        sender=sender,
+                    )
                 )
-            )
-            gas_available -= tx_gas
+                gas_available -= tx_gas
 
     cache_txs: list[Transaction] = []
     if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
@@ -189,6 +190,7 @@ def run_bloated_eoa_benchmark(
                 cache_txs.append(
                     Transaction(
                         gas_limit=tx.gas_limit,
+                        data=tx.data,
                         to=authority,
                         sender=cache_sender,
                     )
@@ -588,6 +590,105 @@ def test_sload_bloated_multi_contract(
     )
 
 
+def _build_sstore_runtime(
+    *,
+    fork: Fork,
+    existing_slots: bool,
+    write_new_value: bool,
+    cache_strategy: CacheStrategy,
+) -> IteratingBytecode:
+    """
+    Build the calldata-driven SSTORE runtime for `test_sstore_bloated`.
+
+    Calldata layout (mirrors `create_sstore_executor`):
+      CALLDATA[0..32]   start slot
+      CALLDATA[32..64]  end slot (exclusive)
+
+    For `write_new_value=False` each iteration writes value=slot;
+    for `write_new_value=True` each iteration writes value=slot+1.
+    SSTORE metadata is set to make the framework's
+    `_calculate_sstore_gas` produce the correct combined regular+state
+    cost for the (existing_slots, write_new_value) combination. The
+    returned bytecode also carries the per-iter state-gas portion
+    (`iterating_state_gas`), which `transactions_by_gas_limit`
+    uses to honor the EIP-8037 split when sizing each tx.
+    """
+    setup = (
+        Op.CALLDATALOAD(32)  # [end_slot]
+        + Op.CALLDATALOAD(0)  # [counter, end_slot]
+    )
+
+    sstore_metadata: dict[str, Any]
+    if not existing_slots:
+        sstore_metadata = {
+            "original_value": 0,
+            "current_value": 0,
+            "new_value": 1,
+        }
+    elif write_new_value:
+        sstore_metadata = {
+            "original_value": 1,
+            "current_value": 1,
+            "new_value": 2,
+        }
+    else:
+        sstore_metadata = {
+            "original_value": 1,
+            "current_value": 1,
+            "new_value": 1,
+        }
+    sstore_metadata["key_warm"] = cache_strategy == CacheStrategy.CACHE_TX
+
+    loop = Bytecode()
+    loop += Op.JUMPDEST  # jump target
+    if cache_strategy == CacheStrategy.CACHE_TX:
+        loop += (
+            Op.DUP1  # [counter, counter, end_slot]
+            + Op.SLOAD(key_warm=False)  # [s[counter], counter, end_slot]
+            + Op.POP  # [counter, end_slot]
+        )
+
+    if write_new_value:
+        loop += (
+            Op.DUP1  # [counter, counter, end_slot]
+            + Op.DUP1  # [counter, counter, counter, end_slot]
+            + Op.PUSH1(1)  # [1, counter, counter, counter, end_slot]
+            + Op.ADD  # [counter+1, counter, counter, end_slot]
+            + Op.SWAP1  # [counter, counter+1, counter, end_slot]
+            + Op.SSTORE(**sstore_metadata)  # s[counter] = counter+1
+            # [counter, end_slot]
+        )
+    else:
+        loop += (
+            Op.DUP1  # [counter, counter, end_slot]
+            + Op.DUP1  # [counter, counter, counter, end_slot]
+            + Op.SSTORE(**sstore_metadata)  # s[counter] = counter
+            # [counter, end_slot]
+        )
+
+    # Increment counter and loop while counter+1 < end_slot.
+    loop += (
+        Op.PUSH1(1)  # [1, counter, end_slot]
+        + Op.ADD  # [counter+1, end_slot]
+        + Op.DUP2  # [end_slot, counter+1, end_slot]
+        + Op.DUP2  # [counter+1, end_slot, counter+1, end_slot]
+        + Op.LT  # [counter+1<end_slot, counter+1, end_slot]
+        + Op.PUSH1(len(setup))  # jump back to JUMPDEST
+        + Op.JUMPI  # [counter+1, end_slot]
+    )
+
+    cleanup = Op.STOP
+
+    iterating_state_gas = fork.sstore_state_gas() if not existing_slots else 0
+
+    return IteratingBytecode(
+        setup=setup,
+        iterating=loop,
+        cleanup=cleanup,
+        iterating_state_gas=iterating_state_gas,
+    )
+
+
 @pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("write_new_value", [False, True])
@@ -611,57 +712,37 @@ def test_sstore_bloated(
     each slot has the value of the key. Except slot 0, this is the
     pointer to the next free (empty) storage slot.
 
-    For this test to work correctly under all parameters then above
-    has to be true. If this is not the case then some tests will not
-    test what they claim to do. For instance, for `write_new_value`
-    set to False we need to know the current value of the slots.
+    Iteration count per tx is computed by
+    `IteratingBytecode.transactions_by_gas_limit` from the SSTORE
+    metadata, which under EIP-8037 already returns the combined
+    regular+state cost. The block budget is therefore respected
+    inclusive of state gas, and the runtime no longer needs to sense
+    `Op.GAS` at runtime.
     """
-    setup = (
-        Op.PUSH0  # [0]
-        + Op.SLOAD  # [key], s[0] = key
-        + Op.DUP1  # [key, key]
+    runtime_code = _build_sstore_runtime(
+        fork=fork,
+        existing_slots=existing_slots,
+        write_new_value=write_new_value,
+        cache_strategy=cache_strategy,
     )
 
-    if write_new_value:
-        setup += (
-            Op.PUSH1(1)  # [1, key, key]
-            + Op.ADD  # [key+1, key]
-            + Op.SWAP1  # [key, key+1]
+    authority = pre.stub_eoa(token_name)
+    start_slot = 1 if existing_slots else START_SLOT
+
+    def calldata_gen(iteration_count: int, start_iteration: int) -> bytes:
+        return Hash(start_iteration) + Hash(start_iteration + iteration_count)
+
+    def tx_generator(sender: EOA) -> list[Transaction]:
+        return list(
+            runtime_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                sender=sender,
+                to=authority,
+                start_iteration=start_slot,
+                calldata=calldata_gen,
+            )
         )
-
-    # After setup phase, the stack element represents
-    # [slot, value], slot to write and value to write
-
-    cache_op = Bytecode()
-    if cache_strategy == CacheStrategy.CACHE_TX:
-        cache_op = (
-            Op.DUP1  # [slot, slot, value]
-            + Op.SLOAD  # [s[slot], slot, value]
-            + Op.POP  # [slot, value]
-        )
-
-    # The cache mechanism touches the slot before SSTORE
-
-    runtime_code = (
-        setup
-        + While(
-            body=(
-                cache_op  # [slot, value]
-                + Op.DUP2  # [value, slot, value]
-                + Op.DUP2  # [slot, value, slot, value]
-                + Op.SSTORE  # [slot, value], s[slot] = value
-                + Op.PUSH1(1)  # [1, slot, value]
-                + Op.ADD  # [slot+1, value]
-                + Op.SWAP1  # [value, slot+1]
-                + Op.PUSH1(1)  # [1, value, slot+1]
-                + Op.ADD  # [value+1, slot+1]
-                + Op.SWAP1  # [slot+1, value+1]
-            ),
-            condition=Op.GT(Op.GAS, 0xFFFF),
-        )
-        + Op.PUSH0  # [0, slot+1, value+1]
-        + Op.SSTORE  # s[0] = slot+1
-    )
 
     run_bloated_eoa_benchmark(
         benchmark_test=benchmark_test,
@@ -669,10 +750,11 @@ def test_sstore_bloated(
         fork=fork,
         gas_benchmark_value=gas_benchmark_value,
         tx_gas_limit=tx_gas_limit,
-        authority=pre.stub_eoa(token_name),
+        authority=authority,
         existing_slots=existing_slots,
         runtime_code=runtime_code,
         cache_strategy=cache_strategy,
+        tx_generator=tx_generator,
     )
 
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -209,7 +209,14 @@ def run_bloated_eoa_benchmark(
 @pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("existing_slots", [False, True])
-@pytest.mark.parametrize("cache_strategy", [CacheStrategy.NO_CACHE])
+@pytest.mark.parametrize(
+    "cache_strategy",
+    [
+        CacheStrategy.NO_CACHE,
+        CacheStrategy.CACHE_TX,
+        CacheStrategy.CACHE_PREVIOUS_BLOCK,
+    ],
+)
 def test_sload_bloated(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -693,7 +700,14 @@ def _build_sstore_runtime(
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("write_new_value", [False, True])
 @pytest.mark.parametrize("existing_slots", [True, False])
-@pytest.mark.parametrize("cache_strategy", [CacheStrategy.NO_CACHE])
+@pytest.mark.parametrize(
+    "cache_strategy",
+    [
+        CacheStrategy.NO_CACHE,
+        CacheStrategy.CACHE_TX,
+        CacheStrategy.CACHE_PREVIOUS_BLOCK,
+    ],
+)
 def test_sstore_bloated(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -1784,7 +1798,14 @@ class AccountMode(Enum):
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("cache_strategy", [CacheStrategy.NO_CACHE])
+@pytest.mark.parametrize(
+    "cache_strategy",
+    [
+        CacheStrategy.NO_CACHE,
+        CacheStrategy.CACHE_TX,
+        CacheStrategy.CACHE_PREVIOUS_BLOCK,
+    ],
+)
 @pytest.mark.parametrize(
     "opcode,value_sent,account_mode", account_access_params()
 )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

WIP

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
