### PR TITLE
fix(test-consume): better xdist detection for enginex

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_enginex_args.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_enginex_args.py
@@ -1,0 +1,68 @@
+"""Tests for EngineX consume argument processing."""
+
+import pytest
+
+from execution_testing.cli.pytest_commands.processors import (
+    HiveEnvironmentProcessor,
+)
+
+
+@pytest.mark.parametrize(
+    "parallelism_args",
+    [
+        ["-n", "6"],
+        ["-n=6"],
+        ["-n6"],
+        ["--numprocesses", "6"],
+        ["--numprocesses=6"],
+    ],
+)
+def test_enginex_parallelism_uses_loadgroup(
+    monkeypatch: pytest.MonkeyPatch, parallelism_args: list[str]
+) -> None:
+    """EngineX must use xdist loadgroup for every supported -n spelling."""
+    monkeypatch.delenv("HIVE_PARALLELISM", raising=False)
+
+    args = HiveEnvironmentProcessor("enginex").process_args(
+        [*parallelism_args]
+    )
+
+    assert "--dist" in args
+    assert args[args.index("--dist") + 1] == "loadgroup"
+
+
+@pytest.mark.parametrize(
+    "dist_args",
+    [
+        ["--dist", "load"],
+        ["--dist=load"],
+    ],
+)
+def test_enginex_parallelism_overrides_non_loadgroup_dist(
+    monkeypatch: pytest.MonkeyPatch, dist_args: list[str]
+) -> None:
+    """EngineX overrides incompatible xdist distribution modes."""
+    monkeypatch.delenv("HIVE_PARALLELISM", raising=False)
+
+    with pytest.warns(UserWarning, match="requires `--dist=loadgroup`"):
+        args = HiveEnvironmentProcessor("enginex").process_args(
+            ["-n=6", *dist_args]
+        )
+
+    assert "--dist=load" not in args
+    if "--dist" in args:
+        assert args[args.index("--dist") + 1] == "loadgroup"
+    else:
+        assert "--dist=loadgroup" in args
+
+
+def test_consume_engine_parallelism_does_not_force_loadgroup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The loadgroup override is scoped to consume enginex."""
+    monkeypatch.delenv("HIVE_PARALLELISM", raising=False)
+
+    args = HiveEnvironmentProcessor("engine").process_args(["-n=6"])
+
+    assert "--dist" not in args
+    assert "--dist=loadgroup" not in args

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_enginex_args.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_enginex_args.py
@@ -87,6 +87,17 @@ def test_enginex_strips_xdist_load_shorthand(
         assert "--dist=loadgroup" in args
 
 
+def test_enginex_without_parallelism_still_sets_loadgroup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loadgroup is set even without xdist args (inert without `-n`)."""
+    monkeypatch.delenv("HIVE_PARALLELISM", raising=False)
+
+    args = HiveEnvironmentProcessor("enginex").process_args([])
+
+    assert args[args.index("--dist") + 1] == "loadgroup"
+
+
 def test_consume_engine_parallelism_does_not_force_loadgroup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_enginex_args.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_enginex_args.py
