### PR TITLE
test(test-benchmark): add `bn128_add` precompile special case benchmarks

### DIFF
--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -54,6 +54,21 @@ from ..helpers import Precompile, concatenate_parameters
             id="bn128_double",
             marks=pytest.mark.repricing,
         ),
+        # Second point is the negative of the first one
+        pytest.param(
+            0x06,
+            concatenate_parameters(
+                [
+                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
+                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
+                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
+                    "2A27BDD69A111C1D033CF8FC8BE1B1142229D40FD218F75E401363953F898AE1",
+                ]
+            ),
+            Precompile.BN128_ADD,
+            id="bn128_add_negative",
+            marks=pytest.mark.repricing,
+        ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L326
         pytest.param(

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -40,6 +40,20 @@ from ..helpers import Precompile, concatenate_parameters
             id="bn128_add",
             marks=pytest.mark.repricing,
         ),
+        pytest.param(
+            0x06,
+            concatenate_parameters(
+                [
+                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
+                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
+                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
+                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
+                ]
+            ),
+            Precompile.BN128_ADD,
+            id="bn128_double",
+            marks=pytest.mark.repricing,
+        ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L326
         pytest.param(


### PR DESCRIPTION
## 🗒️ Description
This adds 2 new benchmark tests regarding the ecAdd precompile. Notably,
we include test cases for the special cases where we
- double a point
- add the negative of a point to itself
These cases are highly likely to require different code paths in most implementations, to we should benchmark them separately.
