### PR TITLE
Fix __init__.py labels in rendered diff listings

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -25,6 +25,7 @@ on:
       - "src/ethereum/**"
       - "src/ethereum_spec_tools/docc.py"
       - "src/ethereum_spec_tools/forks.py"
+      - "tests/spec_tools/**"
       - "static/**"
       - "docs/**"
       - "packages/testing/**"
@@ -234,6 +235,9 @@ jobs:
           submodules: recursive
 
       - uses: ./.github/actions/setup-uv
+
+      - name: Run docc diff regression test
+        run: uv run --group test --group doc pytest tests/spec_tools/test_docc.py
 
       - name: Build spec documentation
         run: just docs-spec

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -237,7 +237,7 @@ jobs:
       - uses: ./.github/actions/setup-uv
 
       - name: Run docc diff regression test
-        run: uv run --group test --group doc pytest tests/spec_tools/test_docc.py
+        run: uv run --group test pytest tests/spec_tools/test_docc.py
 
       - name: Build spec documentation
         run: just docs-spec

--- a/docs/scripts/gen_test_case_reference.py
+++ b/docs/scripts/gen_test_case_reference.py
@@ -58,6 +58,7 @@ args = [
     "--checklist-doc-gen",
     "--skip-index",
     "--ignore=tests/ported_static",
+    "--ignore=tests/spec_tools",
     "-m",
     "not blockchain_test_engine",
     "-s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ test = [
     "requests-cache>=1.2.1,<2",
     "libcst>=1.8,<2",
     "ethereum-execution-testing",
+    { include-group = "doc" },
 ]
 lint = [
     "codespell==2.4.1",
@@ -253,7 +254,6 @@ dev = [
     { include-group = "test" },
     { include-group = "lint" },
     { include-group = "actionlint" },
-    { include-group = "doc" },
     { include-group = "mkdocs" },
     "ethereum-execution[optimized]",
     "psutil>=7.2.2",

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -148,6 +148,18 @@ def _diff_path(before: Hardfork, after: Hardfork) -> PurePath:
     return PurePath("diffs") / before.short_name / after.short_name
 
 
+def _diff_source_paths(
+    diff_root: PurePath, path: PurePath
+) -> Tuple[PurePath, PurePath]:
+    listing_path = diff_root / path
+    output_path = listing_path
+
+    if path.name == "__init__.py":
+        output_path = output_path.with_name("index")
+
+    return listing_path, output_path
+
+
 class _ForkOrder:
     forks: List[PurePath]
     diffs: List[PurePath]
@@ -295,16 +307,16 @@ class EthereumDiscover(Discover):
 
                 assert before_source or after_source
 
-                if path.name == "__init__.py":
-                    path = path.with_name("index")
-
-                output_path = _diff_path(before, after) / path
+                relative_path, output_path = _diff_source_paths(
+                    _diff_path(before, after), path
+                )
 
                 yield DiffSource(
                     before.name,
                     before_source,
                     after.name,
                     after_source,
+                    relative_path,
                     output_path,
                 )
 
@@ -327,6 +339,7 @@ class DiffSource(Generic[S], Source, Listable):
 
     after_name: str
     after: Optional[S]
+    _relative_path: PurePath
     _output_path: PurePath
 
     def __init__(
@@ -335,6 +348,7 @@ class DiffSource(Generic[S], Source, Listable):
         before: Optional[S],
         after_name: str,
         after: Optional[S],
+        relative_path: PurePath,
         output_path: PurePath,
     ) -> None:
         self.before_name = before_name
@@ -343,6 +357,7 @@ class DiffSource(Generic[S], Source, Listable):
         self.after_name = after_name
         self.after = after
 
+        self._relative_path = relative_path
         self._output_path = output_path
 
     @property
@@ -357,7 +372,7 @@ class DiffSource(Generic[S], Source, Listable):
         """
         Path to the Source (if one exists) relative to the project root.
         """
-        return None
+        return self._relative_path
 
     @property
     def output_path(self) -> PurePath:

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -332,6 +332,10 @@ S = TypeVar("S", bound=Source)
 class DiffSource(Generic[S], Source, Listable):
     """
     A source that represents the difference between two other sources.
+
+    This source is synthetic, so its `relative_path` is synthetic too. We keep
+    it separate from `output_path` because `docc` directory listings use
+    `relative_path` as the visible label.
     """
 
     before_name: str

--- a/tests/spec_tools/test_docc.py
+++ b/tests/spec_tools/test_docc.py
@@ -1,3 +1,5 @@
+"""Regression tests for diff listing labels in docc-generated pages."""
+
 from pathlib import PurePath
 
 from docc.context import Context
@@ -9,6 +11,7 @@ from ethereum_spec_tools.docc import DiffSource, _diff_source_paths
 
 
 def _render_listing_label(source: DiffSource[Source]) -> str:
+    """Render a leaf listing for a single source and return its label text."""
     listing = Listing()
     listing.add_source(source)
 
@@ -24,12 +27,13 @@ def _render_listing_label(source: DiffSource[Source]) -> str:
 
 
 def test_diff_source_renders_init_label_but_writes_to_index() -> None:
+    """Render `__init__.py` in Browse while preserving the `index` output."""
     relative_path, output_path = _diff_source_paths(
         PurePath("diffs/frontier/homestead"),
         PurePath("vm/__init__.py"),
     )
 
-    old_shape_source = DiffSource(
+    old_shape_source: DiffSource[Source] = DiffSource(
         "frontier",
         None,
         "homestead",
@@ -37,7 +41,7 @@ def test_diff_source_renders_init_label_but_writes_to_index() -> None:
         PurePath("diffs/frontier/homestead/vm/index"),
         PurePath("diffs/frontier/homestead/vm/index"),
     )
-    diff_source = DiffSource(
+    diff_source: DiffSource[Source] = DiffSource(
         "frontier",
         None,
         "homestead",
@@ -55,12 +59,13 @@ def test_diff_source_renders_init_label_but_writes_to_index() -> None:
 
 
 def test_diff_source_renders_normal_module_label() -> None:
+    """Render normal modules with their filename unchanged."""
     relative_path, output_path = _diff_source_paths(
         PurePath("diffs/frontier/homestead"),
         PurePath("vm/gas.py"),
     )
 
-    diff_source = DiffSource(
+    diff_source: DiffSource[Source] = DiffSource(
         "frontier",
         None,
         "homestead",

--- a/tests/spec_tools/test_docc.py
+++ b/tests/spec_tools/test_docc.py
@@ -1,0 +1,74 @@
+from pathlib import PurePath
+
+from docc.context import Context
+from docc.plugins import html
+from docc.plugins.listing import Listing, ListingNode, render_html
+from docc.source import Source
+
+from ethereum_spec_tools.docc import DiffSource, _diff_source_paths
+
+
+def _render_listing_label(source: DiffSource[Source]) -> str:
+    listing = Listing()
+    listing.add_source(source)
+
+    context = Context({Source: source, Listing: listing})
+    root = html.HTMLRoot(context)
+    render_html(context, root, ListingNode(True))
+
+    for child in root.children:
+        if isinstance(child, html.HTMLTag):
+            return "".join(child._to_element().itertext()).strip()
+
+    raise AssertionError("listing render produced no HTML output")
+
+
+def test_diff_source_renders_init_label_but_writes_to_index() -> None:
+    relative_path, output_path = _diff_source_paths(
+        PurePath("diffs/frontier/homestead"),
+        PurePath("vm/__init__.py"),
+    )
+
+    old_shape_source = DiffSource(
+        "frontier",
+        None,
+        "homestead",
+        None,
+        PurePath("diffs/frontier/homestead/vm/index"),
+        PurePath("diffs/frontier/homestead/vm/index"),
+    )
+    diff_source = DiffSource(
+        "frontier",
+        None,
+        "homestead",
+        None,
+        relative_path,
+        output_path,
+    )
+
+    assert _render_listing_label(old_shape_source) == "index"
+    assert _render_listing_label(diff_source) == "__init__.py"
+    assert diff_source.output_path == PurePath(
+        "diffs/frontier/homestead/vm/index"
+    )
+    assert diff_source.index_dir == PurePath("diffs/frontier/homestead/vm")
+
+
+def test_diff_source_renders_normal_module_label() -> None:
+    relative_path, output_path = _diff_source_paths(
+        PurePath("diffs/frontier/homestead"),
+        PurePath("vm/gas.py"),
+    )
+
+    diff_source = DiffSource(
+        "frontier",
+        None,
+        "homestead",
+        None,
+        relative_path,
+        output_path,
+    )
+
+    assert _render_listing_label(diff_source) == "gas.py"
+    assert diff_source.output_path == diff_source.relative_path
+    assert diff_source.index_dir is None

--- a/tests/spec_tools/test_docc.py
+++ b/tests/spec_tools/test_docc.py
@@ -4,24 +4,28 @@ from pathlib import PurePath
 
 from docc.context import Context
 from docc.plugins import html
-from docc.plugins.listing import Listing, ListingNode, render_html
+from docc.plugins.listing import ListingNode, ListingSource, render_html
 from docc.source import Source
 
 from ethereum_spec_tools.docc import DiffSource, _diff_source_paths
 
 
 def _render_listing_label(source: DiffSource[Source]) -> str:
-    """Render a leaf listing for a single source and return its label text."""
-    listing = Listing()
-    listing.add_source(source)
+    """Render a leaf listing for a single source and return its leaf label."""
+    listing = ListingSource(
+        PurePath("diffs/frontier/homestead/vm"),
+        PurePath("diffs/frontier/homestead/vm/index"),
+        {source},
+    )
 
-    context = Context({Source: source, Listing: listing})
+    context = Context({Source: listing})
     root = html.HTMLRoot(context)
-    render_html(context, root, ListingNode(True))
+    render_html(context, root, ListingNode({source}))
 
     for child in root.children:
         if isinstance(child, html.HTMLTag):
-            return "".join(child._to_element().itertext()).strip()
+            text = "".join(child._to_element().itertext()).strip()
+            return PurePath(text).name
 
     raise AssertionError("listing render produced no HTML output")
 

--- a/uv.lock
+++ b/uv.lock
@@ -927,10 +927,13 @@ mkdocs = [
     { name = "pyspelling" },
 ]
 test = [
+    { name = "docc" },
     { name = "ethereum-execution-testing" },
     { name = "filelock" },
+    { name = "fladrif" },
     { name = "gitpython" },
     { name = "libcst" },
+    { name = "mistletoe" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -1035,10 +1038,13 @@ mkdocs = [
     { name = "pyspelling", specifier = ">=2.8.2,<3" },
 ]
 test = [
+    { name = "docc", specifier = ">=0.6.0,<0.7.0" },
     { name = "ethereum-execution-testing", editable = "packages/testing" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
+    { name = "fladrif", specifier = ">=0.2.0,<0.3.0" },
     { name = "gitpython", specifier = ">=3.1.0,<3.2" },
     { name = "libcst", specifier = ">=1.8,<2" },
+    { name = "mistletoe", specifier = ">=1.5.0,<2" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = ">=4.1.0,<5" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },


### PR DESCRIPTION
## Summary

Fix diff Browse labels for package modules so `__init__.py` is displayed correctly instead of `index`.
 ## What changed

  - split diff source metadata into:
    - a listing/display path
    - an output path
  - keep `__init__.py` as the listing path for diff sources
  - keep `index` as the emitted output path so diff URLs remain unchanged
  - add a render-level regression test for the Browse listing
  - run the targeted docc regression test in the docs workflow

  ## Why

  The diff renderer was reusing the rewritten output path (`.../index`) as the visible listing path. That caused Browse sections on diff pages to show `index` instead of `__init__.py` for package
  modules.

  This change fixes the label at the source metadata layer while preserving existing generated diff URLs like `.../index.html`.

  ## Testing

  - `uv run --group test --group doc pytest tests/spec_tools/test_docc.py`
  - `just docs-spec`

  Verified in generated docs that pages such as `diffs/bpo5/amsterdam/vm/index.html` now show `__init__.py` in the Browse section.

  Closes #2788