@@ -56,6 +56,37 @@ def test_enginex_parallelism_overrides_non_loadgroup_dist(
         assert "--dist=loadgroup" in args
 
 
+@pytest.mark.parametrize(
+    "dist_args",
+    [
+        ["-d"],
+        ["-d", "--dist=loadgroup"],
+        ["--dist", "load", "-d"],
+    ],
+)
+def test_enginex_strips_xdist_load_shorthand(
+    monkeypatch: pytest.MonkeyPatch, dist_args: list[str]
+) -> None:
+    """
+    EngineX removes xdist's `-d` shorthand for `--dist=load`.
+
+    `-d` overrides any `--dist` value within pytest-xdist's cmdline
+    hook, so overriding `--dist` alone is not enough.
+    """
+    monkeypatch.delenv("HIVE_PARALLELISM", raising=False)
+
+    with pytest.warns(UserWarning, match="requires `--dist=loadgroup`"):
+        args = HiveEnvironmentProcessor("enginex").process_args(
+            ["-n=6", *dist_args]
+        )
+
+    assert "-d" not in args
+    if "--dist" in args:
+        assert args[args.index("--dist") + 1] == "loadgroup"
+    else:
+        assert "--dist=loadgroup" in args
+
+
 def test_consume_engine_parallelism_does_not_force_loadgroup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
@@ -162,6 +162,9 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
         `--dist=loadgroup` is inert when xdist is not active (no `-n`), so
         it is safe to ensure unconditionally.
         """
+        if any("no:xdist" in arg for arg in args):
+            # Without xdist, `--dist` is an unknown argument.
+            return args[:]
         modified_args = args[:]
         found_dist = False
         changed_dist = False
@@ -172,7 +175,13 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
             if arg == "--dist":
                 found_dist = True
                 if index + 1 < len(modified_args):
-                    if modified_args[index + 1] != "loadgroup":
+                    value = modified_args[index + 1]
+                    if value.startswith("-"):
+                        # Malformed `--dist <flag>`: leave it for
+                        # argparse to reject with a clear error.
+                        index += 1
+                        continue
+                    if value != "loadgroup":
                         modified_args[index + 1] = "loadgroup"
                         changed_dist = True
                     index += 2

--- a/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
@@ -183,11 +183,18 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
                 if arg != "--dist=loadgroup":
                     modified_args[index] = "--dist=loadgroup"
                     changed_dist = True
+            elif arg == "-d":
+                # xdist's shorthand for `--dist=load`; it clobbers any
+                # `--dist` value during pytest-xdist's cmdline hook, so
+                # it must be removed rather than overridden.
+                del modified_args[index]
+                changed_dist = True
+                continue
             index += 1
 
         if not found_dist:
             modified_args.extend(["--dist", "loadgroup"])
-        elif changed_dist:
+        if changed_dist:
             warnings.warn(
                 "`consume enginex` requires `--dist=loadgroup`; overriding "
                 "the provided xdist distribution mode.",

--- a/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
@@ -108,9 +108,7 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
 
         # For enginex: ensure xdist uses loadgroup distribution so tests with
         # the same xdist_group marker (pre-alloc group) run on the same worker
-        if self.command_name == "enginex" and self._has_parallelism_flag(
-            modified_args
-        ):
+        if self.command_name == "enginex":
             modified_args = self._ensure_loadgroup_dist(modified_args)
 
         if os.getenv("HIVE_RANDOM_SEED") is not None:
@@ -160,6 +158,9 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
         group. Any xdist distribution mode other than loadgroup can split a
         pre-alloc group across workers, causing each worker to start its own
         group client and defer cleanup until session teardown.
+
+        `--dist=loadgroup` is inert when xdist is not active (no `-n`), so
+        it is safe to ensure unconditionally.
         """
         modified_args = args[:]
         found_dist = False

--- a/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
@@ -111,8 +111,7 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
         if self.command_name == "enginex" and self._has_parallelism_flag(
             modified_args
         ):
-            if "--dist" not in modified_args:
-                modified_args.extend(["--dist", "loadgroup"])
+            modified_args = self._ensure_loadgroup_dist(modified_args)
 
         if os.getenv("HIVE_RANDOM_SEED") is not None:
             warnings.warn(
@@ -146,7 +145,56 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
 
     def _has_parallelism_flag(self, args: List[str]) -> bool:
         """Check if args already contain parallelism flag."""
-        return "-n" in args
+        return any(
+            arg.startswith("-n")
+            or arg == "--numprocesses"
+            or arg.startswith("--numprocesses=")
+            for arg in args
+        )
+
+    def _ensure_loadgroup_dist(self, args: List[str]) -> List[str]:
+        """
+        Ensure EngineX xdist runs keep pre-alloc groups on one worker.
+
+        EngineX client cleanup depends on each worker seeing every test in a
+        group. Any xdist distribution mode other than loadgroup can split a
+        pre-alloc group across workers, causing each worker to start its own
+        group client and defer cleanup until session teardown.
+        """
+        modified_args = args[:]
+        found_dist = False
+        changed_dist = False
+        index = 0
+
+        while index < len(modified_args):
+            arg = modified_args[index]
+            if arg == "--dist":
+                found_dist = True
+                if index + 1 < len(modified_args):
+                    if modified_args[index + 1] != "loadgroup":
+                        modified_args[index + 1] = "loadgroup"
+                        changed_dist = True
+                    index += 2
+                    continue
+                modified_args.append("loadgroup")
+                changed_dist = True
+            elif arg.startswith("--dist="):
+                found_dist = True
+                if arg != "--dist=loadgroup":
+                    modified_args[index] = "--dist=loadgroup"
+                    changed_dist = True
+            index += 1
+
+        if not found_dist:
+            modified_args.extend(["--dist", "loadgroup"])
+        elif changed_dist:
+            warnings.warn(
+                "`consume enginex` requires `--dist=loadgroup`; overriding "
+                "the provided xdist distribution mode.",
+                stacklevel=2,
+            )
+
+        return modified_args
 
 
 class WatchFlagsProcessor(ArgumentProcessor):


### PR DESCRIPTION
TLDR: This fixes a client clean-up bug due to failing to detect whether we're running with xdist, n>1. It is only relevant when running `uv run consume enginex` against a `./hive --dev` instance: In dev mode, users can specify workers via various command-line flags, when being ran via `./hive -sim` the method is fixed (`-n <N>`) and detection is already robust.

EngineX relies on each pre-alloc group being executed by a single xdist worker so that the per-worker client manager sees every test in the group and can stop the shared client as soon as the group completes.

The previous parallelism detection only matched '-n' as a separate argument. Common spellings such as '-n=6', '-n6', and '--numprocesses=6' did not trigger the EngineX loadgroup override, so pytest-xdist could use its default distribution and split one pre-alloc group across workers.

Detect all supported xdist parallelism spellings and ensure consume enginex always runs with '--dist=loadgroup', overriding incompatible distribution modes with a warning. Keep the behavior scoped to EngineX so consume engine and the other simulators are unchanged.

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="986" height="648" alt="image" src="https://github.com/user-attachments/assets/f9b9d843-3374-4b34-a229-b9fea7d8dcd1" />
