### PR TITLE
test: Add 64 byte test cases for SHA256 and RIPEMD160 precompile benchmarks

### DIFF
--- a/tests/benchmark/compute/precompile/test_ripemd160.py
+++ b/tests/benchmark/compute/precompile/test_ripemd160.py
@@ -53,7 +53,7 @@ def test_ripemd160(
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("size", [0, 32, 256, 1024])
+@pytest.mark.parametrize("size", [0, 32, 64, 256, 1024])
 def test_ripemd160_fixed_size(
     benchmark_test: BenchmarkTestFiller, size: int
 ) -> None:
@@ -71,7 +71,7 @@ def test_ripemd160_fixed_size(
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("size", [32, 256, 1024])
+@pytest.mark.parametrize("size", [32, 64, 256, 1024])
 def test_ripemd160_uncachable(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,

--- a/tests/benchmark/compute/precompile/test_sha256.py
+++ b/tests/benchmark/compute/precompile/test_sha256.py
@@ -53,7 +53,7 @@ def test_sha256(
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("size", [0, 32, 256, 1024])
+@pytest.mark.parametrize("size", [0, 32, 64, 256, 1024])
 def test_sha256_fixed_size(
     benchmark_test: BenchmarkTestFiller, size: int
 ) -> None:
@@ -71,7 +71,7 @@ def test_sha256_fixed_size(
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("size", [32, 256, 1024])
+@pytest.mark.parametrize("size", [32, 64, 256, 1024])
 def test_sha256_uncachable(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,


### PR DESCRIPTION
benchmarks/compute/precompile/test_ripemd160.py: Add 64 byte test cases.

Due to how, internally, padding+splitting into blocks (of 64bytes) in the actual hash functions works, even multiples of 32bytes behave slightly differently wrt. gas pricing. So we need to add a 64byte test case here.

## 🗒️ Description
This just adds a 64 byte test case (to the existing list) to the relevant hash function precompile benchmarks.

## 🔗 Related Issues or PRs
Internally, both SHA256 and RIPEMD160 start input processing by padding (to store the length and to align the size with the internal blocksize) and then chopping the result into 64byte blocks. Each block is then processed sequentially. As a consequence, both 0byte and 32byte inputs result in 1 block, 64byte and 96byte inputs result in 2 blocks etc.
The number of such blocks largely determines the amount of actual work that needs to be done in hashing.
Since the gas consumed is computed on a 32byte granularity level (rather than the 64byte blocksize), the behaviour, for small input lengths, of
work_done/gas_consumed
may differ for even and odd multiples of 32bytes. The worst-case should be EVEN multiples.
Consequently, we should add a 64byte test case to cover this.

See STEEL discord benchmarking/Cryptography precompile worst case

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [X ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [X ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
