### PR TITLE
chore(test-benchmark): re-enable `blockhash` benchmark

### DIFF
--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -48,7 +48,6 @@ def test_block_context_ops(
     )
 
 
-@pytest.mark.skip(reason="Temporarily disabled pending investigation")
 @pytest.mark.repricing
 @pytest.mark.parametrize(
     "index,chain_length",


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The `blockhash` benchmark was skipped since it takes a long time to generate fixture last November, however, with recent optimizations, i do a experimental release ([link](https://github.com/ethereum/execution-specs/actions/runs/25420154041/job/74560273418), took 8 minutes), it does not take hours for generation. As a result, this PR re-enable `blockhash` benchmark again.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes #1792

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
