### PR TITLE
feat(spec,test): backport interop related changes

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -221,6 +221,39 @@ class _DeferredFundAddress:
     minimum_balance: bool
 
 
+def _compute_deploy_gas_limit(
+    fork: Fork,
+    *,
+    deploy_code_size: int,
+    initcode: Bytes | Initcode,
+    storage_slots: int = 0,
+) -> int:
+    """
+    Compute the gas_limit for a contract-deploy transaction.
+
+    Sums TX_BASE + TX_CREATE, the legacy code-deposit cost, the
+    EIP-8037 state-gas surcharge (zero on pre-Amsterdam forks),
+    memory expansion over the initcode, calldata cost, and the SSTORE
+    cost from an injected storage-init prefix, then doubles the total
+    as a safety buffer. Without the EIP-8037 component the buffer is
+    too small for larger contracts under Amsterdam and the deploy tx
+    runs out of gas mid-construction.
+    """
+    gas_costs = fork.gas_costs()
+    memory_expansion_gas_calculator = fork.memory_expansion_gas_calculator()
+    calldata_gas_calculator = fork.calldata_gas_calculator()
+
+    deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
+    deploy_gas_limit += storage_slots * 22_600
+    deploy_gas_limit += deploy_code_size * gas_costs.CODE_DEPOSIT_PER_BYTE
+    deploy_gas_limit += fork.code_deposit_state_gas(code_size=deploy_code_size)
+    deploy_gas_limit += memory_expansion_gas_calculator(
+        new_bytes=len(bytes(initcode))
+    )
+    deploy_gas_limit += calldata_gas_calculator(data=initcode)
+    return deploy_gas_limit * 2
+
+
 class Alloc(SharedAlloc):
     """A custom class that inherits from the original Alloc class."""
 
@@ -323,11 +356,6 @@ class Alloc(SharedAlloc):
         fork = self._fork.fork_at(
             block_number=self._block_number, timestamp=self._timestamp
         )
-        gas_costs = fork.gas_costs()
-        memory_expansion_gas_calculator = (
-            fork.memory_expansion_gas_calculator()
-        )
-        calldata_gas_calculator = fork.calldata_gas_calculator()
         if not isinstance(deploy_code, Bytes):
             deploy_code = Bytes(deploy_code)
         if initcode is None:
@@ -350,13 +378,11 @@ class Alloc(SharedAlloc):
             raise ValueError(
                 f"initcode too large {len(initcode)} > {max_initcode_size}"
             )
-        deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
-        deploy_gas_limit += len(deploy_code) * gas_costs.CODE_DEPOSIT_PER_BYTE
-        deploy_gas_limit += memory_expansion_gas_calculator(
-            new_bytes=len(initcode)
+        deploy_gas_limit = _compute_deploy_gas_limit(
+            fork,
+            deploy_code_size=len(deploy_code),
+            initcode=initcode,
         )
-        deploy_gas_limit += calldata_gas_calculator(data=initcode)
-        deploy_gas_limit = deploy_gas_limit * 2
         tx_gas_limit_cap = fork.transaction_gas_limit_cap()
         if tx_gas_limit_cap and deploy_gas_limit > tx_gas_limit_cap:
             raise ValueError(
@@ -405,11 +431,6 @@ class Alloc(SharedAlloc):
         fork = self._fork.fork_at(
             block_number=self._block_number, timestamp=self._timestamp
         )
-        gas_costs = fork.gas_costs()
-        memory_expansion_gas_calculator = (
-            fork.memory_expansion_gas_calculator()
-        )
-        calldata_gas_calculator = fork.calldata_gas_calculator()
 
         if not isinstance(storage, Storage):
             storage = Storage(storage)  # type: ignore
@@ -445,13 +466,10 @@ class Alloc(SharedAlloc):
 
         initcode_prefix = Bytecode()
 
-        deploy_gas_limit = gas_costs.TX_BASE + gas_costs.TX_CREATE
-
         if len(storage.root) > 0:
             initcode_prefix += sum(
                 Op.SSTORE(key, value) for key, value in storage.root.items()
             )
-            deploy_gas_limit += len(storage.root) * 22_600
 
         assert isinstance(code, Bytecode), (
             f"incompatible code type: {type(code)}"
@@ -462,13 +480,8 @@ class Alloc(SharedAlloc):
         if len(code) > max_code_size:
             raise ValueError(f"code too large: {len(code)} > {max_code_size}")
 
-        deploy_gas_limit += len(code) * gas_costs.CODE_DEPOSIT_PER_BYTE
-
         prepared_initcode = Initcode(
             deploy_code=code, initcode_prefix=initcode_prefix
-        )
-        deploy_gas_limit += memory_expansion_gas_calculator(
-            new_bytes=len(bytes(prepared_initcode))
         )
 
         max_initcode_size = fork.max_initcode_size()
@@ -478,9 +491,12 @@ class Alloc(SharedAlloc):
                 f"initcode too large {initcode_len} > {max_initcode_size}"
             )
 
-        deploy_gas_limit += calldata_gas_calculator(data=prepared_initcode)
-
-        deploy_gas_limit = deploy_gas_limit * 2
+        deploy_gas_limit = _compute_deploy_gas_limit(
+            fork,
+            deploy_code_size=len(code),
+            initcode=prepared_initcode,
+            storage_slots=len(storage.root),
+        )
         tx_gas_limit_cap = fork.transaction_gas_limit_cap()
         if tx_gas_limit_cap and deploy_gas_limit > tx_gas_limit_cap:
             raise ValueError(

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -76,7 +76,7 @@ class EIP8037(BaseFork):
                 + STATE_BYTES_PER_STORAGE_SET * cpsb
             ),
             NEW_ACCOUNT=new_acct,
-            OPCODE_CREATE_BASE=REGULAR_GAS_CREATE + new_acct,
+            OPCODE_CREATE_BASE=REGULAR_GAS_CREATE,
             TX_CREATE=(REGULAR_GAS_CREATE + new_acct),
             AUTH_PER_EMPTY_ACCOUNT=(
                 PER_AUTH_BASE_COST
@@ -132,6 +132,15 @@ class EIP8037(BaseFork):
                 op, gas_costs
             ),
             Opcodes.RETURN: lambda op: cls._calculate_return_state_gas(
+                op, gas_costs
+            ),
+            # New-account state gas (NEW_ACCOUNT × CPSB) lives here so
+            # that `OPCODE_CREATE_BASE` stays regular-only and matches
+            # the spec EVM constant.
+            Opcodes.CREATE: lambda op: cls._calculate_create_state_gas(
+                op, gas_costs
+            ),
+            Opcodes.CREATE2: lambda op: cls._calculate_create_state_gas(
                 op, gas_costs
             ),
         }
@@ -445,3 +454,17 @@ class EIP8037(BaseFork):
         if code_deposit_size > 0:
             return code_deposit_size * cls.cost_per_state_byte()
         return 0
+
+    @classmethod
+    def _calculate_create_state_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """
+        Calculate CREATE/CREATE2 state gas cost (`NEW_ACCOUNT × CPSB`).
+
+        Pre-EIP-8037 this was folded into `OPCODE_CREATE_BASE`; under
+        EIP-8037 it is exposed here so that `OPCODE_CREATE_BASE` stays
+        regular-only and matches the spec EVM constant.
+        """
+        del opcode
+        return gas_costs.NEW_ACCOUNT

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -26,23 +26,9 @@ class EIP8037(BaseFork):
     @classmethod
     def cost_per_state_byte(cls) -> int:
         """
-        Calculate the state gas cost per byte based on `cls._env_gas_limit`.
-
-        Mirror the EELS `state_gas_per_byte()` function with binary
-        floating-point quantization (EIP-8037).
-
-        At a gas limit of 100,000,000 this returns 1174.
+        Return the fixed cost per state byte for EIP-8037.
         """
-        TARGET = 100 * 1024**3  # noqa: N806
-        BLOCKS_PER_YEAR = 2_628_000  # noqa: N806
-        SIG_BITS = 5  # noqa: N806
-        OFFSET = 9578  # noqa: N806
-        gas_limit = cls._env_gas_limit
-        raw = (gas_limit * BLOCKS_PER_YEAR + 2 * TARGET - 1) // (2 * TARGET)
-        shifted = raw + OFFSET
-        shift = max(shifted.bit_length() - SIG_BITS, 0)
-        quantized = (shifted >> shift) << shift
-        return max(quantized - OFFSET, 1)
+        return 1174
 
     @classmethod
     def sstore_state_gas(cls) -> int:

--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -38,6 +38,8 @@ class Bytecode:
     _gas_cost_fork_: Type[ForkOpcodeInterface] | None = None
     _state_cost_: int | None = None
     _state_cost_fork_: Type[ForkOpcodeInterface] | None = None
+    _regular_cost_: int | None = None
+    _regular_cost_fork_: Type[ForkOpcodeInterface] | None = None
     _refund_: int | None = None
     _refund_fork_: Type[ForkOpcodeInterface] | None = None
     _state_refund_: int | None = None
@@ -318,6 +320,20 @@ class Bytecode:
             for opcode in self.opcode_list:
                 self._state_cost_ += opcode_state_calculator(opcode)
         return self._state_cost_
+
+    def regular_cost(self, fork: Type[ForkOpcodeInterface]) -> int:
+        """
+        Use a fork object to calculate the regular gas used by this
+        bytecode (i.e. excluding the state-gas portion under EIP-8037).
+
+        Useful for OOG-boundary tests that need to land at the regular
+        gas charge of an opcode rather than its combined regular + state
+        cost.
+        """
+        if self._regular_cost_ is None or self._regular_cost_fork_ != fork:
+            self._regular_cost_fork_ = fork
+            self._regular_cost_ = self.gas_cost(fork) - self.state_cost(fork)
+        return self._regular_cost_
 
     def refund(self, fork: Type[ForkOpcodeInterface]) -> int:
         """Use a fork object to calculate the gas refund from this bytecode."""

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1095,7 +1095,7 @@ def process_transaction(
                 # pre-deletion.
                 account = get_account(tx_state, address)
                 code = get_code(tx_state, account.code_hash)
-                selfdestruct_refund += Uint(len(code)) * COST_PER_STATE_BYTE
+                selfdestruct_refund += ulen(code) * COST_PER_STATE_BYTE
                 selfdestruct_refund = min(
                     selfdestruct_refund, tx_output.state_gas_used
                 )

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -99,6 +99,7 @@ from .utils.message import prepare_message
 from .vm import Message
 from .vm.eoa_delegation import is_valid_delegation
 from .vm.gas import (
+    COST_PER_STATE_BYTE,
     STATE_BYTES_PER_NEW_ACCOUNT,
     STATE_BYTES_PER_STORAGE_SET,
     GasCosts,
@@ -106,7 +107,6 @@ from .vm.gas import (
     calculate_data_fee,
     calculate_excess_blob_gas,
     calculate_total_blob_gas,
-    state_gas_per_byte,
 )
 from .vm.interpreter import MessageCallOutput, process_message_call
 
@@ -994,7 +994,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx, block_env.block_gas_limit)
+    intrinsic = validate_transaction(tx)
 
     intrinsic_gas = intrinsic.regular + intrinsic.state
 
@@ -1077,18 +1077,17 @@ def process_transaction(
     else:
         # Refund state gas for accounts created and destroyed in the
         # same tx (EIP-6780). Covers account, storage, and code.
-        cost_per_state_byte = state_gas_per_byte(block_env.block_gas_limit)
         for address in tx_output.accounts_to_delete:
             if address in tx_state.created_accounts:
                 selfdestruct_refund = (
-                    STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+                    STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
                 )
                 storage = tx_state.storage_writes.get(address, {})
                 created_slots = sum(1 for v in storage.values() if v != 0)
                 selfdestruct_refund += (
                     Uint(created_slots)
                     * STATE_BYTES_PER_STORAGE_SET
-                    * cost_per_state_byte
+                    * COST_PER_STATE_BYTE
                 )
                 # EIP-6780 defers account/storage/code removal to
                 # tx-end, so `account.code_hash` still points at the
@@ -1096,7 +1095,7 @@ def process_transaction(
                 # pre-deletion.
                 account = get_account(tx_state, address)
                 code = get_code(tx_state, account.code_hash)
-                selfdestruct_refund += Uint(len(code)) * cost_per_state_byte
+                selfdestruct_refund += Uint(len(code)) * COST_PER_STATE_BYTE
                 selfdestruct_refund = min(
                     selfdestruct_refund, tx_output.state_gas_used
                 )

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -531,7 +531,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -563,7 +563,7 @@ def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic = calculate_intrinsic_cost(tx, gas_limit)
+    intrinsic = calculate_intrinsic_cost(tx)
     intrinsic_gas = intrinsic.regular + intrinsic.state
     if max(intrinsic_gas, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
@@ -579,9 +579,7 @@ def validate_transaction(tx: Transaction, gas_limit: Uint) -> IntrinsicGasCost:
     return intrinsic
 
 
-def calculate_intrinsic_cost(
-    tx: Transaction, gas_limit: Uint
-) -> IntrinsicGasCost:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,25 +605,23 @@ def calculate_intrinsic_cost(
     minimum gas cost used by the transaction based on the calldata size.
     """
     from .vm.gas import (
+        COST_PER_STATE_BYTE,
         PER_AUTH_BASE_COST,
         REGULAR_GAS_CREATE,
         STATE_BYTES_PER_AUTH_BASE,
         STATE_BYTES_PER_NEW_ACCOUNT,
         GasCosts,
         init_code_cost,
-        state_gas_per_byte,
     )
 
     tokens_in_calldata = count_tokens_in_data(tx.data)
 
     data_cost = tokens_in_calldata * GasCosts.TX_DATA_TOKEN_STANDARD
 
-    cost_per_state_byte = state_gas_per_byte(gas_limit)
-
     create_regular_gas = Uint(0)
     create_state_gas = Uint(0)
     if tx.to == Bytes0(b""):
-        create_state_gas = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+        create_state_gas = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
         create_regular_gas = REGULAR_GAS_CREATE + init_code_cost(ulen(tx.data))
 
     access_list_gas = Uint(0)
@@ -646,7 +642,7 @@ def calculate_intrinsic_cost(
         auth_regular_gas = PER_AUTH_BASE_COST * ulen(tx.authorizations)
         auth_state_gas = (
             (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE)
-            * cost_per_state_byte
+            * COST_PER_STATE_BYTE
             * ulen(tx.authorizations)
         )
 

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -22,9 +22,9 @@ from ..state_tracker import (
 )
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import (
+    COST_PER_STATE_BYTE,
     STATE_BYTES_PER_NEW_ACCOUNT,
     GasCosts,
-    state_gas_per_byte,
 )
 from . import Evm, Message
 
@@ -172,7 +172,6 @@ def set_delegation(message: Message) -> None:
 
     """
     tx_state = message.tx_env.state
-    cost_per_state_byte = state_gas_per_byte(message.block_env.block_gas_limit)
     for auth in message.tx_env.authorizations:
         if auth.chain_id not in (message.block_env.chain_id, U256(0)):
             continue
@@ -201,7 +200,7 @@ def set_delegation(message: Message) -> None:
         # Refund the account creation state gas to the reservoir.
         # intrinsic_state_gas is immutable after validation.
         if account_exists(tx_state, authority):
-            refund = STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+            refund = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
             message.state_gas_reservoir += refund
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -26,10 +26,7 @@ from . import Evm
 from .exceptions import OutOfGasError
 
 # EIP-8037 state gas accounting constants
-TARGET_STATE_GROWTH_PER_YEAR = Uint(100 * 1024**3)
-BLOCKS_PER_YEAR = Uint(2_628_000)
-COST_PER_STATE_BYTE_SIGNIFICANT_BITS = Uint(5)
-COST_PER_STATE_BYTE_OFFSET = Uint(9578)
+COST_PER_STATE_BYTE = Uint(1174)
 
 STATE_BYTES_PER_NEW_ACCOUNT = Uint(112)
 STATE_BYTES_PER_STORAGE_SET = Uint(32)
@@ -238,37 +235,6 @@ class MessageCallGas:
 
     cost: Uint
     sub_call: Uint
-
-
-def state_gas_per_byte(gas_limit: Uint) -> Uint:
-    """
-    Calculate the state gas cost per byte based on the block gas limit.
-
-    At a gas limit of 100,000,000 this returns 1174.
-
-    Parameters
-    ----------
-    gas_limit :
-        The block gas limit.
-
-    Returns
-    -------
-    state_gas_per_byte : `Uint`
-        The state gas cost per byte.
-
-    """
-    numerator = gas_limit * BLOCKS_PER_YEAR
-    denominator = Uint(2) * TARGET_STATE_GROWTH_PER_YEAR
-    raw = (numerator + denominator - Uint(1)) // denominator
-    shifted = raw + COST_PER_STATE_BYTE_OFFSET
-    shift = max(
-        shifted.bit_length() - COST_PER_STATE_BYTE_SIGNIFICANT_BITS,
-        Uint(0),
-    )
-    quantized = (shifted >> shift) << shift
-    if quantized > COST_PER_STATE_BYTE_OFFSET:
-        return quantized - COST_PER_STATE_BYTE_OFFSET
-    return Uint(1)
 
 
 def check_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -23,12 +23,12 @@ from ...state_tracker import (
 from .. import Evm, credit_state_gas_refund
 from ..exceptions import WriteInStaticContext
 from ..gas import (
+    COST_PER_STATE_BYTE,
     STATE_BYTES_PER_STORAGE_SET,
     GasCosts,
     charge_gas,
     charge_state_gas,
     check_gas,
-    state_gas_per_byte,
 )
 from ..stack import pop, push
 
@@ -90,10 +90,7 @@ def sstore(evm: Evm) -> None:
     )
     current_value = get_storage(tx_state, evm.message.current_target, key)
 
-    cost_per_state_byte = state_gas_per_byte(
-        evm.message.block_env.block_gas_limit
-    )
-    state_gas_storage_set = STATE_BYTES_PER_STORAGE_SET * cost_per_state_byte
+    state_gas_storage_set = STATE_BYTES_PER_STORAGE_SET * COST_PER_STATE_BYTE
     gas_cost = Uint(0)
 
     if (evm.message.current_target, key) not in evm.accessed_storage_keys:

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -44,6 +44,7 @@ from .. import (
 )
 from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
 from ..gas import (
+    COST_PER_STATE_BYTE,
     REGULAR_GAS_CREATE,
     STATE_BYTES_PER_NEW_ACCOUNT,
     GasCosts,
@@ -54,7 +55,6 @@ from ..gas import (
     check_gas,
     init_code_cost,
     max_message_call_gas,
-    state_gas_per_byte,
 )
 from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
@@ -84,11 +84,8 @@ def generic_create(
 
     # Charge state gas for account creation (pay-before-execute).
     # Refunded to the reservoir on any failure path below.
-    cost_per_state_byte = state_gas_per_byte(
-        evm.message.block_env.block_gas_limit
-    )
     create_account_state_gas = (
-        STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+        STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
     )
     charge_state_gas(evm, create_account_state_gas)
 
@@ -463,11 +460,8 @@ def call(evm: Evm) -> None:
     # Applies here and in create, create2, selfdestruct. See #2526.
     charge_gas(evm, extra_gas + extend_memory.cost)
     if value != 0 and not is_account_alive(tx_state, to):
-        cost_per_state_byte = state_gas_per_byte(
-            evm.message.block_env.block_gas_limit
-        )
         charge_state_gas(
-            evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+            evm, STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
         )
 
     message_call_gas = calculate_message_call_gas(
@@ -669,11 +663,8 @@ def selfdestruct(evm: Evm) -> None:
     # reservoir on frame failure.
     charge_gas(evm, gas_cost)
     if needs_state_gas:
-        cost_per_state_byte = state_gas_per_byte(
-            evm.message.block_env.block_gas_limit
-        )
         charge_state_gas(
-            evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+            evm, STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
         )
 
     originator = evm.message.current_target

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -125,13 +125,13 @@ def process_message_call(message: Message) -> MessageCallOutput:
         if is_collision:
             return MessageCallOutput(
                 gas_left=Uint(0),
-                state_gas_left=Uint(0),
+                state_gas_left=message.state_gas_reservoir,
                 refund_counter=U256(0),
                 logs=tuple(),
                 accounts_to_delete=set(),
                 error=AddressCollision(),
                 return_data=Bytes(b""),
-                regular_gas_used=Uint(0),
+                regular_gas_used=message.gas,
                 state_gas_used=Uint(0),
             )
         else:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -48,10 +48,10 @@ from ..state_tracker import (
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
 from ..vm.gas import (
+    COST_PER_STATE_BYTE,
     GasCosts,
     charge_gas,
     charge_state_gas,
-    state_gas_per_byte,
 )
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Evm
@@ -230,11 +230,8 @@ def process_create_message(message: Message) -> Evm:
                 // Uint(32)
             )
             charge_gas(evm, code_hash_gas)
-            cost_per_state_byte = state_gas_per_byte(
-                message.block_env.block_gas_limit
-            )
             code_deposit_state_gas = (
-                Uint(len(contract_code)) * cost_per_state_byte
+                Uint(len(contract_code)) * COST_PER_STATE_BYTE
             )
             charge_state_gas(evm, code_deposit_state_gas)
         except ExceptionalHalt as error:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -236,8 +236,19 @@ def process_create_message(message: Message) -> Evm:
             restore_tx_state(tx_state, snapshot)
             evm.regular_gas_used += evm.gas_left
             evm.gas_left = Uint(0)
-            # State gas is preserved on exceptional halt so it can be
-            # returned to the parent frame via incorporate_child_on_error.
+            # On halt, restore the state gas reservoir to what was
+            # passed into this frame. State-gas charges in excess of
+            # the original reservoir came from gas_left (spill) or
+            # from a child revert refund; either way they get
+            # re-classified as regular gas usage on halt.
+            total_state = evm.state_gas_used + evm.state_gas_left
+            reservoir = evm.message.state_gas_reservoir
+            if total_state > reservoir:
+                evm.regular_gas_used += total_state - reservoir
+            evm.state_gas_left = reservoir
+            evm.state_gas_used = Uint(0)
+            evm.state_gas_refund = Uint(0)
+            evm.state_gas_refund_pending = Uint(0)
             evm.output = b""
             evm.error = error
         else:
@@ -323,8 +334,19 @@ def process_message(message: Message) -> Evm:
         evm_trace(evm, OpException(error))
         evm.regular_gas_used += evm.gas_left
         evm.gas_left = Uint(0)
-        # State gas is preserved on exceptional halt so it can be
-        # returned to the parent frame via incorporate_child_on_error.
+        # On halt, restore the state gas reservoir to what was passed
+        # into this frame. State-gas charges in excess of the original
+        # reservoir came from gas_left (spill) or from a child revert
+        # refund; either way they get re-classified as regular gas
+        # usage on halt.
+        total_state = evm.state_gas_used + evm.state_gas_left
+        reservoir = evm.message.state_gas_reservoir
+        if total_state > reservoir:
+            evm.regular_gas_used += total_state - reservoir
+        evm.state_gas_left = reservoir
+        evm.state_gas_used = Uint(0)
+        evm.state_gas_refund = Uint(0)
+        evm.state_gas_refund_pending = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -226,13 +226,11 @@ def process_create_message(message: Message) -> Evm:
             # Hash cost for computing keccak256 of deployed bytecode
             code_hash_gas = (
                 GasCosts.OPCODE_KECCACK256_PER_WORD
-                * ceil32(Uint(len(contract_code)))
+                * ceil32(ulen(contract_code))
                 // Uint(32)
             )
             charge_gas(evm, code_hash_gas)
-            code_deposit_state_gas = (
-                Uint(len(contract_code)) * COST_PER_STATE_BYTE
-            )
+            code_deposit_state_gas = ulen(contract_code) * COST_PER_STATE_BYTE
             charge_state_gas(evm, code_deposit_state_gas)
         except ExceptionalHalt as error:
             restore_tx_state(tx_state, snapshot)

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -2975,9 +2975,13 @@ def test_bal_create_and_oog(
     )
 
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
-    create_static_cost = factory_mstore.gas_cost(
+    # Use regular gas only: under EIP-8037 the CREATE static-charge
+    # gate is regular-gas-only (state-byte cost is settled at
+    # frame-end). `gas_cost(fork)` would also include the deferred
+    # state portion and overshoot the boundary by NEW_ACCOUNT × CPSB.
+    create_static_cost = factory_mstore.regular_cost(
         fork
-    ) + factory_create.gas_cost(fork)
+    ) + factory_create.regular_cost(fork)
 
     if oog_boundary == OutOfGasBoundary.OOG_BEFORE_TARGET_ACCESS:
         # 1 gas short of CREATE static cost — no state access
@@ -2987,8 +2991,12 @@ def test_bal_create_and_oog(
         # frame gets 0 gas, CREATE fails, parent OOGs at next opcode
         gas_limit = intrinsic_cost + create_static_cost
     else:
-        # Full success: static cost + child frame (63/64 rule) + SSTORE
-        child_gas = init_code.gas_cost(fork)
+        # Full success: child needs init-code gas (incl. RETURN's
+        # code-deposit state) plus the NEW_ACCOUNT state cost that
+        # spills into its `gas_left` at frame-end. Parent must forward
+        # `child_gas × 64/63` to satisfy EIP-150's 63/64 rule, then
+        # has its 1/64 retention + unused child gas to pay SSTORE.
+        child_gas = init_code.gas_cost(fork) + factory_create.state_cost(fork)
         remaining_needed = (child_gas * 64 + 62) // 63
         gas_limit = (
             intrinsic_cost

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -266,13 +266,15 @@ def test_reservoir_restored_after_child_spill_and_halt(
     fork: Fork,
 ) -> None:
     """
-    Test all state gas recovered when child spills then halts.
+    Test parent gets reservoir back after child spill + halt.
 
     The child performs two SSTOREs (zero-to-nonzero), exhausting the
     reservoir and spilling into `gas_left`, then hits INVALID causing
-    an exceptional halt. On halt `gas_left` is zeroed but all state gas
-    (reservoir + spill) is restored to the parent's reservoir. The
-    parent can then perform two SSTOREs using the recovered reservoir.
+    an exceptional halt. The child's halt resets its frame to (0,
+    R0_child) — only the reservoir-portion is returned to the
+    parent; the spilled gas stays burned (re-classified as regular).
+    The parent does two SSTOREs: the first drains the recovered
+    reservoir, the second spills from the parent's own `gas_left`.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -288,8 +290,9 @@ def test_reservoir_restored_after_child_spill_and_halt(
     parent = pre.deploy_contract(
         code=(
             Op.POP(Op.CALL(gas=500_000, address=child))
-            # All state gas recovered (reservoir + spill), parent
-            # can perform two SSTOREs from the recovered reservoir
+            # First SSTORE drains the recovered reservoir; second
+            # SSTORE spills from parent's gas_left (gas_limit_cap is
+            # large enough to absorb it).
             + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.SSTORE(parent_storage.store_next(1), 1)
         ),
@@ -1358,8 +1361,15 @@ def test_top_level_halt_preserves_restored_reservoir(
     reservoir_delta: int,
 ) -> None:
     """
-    Verify the reservoir is refunded on a top-level halt after a
-    failing child restored state gas to the parent frame.
+    Verify a top-level halt resets `state_gas_left` to the frame's
+    entry reservoir regardless of child failure mode or in-frame
+    drain/spill. The parent calls a child that either reverts (which
+    refunds the full `state_gas_used` back to the parent's reservoir)
+    or halts (which leaves only the reservoir-portion behind), then
+    the parent INVALIDs. In both child-failure paths and across all
+    three reservoir sizes (one short / exact / one over the child's
+    SSTORE cost), the top-level halt collapses to a final reservoir
+    equal to the original tx-level R0 — billed as `gas_limit_cap`.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1382,14 +1392,13 @@ def test_top_level_halt_preserves_restored_reservoir(
         sender=pre.fund_eoa(),
     )
 
-    # New model: SSTORE never drains the reservoir at opcode time,
-    # so reservoir-vs-child-cost relationship is irrelevant on a
-    # failing child path. All three reservoir sizes produce the
-    # same gas_used: parent's INVALID consumes its regular gas_left,
-    # incorporate_child_on_error returns the child's reservoir
-    # untouched, and top-level halt restores any remaining
-    # state_gas_used into the reservoir. Block totals: regular =
-    # gas_limit_cap (full burn), state = 0.
+    # Halt rule: every halted frame's (gas_left, state_gas_left) is
+    # reset to (0, message.state_gas_reservoir). Whatever the child
+    # did inside the call — drain, spill, or revert refund — is
+    # wiped when the parent's INVALID hits. The user's final
+    # reservoir is exactly the top-level R0 = sstore + delta, and
+    # `tx_gas_used = tx.gas - 0 - R0 = gas_limit_cap` for all six
+    # combinations.
     expected_gas_used = gas_limit_cap
 
     blockchain_test(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -88,6 +88,50 @@ def test_child_call_uses_reservoir(
 
 
 @pytest.mark.valid_from("EIP8037")
+def test_delegatecall_child_spill_not_double_charged(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test DELEGATECALL child state gas paid from `gas_left` is not recharged.
+
+    With gas below the Amsterdam tx gas cap, the top-level frame starts with
+    no state gas reservoir and the child pays for SSTOREs by spilling from
+    `gas_left`. The parent frame must not charge the same state growth again
+    at frame end.
+    """
+    env = Environment()
+
+    child_code = sum(Op.SSTORE(i, i + 1) for i in range(6)) + Op.STOP
+    child = pre.deploy_contract(code=child_code)
+
+    caller = pre.deploy_contract(
+        code=Op.POP(
+            Op.DELEGATECALL(
+                gas=Op.GAS,
+                address=child,
+                args_offset=0,
+                args_size=0,
+                ret_offset=0,
+                ret_size=0,
+            )
+        )
+    )
+
+    tx = Transaction(
+        to=caller,
+        gas_limit=500_000,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        caller: Account(storage={i: i + 1 for i in range(6)}),
+    }
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
 def test_reservoir_returned_on_revert(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1338,10 +1382,15 @@ def test_top_level_halt_preserves_restored_reservoir(
         sender=pre.fund_eoa(),
     )
 
-    # When the reservoir is one short of the child's SSTORE, the
-    # spill from regular gas is restored on the child's failure,
-    # lowering the block regular total by the same amount.
-    expected_gas_used = gas_limit_cap + min(reservoir_delta, 0)
+    # New model: SSTORE never drains the reservoir at opcode time,
+    # so reservoir-vs-child-cost relationship is irrelevant on a
+    # failing child path. All three reservoir sizes produce the
+    # same gas_used: parent's INVALID consumes its regular gas_left,
+    # incorporate_child_on_error returns the child's reservoir
+    # untouched, and top-level halt restores any remaining
+    # state_gas_used into the reservoir. Block totals: regular =
+    # gas_limit_cap (full burn), state = 0.
+    expected_gas_used = gas_limit_cap
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2202,7 +2202,6 @@ def test_inner_create_fail_refunds_in_creation_tx(
 def test_create_collision_burned_gas_counted_in_block_regular(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    fork: Fork,
     create_opcode: Op,
 ) -> None:
     """
@@ -2244,7 +2243,7 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     # header.gas_used equals the regular-gas total. A mutation that
     # drops the burned create_message_gas from regular accounting
     # would reduce this value.
-    baseline_gas_used = 0x03C325
+    baseline_gas_used = 117132
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -614,42 +614,38 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
     gas_costs = fork.gas_costs()
     code_deposit_state = fork.code_deposit_state_gas(code_size=1)
 
+    factory_mstore = Op.MSTORE(
+        0, Op.PUSH32(bytes(init_code)), new_memory_size=32
+    )
+    factory_create = Op.CREATE(
+        value=0,
+        offset=32 - len(init_code),
+        size=len(init_code),
+        init_code_size=len(init_code),
+    )
     factory = pre.deploy_contract(
-        code=(
-            Op.MSTORE(0, Op.PUSH32(bytes(init_code)))
-            + Op.POP(
-                Op.CREATE(
-                    value=0,
-                    offset=32 - len(init_code),
-                    size=len(init_code),
-                ),
-            )
-        ),
+        code=factory_mstore + Op.POP(factory_create),
     )
     created = compute_create_address(address=factory, nonce=1)
 
-    # Gas consumed before the child CREATE frame receives gas:
-    # Intrinsic + factory code (PUSH32+PUSH1+MSTORE+mem +
-    # 3xPUSH1) + CREATE regular (+ init_code_cost) + new account
-    # state gas (spilled from gas_left, no reservoir).
-    init_code_word_cost = gas_costs.CODE_INIT_PER_WORD * (
-        (len(init_code) + 31) // 32
-    )
-    pre_child_gas = (
-        gas_costs.TX_BASE
-        + 7 * gas_costs.VERY_LOW
-        + gas_costs.MEMORY_PER_WORD
-        + gas_costs.OPCODE_CREATE_BASE
-        + init_code_word_cost
-    )
-
-    # Init code cost: PUSH1 + PUSH1 + RETURN(+mem expansion)
+    # Init code child execution: PUSH1 + PUSH1 + RETURN's mem_exp.
+    # Code deposit (keccak + state) is charged AFTER the child returns.
     init_cost = 2 * gas_costs.VERY_LOW + gas_costs.MEMORY_PER_WORD
-    # Target child gas: enough for init, not enough for code deposit
+    # Target child: enough for init, not enough for code deposit state.
     target_child = (init_cost + code_deposit_state) // 2
-    # Invert EIP-150 63/64ths rule: ceil(target_child * 64 / 63)
+    # Invert EIP-150 63/64ths rule: ceil(target_child * 64 / 63).
     factory_remaining = (target_child * 64 + 62) // 63
-    gas_limit = pre_child_gas + factory_remaining
+
+    # NEW_ACCOUNT state gas spills into gas_left (no reservoir at the
+    # top level), so it must be funded out of the regular budget.
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = (
+        intrinsic_cost
+        + factory_mstore.regular_cost(fork)
+        + factory_create.regular_cost(fork)
+        + gas_costs.NEW_ACCOUNT
+        + factory_remaining
+    )
 
     tx = Transaction(
         to=factory,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -27,6 +27,7 @@ from execution_testing import (
     Storage,
     Transaction,
     TransactionException,
+    compute_create2_address,
     compute_create_address,
 )
 from execution_testing.checklists import EIPChecklist
@@ -143,6 +144,54 @@ def test_create_with_reservoir(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.valid_from("EIP8037")
+def test_create2_child_spill_not_double_charged(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test CREATE2 child state gas paid from `gas_left` is not recharged.
+
+    The factory executes below the Amsterdam tx gas cap, so the CREATE2 child
+    pays new-account and storage state gas by spilling from `gas_left`. The
+    factory must not charge the same state growth again at frame end.
+    """
+    env = Environment()
+
+    init_code = sum(Op.SSTORE(i, i + 1) for i in range(6)) + Op.STOP
+    mstore_value, initcode_size = init_code_at_high_bytes(init_code)
+
+    factory = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, mstore_value)
+            + Op.POP(
+                Op.CREATE2(
+                    value=0,
+                    offset=0,
+                    size=initcode_size,
+                    salt=0,
+                )
+            )
+        )
+    )
+    created = compute_create2_address(
+        address=factory,
+        salt=0,
+        initcode=bytes(init_code),
+    )
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=500_000,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        created: Account(nonce=1, storage={i: i + 1 for i in range(6)}),
+    }
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
 @pytest.mark.parametrize(
     "code_size",
     [
@@ -200,6 +249,73 @@ def test_code_deposit_state_gas_scales_with_size(
         post = {}
 
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_repeated_create_same_code_charges_each_account(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test code deposit is charged per-account, not per code hash.
+
+    Two CREATEs with identical init code deploy identical bytecode
+    and so share a single ``code_hash``. The factory snapshots
+    ``gas_left`` around each CREATE via ``Op.GAS`` and stores
+    ``(g0 - g1) - (g1 - g2)`` in slot 0. Identical work must cost
+    the same — so the difference must be zero.
+
+    Runtime measurement is required: the bug manifests as a
+    child-frame state-gas spillover into ``gas_left`` (a runtime
+    quantity), which static helpers like ``bytecode.gas_cost()``
+    do not model.
+
+    A non-zero result indicates ``compute_state_byte_diff`` is
+    keying code-deposit accounting by hash via ``code_writes``,
+    silently dropping the second CREATE's ``len(code) × CPSB``
+    charge.
+    """
+    # Y init code returns memory[0:1] = 0x00 to deploy a 1-byte STOP.
+    y_init = Op.PUSH1(1) + Op.PUSH1(0) + Op.RETURN
+    y_size = len(bytes(y_init))
+
+    # Memory layout:
+    #   [ 0: 32) — Y init code (right-aligned PUSH32 padding)
+    #   [32: 64) — g0 (gas before first CREATE)
+    #   [64: 96) — g1 (gas between the two CREATEs)
+    #   [96:128) — g2 (gas after second CREATE)
+    factory_code = (
+        Op.MSTORE(0, Op.PUSH32(bytes(y_init)))
+        + Op.MSTORE(32, Op.GAS)
+        + Op.POP(Op.CREATE(value=0, offset=32 - y_size, size=y_size))
+        + Op.MSTORE(64, Op.GAS)
+        + Op.POP(Op.CREATE(value=0, offset=32 - y_size, size=y_size))
+        + Op.MSTORE(96, Op.GAS)
+        + Op.SSTORE(
+            0,
+            Op.SUB(
+                Op.SUB(Op.MLOAD(32), Op.MLOAD(64)),  # cost of CREATE 1
+                Op.SUB(Op.MLOAD(64), Op.MLOAD(96)),  # cost of CREATE 2
+            ),
+        )
+        + Op.STOP
+    )
+
+    factory_storage = Storage()
+    factory_storage[0] = 0
+    factory = pre.deploy_contract(code=factory_code, storage=factory_storage)
+
+    tx = Transaction(
+        to=factory,
+        sender=pre.fund_eoa(),
+        gas_limit=2_000_000,
+    )
+
+    state_test(
+        pre=pre,
+        post={factory: Account(storage=factory_storage)},
+        tx=tx,
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -304,7 +420,7 @@ def test_create_insufficient_state_gas(
     # enough for the new account state gas
     gas_costs = fork.gas_costs()
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    regular_create_gas = gas_costs.OPCODE_CREATE_BASE - gas_costs.NEW_ACCOUNT
+    regular_create_gas = gas_costs.OPCODE_CREATE_BASE
     gas_limit = intrinsic_cost() + regular_create_gas + 10_000
 
     tx = Transaction(
@@ -496,7 +612,6 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
     """
     init_code = Op.RETURN(0, 1)
     gas_costs = fork.gas_costs()
-    new_acct_state = gas_costs.NEW_ACCOUNT
     code_deposit_state = fork.code_deposit_state_gas(code_size=1)
 
     factory = pre.deploy_contract(
@@ -524,9 +639,8 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
         gas_costs.TX_BASE
         + 7 * gas_costs.VERY_LOW
         + gas_costs.MEMORY_PER_WORD
-        + (gas_costs.OPCODE_CREATE_BASE - new_acct_state)
+        + gas_costs.OPCODE_CREATE_BASE
         + init_code_word_cost
-        + new_acct_state
     )
 
     # Init code cost: PUSH1 + PUSH1 + RETURN(+mem expansion)
@@ -1824,9 +1938,10 @@ def test_inner_create_succeeds_code_deposit_state_gas(
         calldata=bytes(initcode), contract_creation=True
     )
 
-    # Static cost excludes inner code-deposit, so add it to give
-    # the initcode enough to reach RETURN in the child frame.
-    initcode_gas = initcode.gas_cost(fork)
+    if outer_outcome == "halts":
+        initcode_gas = initcode.regular_cost(fork)
+    else:
+        initcode_gas = initcode.gas_cost(fork)
     gas_limit = intrinsic_total + initcode_gas + inner_code_deposit + 1000
 
     if outer_outcome == "succeeds":
@@ -2129,7 +2244,7 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     # header.gas_used equals the regular-gas total. A mutation that
     # drops the burned create_message_gas from regular accounting
     # would reduce this value.
-    baseline_gas_used = 0x01C98C
+    baseline_gas_used = 0x03C325
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
@@ -281,7 +281,7 @@ def test_create_oog_reservoir_inflation_detection(
         child_code = create_opcode(value=0, offset=0, size=0, salt=0)
         pushes_gas = 4 * gas_costs.VERY_LOW
 
-    create_regular_gas = gas_costs.OPCODE_CREATE_BASE - new_account_state_gas
+    create_regular_gas = gas_costs.OPCODE_CREATE_BASE
     child_gas = pushes_gas + create_regular_gas + new_account_state_gas - 1
     child = pre.deploy_contract(child_code)
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -265,10 +265,11 @@ def test_block_state_gas_limit_boundary(
     """
     Verify the per-tx state check at the strict-greater-than boundary.
 
-    tx1 consumes `tx1_state` via cold SSTOREs. tx2 is sized so its
-    worst-case state contribution `tx.gas` equals `state_available`
-    (delta=0, accepted because the check is strict `>`) or exceeds it
-    by 1 (delta=1, rejected with `GAS_ALLOWANCE_EXCEEDED`).
+    tx1 consumes `tx1_state` via cold SSTOREs. tx2 is sized so that
+    its worst-case state contribution `tx.gas - intrinsic_regular`
+    equals `state_available` (delta=0, accepted because the check is
+    strict `>`) or exceeds it by 1 (delta=1, rejected with
+    `GAS_ALLOWANCE_EXCEEDED`).
 
     The regular check is asserted to pass so rejection on delta=1 is
     pinned to the state dimension.
@@ -296,8 +297,11 @@ def test_block_state_gas_limit_boundary(
     tx1_regular = intrinsic_cost() + tx1_code.gas_cost(fork) - tx1_state
     tx1_gas = gas_limit_cap + tx1_state
 
+    # tx2: worst-case state contribution = tx.gas - intrinsic_regular.
+    # Plain call, so intrinsic_state is zero.
+    tx2_intrinsic_regular = intrinsic_cost()
     state_available = block_gas_limit - tx1_state
-    tx2_gas = state_available + delta
+    tx2_gas = tx2_intrinsic_regular + state_available + delta
 
     # Pin the rejection (when delta > 0) to the state check: the
     # regular check must not fire.
@@ -339,22 +343,22 @@ def test_block_state_gas_limit_boundary(
     )
 
 
-@pytest.mark.exception_test
 @pytest.mark.valid_from("EIP8037")
-def test_creation_tx_regular_check_no_intrinsic_state_subtraction(
+def test_creation_tx_regular_check_subtracts_intrinsic_state(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Verify the regular check uses raw `tx.gas`, not `tx.gas - intrinsic.state`.
+    Verify the regular check subtracts `intrinsic.state` from tx.gas.
 
-    The current EIP regular check is
-    `min(TX_MAX, tx.gas) > regular_available`. For a creation tx whose
-    raw `tx.gas` exceeds `regular_available` but `tx.gas -
-    intrinsic.state` would fit, the tx must be **rejected**. A prior
-    spec draft used `min(TX_MAX, tx.gas - intrinsic.state)` and would
-    have accepted the same tx; this test pins the current behavior.
+    The EIP regular check is
+    `min(TX_MAX, tx.gas - intrinsic.state) > regular_available`. For a
+    creation tx, `intrinsic.state = GAS_NEW_ACCOUNT`. This test sizes a
+    creation tx whose raw `tx.gas` exceeds `regular_available` but
+    `tx.gas - intrinsic.state` fits; it must be accepted. The old
+    formula `min(TX_MAX, tx.gas)` would reject the same tx, proving
+    the subtraction is honored.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -368,10 +372,10 @@ def test_creation_tx_regular_check_no_intrinsic_state_subtraction(
     ) - fork.transaction_intrinsic_state_gas(contract_creation=True)
 
     # Tight boundary: after the filler consumes gas_limit_cap, the
-    # remaining regular is exactly intrinsic_regular + 1. The current
+    # remaining regular is exactly intrinsic_regular + 1. The old
     # formula `min(TX_MAX, tx.gas)` rejects (tx.gas = intrinsic_total
-    # > intrinsic_regular + 1); the prior formula `min(TX_MAX, tx.gas
-    # - intrinsic.state)` would have accepted (equals intrinsic_regular).
+    # > intrinsic_regular + 1); the new formula `min(TX_MAX, tx.gas
+    # - intrinsic.state)` accepts (equals intrinsic_regular).
     block_gas_limit = gas_limit_cap + intrinsic_regular + 1
 
     # TODO(EIP-8037): pin `_env_gas_limit` to the actual block limit
@@ -393,11 +397,10 @@ def test_creation_tx_regular_check_no_intrinsic_state_subtraction(
     remaining_regular = block_gas_limit - gas_limit_cap
 
     assert create_tx_gas > remaining_regular, (
-        "current formula must reject (tx.gas exceeds remaining regular)"
+        "old formula must reject to prove new formula differs"
     )
     assert create_tx_gas - intrinsic_state <= remaining_regular, (
-        "prior formula would have accepted (after subtracting "
-        "intrinsic.state); test pins divergence between formulas"
+        "new formula must accept"
     )
 
     filler_tx = Transaction(
@@ -409,7 +412,6 @@ def test_creation_tx_regular_check_no_intrinsic_state_subtraction(
         to=None,
         gas_limit=create_tx_gas,
         sender=pre.fund_eoa(),
-        error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
     )
 
     blockchain_test(
@@ -419,7 +421,6 @@ def test_creation_tx_regular_check_no_intrinsic_state_subtraction(
             Block(
                 txs=[filler_tx, create_tx],
                 gas_limit=block_gas_limit,
-                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
             )
         ],
         post={},
@@ -1093,43 +1094,6 @@ def test_top_level_opcode_oog_before_frame_end_does_not_refund_state_gas(
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(
             cumulative_gas_used=tx_gas,
-        ),
-    )
-
-    state_test(pre=pre, post={contract: Account(storage={})}, tx=tx)
-
-
-@pytest.mark.valid_from("EIP8037")
-def test_top_level_frame_end_oog_does_not_refund_unsettled_state_gas(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Verify frame-end OOG does not refund state gas that never settled.
-
-    The opcode path completes after a zero-to-nonzero SSTORE, but the
-    tx is one gas short of paying the frame-end state-growth charge. The
-    frame reports an error without ever increasing `state_gas_used`, so
-    the sender is billed only the intrinsic and regular execution gas
-    plus the final missing gas unit.
-    """
-    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
-    sstore_state_gas = fork.sstore_state_gas()
-
-    code = Op.SSTORE(0, 1) + Op.STOP
-    contract = pre.deploy_contract(code=code)
-
-    # One gas short of the full successful execution cost.
-    tx_gas = intrinsic_cost + code.gas_cost(fork) - 1
-    expected_cumulative = tx_gas - (sstore_state_gas - 1)
-
-    tx = Transaction(
-        to=contract,
-        gas_limit=tx_gas,
-        sender=pre.fund_eoa(),
-        expected_receipt=TransactionReceipt(
-            cumulative_gas_used=expected_cumulative,
         ),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -1069,13 +1069,11 @@ def test_top_level_failure_propagated_state_gas(
     child_code = Op.SSTORE(0, 1)
     child = pre.deploy_contract(code=child_code)
     if failure_mode == "revert":
-        parent_code = (
-            Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.REVERT(0, 0)
+        parent_code = Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.REVERT(
+            0, 0
         )
     else:
-        parent_code = (
-            Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.INVALID
-        )
+        parent_code = Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.INVALID
     parent = pre.deploy_contract(code=parent_code)
 
     # Reservoir sized to half the SSTORE state gas so the child's
@@ -1109,6 +1107,162 @@ def test_top_level_failure_propagated_state_gas(
     )
 
     state_test(pre=pre, post={child: Account(storage={})}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "frame_bodies",
+    [
+        pytest.param(
+            [
+                Op.SSTORE(0, 1),
+                Op.SSTORE(1, 1),
+                Op.SSTORE(2, 1),
+                Op.SSTORE(3, 1),
+            ],
+            id="depth_4_sstore_each",
+        ),
+        pytest.param(
+            [
+                Op.SSTORE(0, 1),
+                Bytecode(),
+                Op.SSTORE(2, 1),
+                Bytecode(),
+            ],
+            id="depth_4_alternating_state",
+        ),
+        pytest.param(
+            [Bytecode(), Bytecode(), Bytecode(), Bytecode()],
+            id="depth_4_no_state",
+        ),
+        pytest.param(
+            [
+                Op.SSTORE(0, 1) + Op.SSTORE(1, 1),
+                Op.SSTORE(2, 1) + Op.SSTORE(3, 1),
+                Op.SSTORE(4, 1) + Op.SSTORE(5, 1),
+            ],
+            id="depth_3_two_sstores_each",
+        ),
+        pytest.param(
+            [
+                Bytecode(),
+                Bytecode(),
+                Op.SSTORE(0, 1)
+                + Op.SSTORE(
+                    0,
+                    0,
+                    key_warm=True,
+                    original_value=0,
+                    current_value=1,
+                    new_value=0,
+                ),
+            ],
+            id="depth_3_deepest_0_to_x_to_0",
+        ),
+        pytest.param(
+            [
+                Bytecode(),
+                Bytecode(),
+                Op.SSTORE(0, 1)
+                + Op.SSTORE(
+                    0,
+                    2,
+                    key_warm=True,
+                    original_value=0,
+                    current_value=1,
+                    new_value=2,
+                )
+                + Op.SSTORE(
+                    0,
+                    0,
+                    key_warm=True,
+                    original_value=0,
+                    current_value=2,
+                    new_value=0,
+                ),
+            ],
+            id="depth_3_deepest_0_to_x_to_y_to_0",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_nested_failure_resets_to_tx_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    failure_mode: str,
+    frame_bodies: list[Bytecode],
+) -> None:
+    """
+    Verify failure cascade resets state_gas_left to R_tx for any chain.
+
+    Each frame runs its parametrized body, then calls the next frame
+    or terminates; every frame ends with the failure terminator so
+    the cascade reaches the top. Bodies need accurate opcode
+    metadata for `regular_cost(fork)`, `state_cost(fork)` and
+    `state_refund(fork)` to match the actual runtime charges.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+
+    # Reservoir covers all body state costs without spilling.
+    body_state_total = sum(b.state_cost(fork) for b in frame_bodies)
+    reservoir = max(body_state_total + sstore_state_gas, sstore_state_gas)
+    tx_gas = gas_limit_cap + reservoir
+
+    terminator = Op.REVERT(0, 0) if failure_mode == "revert" else Op.INVALID
+
+    deepest_idx = len(frame_bodies) - 1
+    deepest_code = frame_bodies[deepest_idx] + terminator
+    frame_codes: list[Bytecode] = [deepest_code]
+    inner_addr = pre.deploy_contract(code=deepest_code)
+    for depth in range(deepest_idx - 1, -1, -1):
+        code = (
+            frame_bodies[depth]
+            + Op.POP(Op.CALL(gas=Op.GAS, address=inner_addr))
+            + terminator
+        )
+        inner_addr = pre.deploy_contract(code=code)
+        frame_codes.insert(0, code)
+
+    top = inner_addr
+
+    if failure_mode == "halt":
+        expected_cumulative = tx_gas - reservoir
+    elif failure_mode == "revert":
+        sum_regular = sum(code.regular_cost(fork) for code in frame_codes)
+        # Non-top frames' inline state-gas refunds get burned at the
+        # incorporate boundary (incorporate_child_on_error subtracts
+        # `state_gas_refund` so the refund doesn't leak across the
+        # rolled-back state change). Top frame's refund is preserved
+        # by the tx-level error handler.
+        non_top_refund_burn = sum(
+            b.state_refund(fork) for b in frame_bodies[1:]
+        )
+        expected_cumulative = (
+            intrinsic_cost + sum_regular + non_top_refund_burn
+        )
+    else:
+        raise ValueError("Invariant, unreachable code.")
+
+    tx = Transaction(
+        to=top,
+        gas_limit=tx_gas,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
 
 
 @pytest.mark.valid_from("EIP8037")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -1193,7 +1193,7 @@ def test_top_level_failure_propagated_state_gas(
 )
 @pytest.mark.valid_from("EIP8037")
 def test_nested_failure_resets_to_tx_reservoir(
-    state_test: StateTestFiller,
+    blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     failure_mode: str,
@@ -1207,6 +1207,14 @@ def test_nested_failure_resets_to_tx_reservoir(
     the cascade reaches the top. Bodies need accurate opcode
     metadata for `regular_cost(fork)`, `state_cost(fork)` and
     `state_refund(fork)` to match the actual runtime charges.
+
+    Two assertions cross-check the gas accounting:
+    - `cumulative_gas_used` (receipt) pins `tx.gas - gas_left -
+      state_gas_left`, catching bugs in the leftover split.
+    - `header.gas_used` pins `regular_gas_used + state_gas_used`
+      via the block accumulators, catching bugs in the
+      regular-vs-state attribution. They differ by exactly
+      `refund_burn` in REVERT cases with non-top inline refunds.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1235,10 +1243,14 @@ def test_nested_failure_resets_to_tx_reservoir(
 
     top = inner_addr
 
+    sum_regular = sum(code.regular_cost(fork) for code in frame_codes)
     if failure_mode == "halt":
+        # gas_left = 0 (consumed by halt), state_gas_left = R_tx
+        # (entry reservoir restored). regular_gas_used eats every
+        # post-intrinsic gas unit (charges + burned gas_left).
         expected_cumulative = tx_gas - reservoir
+        expected_header_gas_used = gas_limit_cap
     elif failure_mode == "revert":
-        sum_regular = sum(code.regular_cost(fork) for code in frame_codes)
         # Non-top frames' inline state-gas refunds get burned at the
         # incorporate boundary (incorporate_child_on_error subtracts
         # `state_gas_refund` so the refund doesn't leak across the
@@ -1250,6 +1262,12 @@ def test_nested_failure_resets_to_tx_reservoir(
         expected_cumulative = (
             intrinsic_cost + sum_regular + non_top_refund_burn
         )
+        # Header reflects the regular-vs-state attribution directly:
+        # state_gas_used is zeroed by the tx error handler, so only
+        # regular gas usage shows up. The refund burn lives in the
+        # `state_gas_left` shortfall (visible in cumulative), not
+        # the regular accumulator.
+        expected_header_gas_used = intrinsic_cost + sum_regular
     else:
         raise ValueError("Invariant, unreachable code.")
 
@@ -1262,7 +1280,16 @@ def test_nested_failure_resets_to_tx_reservoir(
         ),
     )
 
-    state_test(pre=pre, post={}, tx=tx)
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_header_gas_used),
+            )
+        ],
+        post={},
+    )
 
 
 @pytest.mark.valid_from("EIP8037")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -265,11 +265,10 @@ def test_block_state_gas_limit_boundary(
     """
     Verify the per-tx state check at the strict-greater-than boundary.
 
-    tx1 consumes `tx1_state` via cold SSTOREs. tx2 is sized so that
-    its worst-case state contribution `tx.gas - intrinsic_regular`
-    equals `state_available` (delta=0, accepted because the check is
-    strict `>`) or exceeds it by 1 (delta=1, rejected with
-    `GAS_ALLOWANCE_EXCEEDED`).
+    tx1 consumes `tx1_state` via cold SSTOREs. tx2 is sized so its
+    worst-case state contribution `tx.gas` equals `state_available`
+    (delta=0, accepted because the check is strict `>`) or exceeds it
+    by 1 (delta=1, rejected with `GAS_ALLOWANCE_EXCEEDED`).
 
     The regular check is asserted to pass so rejection on delta=1 is
     pinned to the state dimension.
@@ -297,11 +296,8 @@ def test_block_state_gas_limit_boundary(
     tx1_regular = intrinsic_cost() + tx1_code.gas_cost(fork) - tx1_state
     tx1_gas = gas_limit_cap + tx1_state
 
-    # tx2: worst-case state contribution = state_available + delta.
-    # Plain call, so intrinsic_state is zero.
-    tx2_intrinsic_regular = intrinsic_cost()
     state_available = block_gas_limit - tx1_state
-    tx2_gas = tx2_intrinsic_regular + state_available + delta
+    tx2_gas = state_available + delta
 
     # Pin the rejection (when delta > 0) to the state check: the
     # regular check must not fire.
@@ -343,22 +339,22 @@ def test_block_state_gas_limit_boundary(
     )
 
 
+@pytest.mark.exception_test
 @pytest.mark.valid_from("EIP8037")
-def test_creation_tx_regular_check_subtracts_intrinsic_state(
+def test_creation_tx_regular_check_no_intrinsic_state_subtraction(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Verify the regular check subtracts `intrinsic.state` from tx.gas.
+    Verify the regular check uses raw `tx.gas`, not `tx.gas - intrinsic.state`.
 
-    The EIP regular check is
-    `min(TX_MAX, tx.gas - intrinsic.state) > regular_available`. For a
-    creation tx, `intrinsic.state = GAS_NEW_ACCOUNT`. This test sizes a
-    creation tx whose raw `tx.gas` exceeds `regular_available` but
-    `tx.gas - intrinsic.state` fits; it must be accepted. The old
-    formula `min(TX_MAX, tx.gas)` would reject the same tx, proving
-    the subtraction is honored.
+    The current EIP regular check is
+    `min(TX_MAX, tx.gas) > regular_available`. For a creation tx whose
+    raw `tx.gas` exceeds `regular_available` but `tx.gas -
+    intrinsic.state` would fit, the tx must be **rejected**. A prior
+    spec draft used `min(TX_MAX, tx.gas - intrinsic.state)` and would
+    have accepted the same tx; this test pins the current behavior.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -372,10 +368,10 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
     ) - fork.transaction_intrinsic_state_gas(contract_creation=True)
 
     # Tight boundary: after the filler consumes gas_limit_cap, the
-    # remaining regular is exactly intrinsic_regular + 1. The old
+    # remaining regular is exactly intrinsic_regular + 1. The current
     # formula `min(TX_MAX, tx.gas)` rejects (tx.gas = intrinsic_total
-    # > intrinsic_regular + 1); the new formula `min(TX_MAX, tx.gas
-    # - intrinsic.state)` accepts (equals intrinsic_regular).
+    # > intrinsic_regular + 1); the prior formula `min(TX_MAX, tx.gas
+    # - intrinsic.state)` would have accepted (equals intrinsic_regular).
     block_gas_limit = gas_limit_cap + intrinsic_regular + 1
 
     # TODO(EIP-8037): pin `_env_gas_limit` to the actual block limit
@@ -397,10 +393,11 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
     remaining_regular = block_gas_limit - gas_limit_cap
 
     assert create_tx_gas > remaining_regular, (
-        "old formula must reject to prove new formula differs"
+        "current formula must reject (tx.gas exceeds remaining regular)"
     )
     assert create_tx_gas - intrinsic_state <= remaining_regular, (
-        "new formula must accept"
+        "prior formula would have accepted (after subtracting "
+        "intrinsic.state); test pins divergence between formulas"
     )
 
     filler_tx = Transaction(
@@ -412,6 +409,7 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
         to=None,
         gas_limit=create_tx_gas,
         sender=pre.fund_eoa(),
+        error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
     )
 
     blockchain_test(
@@ -421,6 +419,7 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
             Block(
                 txs=[filler_tx, create_tx],
                 gas_limit=block_gas_limit,
+                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
             )
         ],
         post={},
@@ -1057,6 +1056,86 @@ def test_top_level_failure_refunds_state_gas_propagated_from_child(
     state_test(pre=pre, post={child: Account(storage={})}, tx=tx)
 
 
+@pytest.mark.valid_from("EIP8037")
+def test_top_level_opcode_oog_before_frame_end_does_not_refund_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify an opcode OOG before frame-end settlement does not refund
+    unsettled state gas.
+
+    The transaction has enough gas for the SSTORE and all preceding
+    regular work, but is one gas short of the MCOPY regular cost. The
+    frame halts before frame-end settlement runs, so the earlier SSTORE
+    never contributes execution state gas to refund.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    sstore_state_gas = fork.sstore_state_gas()
+
+    code = Op.SSTORE(0, 1) + Op.MCOPY(
+        0x1000,
+        0,
+        1,
+        old_memory_size=0,
+        new_memory_size=0x1001,
+        data_size=1,
+    )
+    contract = pre.deploy_contract(code=code)
+
+    # One gas short of the regular-gas portion of successful execution.
+    tx_gas = intrinsic_cost + code.gas_cost(fork) - sstore_state_gas - 1
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=tx_gas,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=tx_gas,
+        ),
+    )
+
+    state_test(pre=pre, post={contract: Account(storage={})}, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_top_level_frame_end_oog_does_not_refund_unsettled_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify frame-end OOG does not refund state gas that never settled.
+
+    The opcode path completes after a zero-to-nonzero SSTORE, but the
+    tx is one gas short of paying the frame-end state-growth charge. The
+    frame reports an error without ever increasing `state_gas_used`, so
+    the sender is billed only the intrinsic and regular execution gas
+    plus the final missing gas unit.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    sstore_state_gas = fork.sstore_state_gas()
+
+    code = Op.SSTORE(0, 1) + Op.STOP
+    contract = pre.deploy_contract(code=code)
+
+    # One gas short of the full successful execution cost.
+    tx_gas = intrinsic_cost + code.gas_cost(fork) - 1
+    expected_cumulative = tx_gas - (sstore_state_gas - 1)
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=tx_gas,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
+    )
+
+    state_test(pre=pre, post={contract: Account(storage={})}, tx=tx)
+
+
 @pytest.mark.parametrize(
     "num_access_list_entries",
     [
@@ -1161,3 +1240,279 @@ def test_access_list_warm_savings_stay_regular(
         ],
         post={contract: Account(storage={0: 1})},
     )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_subcall_revert_does_not_leak_grandchild_storage_clear_credit(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify a grandchild's storage-clear reservoir credit cannot leak
+    past a reverting parent into the top frame's reservoir.
+
+    Three-frame DELEGATECALL chain so all SSTOREs target the top
+    contract's storage:
+
+      - top: SSTOREs slots[0..4]=1, DELEGATECALLs `mid`, then
+        SSTOREs slots[10..14]=1.
+      - mid: DELEGATECALLs `inner`, then REVERTs.
+      - inner: SSTOREs slots[0..4]=0, clearing what top set.
+
+    Inner's frame-end sees byte_delta=-160 against its own snapshot
+    (slots non-zero at frame entry, zero at tx start, zero at exit)
+    and credits its reservoir by 5 * sstore_state_gas. On mid's
+    revert that storage clear is rolled back, but the credit lives
+    on inside mid's reservoir from the prior
+    `incorporate_child_on_success`. The credit must not propagate
+    out of mid via `incorporate_child_on_error`, because the
+    underlying state transition no longer exists.
+
+    The reservoir is sized to the legitimate state cost
+    (10 * sstore_state_gas: 5 setup writes + 5 phantom writes). Top
+    drains the reservoir at frame-end and the receipt charges the
+    full legitimate cost. If the credit leaks, an extra
+    5 * sstore_state_gas remains in `state_gas_reservoir` at tx end
+    and the receipt formula `tx.gas - gas_left -
+    state_gas_reservoir` would charge the sender 5 * sstore_state_gas
+    less.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+
+    num_slots = 5
+    phantom_base = 10
+
+    # `inner` clears slots [0..num_slots-1] in the caller's storage
+    # context, which under the DELEGATECALL chain is `top`. The
+    # slots are warm because top accessed them during setup and
+    # `accessed_storage_keys` propagated through the DELEGATECALLs.
+    inner_code = Bytecode()
+    for i in range(num_slots):
+        inner_code += Op.SSTORE.with_metadata(
+            key_warm=True,
+            original_value=0,
+            current_value=1,
+            new_value=0,
+        )(i, 0)
+    inner = pre.deploy_contract(code=inner_code)
+
+    mid_code = Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=inner)) + Op.REVERT(
+        0, 0
+    )
+    mid = pre.deploy_contract(code=mid_code)
+
+    setup_code = Bytecode()
+    for i in range(num_slots):
+        setup_code += Op.SSTORE(i, 1)
+    delegatecall_step = Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=mid))
+    phantom_code = Bytecode()
+    for i in range(num_slots):
+        phantom_code += Op.SSTORE(phantom_base + i, 1)
+    top_code = setup_code + delegatecall_step + phantom_code
+    top = pre.deploy_contract(code=top_code)
+
+    # Reservoir sized to the legitimate state cost only; any
+    # phantom credit surfaces as residual reservoir at tx end.
+    legit_state_cost = 2 * num_slots * sstore_state_gas
+    tx_gas = gas_limit_cap + legit_state_cost
+
+    # `bytecode.gas_cost(fork)` sums each opcode's regular and state
+    # contributions. Setup/phantom SSTOREs predict +sstore_state_gas
+    # each; inner's clears predict 0 (the negative byte_delta is a
+    # frame-level effect, not per-opcode). The frame-end byte_delta
+    # at top is +320 (10 set slots persist, the inner clear is rolled
+    # back), so the predicted state total of 10 * sstore_state_gas
+    # matches the actual charge.
+    expected_cumulative = (
+        intrinsic_cost
+        + top_code.gas_cost(fork)
+        + mid_code.gas_cost(fork)
+        + inner_code.gas_cost(fork)
+    )
+
+    tx = Transaction(
+        to=top,
+        gas_limit=tx_gas,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
+    )
+    expected_storage = dict.fromkeys(range(num_slots), 1) | {
+        phantom_base + i: 1 for i in range(num_slots)
+    }
+
+    state_test(
+        pre=pre,
+        post={top: Account(storage=expected_storage)},
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "intermediate_depth",
+    [
+        pytest.param(0, id="direct"),
+        pytest.param(1, id="depth_1"),
+        pytest.param(3, id="depth_3"),
+        pytest.param(10, id="depth_10"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_revert_discards_descendant_storage_clear_credit_through_depth(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    intermediate_depth: int,
+) -> None:
+    """
+    A reverted ancestor must discard a clear-credit regardless of
+    how many successful frames sit between the X→0 source and the
+    revert.
+
+    top → reverter (REVERT)
+            → pass_1 → … → pass_k → inner (X→0)
+
+    Each pass frame returns successfully, so the inner credit walks
+    up through `incorporate_child_on_success` at every layer before
+    landing in the reverter, where it must be dropped on
+    `incorporate_child_on_error`. The receipt invariant holds for
+    every `k`.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+
+    num_slots = 5
+    phantom_base = 10
+
+    # Slots are warm at inner: top's setup populates the access list
+    # and DELEGATECALL preserves it down the chain.
+    inner_code = Bytecode()
+    for i in range(num_slots):
+        inner_code += Op.SSTORE.with_metadata(
+            key_warm=True,
+            original_value=0,
+            current_value=1,
+            new_value=0,
+        )(i, 0)
+    inner = pre.deploy_contract(code=inner_code)
+
+    # Build the pass-through chain bottom-up so each frame can encode
+    # the next address. Each pass_i DELEGATECALLs into the next frame
+    # and STOPs successfully, propagating inner's credit upward.
+    pass_codes = []
+    next_addr = inner
+    for _ in range(intermediate_depth):
+        pass_code = (
+            Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=next_addr)) + Op.STOP
+        )
+        pass_codes.append(pass_code)
+        next_addr = pre.deploy_contract(code=pass_code)
+
+    # Reverter sits between top and the chain: enters, then REVERTs.
+    reverter_code = Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=next_addr)) + (
+        Op.REVERT(0, 0)
+    )
+    reverter = pre.deploy_contract(code=reverter_code)
+
+    setup_code = Bytecode()
+    for i in range(num_slots):
+        setup_code += Op.SSTORE(i, 1)
+    delegatecall_step = Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=reverter))
+    phantom_code = Bytecode()
+    for i in range(num_slots):
+        phantom_code += Op.SSTORE(phantom_base + i, 1)
+    top_code = setup_code + delegatecall_step + phantom_code
+    top = pre.deploy_contract(code=top_code)
+
+    legit_state_cost = 2 * num_slots * sstore_state_gas
+    tx_gas = gas_limit_cap + legit_state_cost
+
+    expected_cumulative = (
+        intrinsic_cost
+        + top_code.gas_cost(fork)
+        + reverter_code.gas_cost(fork)
+        + sum(c.gas_cost(fork) for c in pass_codes)
+        + inner_code.gas_cost(fork)
+    )
+
+    tx = Transaction(
+        to=top,
+        gas_limit=tx_gas,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
+    )
+    expected_storage = dict.fromkeys(range(num_slots), 1) | {
+        phantom_base + i: 1 for i in range(num_slots)
+    }
+
+    state_test(
+        pre=pre,
+        post={top: Account(storage=expected_storage)},
+        tx=tx,
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_set_and_clear_pays_no_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    A 0→X SSTORE paired with an X→0 on the same slot must cancel in
+    the state-gas reservoir. With a tight regular-gas budget and no
+    reservoir headroom (tx.gas <= TX_MAX_GAS_LIMIT, so reservoir = 0),
+    the tx completes only because the frame-end byte_delta nets to
+    zero.
+
+    A standalone 0→X here would charge +sstore_state_gas at frame
+    end, spill into gas_left, and OOG against this budget. The
+    follow-up X→0 returns the slot to its tx-start original (0), so
+    `compute_state_byte_diff` reports byte_delta=0 and the
+    state-gas reservoir is never touched.
+    """
+    gas_costs = fork.gas_costs()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+
+    # Same slot, set then cleared. Frame-end byte_delta = 0.
+    set_op = Op.SSTORE.with_metadata(
+        key_warm=False,
+        original_value=0,
+        current_value=0,
+        new_value=1,
+    )(0, 1)
+    clear_op = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )(0, 0)
+    code = set_op + clear_op
+    contract = pre.deploy_contract(code=code)
+
+    # Tight budget: bytecode regular gas plus the headroom required by
+    # the warm SSTORE's `check_gas(CALL_STIPEND + 1)` precondition.
+    # The warm 100-gas charge is already inside `code.regular_cost`,
+    # so the extra headroom needed is `CALL_STIPEND + 1 - WARM_ACCESS`.
+    extra_for_stipend = gas_costs.CALL_STIPEND + 1 - gas_costs.WARM_ACCESS
+    gas_limit = intrinsic_cost + code.regular_cost(fork) + extra_for_stipend
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    # Slot 0 returns to its tx-start value (0). The reservoir was
+    # never touched because frame-end byte_delta was zero.
+    post = {contract: Account(storage={0: 0})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -964,36 +964,60 @@ def test_subcall_failure_does_not_zero_top_level_state_gas(
     )
 
 
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
-def test_top_level_failure_refunds_spilled_state_gas(
+def test_top_level_failure_spilled_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    failure_mode: str,
 ) -> None:
     """
-    Verify the top level failure refund covers state gas that
-    spilled from the reservoir into gas_left.
+    Verify the top-level failure handling for state gas that spilled
+    from the reservoir into `gas_left`.
 
     When the reservoir is smaller than the state gas charge, the
-    overflow spills and is drawn from gas_left. On top level failure
-    the full consumed state gas (reservoir portion plus spilled
-    portion) is credited back to the reservoir so the sender is not
-    billed for any of it.
+    overflow spills and is drawn from `gas_left`. The two failure
+    modes diverge in how the spill is treated:
+
+    - REVERT preserves `gas_left` and refunds the full
+      `state_gas_used` (reservoir-portion + spilled-portion) to the
+      reservoir. The user is billed only the regular component.
+    - Exceptional halt resets the frame to `(0, R0)`. The spilled
+      portion stays burned alongside `gas_left` (re-classified as
+      regular gas usage). Only the reservoir-portion is restored.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     sstore_state_gas = fork.sstore_state_gas()
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
 
-    code = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
+    if failure_mode == "revert":
+        code = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
+    else:
+        code = Op.SSTORE(0, 1) + Op.INVALID
     contract = pre.deploy_contract(code=code)
 
     # Reservoir sized to cover only half the SSTORE state gas; the
-    # other half must spill into gas_left.
+    # other half spills into gas_left.
     tx_gas = gas_limit_cap + sstore_state_gas // 2
-    expected_cumulative = (
-        intrinsic_cost + code.gas_cost(fork) - sstore_state_gas
-    )
+
+    if failure_mode == "revert":
+        # gas_left preserved; full state_gas_used refunded to
+        # reservoir → sender billed only the regular component.
+        expected_cumulative = (
+            intrinsic_cost + code.gas_cost(fork) - sstore_state_gas
+        )
+    else:
+        # gas_left burned; only the reservoir-portion (sstore/2) is
+        # restored. tx_gas_used = tx_gas - 0 - sstore/2.
+        expected_cumulative = tx_gas - sstore_state_gas // 2
 
     tx = Transaction(
         to=contract,
@@ -1007,21 +1031,35 @@ def test_top_level_failure_refunds_spilled_state_gas(
     state_test(pre=pre, post={contract: Account(storage={})}, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
-def test_top_level_failure_refunds_state_gas_propagated_from_child(
+def test_top_level_failure_propagated_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    failure_mode: str,
 ) -> None:
     """
-    Verify the top level failure refund catches state gas propagated
+    Verify the top-level failure handling for state gas propagated
     from a successful subcall.
 
     The parent calls a child that runs SSTORE and returns. The
-    child's state gas usage is folded into the parent frame via the
-    success path. When the parent then reverts at the top level, the
-    full propagated state gas must be refunded so the sender fee
-    excludes it.
+    child's `state_gas_used` is folded into the parent frame via the
+    success path so the parent's reservoir is empty and its
+    `state_gas_used` carries the SSTORE charge.
+
+    - REVERT preserves `gas_left` and refunds the full propagated
+      `state_gas_used` to the reservoir. The user is billed only the
+      regular component.
+    - Exceptional halt resets the parent frame to `(0, R0)`, where
+      `R0 = sstore_state_gas`. The propagated charge re-converges to
+      the entry reservoir; `tx_gas_used = tx_gas - R0 = gas_limit_cap`.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1030,20 +1068,36 @@ def test_top_level_failure_refunds_state_gas_propagated_from_child(
 
     child_code = Op.SSTORE(0, 1)
     child = pre.deploy_contract(code=child_code)
-    parent_code = Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.REVERT(0, 0)
+    if failure_mode == "revert":
+        parent_code = (
+            Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.REVERT(0, 0)
+        )
+    else:
+        parent_code = (
+            Op.POP(Op.CALL(gas=Op.GAS, address=child)) + Op.INVALID
+        )
     parent = pre.deploy_contract(code=parent_code)
 
-    # Reservoir sized for the child's SSTORE. After the propagated
-    # state gas is refunded, the sender is billed only the regular
-    # gas: parent + CALL dispatch + child regular (SSTORE minus its
-    # state component).
-    tx_gas = gas_limit_cap + sstore_state_gas
-    expected_cumulative = (
-        intrinsic_cost
-        + parent_code.gas_cost(fork)
-        + child_code.gas_cost(fork)
-        - sstore_state_gas
-    )
+    # Reservoir sized to half the SSTORE state gas so the child's
+    # charge drains the reservoir AND spills into gas_left. This
+    # makes the halt path actually exercise the (0, R0) rule (no
+    # spill at the parent boundary would let halt and revert
+    # produce identical answers).
+    tx_gas = gas_limit_cap + sstore_state_gas // 2
+
+    if failure_mode == "revert":
+        # gas_left preserved; full propagated state_gas_used refunded
+        # → sender billed only the regular component.
+        expected_cumulative = (
+            intrinsic_cost
+            + parent_code.gas_cost(fork)
+            + child_code.gas_cost(fork)
+            - sstore_state_gas
+        )
+    else:
+        # Halt resets parent to (0, R0=sstore/2); the spilled
+        # portion stays burned. tx_gas_used = tx_gas - 0 - sstore/2.
+        expected_cumulative = tx_gas - sstore_state_gas // 2
 
     tx = Transaction(
         to=parent,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_snobal_quirks.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_snobal_quirks.py
@@ -1,0 +1,94 @@
+"""
+Snøbal devnet-specific tests locking in current spec behavior under
+EIP-8037.
+
+These tests document accounting quirks present in the snøbal devnet
+spec so client implementations targeting the devnet can be verified
+end-to-end. They do **not** describe the intended long-term semantics.
+
+Bug locked in here:
+  `set_delegation` (vm/eoa_delegation.py) credits
+  `message.state_gas_reservoir` when the authority pre-exists in state,
+  but `process_transaction` (fork.py) does not deduct that refund from
+  `tx_state_gas`. Result: `block_state_gas_used` over-counts state gas
+  by `STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE` per
+  existing-authority auth tuple.
+
+Delete this file when the spec is fixed (e.g. by adding
+`MessageCallOutput.state_refund` and subtracting it from `tx_state_gas`,
+mirroring the post-execution selfdestruct refund pattern).
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    AuthorizationTuple,
+    Block,
+    BlockchainTestFiller,
+    Fork,
+    Header,
+    Op,
+    Transaction,
+)
+
+from .spec import ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_snobal_block_gas_used_inflated_by_7702_auth_refund(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Lock in: block.header.gas_used reflects the FULL intrinsic state
+    gas for an EIP-7702 SetCodeTx whose authority pre-exists in state.
+
+    Scenario: one SetCodeTx with one authorization tuple pointing at a
+    do-nothing contract. The authority is funded so it pre-exists,
+    triggering the auth-refund credit to `state_gas_reservoir` inside
+    `set_delegation`. The tx body executes only the delegated `STOP`,
+    so `state_gas_used == 0` and `tx_state_gas == intrinsic_state_gas`
+    under the current (buggy) accounting.
+
+    Snøbal expected: block.gas_used = intrinsic_state_gas
+        (since intrinsic_state_gas dominates intrinsic_regular)
+    Post-fix expected: block.gas_used = intrinsic_regular
+        (after auth_state_refund deduction, regular dominates)
+    """
+    sender = pre.fund_eoa()
+    authority = pre.fund_eoa()
+    target = pre.deploy_contract(code=Op.STOP)
+
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    tx = Transaction(
+        to=authority,
+        gas_limit=gas_limit_cap + auth_state_gas,
+        sender=sender,
+        authorization_list=[
+            AuthorizationTuple(
+                address=target,
+                nonce=0,
+                signer=authority,
+            ),
+        ],
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=auth_state_gas),
+            )
+        ],
+        post={},
+    )

--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -11,7 +11,6 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
-    Fork,
     Op,
     StateTestFiller,
     Transaction,
@@ -489,7 +488,6 @@ def test_modexp(
     mod_exp_input: ModExpInput | Bytes,
     output: ModExpOutput,
     pre: Alloc,
-    fork: Fork,
 ) -> None:
     """Test the MODEXP precompile."""
     env = Environment()
@@ -531,15 +529,11 @@ def test_modexp(
         + Op.STOP(),
     )
 
-    gas_limit = 2_000_000
-    if fork.is_eip_enabled(8037):
-        gas_limit = 4_000_000
-
     tx = Transaction(
         ty=0x0,
         to=account,
         data=mod_exp_input,
-        gas_limit=gas_limit,
+        gas_limit=2_000_000,
         protected=True,
         sender=sender,
     )

--- a/tests/byzantium/eip214_staticcall/test_staticcall.py
+++ b/tests/byzantium/eip214_staticcall/test_staticcall.py
@@ -446,12 +446,16 @@ def test_staticcall_nested_call_to_precompile(
             account_expectations=account_expectations
         )
 
+    gas_limit = 500_000
+    if fork.is_eip_enabled(8037):
+        gas_limit = 2_000_000
+
     state_test(
         pre=pre,
         tx=Transaction(
             sender=alice,
             to=contract_b,
-            gas_limit=500_000,
+            gas_limit=gas_limit,
             value=tx_value,
             protected=True,
         ),

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -87,21 +87,6 @@ def tx_access_list() -> List[AccessList]:
 
 
 @pytest.fixture
-def failed_state_gas_refund(  # noqa: D103
-    request: pytest.FixtureRequest,
-    fork: Fork,
-    successful: bool,
-) -> int:
-    if (
-        getattr(request, "param", "none") == "settled_sstore_minus_one"
-        and not successful
-        and fork.is_eip_enabled(8037)
-    ):
-        return fork.sstore_state_gas() - 1
-    return 0
-
-
-@pytest.fixture
 def block_gas_limit(env: Environment) -> int:  # noqa: D103
     return env.gas_limit
 
@@ -143,9 +128,15 @@ def tx(  # noqa: D103
     initial_memory: bytes,
     tx_gas_limit: int,
     tx_access_list: List[AccessList],
-    failed_state_gas_refund: int,
+    fork: Fork,
+    successful: bool,
 ) -> Transaction:
-    expected_gas = tx_gas_limit - failed_state_gas_refund
+    # EIP-8037: on top-level OOG, execution state gas is returned to the
+    # reservoir and not billed. The callee's SSTORE contributes state
+    # gas that gets refunded on failure.
+    expected_gas = tx_gas_limit
+    if not successful and fork.is_eip_enabled(8037):
+        expected_gas -= fork.sstore_state_gas()
     return Transaction(
         sender=sender,
         to=caller_address,
@@ -207,11 +198,6 @@ def post(  # noqa: D103
         "from_empty_memory",
     ],
 )
-@pytest.mark.parametrize(
-    "failed_state_gas_refund",
-    ["settled_sstore_minus_one"],
-    indirect=True,
-)
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_memory_expansion(
     state_test: StateTestFiller,
@@ -269,7 +255,6 @@ def test_mcopy_memory_expansion(
         "from_empty_memory",
     ],
 )
-@pytest.mark.parametrize("failed_state_gas_refund", [0], indirect=True)
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_huge_memory_expansion(
     state_test: StateTestFiller,

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -87,6 +87,21 @@ def tx_access_list() -> List[AccessList]:
 
 
 @pytest.fixture
+def failed_state_gas_refund(  # noqa: D103
+    request: pytest.FixtureRequest,
+    fork: Fork,
+    successful: bool,
+) -> int:
+    if (
+        getattr(request, "param", "none") == "settled_sstore_minus_one"
+        and not successful
+        and fork.is_eip_enabled(8037)
+    ):
+        return fork.sstore_state_gas() - 1
+    return 0
+
+
+@pytest.fixture
 def block_gas_limit(env: Environment) -> int:  # noqa: D103
     return env.gas_limit
 
@@ -128,15 +143,9 @@ def tx(  # noqa: D103
     initial_memory: bytes,
     tx_gas_limit: int,
     tx_access_list: List[AccessList],
-    fork: Fork,
-    successful: bool,
+    failed_state_gas_refund: int,
 ) -> Transaction:
-    # EIP-8037: on top-level OOG, execution state gas is returned to the
-    # reservoir and not billed. The callee's SSTORE contributes state
-    # gas that gets refunded on failure.
-    expected_gas = tx_gas_limit
-    if not successful and fork.is_eip_enabled(8037):
-        expected_gas -= fork.sstore_state_gas()
+    expected_gas = tx_gas_limit - failed_state_gas_refund
     return Transaction(
         sender=sender,
         to=caller_address,
@@ -198,6 +207,11 @@ def post(  # noqa: D103
         "from_empty_memory",
     ],
 )
+@pytest.mark.parametrize(
+    "failed_state_gas_refund",
+    ["settled_sstore_minus_one"],
+    indirect=True,
+)
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_memory_expansion(
     state_test: StateTestFiller,
@@ -255,6 +269,7 @@ def test_mcopy_memory_expansion(
         "from_empty_memory",
     ],
 )
+@pytest.mark.parametrize("failed_state_gas_refund", [0], indirect=True)
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_huge_memory_expansion(
     state_test: StateTestFiller,

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -128,15 +128,8 @@ def tx(  # noqa: D103
     initial_memory: bytes,
     tx_gas_limit: int,
     tx_access_list: List[AccessList],
-    fork: Fork,
-    successful: bool,
 ) -> Transaction:
-    # EIP-8037: on top-level OOG, execution state gas is returned to the
-    # reservoir and not billed. The callee's SSTORE contributes state
-    # gas that gets refunded on failure.
     expected_gas = tx_gas_limit
-    if not successful and fork.is_eip_enabled(8037):
-        expected_gas -= fork.sstore_state_gas()
     return Transaction(
         sender=sender,
         to=caller_address,

--- a/tests/frontier/create/test_create_deposit_oog.py
+++ b/tests/frontier/create/test_create_deposit_oog.py
@@ -60,19 +60,14 @@ def test_create_deposit_oog(
         factory_memory_expansion_code + factory_create_code + Op.STOP
     )
 
-    factory_address = pre.deploy_contract(code=factory_code, label="factory")
+    factory_address = pre.deploy_contract(code=factory_code)
     create_gas = return_code.gas_cost(fork) + expand_memory_code.gas_cost(fork)
     if not enough_gas:
         create_gas -= 1
     if fork >= TangerineWhistle:
         # Increment the gas for the 63/64 rule
         create_gas = (create_gas * 64) // 63
-    call_gas = create_gas + factory_code.regular_cost(fork)
-    if fork.is_eip_enabled(8037) and enough_gas:
-        # On success, factory's own frame-end byte_delta covers the new
-        # account + deposited code, charging NEW_ACCOUNT × CPSB of state
-        # gas out of gas_left. Add that margin so factory survives.
-        call_gas += fork.gas_costs().NEW_ACCOUNT
+    call_gas = create_gas + factory_code.gas_cost(fork)
     caller_address = pre.deploy_contract(
         code=Op.CALL(
             gas=call_gas, address=factory_address, ret_offset=0, ret_size=32
@@ -96,17 +91,9 @@ def test_create_deposit_oog(
     )
 
     created_account: Account | None = Account(code=b"\x00" * deposited_len)
-    if fork.is_eip_enabled(8037):
-        # Under EIP-8037 we charge for the new account being created at the
-        # parent frame, so to avoid that charge and being able to return from
-        # the parent successfully, we pre-fund the created contract's address.
-        pre.fund_address(new_address, 1)
     if not enough_gas:
         if fork > Frontier:
-            if fork.is_eip_enabled(8037):
-                created_account = Account(balance=1)
-            else:
-                created_account = None
+            created_account = None
         else:
             # At Frontier, OOG on return yields an empty account.
             created_account = Account()

--- a/tests/frontier/create/test_create_deposit_oog.py
+++ b/tests/frontier/create/test_create_deposit_oog.py
@@ -60,14 +60,19 @@ def test_create_deposit_oog(
         factory_memory_expansion_code + factory_create_code + Op.STOP
     )
 
-    factory_address = pre.deploy_contract(code=factory_code)
+    factory_address = pre.deploy_contract(code=factory_code, label="factory")
     create_gas = return_code.gas_cost(fork) + expand_memory_code.gas_cost(fork)
     if not enough_gas:
         create_gas -= 1
     if fork >= TangerineWhistle:
         # Increment the gas for the 63/64 rule
         create_gas = (create_gas * 64) // 63
-    call_gas = create_gas + factory_code.gas_cost(fork)
+    call_gas = create_gas + factory_code.regular_cost(fork)
+    if fork.is_eip_enabled(8037) and enough_gas:
+        # On success, factory's own frame-end byte_delta covers the new
+        # account + deposited code, charging NEW_ACCOUNT × CPSB of state
+        # gas out of gas_left. Add that margin so factory survives.
+        call_gas += fork.gas_costs().NEW_ACCOUNT
     caller_address = pre.deploy_contract(
         code=Op.CALL(
             gas=call_gas, address=factory_address, ret_offset=0, ret_size=32
@@ -91,9 +96,17 @@ def test_create_deposit_oog(
     )
 
     created_account: Account | None = Account(code=b"\x00" * deposited_len)
+    if fork.is_eip_enabled(8037):
+        # Under EIP-8037 we charge for the new account being created at the
+        # parent frame, so to avoid that charge and being able to return from
+        # the parent successfully, we pre-fund the created contract's address.
+        pre.fund_address(new_address, 1)
     if not enough_gas:
         if fork > Frontier:
-            created_account = None
+            if fork.is_eip_enabled(8037):
+                created_account = Account(balance=1)
+            else:
+                created_account = None
         else:
             # At Frontier, OOG on return yields an empty account.
             created_account = Account()

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -148,6 +148,11 @@ def test_call_memory_expands_on_early_revert(
         ).gas_cost(fork)
         - gsc.CALL_STIPEND
     )
+    if fork.is_eip_enabled(8037):
+        # EIP-8037 reclassifies NEW_ACCOUNT as state-gas paid at the new
+        # account's frame end. This CALL early-reverts on the balance check,
+        # so the cost is never paid, and we must subtract that out.
+        call_cost -= gsc.NEW_ACCOUNT
 
     # mstore cost: base cost. No memory expansion cost needed, it was expanded
     # on CALL.
@@ -155,6 +160,9 @@ def test_call_memory_expands_on_early_revert(
     state_test(
         env=Environment(),
         pre=pre,
+        # EIP-8037 reclassifies NEW_ACCOUNT as state-gas paid at the new
+        # account's frame end. This CALL early-reverts on the balance check,
+        # so the cost is never paid.
         tx=tx,
         post={
             contract: Account(

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -148,11 +148,6 @@ def test_call_memory_expands_on_early_revert(
         ).gas_cost(fork)
         - gsc.CALL_STIPEND
     )
-    if fork.is_eip_enabled(8037):
-        # EIP-8037 reclassifies NEW_ACCOUNT as state-gas paid at the new
-        # account's frame end. This CALL early-reverts on the balance check,
-        # so the cost is never paid, and we must subtract that out.
-        call_cost -= gsc.NEW_ACCOUNT
 
     # mstore cost: base cost. No memory expansion cost needed, it was expanded
     # on CALL.
@@ -160,9 +155,6 @@ def test_call_memory_expands_on_early_revert(
     state_test(
         env=Environment(),
         pre=pre,
-        # EIP-8037 reclassifies NEW_ACCOUNT as state-gas paid at the new
-        # account's frame end. This CALL early-reverts on the balance check,
-        # so the cost is never paid.
         tx=tx,
         post={
             contract: Account(

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -84,25 +84,7 @@ def sufficient_gas(
     """
     is_value_call = callee_opcode in [Op.CALL, Op.CALLCODE]
 
-    if (
-        fork.is_eip_enabled(8037)
-        and is_value_call
-        and callee_opcode == Op.CALL
-    ):
-        # EIP-8037 moves NEW_ACCOUNT off the CALL static gate. The new
-        # account is created by `move_ether` before the grandchild's
-        # diff snapshot, so the +112-byte delta lands at the *callee's*
-        # frame end. The grandchild has no code and runs no opcodes, so
-        # it returns its (forward + stipend) gas to the callee intact;
-        # the only net drain through the CALL is `static_cost - stipend`.
-        # `sufficient_gas` therefore needs `NEW_ACCOUNT - stipend` of
-        # extra budget on top of the static cost so that the callee
-        # has exactly `NEW_ACCOUNT` gas left when the state-gas charge
-        # lands; one gas short tips it into OOG.
-        gas_costs = fork.gas_costs()
-        static_cost = gas_costs.COLD_ACCOUNT_ACCESS + gas_costs.CALL_VALUE
-        cost = static_cost + gas_costs.NEW_ACCOUNT - gas_costs.CALL_STIPEND
-    elif fork >= Berlin:
+    if fork >= Berlin:
         metadata: dict = {"address_warm": False}
         if is_value_call:
             metadata["value_transfer"] = True

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -84,7 +84,25 @@ def sufficient_gas(
     """
     is_value_call = callee_opcode in [Op.CALL, Op.CALLCODE]
 
-    if fork >= Berlin:
+    if (
+        fork.is_eip_enabled(8037)
+        and is_value_call
+        and callee_opcode == Op.CALL
+    ):
+        # EIP-8037 moves NEW_ACCOUNT off the CALL static gate. The new
+        # account is created by `move_ether` before the grandchild's
+        # diff snapshot, so the +112-byte delta lands at the *callee's*
+        # frame end. The grandchild has no code and runs no opcodes, so
+        # it returns its (forward + stipend) gas to the callee intact;
+        # the only net drain through the CALL is `static_cost - stipend`.
+        # `sufficient_gas` therefore needs `NEW_ACCOUNT - stipend` of
+        # extra budget on top of the static cost so that the callee
+        # has exactly `NEW_ACCOUNT` gas left when the state-gas charge
+        # lands; one gas short tips it into OOG.
+        gas_costs = fork.gas_costs()
+        static_cost = gas_costs.COLD_ACCOUNT_ACCESS + gas_costs.CALL_VALUE
+        cost = static_cost + gas_costs.NEW_ACCOUNT - gas_costs.CALL_STIPEND
+    elif fork >= Berlin:
         metadata: dict = {"address_warm": False}
         if is_value_call:
             metadata["value_transfer"] = True

--- a/tests/paris/eip7610_create_collision/test_collision_selfdestruct.py
+++ b/tests/paris/eip7610_create_collision/test_collision_selfdestruct.py
@@ -80,7 +80,7 @@ def test_selfdestruct_after_create2_collision(
         # Call target to trigger SELFDESTRUCT
         + Op.SSTORE(
             storage.store_next(1, "selfdestruct_call_success"),
-            Op.CALL(gas=100_000, address=target_address),
+            Op.CALL(gas=500_000, address=target_address),
         )
         + Op.STOP
     )

--- a/tests/ported_static/amsterdam_skip_list.txt
+++ b/tests/ported_static/amsterdam_skip_list.txt
@@ -8,7 +8,7 @@
 # Entries are substring-matched against each pytest nodeid (after
 # stripping the fixture-format suffix in conftest.py).
 #
-# Total entries: 5469
+# Total entries: 5479
 
 # stAttackTest (2)
 stAttackTest/test_contract_creation_spam.py::test_contract_creation_spam[fork_Amsterdam]
@@ -133,7 +133,7 @@ stCreate2/test_revert_depth_create_address_collision.py::test_revert_depth_creat
 stCreate2/test_revert_depth_create_address_collision_berlin.py::test_revert_depth_create_address_collision_berlin[fork_Amsterdam-d1-g1-v0]
 stCreate2/test_revert_depth_create_address_collision_berlin.py::test_revert_depth_create_address_collision_berlin[fork_Amsterdam-d1-g1-v1]
 
-# stCreateTest (61)
+# stCreateTest (65)
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-0xef-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-code-too-big-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-contructor-revert-v1]
@@ -141,14 +141,18 @@ stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_af
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-high-nonce-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-invalid-opcode-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-ok-v1]
+stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-oog-constructor-v0]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-oog-constructor-v1]
+stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-oog-post-constr-v0]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create-oog-post-constr-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-0xef-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-code-too-big-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-contructor-revert-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-invalid-opcode-v1]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-ok-v1]
+stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-oog-constructor-v0]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-oog-constructor-v1]
+stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-oog-post-constr-v0]
 stCreateTest/test_create_address_warm_after_fail.py::test_create_address_warm_after_fail[fork_Amsterdam-create2-oog-post-constr-v1]
 stCreateTest/test_create_collision_to_empty2.py::test_create_collision_to_empty2[fork_Amsterdam-d0-g0-v0]
 stCreateTest/test_create_collision_to_empty2.py::test_create_collision_to_empty2[fork_Amsterdam-d0-g0-v1]
@@ -345,8 +349,9 @@ stInitCodeTest/test_out_of_gas_prefunded_contract_creation.py::test_out_of_gas_p
 stInitCodeTest/test_transaction_create_auto_suicide_contract.py::test_transaction_create_auto_suicide_contract[fork_Amsterdam]
 stInitCodeTest/test_transaction_create_stop_in_initcode.py::test_transaction_create_stop_in_initcode[fork_Amsterdam]
 
-# stMemExpandingEIP150Calls (3)
+# stMemExpandingEIP150Calls (4)
 stMemExpandingEIP150Calls/test_call_ask_more_gas_on_depth2_then_transaction_has_with_mem_expanding_calls.py::test_call_ask_more_gas_on_depth2_then_transaction_has_with_mem_expanding_calls[fork_Amsterdam]
+stMemExpandingEIP150Calls/test_call_goes_oog_on_second_level_with_mem_expanding_calls.py::test_call_goes_oog_on_second_level_with_mem_expanding_calls[fork_Amsterdam]
 stMemExpandingEIP150Calls/test_create_and_gas_inside_create_with_mem_expanding_calls.py::test_create_and_gas_inside_create_with_mem_expanding_calls[fork_Amsterdam]
 stMemExpandingEIP150Calls/test_new_gas_price_for_codes_with_mem_expanding_calls.py::test_new_gas_price_for_codes_with_mem_expanding_calls[fork_Amsterdam]
 
@@ -409,6 +414,9 @@ stPreCompiledContracts2/test_modexp_0_0_0_22000.py::test_modexp_0_0_0_22000[fork
 stPreCompiledContracts2/test_modexp_0_0_0_25000.py::test_modexp_0_0_0_25000[fork_Amsterdam--g0]
 stPreCompiledContracts2/test_modexp_0_0_0_35000.py::test_modexp_0_0_0_35000[fork_Amsterdam--g0]
 
+# stRecursiveCreate (1)
+stRecursiveCreate/test_recursive_create.py::test_recursive_create[fork_Amsterdam]
+
 # stRefundTest (7)
 stRefundTest/test_refund50_2.py::test_refund50_2[fork_Amsterdam]
 stRefundTest/test_refund50percent_cap.py::test_refund50percent_cap[fork_Amsterdam]
@@ -418,7 +426,10 @@ stRefundTest/test_refund_suicide50procent_cap.py::test_refund_suicide50procent_c
 stRefundTest/test_refund_suicide50procent_cap.py::test_refund_suicide50procent_cap[fork_Amsterdam-d1]
 stRefundTest/test_refund_tx_to_suicide.py::test_refund_tx_to_suicide[fork_Amsterdam]
 
-# stRevertTest (4)
+# stRevertTest (7)
+stRevertTest/test_revert_depth2.py::test_revert_depth2[fork_Amsterdam--g1]
+stRevertTest/test_revert_depth_create_address_collision.py::test_revert_depth_create_address_collision[fork_Amsterdam-d1-g1-v0]
+stRevertTest/test_revert_depth_create_address_collision.py::test_revert_depth_create_address_collision[fork_Amsterdam-d1-g1-v1]
 stRevertTest/test_revert_depth_create_oog.py::test_revert_depth_create_oog[fork_Amsterdam-d1-g1-v0]
 stRevertTest/test_revert_depth_create_oog.py::test_revert_depth_create_oog[fork_Amsterdam-d1-g1-v1]
 stRevertTest/test_revert_opcode_in_init.py::test_revert_opcode_in_init[fork_Amsterdam--v0]
@@ -611,6 +622,9 @@ stSStoreTest/test_sstore_xto_yto_z.py::test_sstore_xto_yto_z[fork_Amsterdam-d2-g
 stSStoreTest/test_sstore_xto_yto_z.py::test_sstore_xto_yto_z[fork_Amsterdam-d2-g1]
 stSStoreTest/test_sstore_xto_yto_z.py::test_sstore_xto_yto_z[fork_Amsterdam-d3-g0]
 stSStoreTest/test_sstore_xto_yto_z.py::test_sstore_xto_yto_z[fork_Amsterdam-d4-g0]
+
+# stSolidityTest (1)
+stSolidityTest/test_recursive_create_contracts.py::test_recursive_create_contracts[fork_Amsterdam]
 
 # stSpecialTest (1)
 stSpecialTest/test_make_money.py::test_make_money[fork_Amsterdam]

--- a/tests/ported_static/stCallCodes/test_callcallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcallcallcode_abcb_recursive.py
@@ -116,7 +116,12 @@ def test_callcallcallcode_abcb_recursive(
     post = {
         target: Account(storage={0: 1, 1: 0}),
         addr: Account(storage={1: 1, 2: 0}),
-        addr_2: Account(storage={1: 0, 2: 0}),
+        addr_2: Account(
+            storage={
+                1: 0,
+                2: 0,
+            }
+        ),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stCallCodes/test_callcodecallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcallcode_abcb_recursive.py
@@ -116,7 +116,12 @@ def test_callcodecallcallcode_abcb_recursive(
     post = {
         target: Account(storage={0: 1, 1: 1}),
         addr: Account(storage={1: 0, 2: 0}),
-        addr_2: Account(storage={1: 0, 2: 0}),
+        addr_2: Account(
+            storage={
+                1: 0,
+                2: 0,
+            }
+        ),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stCallCodes/test_callcodecallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcodecall_abcb_recursive.py
@@ -114,8 +114,13 @@ def test_callcodecallcodecall_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
-        addr: Account(storage={1: 0, 2: 0}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
+        addr: Account(
+            storage={
+                1: 0,
+                2: 0,
+            }
+        ),
         addr_2: Account(storage={1: 0, 2: 0}),
     }
 

--- a/tests/ported_static/stCallCodes/test_callcodecallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcodecallcode_abcb_recursive.py
@@ -116,7 +116,7 @@ def test_callcodecallcodecallcode_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
     }

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcallcode_abcb_recursive.py
@@ -115,7 +115,7 @@ def test_callcallcallcode_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
     }

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecall_abcb_recursive.py
@@ -115,7 +115,7 @@ def test_callcallcodecall_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
     }

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecallcode_abcb_recursive.py
@@ -114,7 +114,7 @@ def test_callcallcodecallcode_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
     }

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcallcode_abcb_recursive.py
@@ -114,7 +114,7 @@ def test_callcodecallcallcode_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
         sender: Account(storage={1: 0}),

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecall_abcb_recursive.py
@@ -114,7 +114,7 @@ def test_callcodecallcodecall_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
         sender: Account(storage={1: 0}),

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecallcode_abcb_recursive.py
@@ -113,7 +113,7 @@ def test_callcodecallcodecallcode_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
         sender: Account(storage={1: 0}),

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcallcode_abcb_recursive.py
@@ -117,7 +117,12 @@ def test_callcallcallcode_abcb_recursive(
     post = {
         target: Account(storage={0: 1, 1: 0}),
         addr: Account(storage={1: 1, 2: 0}),
-        addr_2: Account(storage={1: 0, 2: 0}),
+        addr_2: Account(
+            storage={
+                1: 0,
+                2: 0,
+            }
+        ),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcallcode_abcb_recursive.py
@@ -116,7 +116,12 @@ def test_callcodecallcallcode_abcb_recursive(
     post = {
         target: Account(storage={0: 1, 1: 1}),
         addr: Account(storage={1: 0, 2: 0}),
-        addr_2: Account(storage={1: 0, 2: 0}),
+        addr_2: Account(
+            storage={
+                1: 0,
+                2: 0,
+            }
+        ),
         sender: Account(storage={1: 0}),
     }
 

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecall_abcb_recursive.py
@@ -114,8 +114,13 @@ def test_callcodecallcodecall_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
-        addr: Account(storage={1: 0, 2: 0}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
+        addr: Account(
+            storage={
+                1: 0,
+                2: 0,
+            }
+        ),
         addr_2: Account(storage={1: 0, 2: 0}),
         sender: Account(storage={1: 0}),
     }

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecallcode_abcb_recursive.py
@@ -113,7 +113,7 @@ def test_callcodecallcodecallcode_abcb_recursive(
     )
 
     post = {
-        target: Account(storage={0: 1, 1: 1}),
+        target: Account(storage={0: 1, 1: 1, 2: 0}),
         addr: Account(storage={1: 0, 2: 0}),
         addr_2: Account(storage={1: 0, 2: 0}),
         sender: Account(storage={1: 0}),

--- a/tests/ported_static/stCodeSizeLimit/test_codesize_oog_invalid_size.py
+++ b/tests/ported_static/stCodeSizeLimit/test_codesize_oog_invalid_size.py
@@ -43,6 +43,7 @@ REFERENCE_SPEC_VERSION = "N/A"
         ),
     ],
 )
+@pytest.mark.pre_alloc_mutable
 def test_codesize_oog_invalid_size(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/ported_static/stCreateTest/test_create_address_warm_after_fail.py
+++ b/tests/ported_static/stCreateTest/test_create_address_warm_after_fail.py
@@ -858,7 +858,12 @@ def test_create_address_warm_after_fail(
         Bytes("52c3fd24") + Hash(0x7),
         Bytes("52c3fd24") + Hash(0x11),
     ]
-    tx_gas = [16777216]
+    # The dispatcher writes to ~14 fresh storage slots; under EIP-8037
+    # each slot's 32-byte cost is settled at frame end out of the
+    # reservoir/`gas_left` (~37_500 gas/slot on Amsterdam). Add that
+    # headroom — `sstore_state_gas` is 0 pre-EIP-8037, so the budget
+    # is unchanged on older forks.
+    tx_gas = [16777216 + 14 * fork.sstore_state_gas()]
     tx_value = [0, 1]
 
     tx = Transaction(

--- a/tests/ported_static/stCreateTest/test_create_collision_to_empty2.py
+++ b/tests/ported_static/stCreateTest/test_create_collision_to_empty2.py
@@ -252,7 +252,13 @@ def test_create_collision_to_empty2(
         Hash(contract_2, left_padding=True),
         Hash(contract_3, left_padding=True),
     ]
-    tx_gas = [600000, 54000]
+    # The `g1` budget is the gas-cliff variant: it must leave the
+    # callee with too little gas to complete CREATE, so the inner
+    # frame OOGs and the d0 attempt rolls back. EIP-8037 cuts
+    # `OPCODE_CREATE_BASE` from 32_000 to 9_000, so reduce the
+    # original 54_000 budget by the same delta to track the cliff.
+    create_base_delta = 32000 - fork.gas_costs().OPCODE_CREATE_BASE
+    tx_gas = [600000, 54000 - create_base_delta]
     tx_value = [0, 1]
 
     tx = Transaction(

--- a/tests/ported_static/stCreateTest/test_create_oo_gafter_init_code_revert2.py
+++ b/tests/ported_static/stCreateTest/test_create_oo_gafter_init_code_revert2.py
@@ -76,17 +76,28 @@ def test_create_oo_gafter_init_code_revert2(
     )
 
     pre[sender] = Account(balance=0xE8D4A51000)
+    # The two CALL budgets below straddle the callee's CREATE base
+    # charge: contract_1 sits ~1_000 gas above so its CREATE+REVERT
+    # completes; contract_2 sits ~1_000 gas below so it OOGs at
+    # CREATE and contract_2 reads zero from the un-written return
+    # buffer. Derived from `fork.gas_costs().OPCODE_CREATE_BASE`
+    # (32_000 pre-EIP-8037, 9_000 on Amsterdam+) so the cliff stays
+    # correct as the constant evolves.
+    create_base = fork.gas_costs().OPCODE_CREATE_BASE
+    contract_1_call_gas = create_base + 1000
+    contract_2_call_gas = create_base - 1000
+
     # Source: lll
     # { (CALL (GAS) (CALLDATALOAD 0) 0 0 0 0 0) }
     contract_0 = pre.deploy_contract(  # noqa: F841
         code=Op.CALL(
             gas=Op.GAS,
-            address=Op.CALLDATALOAD(offset=0x0),
-            value=0x0,
-            args_offset=0x0,
-            args_size=0x0,
-            ret_offset=0x0,
-            ret_size=0x0,
+            address=Op.CALLDATALOAD(offset=0),
+            value=0,
+            args_offset=0,
+            args_size=0,
+            ret_offset=0,
+            ret_size=0,
         )
         + Op.STOP,
         balance=0xE8D4A51000,
@@ -96,9 +107,9 @@ def test_create_oo_gafter_init_code_revert2(
     # Source: lll
     # { (MSTORE 0 0x6460016001556000526005601bf3) (CREATE 0 18 14) (REVERT 0 32) }  # noqa: E501
     contract_3 = pre.deploy_contract(  # noqa: F841
-        code=Op.MSTORE(offset=0x0, value=0x6460016001556000526005601BF3)
-        + Op.POP(Op.CREATE(value=0x0, offset=0x12, size=0xE))
-        + Op.REVERT(offset=0x0, size=0x20)
+        code=Op.MSTORE(offset=0, value=0x6460016001556000526005601BF3)
+        + Op.POP(Op.CREATE(value=0, offset=18, size=14))
+        + Op.REVERT(offset=0, size=32)
         + Op.STOP,
         nonce=0,
         address=Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B),  # noqa: E501
@@ -108,16 +119,16 @@ def test_create_oo_gafter_init_code_revert2(
     contract_1 = pre.deploy_contract(  # noqa: F841
         code=Op.POP(
             Op.CALL(
-                gas=0x80E8,
+                gas=contract_1_call_gas,
                 address=0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B,
-                value=0x0,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x20,
+                value=0,
+                args_offset=0,
+                args_size=0,
+                ret_offset=0,
+                ret_size=32,
             )
         )
-        + Op.SSTORE(key=0x1, value=Op.MLOAD(offset=0x0))
+        + Op.SSTORE(key=1, value=Op.MLOAD(offset=0))
         + Op.STOP,
         storage={1: 255},
         nonce=0,
@@ -128,16 +139,16 @@ def test_create_oo_gafter_init_code_revert2(
     contract_2 = pre.deploy_contract(  # noqa: F841
         code=Op.POP(
             Op.CALL(
-                gas=0x59D8,
+                gas=contract_2_call_gas,
                 address=0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B,
-                value=0x0,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x20,
+                value=0,
+                args_offset=0,
+                args_size=0,
+                ret_offset=0,
+                ret_size=32,
             )
         )
-        + Op.SSTORE(key=0x1, value=Op.MLOAD(offset=0x0))
+        + Op.SSTORE(key=1, value=Op.MLOAD(offset=0))
         + Op.STOP,
         storage={1: 255},
         nonce=0,

--- a/tests/ported_static/stCreateTest/test_transaction_collision_to_empty_but_code.py
+++ b/tests/ported_static/stCreateTest/test_transaction_collision_to_empty_but_code.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Header,
     StateTestFiller,
     Transaction,
 )
@@ -136,4 +137,28 @@ def test_transaction_collision_to_empty_but_code(
         error=_exc,
     )
 
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    # On collision, all execution gas is reclassified to regular and the
+    # tx-time state reservoir is restored. Under EIP-8037 2D gas this
+    # gives header.gas_used = max(intrinsic_regular + execution_gas,
+    # intrinsic_state); pre-EIP-8037 the state component is zero, so the
+    # same expression collapses to tx.gas.
+    intrinsic_total = fork.transaction_intrinsic_cost_calculator()(
+        calldata=bytes(tx_data[d]),
+        contract_creation=True,
+    )
+    intrinsic_state = fork.create_state_gas()
+    intrinsic_regular = intrinsic_total - intrinsic_state
+    execution_gas = tx_gas[g] - intrinsic_total
+    expected_header_gas_used = max(
+        intrinsic_regular + execution_gas, intrinsic_state
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=expected_header_gas_used,
+        ),
+    )

--- a/tests/ported_static/stCreateTest/test_transaction_collision_to_empty_but_nonce.py
+++ b/tests/ported_static/stCreateTest/test_transaction_collision_to_empty_but_nonce.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Header,
     StateTestFiller,
     Transaction,
 )
@@ -104,4 +105,28 @@ def test_transaction_collision_to_empty_but_nonce(
         contract_0: Account(storage={1: 0}, nonce=1),
     }
 
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    # On collision, all execution gas is reclassified to regular and the
+    # tx-time state reservoir is restored. Under EIP-8037 2D gas this
+    # gives header.gas_used = max(intrinsic_regular + execution_gas,
+    # intrinsic_state); pre-EIP-8037 the state component is zero, so the
+    # same expression collapses to tx.gas.
+    intrinsic_total = fork.transaction_intrinsic_cost_calculator()(
+        calldata=bytes(tx_data[d]),
+        contract_creation=True,
+    )
+    intrinsic_state = fork.create_state_gas()
+    intrinsic_regular = intrinsic_total - intrinsic_state
+    execution_gas = tx_gas[g] - intrinsic_total
+    expected_header_gas_used = max(
+        intrinsic_regular + execution_gas, intrinsic_state
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=expected_header_gas_used,
+        ),
+    )

--- a/tests/ported_static/stEIP3607/test_init_colliding_with_non_empty_account.py
+++ b/tests/ported_static/stEIP3607/test_init_colliding_with_non_empty_account.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Header,
     StateTestFiller,
     Transaction,
     compute_create_address,
@@ -163,4 +164,28 @@ def test_init_colliding_with_non_empty_account(
         sender: Account(nonce=1),
     }
 
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    # On collision, all execution gas is reclassified to regular and the
+    # tx-time state reservoir is restored. Under EIP-8037 2D gas this
+    # gives header.gas_used = max(intrinsic_regular + execution_gas,
+    # intrinsic_state); pre-EIP-8037 the state component is zero, so the
+    # same expression collapses to tx.gas.
+    intrinsic_total = fork.transaction_intrinsic_cost_calculator()(
+        calldata=bytes(tx_data[d]),
+        contract_creation=True,
+    )
+    intrinsic_state = fork.create_state_gas()
+    intrinsic_regular = intrinsic_total - intrinsic_state
+    execution_gas = tx_gas[g] - intrinsic_total
+    expected_header_gas_used = max(
+        intrinsic_regular + execution_gas, intrinsic_state
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=expected_header_gas_used,
+        ),
+    )

--- a/tests/ported_static/stInitCodeTest/test_call_recursive_contract.py
+++ b/tests/ported_static/stInitCodeTest/test_call_recursive_contract.py
@@ -3,18 +3,22 @@ Test_call_recursive_contract.
 
 Ported from:
 state_tests/stInitCodeTest/CallRecursiveContractFiller.json
+
+@manually-enhanced: Do not overwrite. This test has been manually reviewed and
+enhanced.
 """
+
+from typing import Generator
 
 import pytest
 from execution_testing import (
-    EOA,
     Account,
     Address,
     Alloc,
-    Bytes,
-    Environment,
+    Fork,
     StateTestFiller,
     Transaction,
+    compute_create_address,
 )
 from execution_testing.vm import Op
 
@@ -22,59 +26,80 @@ REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
 
 
+def recursive_create_calculator(
+    contract: Address, depth: int
+) -> Generator[Address, None, None]:
+    """
+    Calculate the resulting address of a contract creating contracts
+    recursively.
+    """
+    while depth > 0:
+        contract = compute_create_address(address=contract, nonce=1)
+        yield contract
+        depth -= 1
+
+
 @pytest.mark.ported_from(
     ["state_tests/stInitCodeTest/CallRecursiveContractFiller.json"],
 )
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.pre_alloc_mutable
 def test_call_recursive_contract(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_recursive_contract."""
-    coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    contract_0 = Address(0x095E7BAEA6A6C7C4C2DFEB977EFAC326AF552D87)
-    sender = EOA(
-        key=0x45A915E4D060149EB4365960E6A7A45F334393093061116B197E3240065FF2D8
-    )
-
-    env = Environment(
-        fee_recipient=coinbase,
-        number=1,
-        timestamp=1000,
-        prev_randao=0x20000,
-        base_fee_per_gas=10,
-        gas_limit=100000000,
-    )
-
-    pre[sender] = Account(balance=0x989680)
+    sender = pre.fund_eoa()
     # Source: lll
     # {[[ 2 ]](ADDRESS)(CODECOPY 0 0 32)(CREATE 0 0 32)}
-    contract_0 = pre.deploy_contract(  # noqa: F841
+    entry_contract = pre.deploy_contract(
         code=Op.SSTORE(key=0x2, value=Op.ADDRESS)
         + Op.CODECOPY(dest_offset=0x0, offset=0x0, size=0x20)
         + Op.CREATE(value=0x0, offset=0x0, size=0x20)
         + Op.STOP,
-        nonce=40,
-        address=Address(0x095E7BAEA6A6C7C4C2DFEB977EFAC326AF552D87),  # noqa: E501
     )
+
+    gas_limit = 400_000
+    pre_fund_deploy_addresses = False
+    if fork.is_eip_enabled(8037):
+        gas_limit = 2_000_000
+        # In 8037, the cost of creating an account is beared by the parent
+        # creating it, so in order to not run out of gas when we return from
+        # contract creation we pre-fund the accounts. This way they are
+        # already in the trie and don't produce a cost.
+        pre_fund_deploy_addresses = True
 
     tx = Transaction(
         sender=sender,
-        to=contract_0,
-        data=Bytes("00"),
-        gas_limit=400000,
-        value=1,
+        to=entry_contract,
+        gas_limit=gas_limit,
     )
 
+    expected_depth = 5
+    for i, contract in enumerate(
+        recursive_create_calculator(entry_contract, depth=expected_depth + 1)
+    ):
+        if pre_fund_deploy_addresses:
+            pre.fund_address(contract, 1)
+        if i == expected_depth - 1:
+            last_expected_contract = contract
+        elif i == expected_depth:
+            first_unexpected_contract = contract
+
+    first_unexpected_contract_account = Account.NONEXISTENT
+    if pre_fund_deploy_addresses:
+        first_unexpected_contract_account = Account(balance=1, code=b"")
+
     post = {
-        contract_0: Account(storage={2: contract_0}, balance=1, nonce=41),
-        Address(
-            0x1A4C83E1A9834CDC7E4A905FF7F0CF44AED73180
-        ): Account.NONEXISTENT,
-        Address(
-            0x8E3411C91D5DD4081B4846FA2F93808F5AD19686
-        ): Account.NONEXISTENT,
+        entry_contract: Account(
+            storage={2: entry_contract}, balance=0, nonce=2
+        ),
+        last_expected_contract: Account(
+            storage={2: last_expected_contract},
+            balance=1 if pre_fund_deploy_addresses else 0,
+            nonce=2,
+        ),
+        first_unexpected_contract: first_unexpected_contract_account,
     }
 
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

~~Backport changes from `devnets/snobal/6` made during the Soldøgn interop to the `eips/amsterdam/eip-8037` branch. The base branch was also rebased with latest `upstream/forks/amsterdam` in order to have the most up-to-date state here.~~

~~This is a first step towards the updates outlined in #2804. We have to align the branch before we can add the improvements. `devnets/bal/7` will have these changes and we should build them here in the eips branch and merge it into the devnet branch along with the other EIPs.~~

This PR now aims to backport the changes from `devnets/bal/7` back to `eips/amsterdam/eip-8037` once that is updated with the new `bal-devnet-7` spec and tests are released and changes are cleaned up. This does _not_ reflect that yet but will update here once there is progress:

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels)
- [ ] stabilize `bal-devnet-7` spec into `devnets/bal/7` branch
- [ ] backport the EIP-8037 changes into `eips/amsterdam/eip-8037`

#### Cute Animal Picture

<img width="639" height="840" alt="Screenshot 2026-05-05 at 15 42 16" src="https://github.com/user-attachments/assets/89ce2b65-da2c-4422-a197-098061f39666" />