### PR TITLE
refactor(test-benchmark): precompile input parameter format

### DIFF
--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -21,7 +21,7 @@ from execution_testing import (
 from py_ecc.bn128 import G1, G2, multiply
 from py_ecc.fields import bn128_FQ2
 
-from tests.benchmark.compute.helpers import Precompile
+from tests.benchmark.compute.helpers import Precompile, concatenate_parameters
 from tests.byzantium.eip196_ec_add_mul.spec import (
     PointG1,
     Scalar,

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -19,22 +19,38 @@ from execution_testing import (
     WhileGas,
 )
 from py_ecc.bn128 import G1, G2, multiply
+from py_ecc.fields import bn128_FQ2
 
-from ..helpers import Precompile, concatenate_parameters
+from tests.benchmark.compute.helpers import Precompile
+from tests.byzantium.eip196_ec_add_mul.spec import (
+    PointG1,
+    Scalar,
+)
+from tests.byzantium.eip196_ec_add_mul.spec import (
+    Spec as EIP196Spec,
+)
+from tests.byzantium.eip197_ec_pairing.spec import (
+    PointG2,
+)
+from tests.byzantium.eip197_ec_pairing.spec import (
+    Spec as EIP197Spec,
+)
 
 
 @pytest.mark.parametrize(
     "precompile_address,calldata,target",
     [
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
-                    "07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED",
-                    "06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7",
-                ]
+            EIP196Spec.ECADD,
+            bytes(
+                PointG1(
+                    x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
+                    y=0x063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266,
+                )
+                + PointG1(
+                    x=0x07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED,
+                    y=0x06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7,
+                )
             ),
             Precompile.BN128_ADD,
             id="bn128_add",
@@ -72,15 +88,8 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L326
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                ]
-            ),
+            EIP196Spec.ECADD,
+            bytes(EIP196Spec.INF_G1 + EIP196Spec.INF_G1),
             Precompile.BN128_ADD,
             id="bn128_add_infinities",
             marks=pytest.mark.repricing,
@@ -88,26 +97,21 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L329
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
-            ),
+            EIP196Spec.ECADD,
+            bytes(EIP196Spec.G1 + EIP196Spec.G1),
             Precompile.BN128_ADD,
             id="bn128_add_1_2",
         ),
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3",
-                    "1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6",
-                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-                ]
+            EIP196Spec.ECMUL,
+            bytes(
+                PointG1(
+                    x=0x1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3,
+                    y=0x1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6,
+                )
+                + Scalar(
+                    x=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                )
             ),
             Precompile.BN128_MUL,
             id="bn128_mul",
@@ -115,27 +119,20 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L335
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
-            ),
+            EIP196Spec.ECMUL,
+            bytes(EIP196Spec.INF_G1 + Scalar(x=2)),
             Precompile.BN128_MUL,
             id="bn128_mul_infinities_2_scalar",
         ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L338
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "25f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd585",
-                ]
+            EIP196Spec.ECMUL,
+            bytes(
+                EIP196Spec.INF_G1
+                + Scalar(
+                    x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
+                )
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_infinities_32_byte_scalar",
@@ -144,27 +141,20 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L341
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
-            ),
+            EIP196Spec.ECMUL,
+            bytes(EIP196Spec.G1 + Scalar(x=2)),
             Precompile.BN128_MUL,
             id="bn128_mul_1_2_2_scalar",
         ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L344
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000001",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                    "25f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd585",
-                ]
+            EIP196Spec.ECMUL,
+            bytes(
+                EIP196Spec.G1
+                + Scalar(
+                    x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
+                )
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_1_2_32_byte_scalar",
@@ -172,13 +162,13 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L347
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf",
-                    "2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b36",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
+            EIP196Spec.ECMUL,
+            bytes(
+                PointG1(
+                    x=0x089142DEBB13C461F61523586A60732D8B69C5B38A3380A74DA7B2961D867DBF,
+                    y=0x2D5FC7BBC013C16D7945F190B232EACC25DA675C0EB093FE6B9F1B4B4E107B36,
+                )
+                + Scalar(x=2)
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_32_byte_coord_and_2_scalar",
@@ -187,53 +177,65 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L350
         pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf",
-                    "2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b36",
-                    "25f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd585",
-                ]
+            EIP196Spec.ECMUL,
+            bytes(
+                PointG1(
+                    x=0x089142DEBB13C461F61523586A60732D8B69C5B38A3380A74DA7B2961D867DBF,
+                    y=0x2D5FC7BBC013C16D7945F190B232EACC25DA675C0EB093FE6B9F1B4B4E107B36,
+                )
+                + Scalar(
+                    x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
+                )
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_32_byte_coord_and_scalar",
             marks=pytest.mark.repricing,
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59",
-                    "3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41",
-                    "209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7",
-                    "04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678",
-                    "2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D",
-                    "120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550",
-                    # Second pairing
-                    "111E129F1CF1097710D41C4AC70FCDFA5BA2023C6FF1CBEAC322DE49D1B6DF7C",
-                    "103188585E2364128FE25C70558F1560F4F9350BAF3959E603CC91486E110936",
-                    "198E9393920D483A7260BFB731FB5D25F1AA493335A9E71297E485B7AEF312C2",
-                    "1800DEEF121F1E76426A00665E5C4479674322D4F75EDADD46DEBD5CD992F6ED",
-                    "090689D0585FF075EC9E99AD690C3395BC4B313370B38EF355ACDADCD122975B",
-                    "12C85EA5DB8C6DEB4AAB71808DCB408FE3D1E7690C43D37B4CE6CC0166FA7DAA",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                # First pairing
+                PointG1(
+                    x=0x1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59,
+                    y=0x3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41,
+                )
+                + PointG2(
+                    x=(
+                        0x209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7,
+                        0x04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678,
+                    ),
+                    y=(
+                        0x2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D,
+                        0x120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550,
+                    ),
+                )
+                # Second pairing
+                + PointG1(
+                    x=0x111E129F1CF1097710D41C4AC70FCDFA5BA2023C6FF1CBEAC322DE49D1B6DF7C,
+                    y=0x103188585E2364128FE25C70558F1560F4F9350BAF3959E603CC91486E110936,
+                )
+                + EIP197Spec.G2
             ),
             Precompile.BN128_PAIRING,
             id="bn128_two_pairings",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59",
-                    "3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41",
-                    "209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7",
-                    "04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678",
-                    "2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D",
-                    "120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                PointG1(
+                    x=0x1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59,
+                    y=0x3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41,
+                )
+                + PointG2(
+                    x=(
+                        0x209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7,
+                        0x04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678,
+                    ),
+                    y=(
+                        0x2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D,
+                        0x120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550,
+                    ),
+                )
             ),
             Precompile.BN128_PAIRING,
             id="bn128_one_pairing",
@@ -241,179 +243,254 @@ from ..helpers import Precompile, concatenate_parameters
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L353
         pytest.param(
-            0x08,
+            EIP197Spec.ECPAIRING,
             [],
             Precompile.BN128_PAIRING,
             id="ec_pairing_zero_input",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da",
-                    "2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6",
-                    "1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc",
-                    "22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9",
-                    "2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90",
-                    "2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e",
-                    # Second pairing
-                    "0000000000000000000000000000000000000000000000000000000000000013",
-                    "0644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd451",
-                    "971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb40",
-                    "91058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc72",
-                    "a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea22",
-                    "3a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc0",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                # First pairing
+                PointG1(
+                    x=0x2CF44499D5D27BB186308B7AF7AF02AC5BC9EEB6A3D147C186B21FB1B76E18DA,
+                    y=0x2C0F001F52110CCFE69108924926E45F0B0C868DF0E7BDE1FE16D3242DC715F6,
+                )
+                + PointG2(
+                    x=(
+                        0x1FB19BB476F6B9E44E2A32234DA8212F61CD63919354BC06AEF31E3CFAFF3EBC,
+                        0x22606845FF186793914E03E21DF544C34FFE2F2F3504DE8A79D9159ECA2D98D9,
+                    ),
+                    y=(
+                        0x2BD368E28381E8ECCB5FA81FC26CF3F048EEA9ABFDD85D7ED3AB3698D63E4F90,
+                        0x2FE02E47887507ADF0FF1743CBAC6BA291E66F59BE6BD763950BB16041A0A85E,
+                    ),
+                )
+                # Second pairing
+                + PointG1(
+                    x=0x0000000000000000000000000000000000000000000000000000000000000013,
+                    y=0x0644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD451,
+                )
+                + PointG2(
+                    x=(
+                        0x971FF0471B09FA93CAAF13CBF443C1AEDE09CC4328F5A62AAD45F40EC133EB40,
+                        0x91058A3141822985733CBDDDFED0FD8D6C104E9E9EFF40BF5ABFEF9AB163BC72,
+                    ),
+                    y=(
+                        0xA23AF9A5CE2BA2796C1F4E453A370EB0AF8C212D9DC9ACD8FC02C2E907BAEA22,
+                        0x3A8EB0B0996252CB548A4487DA97B02422EBC0E834613F954DE6C7E0AFDC1FC0,
+                    ),
+                )
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_2_sets",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters([""]),
+            EIP197Spec.ECPAIRING,
+            b"",
             Precompile.BN128_PAIRING,
             id="ec_pairing_1_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "2371e7d92e9fc444d0e11526f0752b520318c80be68bf0131704b36b7976572e",
-                    "2dca8f05ed5d58e0f2e13c49ae40480c0f99dfcd9268521eea6c81c6387b66c4",
-                    "051a93d697db02afd3dcf8414ecb906a114a2bfdb6b06c95d41798d1801b3cbd",
-                    "2e275fef7a0bdb0a2aea77d8ec5817e66e199b3d55bc0fa308dcdda74e85060b",
-                    "1c7e33c2a72d6e12a31eababad3dbc388525135628102bb64742d9e325f43410",
-                    "115dc41fa10b2dbf99036f252ad6f00e8876b22f02cb4738dc4413b22ea9b2df",
-                    # Second pairing
-                    "09a760ea8f9bd87dc258a949395a03f7d2500c6e72c61f570986328a096b610a",
-                    "148027063c072345298117eb2cb980ad79601db31cc69bba6bcbe4937ada6720",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                # First pairing
+                PointG1(
+                    x=0x2371E7D92E9FC444D0E11526F0752B520318C80BE68BF0131704B36B7976572E,
+                    y=0x2DCA8F05ED5D58E0F2E13C49AE40480C0F99DFCD9268521EEA6C81C6387B66C4,
+                )
+                + PointG2(
+                    x=(
+                        0x051A93D697DB02AFD3DCF8414ECB906A114A2BFDB6B06C95D41798D1801B3CBD,
+                        0x2E275FEF7A0BDB0A2AEA77D8EC5817E66E199B3D55BC0FA308DCDDA74E85060B,
+                    ),
+                    y=(
+                        0x1C7E33C2A72D6E12A31EABABAD3DBC388525135628102BB64742D9E325F43410,
+                        0x115DC41FA10B2DBF99036F252AD6F00E8876B22F02CB4738DC4413B22EA9B2DF,
+                    ),
+                )
+                # Second pairing: G2 generator
+                + PointG1(
+                    x=0x09A760EA8F9BD87DC258A949395A03F7D2500C6E72C61F570986328A096B610A,
+                    y=0x148027063C072345298117EB2CB980AD79601DB31CC69BBA6BCBE4937ADA6720,
+                )
+                + EIP197Spec.G2
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_2_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "0ef4aac9b7954d5fc6eafae7f4f4c2a732ab05b45f8d50d102cee4973f36eb2c",
-                    "23db7d30c99e0a2a7f3bb5cd1f04635aaea58732b58887df93d9239c28230d28",
-                    "2bd99d31a5054f2556d226f2e5ef0e075423d8604178b2e2c08006311caee54f",
-                    "0f11afb0c6073d12d21b13f4f78210e8ca9a66729206d3fcc2c1b04824c425f2",
-                    # Second pairing
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
-                    # Third pairing
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                # First pairing
+                PointG1(x=0, y=0)
+                + PointG2(
+                    x=(
+                        0x0EF4AAC9B7954D5FC6EAFAE7F4F4C2A732AB05B45F8D50D102CEE4973F36EB2C,
+                        0x23DB7D30C99E0A2A7F3BB5CD1F04635AAEA58732B58887DF93D9239C28230D28,
+                    ),
+                    y=(
+                        0x2BD99D31A5054F2556D226F2E5EF0E075423D8604178B2E2C08006311CAEE54F,
+                        0x0F11AFB0C6073D12D21B13F4F78210E8CA9A66729206D3FCC2C1B04824C425F2,
+                    ),
+                )
+                # Second pairing (32 zero + G2 generator = 160 bytes)
+                + bytes(32)
+                + bytes(EIP197Spec.G2)
+                # Third pairing (same structure as second)
+                + bytes(32)
+                + bytes(EIP197Spec.G2)
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_3_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "24ab69f46f3e3333027d67d51af71571141bd5652b9829157a3c5d1268461984",
-                    "0f0e1495665bccf97d627b714e8a49e9c77c21e8d5b383ad7dde7e50040d0f62",
-                    "2cab595b9d579f8b82e433249b83ae1d7b62d7073a4f67cb3aeb9b316988907f",
-                    "1326d1905ffde0c77e8ebd98257aa239b05ae76c8ec7723ec19bbc8282b0debe",
-                    "130502106676b537e01cc356765e91c005d6c4bd1a75f5f6d41d2556c73e56ac",
-                    "2dc4cb08068b4aa5f14b7f1096ab35d5c13d78319ec7e66e9f67a1ff20cbbf03",
-                    # Second pairing
-                    "1459f4140b271cbc8746de9dfcb477d5b72d50ef95bec5fef4a68dd69ddfdb2e",
-                    "2c589584551d16a9723b5d356d1ee2066d10381555cdc739e39efca2612fc544",
-                    "229ab0abdb0a7d1a5f0d93fb36ce41e12a31ba52fd9e3c27bebce524ab6c4e9b",
-                    "00f8756832b244377d06e2d00eeb95ec8096dcfd81f4e4931b50fea23c04a2fe",
-                    "29605352ce973ec48d1ab2c8355643c999b70ff771946078b519c556058c3d56",
-                    "059a65ae6e0189d4e04a966140aa40f781a1345824a90a91bb035e12ad29af1d",
-                    # Third pairing
-                    "1459f4140b271cbc8746de9dfcb477d5b72d50ef95bec5fef4a68dd69ddfdb2e",
-                    "2c589584551d16a9723b5d356d1ee2066d10381555cdc739e39efca2612fc544",
-                    "229ab0abdb0a7d1a5f0d93fb36ce41e12a31ba52fd9e3c27bebce524ab6c4e9b",
-                    "00f8756832b244377d06e2d00eeb95ec8096dcfd81f4e4931b50fea23c04a2fe",
-                    "29605352ce973ec48d1ab2c8355643c999b70ff771946078b519c556058c3d56",
-                    "059a65ae6e0189d4e04a966140aa40f781a1345824a90a91bb035e12ad29af1d",
-                    # Fourth pairing
-                    "24ab69f46f3e3333027d67d51af71571141bd5652b9829157a3c5d1268461984",
-                    "0f0e1495665bccf97d627b714e8a49e9c77c21e8d5b383ad7dde7e50040d0f62",
-                    "2cab595b9d579f8b82e433249b83ae1d7b62d7073a4f67cb3aeb9b316988907f",
-                    "1326d1905ffde0c77e8ebd98257aa239b05ae76c8ec7723ec19bbc8282b0debe",
-                    "130502106676b537e01cc356765e91c005d6c4bd1a75f5f6d41d2556c73e56ac",
-                    "2dc4cb08068b4aa5f14b7f1096ab35d5c13d78319ec7e66e9f67a1ff20cbbf03",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                (
+                    PointG1(
+                        x=0x24AB69F46F3E3333027D67D51AF71571141BD5652B9829157A3C5D1268461984,
+                        y=0x0F0E1495665BCCF97D627B714E8A49E9C77C21E8D5B383AD7DDE7E50040D0F62,
+                    )
+                    + PointG2(
+                        x=(
+                            0x2CAB595B9D579F8B82E433249B83AE1D7B62D7073A4F67CB3AEB9B316988907F,
+                            0x1326D1905FFDE0C77E8EBD98257AA239B05AE76C8EC7723EC19BBC8282B0DEBE,
+                        ),
+                        y=(
+                            0x130502106676B537E01CC356765E91C005D6C4BD1A75F5F6D41D2556C73E56AC,
+                            0x2DC4CB08068B4AA5F14B7F1096AB35D5C13D78319EC7E66E9F67A1FF20CBBF03,
+                        ),
+                    )
+                )
+                + (
+                    PointG1(
+                        x=0x1459F4140B271CBC8746DE9DFCB477D5B72D50EF95BEC5FEF4A68DD69DDFDB2E,
+                        y=0x2C589584551D16A9723B5D356D1EE2066D10381555CDC739E39EFCA2612FC544,
+                    )
+                    + PointG2(
+                        x=(
+                            0x229AB0ABDB0A7D1A5F0D93FB36CE41E12A31BA52FD9E3C27BEBCE524AB6C4E9B,
+                            0x00F8756832B244377D06E2D00EEB95EC8096DCFD81F4E4931B50FEA23C04A2FE,
+                        ),
+                        y=(
+                            0x29605352CE973EC48D1AB2C8355643C999B70FF771946078B519C556058C3D56,
+                            0x059A65AE6E0189D4E04A966140AA40F781A1345824A90A91BB035E12AD29AF1D,
+                        ),
+                    )
+                )
+                + (
+                    PointG1(
+                        x=0x1459F4140B271CBC8746DE9DFCB477D5B72D50EF95BEC5FEF4A68DD69DDFDB2E,
+                        y=0x2C589584551D16A9723B5D356D1EE2066D10381555CDC739E39EFCA2612FC544,
+                    )
+                    + PointG2(
+                        x=(
+                            0x229AB0ABDB0A7D1A5F0D93FB36CE41E12A31BA52FD9E3C27BEBCE524AB6C4E9B,
+                            0x00F8756832B244377D06E2D00EEB95EC8096DCFD81F4E4931B50FEA23C04A2FE,
+                        ),
+                        y=(
+                            0x29605352CE973EC48D1AB2C8355643C999B70FF771946078B519C556058C3D56,
+                            0x059A65AE6E0189D4E04A966140AA40F781A1345824A90A91BB035E12AD29AF1D,
+                        ),
+                    )
+                )
+                + (
+                    PointG1(
+                        x=0x24AB69F46F3E3333027D67D51AF71571141BD5652B9829157A3C5D1268461984,
+                        y=0x0F0E1495665BCCF97D627B714E8A49E9C77C21E8D5B383AD7DDE7E50040D0F62,
+                    )
+                    + PointG2(
+                        x=(
+                            0x2CAB595B9D579F8B82E433249B83AE1D7B62D7073A4F67CB3AEB9B316988907F,
+                            0x1326D1905FFDE0C77E8EBD98257AA239B05AE76C8EC7723EC19BBC8282B0DEBE,
+                        ),
+                        y=(
+                            0x130502106676B537E01CC356765E91C005D6C4BD1A75F5F6D41D2556C73E56AC,
+                            0x2DC4CB08068B4AA5F14B7F1096AB35D5C13D78319EC7E66E9F67A1FF20CBBF03,
+                        ),
+                    )
+                )
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_4_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    # First pairing
-                    "1147057b17237df94a3186435acf66924e1d382b8c935fdd493ceb38c38def73",
-                    "03cd046286139915160357ce5b29b9ea28bfb781b71734455d20ef1a64be76ca",
-                    "0daa7cc4983cf74c94607519df747f61e317307c449bafb6923f6d6a65299a7e",
-                    "1d48db8f275830859fd61370addbc5d5ef3f0ce7491d16918e065f7e3727439d",
-                    "1ca8ac2f4a0f540e5505edbe1d15d13899a2a0dfccb012d068134ac66edec625",
-                    "2162c315417d1d12c9d7028c5619015391003a9006d4d8979784c7af2c4537a3",
-                    # Second pairing
-                    "0d221a19ca86dafa8cb804daff78fd3d1bed30aa32e7d4029b1aa69afda2d750",
-                    "018628c766a98de1d0cca887a6d90303e68a7729490f25f937b76b57624ba0be",
-                    "14550ccf7139312da6fa9eb1259c6365b0bd688a27473ccb42bc5cd6f14c8abd",
-                    "165f8721ee9f614382c8c7edb103c941d3a55c1849c9787f34317777d5d9365b",
-                    "0d19da7439edb573a1b3e357faade63d5d68b6031771fd911459b7ab0bda9d3f",
-                    "25a50a44d10c99c5f107e3b3874f717873cb2d4674699a468204df27c0c50a9a",
-                    # Third pairing
-                    "0d7136c59b907615e1b45cf730fbfd6cf38b7e126e85e52be804620a23ace4fb",
-                    "03e80c29d24ed5cc407329ae093bb1be00f9e3c9332f532bc3658937110d7607",
-                    "2129813bd7247065ac58eac42c81e874044e199f48c12aa749a9fe6bb6e4bddc",
-                    "1b72b9ab4579283e62445555d5b2921424213d09a776152361c46988b82be8a7",
-                    "111bc8198f932e379b8f9825f01af0f5e5cacbf8bfe274bf674f6eaa6e338e04",
-                    "259f58d438fd6391e158c991e155966218e6a432703a84068a32543965749857",
-                    # Fourth pairing
-                    "1ba47a91d487cce77aa78390a295df54d9351637d67810c400415fb374278e3f",
-                    "24318bbc05a4e4d779b9498075841c360c6973c1c51dea254281829bbc9aef33",
-                    "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
-                    "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
-                    "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
-                    "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
-                    # Fifth pairing
-                    "1e219772c16eee72450bbf43e9cadae7bf6b2e6ae6637cfeb1d1e8965287acfb",
-                    "0347e7bf4245debd3d00b6f51d2d50fd718e6769352f4fe1db0efe492fed2fc3",
-                    "24fdcc7d4ed0953e3dad500c7ef9836fc61ded44ba454ec76f0a6d0687f4c1b4",
-                    "282b18f7e59c1db4852e622919b2ce9aa5980ca883eac312049c19a3deb79f6d",
-                    "0c9d6ce303b7811dd7ea506c8fa124837405bd209b8731bda79a66eb7206277b",
-                    "1ac5dac62d2332faa8069faca3b0d27fcdf95d8c8bafc9074ee72b5c1f33aa70",
-                ]
+            EIP197Spec.ECPAIRING,
+            bytes(
+                # First pairing
+                PointG1(
+                    x=0x1147057B17237DF94A3186435ACF66924E1D382B8C935FDD493CEB38C38DEF73,
+                    y=0x03CD046286139915160357CE5B29B9EA28BFB781B71734455D20EF1A64BE76CA,
+                )
+                + PointG2(
+                    x=(
+                        0x0DAA7CC4983CF74C94607519DF747F61E317307C449BAFB6923F6D6A65299A7E,
+                        0x1D48DB8F275830859FD61370ADDBC5D5EF3F0CE7491D16918E065F7E3727439D,
+                    ),
+                    y=(
+                        0x1CA8AC2F4A0F540E5505EDBE1D15D13899A2A0DFCCB012D068134AC66EDEC625,
+                        0x2162C315417D1D12C9D7028C5619015391003A9006D4D8979784C7AF2C4537A3,
+                    ),
+                )
+                # Second pairing
+                + PointG1(
+                    x=0x0D221A19CA86DAFA8CB804DAFF78FD3D1BED30AA32E7D4029B1AA69AFDA2D750,
+                    y=0x018628C766A98DE1D0CCA887A6D90303E68A7729490F25F937B76B57624BA0BE,
+                )
+                + PointG2(
+                    x=(
+                        0x14550CCF7139312DA6FA9EB1259C6365B0BD688A27473CCB42BC5CD6F14C8ABD,
+                        0x165F8721EE9F614382C8C7EDB103C941D3A55C1849C9787F34317777D5D9365B,
+                    ),
+                    y=(
+                        0x0D19DA7439EDB573A1B3E357FAADE63D5D68B6031771FD911459B7AB0BDA9D3F,
+                        0x25A50A44D10C99C5F107E3B3874F717873CB2D4674699A468204DF27C0C50A9A,
+                    ),
+                )
+                # Third pairing
+                + PointG1(
+                    x=0x0D7136C59B907615E1B45CF730FBFD6CF38B7E126E85E52BE804620A23ACE4FB,
+                    y=0x03E80C29D24ED5CC407329AE093BB1BE00F9E3C9332F532BC3658937110D7607,
+                )
+                + PointG2(
+                    x=(
+                        0x2129813BD7247065AC58EAC42C81E874044E199F48C12AA749A9FE6BB6E4BDDC,
+                        0x1B72B9AB4579283E62445555D5B2921424213D09A776152361C46988B82BE8A7,
+                    ),
+                    y=(
+                        0x111BC8198F932E379B8F9825F01AF0F5E5CACBF8BFE274BF674F6EAA6E338E04,
+                        0x259F58D438FD6391E158C991E155966218E6A432703A84068A32543965749857,
+                    ),
+                )
+                # Fourth pairing: G2 generator
+                + PointG1(
+                    x=0x1BA47A91D487CCE77AA78390A295DF54D9351637D67810C400415FB374278E3F,
+                    y=0x24318BBC05A4E4D779B9498075841C360C6973C1C51DEA254281829BBC9AEF33,
+                )
+                + EIP197Spec.G2
+                # Fifth pairing
+                + PointG1(
+                    x=0x1E219772C16EEE72450BBF43E9CADAE7BF6B2E6AE6637CFEB1D1E8965287ACFB,
+                    y=0x0347E7BF4245DEBD3D00B6F51D2D50FD718E6769352F4FE1DB0EFE492FED2FC3,
+                )
+                + PointG2(
+                    x=(
+                        0x24FDCC7D4ED0953E3DAD500C7EF9836FC61DED44BA454EC76F0A6D0687F4C1B4,
+                        0x282B18F7E59C1DB4852E622919B2CE9AA5980CA883EAC312049C19A3DEB79F6D,
+                    ),
+                    y=(
+                        0x0C9D6CE303B7811DD7EA506C8FA124837405BD209B8731BDA79A66EB7206277B,
+                        0x1AC5DAC62D2332FAA8069FACA3B0D27FCDF95D8C8BAFC9074EE72B5C1F33AA70,
+                    ),
+                )
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_5_pair",
         ),
         pytest.param(
-            0x08,
-            concatenate_parameters(
-                [
-                    "0000000000000000000000000000000000000000000000000000000000000000",
-                ]
-            ),
+            EIP197Spec.ECPAIRING,
+            bytes(32),
             Precompile.BN128_PAIRING,
             id="ec_pairing_1_pair_empty",
         ),
@@ -459,21 +536,25 @@ def _generate_bn128_pairs(n: int, seed: int = 0) -> Bytes:
         assert point_y_affine is not None, (
             "G2 multiplication resulted in point at infinity"
         )
+        assert isinstance(point_y_affine[0], bn128_FQ2)
+        assert isinstance(point_y_affine[1], bn128_FQ2)
 
-        g1_x_bytes = point_x_affine[0].n.to_bytes(32, "big")
-        g1_y_bytes = point_x_affine[1].n.to_bytes(32, "big")
-        g1_serialized = g1_x_bytes + g1_y_bytes
-
-        g2_x_c1_bytes = point_y_affine[0].coeffs[1].n.to_bytes(32, "big")  # type: ignore
-        g2_x_c0_bytes = point_y_affine[0].coeffs[0].n.to_bytes(32, "big")  # type: ignore
-        g2_y_c1_bytes = point_y_affine[1].coeffs[1].n.to_bytes(32, "big")  # type: ignore
-        g2_y_c0_bytes = point_y_affine[1].coeffs[0].n.to_bytes(32, "big")  # type: ignore
-        g2_serialized = (
-            g2_x_c1_bytes + g2_x_c0_bytes + g2_y_c1_bytes + g2_y_c0_bytes
+        g1 = PointG1(
+            x=point_x_affine[0].n,
+            y=point_x_affine[1].n,
+        )
+        g2 = PointG2(
+            x=(
+                int(point_y_affine[0].coeffs[1]),
+                int(point_y_affine[0].coeffs[0]),
+            ),
+            y=(
+                int(point_y_affine[1].coeffs[1]),
+                int(point_y_affine[1].coeffs[0]),
+            ),
         )
 
-        pair_calldata = g1_serialized + g2_serialized
-        calldata = Bytes(calldata + pair_calldata)
+        calldata = Bytes(calldata + bytes(g1 + g2))
 
     return calldata
 
@@ -545,7 +626,7 @@ def test_bn128_pairings_amortized(
 
     setup = Op.CALLDATACOPY(size=Op.CALLDATASIZE)
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x08, 0, Op.CALLDATASIZE, 0, 0)
+        Op.STATICCALL(Op.GAS, EIP197Spec.ECPAIRING, 0, Op.CALLDATASIZE, 0, 0)
     )
 
     benchmark_test(
@@ -572,7 +653,11 @@ def test_alt_bn128_benchmark(
     calldata = _generate_bn128_pairs(num_pairs, seed=42)
 
     attack_block = Op.POP(
-        Op.STATICCALL(gas=Op.GAS, address=0x08, args_size=Op.CALLDATASIZE),
+        Op.STATICCALL(
+            gas=Op.GAS,
+            address=EIP197Spec.ECPAIRING,
+            args_size=Op.CALLDATASIZE,
+        ),
     )
 
     benchmark_test(
@@ -611,7 +696,7 @@ def test_ec_pairing(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x08,
+            address=EIP197Spec.ECPAIRING,
             args_offset=Op.MLOAD(Op.CALLDATASIZE),
             args_size=pair_size,
             # gas accounting
@@ -709,24 +794,24 @@ def _generate_g1_point(seed: int) -> Bytes:
     priv_key = rng.randint(1, 2**32 - 1)
     point = multiply(G1, priv_key)
     assert point is not None
-    return Bytes(
-        point[0].n.to_bytes(32, "big") + point[1].n.to_bytes(32, "big")
-    )
+    return Bytes(PointG1(x=point[0].n, y=point[1].n))
 
 
 @pytest.mark.repricing
 @pytest.mark.parametrize(
     "precompile_address,scalar,target",
     [
-        pytest.param(0x06, None, Precompile.BN128_ADD, id="ec_add"),
         pytest.param(
-            0x07,
+            EIP196Spec.ECADD, None, Precompile.BN128_ADD, id="ec_add"
+        ),
+        pytest.param(
+            EIP196Spec.ECMUL,
             2,
             Precompile.BN128_MUL,
             id="ec_mul_small_scalar",
         ),
         pytest.param(
-            0x07,
+            EIP196Spec.ECMUL,
             2**256 - 1,
             Precompile.BN128_MUL,
             id="ec_mul_max_scalar",
@@ -754,7 +839,7 @@ def test_alt_bn128_uncachable(
     gsc = fork.gas_costs()
     precompile_cost = (
         gsc.PRECOMPILE_ECMUL
-        if precompile_address == 0x07
+        if precompile_address == EIP196Spec.ECMUL
         else gsc.PRECOMPILE_ECADD
     )
     attack_block = Op.POP(

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -21,7 +21,7 @@ from execution_testing import (
 from py_ecc.bn128 import G1, G2, multiply
 from py_ecc.fields import bn128_FQ2
 
-from tests.benchmark.compute.helpers import Precompile, concatenate_parameters
+from tests.benchmark.compute.helpers import Precompile
 from tests.byzantium.eip196_ec_add_mul.spec import (
     PointG1,
     Scalar,
@@ -42,29 +42,27 @@ from tests.byzantium.eip197_ec_pairing.spec import (
     [
         pytest.param(
             EIP196Spec.ECADD,
-            bytes(
-                PointG1(
-                    x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
-                    y=0x063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266,
-                )
-                + PointG1(
-                    x=0x07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED,
-                    y=0x06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7,
-                )
+            PointG1(
+                x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
+                y=0x063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266,
+            )
+            + PointG1(
+                x=0x07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED,
+                y=0x06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7,
             ),
             Precompile.BN128_ADD,
             id="bn128_add",
             marks=pytest.mark.repricing,
         ),
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
-                ]
+            EIP196Spec.ECADD,
+            PointG1(
+                x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
+                y=0x063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266,
+            )
+            + PointG1(
+                x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
+                y=0x063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266,
             ),
             Precompile.BN128_ADD,
             id="bn128_double",
@@ -72,14 +70,14 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         # Second point is the negative of the first one
         pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "2A27BDD69A111C1D033CF8FC8BE1B1142229D40FD218F75E401363953F898AE1",
-                ]
+            EIP196Spec.ECADD,
+            PointG1(
+                x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
+                y=0x063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266,
+            )
+            + PointG1(
+                x=0x18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9,
+                y=0x2A27BDD69A111C1D033CF8FC8BE1B1142229D40FD218F75E401363953F898AE1,
             ),
             Precompile.BN128_ADD,
             id="bn128_add_negative",
@@ -89,7 +87,7 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L326
         pytest.param(
             EIP196Spec.ECADD,
-            bytes(EIP196Spec.INF_G1 + EIP196Spec.INF_G1),
+            EIP196Spec.INF_G1 + EIP196Spec.INF_G1,
             Precompile.BN128_ADD,
             id="bn128_add_infinities",
             marks=pytest.mark.repricing,
@@ -98,20 +96,18 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L329
         pytest.param(
             EIP196Spec.ECADD,
-            bytes(EIP196Spec.G1 + EIP196Spec.G1),
+            EIP196Spec.G1 + EIP196Spec.G1,
             Precompile.BN128_ADD,
             id="bn128_add_1_2",
         ),
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(
-                PointG1(
-                    x=0x1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3,
-                    y=0x1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6,
-                )
-                + Scalar(
-                    x=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-                )
+            PointG1(
+                x=0x1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3,
+                y=0x1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6,
+            )
+            + Scalar(
+                x=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
             ),
             Precompile.BN128_MUL,
             id="bn128_mul",
@@ -120,7 +116,7 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L335
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(EIP196Spec.INF_G1 + Scalar(x=2)),
+            EIP196Spec.INF_G1 + Scalar(x=2),
             Precompile.BN128_MUL,
             id="bn128_mul_infinities_2_scalar",
         ),
@@ -128,11 +124,9 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L338
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(
-                EIP196Spec.INF_G1
-                + Scalar(
-                    x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
-                )
+            EIP196Spec.INF_G1
+            + Scalar(
+                x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_infinities_32_byte_scalar",
@@ -142,7 +136,7 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L341
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(EIP196Spec.G1 + Scalar(x=2)),
+            EIP196Spec.G1 + Scalar(x=2),
             Precompile.BN128_MUL,
             id="bn128_mul_1_2_2_scalar",
         ),
@@ -150,11 +144,9 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L344
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(
-                EIP196Spec.G1
-                + Scalar(
-                    x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
-                )
+            EIP196Spec.G1
+            + Scalar(
+                x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_1_2_32_byte_scalar",
@@ -163,13 +155,11 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L347
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(
-                PointG1(
-                    x=0x089142DEBB13C461F61523586A60732D8B69C5B38A3380A74DA7B2961D867DBF,
-                    y=0x2D5FC7BBC013C16D7945F190B232EACC25DA675C0EB093FE6B9F1B4B4E107B36,
-                )
-                + Scalar(x=2)
-            ),
+            PointG1(
+                x=0x089142DEBB13C461F61523586A60732D8B69C5B38A3380A74DA7B2961D867DBF,
+                y=0x2D5FC7BBC013C16D7945F190B232EACC25DA675C0EB093FE6B9F1B4B4E107B36,
+            )
+            + Scalar(x=2),
             Precompile.BN128_MUL,
             id="bn128_mul_32_byte_coord_and_2_scalar",
             marks=pytest.mark.repricing,
@@ -178,14 +168,12 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L350
         pytest.param(
             EIP196Spec.ECMUL,
-            bytes(
-                PointG1(
-                    x=0x089142DEBB13C461F61523586A60732D8B69C5B38A3380A74DA7B2961D867DBF,
-                    y=0x2D5FC7BBC013C16D7945F190B232EACC25DA675C0EB093FE6B9F1B4B4E107B36,
-                )
-                + Scalar(
-                    x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
-                )
+            PointG1(
+                x=0x089142DEBB13C461F61523586A60732D8B69C5B38A3380A74DA7B2961D867DBF,
+                y=0x2D5FC7BBC013C16D7945F190B232EACC25DA675C0EB093FE6B9F1B4B4E107B36,
+            )
+            + Scalar(
+                x=0x25F8C89EA3437F44F8FC8B6BFBB6312074DC6F983809A5E809FF4E1D076DD585
             ),
             Precompile.BN128_MUL,
             id="bn128_mul_32_byte_coord_and_scalar",
@@ -193,49 +181,45 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                # First pairing
-                PointG1(
-                    x=0x1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59,
-                    y=0x3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41,
-                )
-                + PointG2(
-                    x=(
-                        0x209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7,
-                        0x04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678,
-                    ),
-                    y=(
-                        0x2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D,
-                        0x120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550,
-                    ),
-                )
-                # Second pairing
-                + PointG1(
-                    x=0x111E129F1CF1097710D41C4AC70FCDFA5BA2023C6FF1CBEAC322DE49D1B6DF7C,
-                    y=0x103188585E2364128FE25C70558F1560F4F9350BAF3959E603CC91486E110936,
-                )
-                + EIP197Spec.G2
-            ),
+            # First pairing
+            PointG1(
+                x=0x1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59,
+                y=0x3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41,
+            )
+            + PointG2(
+                x=(
+                    0x209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7,
+                    0x04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678,
+                ),
+                y=(
+                    0x2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D,
+                    0x120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550,
+                ),
+            )
+            # Second pairing
+            + PointG1(
+                x=0x111E129F1CF1097710D41C4AC70FCDFA5BA2023C6FF1CBEAC322DE49D1B6DF7C,
+                y=0x103188585E2364128FE25C70558F1560F4F9350BAF3959E603CC91486E110936,
+            )
+            + EIP197Spec.G2,
             Precompile.BN128_PAIRING,
             id="bn128_two_pairings",
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                PointG1(
-                    x=0x1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59,
-                    y=0x3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41,
-                )
-                + PointG2(
-                    x=(
-                        0x209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7,
-                        0x04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678,
-                    ),
-                    y=(
-                        0x2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D,
-                        0x120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550,
-                    ),
-                )
+            PointG1(
+                x=0x1C76476F4DEF4BB94541D57EBBA1193381FFA7AA76ADA664DD31C16024C43F59,
+                y=0x3034DD2920F673E204FEE2811C678745FC819B55D3E9D294E45C9B03A76AEF41,
+            )
+            + PointG2(
+                x=(
+                    0x209DD15EBFF5D46C4BD888E51A93CF99A7329636C63514396B4A452003A35BF7,
+                    0x04BF11CA01483BFA8B34B43561848D28905960114C8AC04049AF4B6315A41678,
+                ),
+                y=(
+                    0x2BB8324AF6CFC93537A2AD1A445CFD0CA2A71ACD7AC41FADBF933C2A51BE344D,
+                    0x120A2A4CF30C1BF9845F20C6FE39E07EA2CCE61F0C9BB048165FE5E4DE877550,
+                ),
             ),
             Precompile.BN128_PAIRING,
             id="bn128_one_pairing",
@@ -250,37 +234,35 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                # First pairing
-                PointG1(
-                    x=0x2CF44499D5D27BB186308B7AF7AF02AC5BC9EEB6A3D147C186B21FB1B76E18DA,
-                    y=0x2C0F001F52110CCFE69108924926E45F0B0C868DF0E7BDE1FE16D3242DC715F6,
-                )
-                + PointG2(
-                    x=(
-                        0x1FB19BB476F6B9E44E2A32234DA8212F61CD63919354BC06AEF31E3CFAFF3EBC,
-                        0x22606845FF186793914E03E21DF544C34FFE2F2F3504DE8A79D9159ECA2D98D9,
-                    ),
-                    y=(
-                        0x2BD368E28381E8ECCB5FA81FC26CF3F048EEA9ABFDD85D7ED3AB3698D63E4F90,
-                        0x2FE02E47887507ADF0FF1743CBAC6BA291E66F59BE6BD763950BB16041A0A85E,
-                    ),
-                )
-                # Second pairing
-                + PointG1(
-                    x=0x0000000000000000000000000000000000000000000000000000000000000013,
-                    y=0x0644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD451,
-                )
-                + PointG2(
-                    x=(
-                        0x971FF0471B09FA93CAAF13CBF443C1AEDE09CC4328F5A62AAD45F40EC133EB40,
-                        0x91058A3141822985733CBDDDFED0FD8D6C104E9E9EFF40BF5ABFEF9AB163BC72,
-                    ),
-                    y=(
-                        0xA23AF9A5CE2BA2796C1F4E453A370EB0AF8C212D9DC9ACD8FC02C2E907BAEA22,
-                        0x3A8EB0B0996252CB548A4487DA97B02422EBC0E834613F954DE6C7E0AFDC1FC0,
-                    ),
-                )
+            # First pairing
+            PointG1(
+                x=0x2CF44499D5D27BB186308B7AF7AF02AC5BC9EEB6A3D147C186B21FB1B76E18DA,
+                y=0x2C0F001F52110CCFE69108924926E45F0B0C868DF0E7BDE1FE16D3242DC715F6,
+            )
+            + PointG2(
+                x=(
+                    0x1FB19BB476F6B9E44E2A32234DA8212F61CD63919354BC06AEF31E3CFAFF3EBC,
+                    0x22606845FF186793914E03E21DF544C34FFE2F2F3504DE8A79D9159ECA2D98D9,
+                ),
+                y=(
+                    0x2BD368E28381E8ECCB5FA81FC26CF3F048EEA9ABFDD85D7ED3AB3698D63E4F90,
+                    0x2FE02E47887507ADF0FF1743CBAC6BA291E66F59BE6BD763950BB16041A0A85E,
+                ),
+            )
+            # Second pairing
+            + PointG1(
+                x=0x0000000000000000000000000000000000000000000000000000000000000013,
+                y=0x0644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD451,
+            )
+            + PointG2(
+                x=(
+                    0x971FF0471B09FA93CAAF13CBF443C1AEDE09CC4328F5A62AAD45F40EC133EB40,
+                    0x91058A3141822985733CBDDDFED0FD8D6C104E9E9EFF40BF5ABFEF9AB163BC72,
+                ),
+                y=(
+                    0xA23AF9A5CE2BA2796C1F4E453A370EB0AF8C212D9DC9ACD8FC02C2E907BAEA22,
+                    0x3A8EB0B0996252CB548A4487DA97B02422EBC0E834613F954DE6C7E0AFDC1FC0,
+                ),
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_2_sets",
@@ -293,123 +275,117 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                # First pairing
-                PointG1(
-                    x=0x2371E7D92E9FC444D0E11526F0752B520318C80BE68BF0131704B36B7976572E,
-                    y=0x2DCA8F05ED5D58E0F2E13C49AE40480C0F99DFCD9268521EEA6C81C6387B66C4,
-                )
-                + PointG2(
-                    x=(
-                        0x051A93D697DB02AFD3DCF8414ECB906A114A2BFDB6B06C95D41798D1801B3CBD,
-                        0x2E275FEF7A0BDB0A2AEA77D8EC5817E66E199B3D55BC0FA308DCDDA74E85060B,
-                    ),
-                    y=(
-                        0x1C7E33C2A72D6E12A31EABABAD3DBC388525135628102BB64742D9E325F43410,
-                        0x115DC41FA10B2DBF99036F252AD6F00E8876B22F02CB4738DC4413B22EA9B2DF,
-                    ),
-                )
-                # Second pairing: G2 generator
-                + PointG1(
-                    x=0x09A760EA8F9BD87DC258A949395A03F7D2500C6E72C61F570986328A096B610A,
-                    y=0x148027063C072345298117EB2CB980AD79601DB31CC69BBA6BCBE4937ADA6720,
-                )
-                + EIP197Spec.G2
-            ),
+            # First pairing
+            PointG1(
+                x=0x2371E7D92E9FC444D0E11526F0752B520318C80BE68BF0131704B36B7976572E,
+                y=0x2DCA8F05ED5D58E0F2E13C49AE40480C0F99DFCD9268521EEA6C81C6387B66C4,
+            )
+            + PointG2(
+                x=(
+                    0x051A93D697DB02AFD3DCF8414ECB906A114A2BFDB6B06C95D41798D1801B3CBD,
+                    0x2E275FEF7A0BDB0A2AEA77D8EC5817E66E199B3D55BC0FA308DCDDA74E85060B,
+                ),
+                y=(
+                    0x1C7E33C2A72D6E12A31EABABAD3DBC388525135628102BB64742D9E325F43410,
+                    0x115DC41FA10B2DBF99036F252AD6F00E8876B22F02CB4738DC4413B22EA9B2DF,
+                ),
+            )
+            # Second pairing: G2 generator
+            + PointG1(
+                x=0x09A760EA8F9BD87DC258A949395A03F7D2500C6E72C61F570986328A096B610A,
+                y=0x148027063C072345298117EB2CB980AD79601DB31CC69BBA6BCBE4937ADA6720,
+            )
+            + EIP197Spec.G2,
             Precompile.BN128_PAIRING,
             id="ec_pairing_2_pair",
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                # First pairing
-                PointG1(x=0, y=0)
-                + PointG2(
-                    x=(
-                        0x0EF4AAC9B7954D5FC6EAFAE7F4F4C2A732AB05B45F8D50D102CEE4973F36EB2C,
-                        0x23DB7D30C99E0A2A7F3BB5CD1F04635AAEA58732B58887DF93D9239C28230D28,
-                    ),
-                    y=(
-                        0x2BD99D31A5054F2556D226F2E5EF0E075423D8604178B2E2C08006311CAEE54F,
-                        0x0F11AFB0C6073D12D21B13F4F78210E8CA9A66729206D3FCC2C1B04824C425F2,
-                    ),
-                )
-                # Second pairing (32 zero + G2 generator = 160 bytes)
-                + bytes(32)
-                + bytes(EIP197Spec.G2)
-                # Third pairing (same structure as second)
-                + bytes(32)
-                + bytes(EIP197Spec.G2)
-            ),
+            # First pairing
+            PointG1(x=0, y=0)
+            + PointG2(
+                x=(
+                    0x0EF4AAC9B7954D5FC6EAFAE7F4F4C2A732AB05B45F8D50D102CEE4973F36EB2C,
+                    0x23DB7D30C99E0A2A7F3BB5CD1F04635AAEA58732B58887DF93D9239C28230D28,
+                ),
+                y=(
+                    0x2BD99D31A5054F2556D226F2E5EF0E075423D8604178B2E2C08006311CAEE54F,
+                    0x0F11AFB0C6073D12D21B13F4F78210E8CA9A66729206D3FCC2C1B04824C425F2,
+                ),
+            )
+            # Second pairing (32 zero + G2 generator = 160 bytes)
+            + bytes(32)
+            + EIP197Spec.G2
+            # Third pairing (same structure as second)
+            + bytes(32)
+            + EIP197Spec.G2,
             Precompile.BN128_PAIRING,
             id="ec_pairing_3_pair",
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                (
-                    PointG1(
-                        x=0x24AB69F46F3E3333027D67D51AF71571141BD5652B9829157A3C5D1268461984,
-                        y=0x0F0E1495665BCCF97D627B714E8A49E9C77C21E8D5B383AD7DDE7E50040D0F62,
-                    )
-                    + PointG2(
-                        x=(
-                            0x2CAB595B9D579F8B82E433249B83AE1D7B62D7073A4F67CB3AEB9B316988907F,
-                            0x1326D1905FFDE0C77E8EBD98257AA239B05AE76C8EC7723EC19BBC8282B0DEBE,
-                        ),
-                        y=(
-                            0x130502106676B537E01CC356765E91C005D6C4BD1A75F5F6D41D2556C73E56AC,
-                            0x2DC4CB08068B4AA5F14B7F1096AB35D5C13D78319EC7E66E9F67A1FF20CBBF03,
-                        ),
-                    )
+            (
+                PointG1(
+                    x=0x24AB69F46F3E3333027D67D51AF71571141BD5652B9829157A3C5D1268461984,
+                    y=0x0F0E1495665BCCF97D627B714E8A49E9C77C21E8D5B383AD7DDE7E50040D0F62,
                 )
-                + (
-                    PointG1(
-                        x=0x1459F4140B271CBC8746DE9DFCB477D5B72D50EF95BEC5FEF4A68DD69DDFDB2E,
-                        y=0x2C589584551D16A9723B5D356D1EE2066D10381555CDC739E39EFCA2612FC544,
-                    )
-                    + PointG2(
-                        x=(
-                            0x229AB0ABDB0A7D1A5F0D93FB36CE41E12A31BA52FD9E3C27BEBCE524AB6C4E9B,
-                            0x00F8756832B244377D06E2D00EEB95EC8096DCFD81F4E4931B50FEA23C04A2FE,
-                        ),
-                        y=(
-                            0x29605352CE973EC48D1AB2C8355643C999B70FF771946078B519C556058C3D56,
-                            0x059A65AE6E0189D4E04A966140AA40F781A1345824A90A91BB035E12AD29AF1D,
-                        ),
-                    )
+                + PointG2(
+                    x=(
+                        0x2CAB595B9D579F8B82E433249B83AE1D7B62D7073A4F67CB3AEB9B316988907F,
+                        0x1326D1905FFDE0C77E8EBD98257AA239B05AE76C8EC7723EC19BBC8282B0DEBE,
+                    ),
+                    y=(
+                        0x130502106676B537E01CC356765E91C005D6C4BD1A75F5F6D41D2556C73E56AC,
+                        0x2DC4CB08068B4AA5F14B7F1096AB35D5C13D78319EC7E66E9F67A1FF20CBBF03,
+                    ),
                 )
-                + (
-                    PointG1(
-                        x=0x1459F4140B271CBC8746DE9DFCB477D5B72D50EF95BEC5FEF4A68DD69DDFDB2E,
-                        y=0x2C589584551D16A9723B5D356D1EE2066D10381555CDC739E39EFCA2612FC544,
-                    )
-                    + PointG2(
-                        x=(
-                            0x229AB0ABDB0A7D1A5F0D93FB36CE41E12A31BA52FD9E3C27BEBCE524AB6C4E9B,
-                            0x00F8756832B244377D06E2D00EEB95EC8096DCFD81F4E4931B50FEA23C04A2FE,
-                        ),
-                        y=(
-                            0x29605352CE973EC48D1AB2C8355643C999B70FF771946078B519C556058C3D56,
-                            0x059A65AE6E0189D4E04A966140AA40F781A1345824A90A91BB035E12AD29AF1D,
-                        ),
-                    )
+            )
+            + (
+                PointG1(
+                    x=0x1459F4140B271CBC8746DE9DFCB477D5B72D50EF95BEC5FEF4A68DD69DDFDB2E,
+                    y=0x2C589584551D16A9723B5D356D1EE2066D10381555CDC739E39EFCA2612FC544,
                 )
-                + (
-                    PointG1(
-                        x=0x24AB69F46F3E3333027D67D51AF71571141BD5652B9829157A3C5D1268461984,
-                        y=0x0F0E1495665BCCF97D627B714E8A49E9C77C21E8D5B383AD7DDE7E50040D0F62,
-                    )
-                    + PointG2(
-                        x=(
-                            0x2CAB595B9D579F8B82E433249B83AE1D7B62D7073A4F67CB3AEB9B316988907F,
-                            0x1326D1905FFDE0C77E8EBD98257AA239B05AE76C8EC7723EC19BBC8282B0DEBE,
-                        ),
-                        y=(
-                            0x130502106676B537E01CC356765E91C005D6C4BD1A75F5F6D41D2556C73E56AC,
-                            0x2DC4CB08068B4AA5F14B7F1096AB35D5C13D78319EC7E66E9F67A1FF20CBBF03,
-                        ),
-                    )
+                + PointG2(
+                    x=(
+                        0x229AB0ABDB0A7D1A5F0D93FB36CE41E12A31BA52FD9E3C27BEBCE524AB6C4E9B,
+                        0x00F8756832B244377D06E2D00EEB95EC8096DCFD81F4E4931B50FEA23C04A2FE,
+                    ),
+                    y=(
+                        0x29605352CE973EC48D1AB2C8355643C999B70FF771946078B519C556058C3D56,
+                        0x059A65AE6E0189D4E04A966140AA40F781A1345824A90A91BB035E12AD29AF1D,
+                    ),
+                )
+            )
+            + (
+                PointG1(
+                    x=0x1459F4140B271CBC8746DE9DFCB477D5B72D50EF95BEC5FEF4A68DD69DDFDB2E,
+                    y=0x2C589584551D16A9723B5D356D1EE2066D10381555CDC739E39EFCA2612FC544,
+                )
+                + PointG2(
+                    x=(
+                        0x229AB0ABDB0A7D1A5F0D93FB36CE41E12A31BA52FD9E3C27BEBCE524AB6C4E9B,
+                        0x00F8756832B244377D06E2D00EEB95EC8096DCFD81F4E4931B50FEA23C04A2FE,
+                    ),
+                    y=(
+                        0x29605352CE973EC48D1AB2C8355643C999B70FF771946078B519C556058C3D56,
+                        0x059A65AE6E0189D4E04A966140AA40F781A1345824A90A91BB035E12AD29AF1D,
+                    ),
+                )
+            )
+            + (
+                PointG1(
+                    x=0x24AB69F46F3E3333027D67D51AF71571141BD5652B9829157A3C5D1268461984,
+                    y=0x0F0E1495665BCCF97D627B714E8A49E9C77C21E8D5B383AD7DDE7E50040D0F62,
+                )
+                + PointG2(
+                    x=(
+                        0x2CAB595B9D579F8B82E433249B83AE1D7B62D7073A4F67CB3AEB9B316988907F,
+                        0x1326D1905FFDE0C77E8EBD98257AA239B05AE76C8EC7723EC19BBC8282B0DEBE,
+                    ),
+                    y=(
+                        0x130502106676B537E01CC356765E91C005D6C4BD1A75F5F6D41D2556C73E56AC,
+                        0x2DC4CB08068B4AA5F14B7F1096AB35D5C13D78319EC7E66E9F67A1FF20CBBF03,
+                    ),
                 )
             ),
             Precompile.BN128_PAIRING,
@@ -417,73 +393,71 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(
-                # First pairing
-                PointG1(
-                    x=0x1147057B17237DF94A3186435ACF66924E1D382B8C935FDD493CEB38C38DEF73,
-                    y=0x03CD046286139915160357CE5B29B9EA28BFB781B71734455D20EF1A64BE76CA,
-                )
-                + PointG2(
-                    x=(
-                        0x0DAA7CC4983CF74C94607519DF747F61E317307C449BAFB6923F6D6A65299A7E,
-                        0x1D48DB8F275830859FD61370ADDBC5D5EF3F0CE7491D16918E065F7E3727439D,
-                    ),
-                    y=(
-                        0x1CA8AC2F4A0F540E5505EDBE1D15D13899A2A0DFCCB012D068134AC66EDEC625,
-                        0x2162C315417D1D12C9D7028C5619015391003A9006D4D8979784C7AF2C4537A3,
-                    ),
-                )
-                # Second pairing
-                + PointG1(
-                    x=0x0D221A19CA86DAFA8CB804DAFF78FD3D1BED30AA32E7D4029B1AA69AFDA2D750,
-                    y=0x018628C766A98DE1D0CCA887A6D90303E68A7729490F25F937B76B57624BA0BE,
-                )
-                + PointG2(
-                    x=(
-                        0x14550CCF7139312DA6FA9EB1259C6365B0BD688A27473CCB42BC5CD6F14C8ABD,
-                        0x165F8721EE9F614382C8C7EDB103C941D3A55C1849C9787F34317777D5D9365B,
-                    ),
-                    y=(
-                        0x0D19DA7439EDB573A1B3E357FAADE63D5D68B6031771FD911459B7AB0BDA9D3F,
-                        0x25A50A44D10C99C5F107E3B3874F717873CB2D4674699A468204DF27C0C50A9A,
-                    ),
-                )
-                # Third pairing
-                + PointG1(
-                    x=0x0D7136C59B907615E1B45CF730FBFD6CF38B7E126E85E52BE804620A23ACE4FB,
-                    y=0x03E80C29D24ED5CC407329AE093BB1BE00F9E3C9332F532BC3658937110D7607,
-                )
-                + PointG2(
-                    x=(
-                        0x2129813BD7247065AC58EAC42C81E874044E199F48C12AA749A9FE6BB6E4BDDC,
-                        0x1B72B9AB4579283E62445555D5B2921424213D09A776152361C46988B82BE8A7,
-                    ),
-                    y=(
-                        0x111BC8198F932E379B8F9825F01AF0F5E5CACBF8BFE274BF674F6EAA6E338E04,
-                        0x259F58D438FD6391E158C991E155966218E6A432703A84068A32543965749857,
-                    ),
-                )
-                # Fourth pairing: G2 generator
-                + PointG1(
-                    x=0x1BA47A91D487CCE77AA78390A295DF54D9351637D67810C400415FB374278E3F,
-                    y=0x24318BBC05A4E4D779B9498075841C360C6973C1C51DEA254281829BBC9AEF33,
-                )
-                + EIP197Spec.G2
-                # Fifth pairing
-                + PointG1(
-                    x=0x1E219772C16EEE72450BBF43E9CADAE7BF6B2E6AE6637CFEB1D1E8965287ACFB,
-                    y=0x0347E7BF4245DEBD3D00B6F51D2D50FD718E6769352F4FE1DB0EFE492FED2FC3,
-                )
-                + PointG2(
-                    x=(
-                        0x24FDCC7D4ED0953E3DAD500C7EF9836FC61DED44BA454EC76F0A6D0687F4C1B4,
-                        0x282B18F7E59C1DB4852E622919B2CE9AA5980CA883EAC312049C19A3DEB79F6D,
-                    ),
-                    y=(
-                        0x0C9D6CE303B7811DD7EA506C8FA124837405BD209B8731BDA79A66EB7206277B,
-                        0x1AC5DAC62D2332FAA8069FACA3B0D27FCDF95D8C8BAFC9074EE72B5C1F33AA70,
-                    ),
-                )
+            # First pairing
+            PointG1(
+                x=0x1147057B17237DF94A3186435ACF66924E1D382B8C935FDD493CEB38C38DEF73,
+                y=0x03CD046286139915160357CE5B29B9EA28BFB781B71734455D20EF1A64BE76CA,
+            )
+            + PointG2(
+                x=(
+                    0x0DAA7CC4983CF74C94607519DF747F61E317307C449BAFB6923F6D6A65299A7E,
+                    0x1D48DB8F275830859FD61370ADDBC5D5EF3F0CE7491D16918E065F7E3727439D,
+                ),
+                y=(
+                    0x1CA8AC2F4A0F540E5505EDBE1D15D13899A2A0DFCCB012D068134AC66EDEC625,
+                    0x2162C315417D1D12C9D7028C5619015391003A9006D4D8979784C7AF2C4537A3,
+                ),
+            )
+            # Second pairing
+            + PointG1(
+                x=0x0D221A19CA86DAFA8CB804DAFF78FD3D1BED30AA32E7D4029B1AA69AFDA2D750,
+                y=0x018628C766A98DE1D0CCA887A6D90303E68A7729490F25F937B76B57624BA0BE,
+            )
+            + PointG2(
+                x=(
+                    0x14550CCF7139312DA6FA9EB1259C6365B0BD688A27473CCB42BC5CD6F14C8ABD,
+                    0x165F8721EE9F614382C8C7EDB103C941D3A55C1849C9787F34317777D5D9365B,
+                ),
+                y=(
+                    0x0D19DA7439EDB573A1B3E357FAADE63D5D68B6031771FD911459B7AB0BDA9D3F,
+                    0x25A50A44D10C99C5F107E3B3874F717873CB2D4674699A468204DF27C0C50A9A,
+                ),
+            )
+            # Third pairing
+            + PointG1(
+                x=0x0D7136C59B907615E1B45CF730FBFD6CF38B7E126E85E52BE804620A23ACE4FB,
+                y=0x03E80C29D24ED5CC407329AE093BB1BE00F9E3C9332F532BC3658937110D7607,
+            )
+            + PointG2(
+                x=(
+                    0x2129813BD7247065AC58EAC42C81E874044E199F48C12AA749A9FE6BB6E4BDDC,
+                    0x1B72B9AB4579283E62445555D5B2921424213D09A776152361C46988B82BE8A7,
+                ),
+                y=(
+                    0x111BC8198F932E379B8F9825F01AF0F5E5CACBF8BFE274BF674F6EAA6E338E04,
+                    0x259F58D438FD6391E158C991E155966218E6A432703A84068A32543965749857,
+                ),
+            )
+            # Fourth pairing: G2 generator
+            + PointG1(
+                x=0x1BA47A91D487CCE77AA78390A295DF54D9351637D67810C400415FB374278E3F,
+                y=0x24318BBC05A4E4D779B9498075841C360C6973C1C51DEA254281829BBC9AEF33,
+            )
+            + EIP197Spec.G2
+            # Fifth pairing
+            + PointG1(
+                x=0x1E219772C16EEE72450BBF43E9CADAE7BF6B2E6AE6637CFEB1D1E8965287ACFB,
+                y=0x0347E7BF4245DEBD3D00B6F51D2D50FD718E6769352F4FE1DB0EFE492FED2FC3,
+            )
+            + PointG2(
+                x=(
+                    0x24FDCC7D4ED0953E3DAD500C7EF9836FC61DED44BA454EC76F0A6D0687F4C1B4,
+                    0x282B18F7E59C1DB4852E622919B2CE9AA5980CA883EAC312049C19A3DEB79F6D,
+                ),
+                y=(
+                    0x0C9D6CE303B7811DD7EA506C8FA124837405BD209B8731BDA79A66EB7206277B,
+                    0x1AC5DAC62D2332FAA8069FACA3B0D27FCDF95D8C8BAFC9074EE72B5C1F33AA70,
+                ),
             ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_5_pair",
@@ -554,7 +528,7 @@ def _generate_bn128_pairs(n: int, seed: int = 0) -> Bytes:
             ),
         )
 
-        calldata = Bytes(calldata + bytes(g1 + g2))
+        calldata = Bytes(calldata + g1 + g2)
 
     return calldata
 

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -33,7 +33,7 @@ from tests.prague.eip2537_bls_12_381_precompiles.spec import (
     [
         pytest.param(
             bls12381_spec.Spec.G1ADD,
-            bytes(bls12381_spec.Spec.G1 + bls12381_spec.Spec.P1),
+            bls12381_spec.Spec.G1 + bls12381_spec.Spec.P1,
             Precompile.BLS12_G1ADD,
             id="bls12_g1add",
             marks=pytest.mark.repricing,
@@ -50,7 +50,7 @@ from tests.prague.eip2537_bls_12_381_precompiles.spec import (
         ),
         pytest.param(
             bls12381_spec.Spec.G2ADD,
-            bytes(bls12381_spec.Spec.G2 + bls12381_spec.Spec.P2),
+            bls12381_spec.Spec.G2 + bls12381_spec.Spec.P2,
             Precompile.BLS12_G2ADD,
             id="bls12_g2add",
             marks=pytest.mark.repricing,
@@ -71,23 +71,21 @@ from tests.prague.eip2537_bls_12_381_precompiles.spec import (
         ),
         pytest.param(
             bls12381_spec.Spec.PAIRING,
-            bytes(bls12381_spec.Spec.G1 + bls12381_spec.Spec.G2),
+            bls12381_spec.Spec.G1 + bls12381_spec.Spec.G2,
             Precompile.BLS12_PAIRING,
             id="bls12_pairing_check",
         ),
         pytest.param(
             bls12381_spec.Spec.MAP_FP_TO_G1,
-            bytes(bls12381_spec.FP(bls12381_spec.Spec.P - 1)),
+            bls12381_spec.FP(bls12381_spec.Spec.P - 1),
             Precompile.BLS12_MAP_FP_TO_G1,
             id="bls12_fp_to_g1",
             marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.MAP_FP2_TO_G2,
-            bytes(
-                bls12381_spec.FP2(
-                    (bls12381_spec.Spec.P - 1, bls12381_spec.Spec.P - 1)
-                )
+            bls12381_spec.FP2(
+                (bls12381_spec.Spec.P - 1, bls12381_spec.Spec.P - 1)
             ),
             Precompile.BLS12_MAP_FP2_TO_G2,
             id="bls12_fp_to_g2",
@@ -279,19 +277,19 @@ def _generate_bls12_pairs(n: int, seed: int = 0) -> Bytes:
 
 def _g1add_calldata(seed: int) -> Bytes:
     """Generate G1ADD calldata with unique first point."""
-    return Bytes(_generate_bls12_g1_point(seed) + bytes(bls12381_spec.Spec.P1))
+    return Bytes(_generate_bls12_g1_point(seed) + bls12381_spec.Spec.P1)
 
 
 def _g2add_calldata(seed: int) -> Bytes:
     """Generate G2ADD calldata with unique first point."""
-    return Bytes(_generate_bls12_g2_point(seed) + bytes(bls12381_spec.Spec.P2))
+    return Bytes(_generate_bls12_g2_point(seed) + bls12381_spec.Spec.P2)
 
 
 def _g1msm_calldata(seed: int) -> Bytes:
     """Generate G1MSM calldata with unique point."""
     return Bytes(
         _generate_bls12_g1_point(seed)
-        + bytes(bls12381_spec.Scalar(bls12381_spec.Spec.Q))
+        + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
     )
 
 
@@ -299,7 +297,7 @@ def _g2msm_calldata(seed: int) -> Bytes:
     """Generate G2MSM calldata with unique point."""
     return Bytes(
         _generate_bls12_g2_point(seed)
-        + bytes(bls12381_spec.Scalar(bls12381_spec.Spec.Q))
+        + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
     )
 
 

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -21,12 +21,11 @@ from execution_testing import (
 )
 from py_ecc import optimized_bls12_381 as bls_curve
 
+from tests.benchmark.compute.helpers import Precompile
 from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
 from tests.prague.eip2537_bls_12_381_precompiles.spec import (
     build_gas_calculation_function_map,
 )
-
-from ..helpers import Precompile, concatenate_parameters
 
 
 @pytest.mark.parametrize(
@@ -34,90 +33,61 @@ from ..helpers import Precompile, concatenate_parameters
     [
         pytest.param(
             bls12381_spec.Spec.G1ADD,
-            concatenate_parameters(
-                [
-                    bls12381_spec.Spec.G1,
-                    bls12381_spec.Spec.P1,
-                ]
-            ),
+            bytes(bls12381_spec.Spec.G1 + bls12381_spec.Spec.P1),
             Precompile.BLS12_G1ADD,
             id="bls12_g1add",
             marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.G1MSM,
-            concatenate_parameters(
-                [
-                    (
-                        bls12381_spec.Spec.P1
-                        + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
-                    )
-                    * (len(bls12381_spec.Spec.G1MSM_DISCOUNT_TABLE) - 1),
-                ]
-            ),
+            (
+                bls12381_spec.Spec.P1
+                + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
+            )
+            * (len(bls12381_spec.Spec.G1MSM_DISCOUNT_TABLE) - 1),
             Precompile.BLS12_G1MSM,
             id="bls12_g1msm",
         ),
         pytest.param(
             bls12381_spec.Spec.G2ADD,
-            concatenate_parameters(
-                [
-                    bls12381_spec.Spec.G2,
-                    bls12381_spec.Spec.P2,
-                ]
-            ),
+            bytes(bls12381_spec.Spec.G2 + bls12381_spec.Spec.P2),
             Precompile.BLS12_G2ADD,
             id="bls12_g2add",
             marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.G2MSM,
-            concatenate_parameters(
-                [
-                    # TODO: the //2 is required due to a limitation of the max
-                    # contract size limit. In a further iteration we can insert
-                    # inputs as calldata or storage and avoid doing PUSHes
-                    # which has this limitation. This also applies to G1MSM.
-                    (
-                        bls12381_spec.Spec.P2
-                        + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
-                    )
-                    * (len(bls12381_spec.Spec.G2MSM_DISCOUNT_TABLE) // 2),
-                ]
-            ),
+            # TODO: the //2 is required due to a limitation of the max
+            # contract size limit. In a further iteration we can insert
+            # inputs as calldata or storage and avoid doing PUSHes which
+            # has this limitation. This also applies to G1MSM.
+            (
+                bls12381_spec.Spec.P2
+                + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
+            )
+            * (len(bls12381_spec.Spec.G2MSM_DISCOUNT_TABLE) // 2),
             Precompile.BLS12_G2MSM,
             id="bls12_g2msm",
         ),
         pytest.param(
             bls12381_spec.Spec.PAIRING,
-            concatenate_parameters(
-                [
-                    bls12381_spec.Spec.G1,
-                    bls12381_spec.Spec.G2,
-                ]
-            ),
+            bytes(bls12381_spec.Spec.G1 + bls12381_spec.Spec.G2),
             Precompile.BLS12_PAIRING,
             id="bls12_pairing_check",
         ),
         pytest.param(
             bls12381_spec.Spec.MAP_FP_TO_G1,
-            concatenate_parameters(
-                [
-                    bls12381_spec.FP(bls12381_spec.Spec.P - 1),
-                ]
-            ),
+            bytes(bls12381_spec.FP(bls12381_spec.Spec.P - 1)),
             Precompile.BLS12_MAP_FP_TO_G1,
             id="bls12_fp_to_g1",
             marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.MAP_FP2_TO_G2,
-            concatenate_parameters(
-                [
-                    bls12381_spec.FP2(
-                        (bls12381_spec.Spec.P - 1, bls12381_spec.Spec.P - 1)
-                    ),
-                ]
+            bytes(
+                bls12381_spec.FP2(
+                    (bls12381_spec.Spec.P - 1, bls12381_spec.Spec.P - 1)
+                )
             ),
             Precompile.BLS12_MAP_FP2_TO_G2,
             id="bls12_fp_to_g2",

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -9,7 +9,9 @@ from execution_testing import (
     Op,
 )
 
-from ..helpers import Precompile, concatenate_parameters
+from tests.benchmark.compute.helpers import Precompile
+from tests.frontier.precompiles.spec import EcrecoverInput
+from tests.frontier.precompiles.spec import Spec as EcrecoverSpec
 
 
 @pytest.mark.repricing
@@ -17,16 +19,16 @@ from ..helpers import Precompile, concatenate_parameters
     "precompile_address,calldata",
     [
         pytest.param(
-            0x01,
-            concatenate_parameters(
-                [
-                    # Inputs below are a valid signature, thus ECRECOVER call
-                    # will perform full computation, not blocked by validation.
-                    "38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E",
-                    "000000000000000000000000000000000000000000000000000000000000001B",
-                    "38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E",
-                    "789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02",
-                ]
+            EcrecoverSpec.ECRECOVER,
+            # Inputs below are a valid signature, thus ECRECOVER call
+            # will perform full computation, not blocked by validation.
+            bytes(
+                EcrecoverInput(
+                    msg_hash=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
+                    v=0x1B,
+                    r=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
+                    s=0x789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02,
+                )
             ),
             id="ecrecover",
         )

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -22,13 +22,11 @@ from tests.frontier.precompiles.spec import Spec as EcrecoverSpec
             EcrecoverSpec.ECRECOVER,
             # Inputs below are a valid signature, thus ECRECOVER call
             # will perform full computation, not blocked by validation.
-            bytes(
-                EcrecoverInput(
-                    msg_hash=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
-                    v=0x1B,
-                    r=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
-                    s=0x789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02,
-                )
+            EcrecoverInput(
+                msg_hash=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
+                v=0x1B,
+                r=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
+                s=0x789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02,
             ),
             id="ecrecover",
         )

--- a/tests/benchmark/compute/precompile/test_identity.py
+++ b/tests/benchmark/compute/precompile/test_identity.py
@@ -16,7 +16,11 @@ from execution_testing import (
     WhileGas,
 )
 
-from ..helpers import Precompile, calculate_optimal_input_length
+from tests.benchmark.compute.helpers import (
+    Precompile,
+    calculate_optimal_input_length,
+)
+from tests.frontier.identity_precompile.spec import Spec as IdentitySpec
 
 
 def test_identity(
@@ -39,7 +43,12 @@ def test_identity(
 
     attack_block = Op.POP(
         Op.STATICCALL(
-            Op.GAS, 0x04, Op.PUSH0, optimal_input_length, Op.PUSH0, Op.PUSH0
+            Op.GAS,
+            IdentitySpec.IDENTITY,
+            Op.PUSH0,
+            optimal_input_length,
+            Op.PUSH0,
+            Op.PUSH0,
         )
     )
 
@@ -59,7 +68,9 @@ def test_identity_fixed_size(
 ) -> None:
     """Benchmark IDENTITY with fixed size input."""
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x04, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+        Op.STATICCALL(
+            Op.GAS, IdentitySpec.IDENTITY, Op.PUSH0, size, Op.PUSH0, Op.PUSH0
+        )
     )
 
     benchmark_test(
@@ -97,7 +108,7 @@ def test_identity_uncachable(
             Op.MLOAD(0),
             Op.STATICCALL(
                 gas=Op.GAS,
-                address=0x04,
+                address=IdentitySpec.IDENTITY,
                 args_size=size,
                 ret_size=size,
                 # gas accounting

--- a/tests/benchmark/compute/precompile/test_modexp.py
+++ b/tests/benchmark/compute/precompile/test_modexp.py
@@ -488,7 +488,7 @@ def test_modexp_uncachable(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x05,
+            address=Spec.MODEXP_ADDRESS,
             args_size=Op.CALLDATASIZE,
             ret_offset=96,
             ret_size=base_length,

--- a/tests/benchmark/compute/precompile/test_p256verify.py
+++ b/tests/benchmark/compute/precompile/test_p256verify.py
@@ -14,9 +14,9 @@ from execution_testing import (
     WhileGas,
 )
 
+from tests.benchmark.compute.helpers import Precompile
 from tests.osaka.eip7951_p256verify_precompiles import spec as p256verify_spec
-
-from ..helpers import Precompile, concatenate_parameters
+from tests.osaka.eip7951_p256verify_precompiles.spec import H, R, S, X, Y
 
 
 @pytest.mark.parametrize(
@@ -24,14 +24,12 @@ from ..helpers import Precompile, concatenate_parameters
     [
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            concatenate_parameters(
-                [
-                    p256verify_spec.Spec.H0,
-                    p256verify_spec.Spec.R0,
-                    p256verify_spec.Spec.S0,
-                    p256verify_spec.Spec.X0,
-                    p256verify_spec.Spec.Y0,
-                ]
+            bytes(
+                p256verify_spec.Spec.H0
+                + p256verify_spec.Spec.R0
+                + p256verify_spec.Spec.S0
+                + p256verify_spec.Spec.X0
+                + p256verify_spec.Spec.Y0
             ),
             id="p256verify",
             marks=[
@@ -43,27 +41,43 @@ from ..helpers import Precompile, concatenate_parameters
         ),
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            concatenate_parameters(
-                [
-                    "235060CAFE19A407880C272BC3E73600E3A12294F56143ED61929C2FF4525ABB",
-                    "182E5CBDF96ACCB859E8EEA1850DE5FF6E430A19D1D9A680ECD5946BBEA8A32B",
-                    "76DDFAE6797FA6777CAAB9FA10E75F52E70A4E6CEB117B3C5B2F445D850BD64C",
-                    "3828736CDFC4C8696008F71999260329AD8B12287846FEDCEDE3BA1205B12729",
-                    "3E5141734E971A8D55015068D9B3666760F4608A49B11F92E500ACEA647978C7",
-                ]
+            bytes(
+                H(
+                    value=0x235060CAFE19A407880C272BC3E73600E3A12294F56143ED61929C2FF4525ABB
+                )
+                + R(
+                    value=0x182E5CBDF96ACCB859E8EEA1850DE5FF6E430A19D1D9A680ECD5946BBEA8A32B
+                )
+                + S(
+                    value=0x76DDFAE6797FA6777CAAB9FA10E75F52E70A4E6CEB117B3C5B2F445D850BD64C
+                )
+                + X(
+                    value=0x3828736CDFC4C8696008F71999260329AD8B12287846FEDCEDE3BA1205B12729
+                )
+                + Y(
+                    value=0x3E5141734E971A8D55015068D9B3666760F4608A49B11F92E500ACEA647978C7
+                )
             ),
             id="p256verify_wrong_endianness",
         ),
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            concatenate_parameters(
-                [
-                    "BB5A52F42F9C9261ED4361F59422A1E30036E7C32B270C8807A419FECA605023",
-                    "000000000000000000000000000000004319055358E8617B0C46353D039CDAAB",
-                    "FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC63254E",
-                    "0AD99500288D466940031D72A9F5445A4D43784640855BF0A69874D2DE5FE103",
-                    "C5011E6EF2C42DCD50D5D3D29F99AE6EBA2C80C9244F4C5422F0979FF0C3BA5E",
-                ]
+            bytes(
+                H(
+                    value=0xBB5A52F42F9C9261ED4361F59422A1E30036E7C32B270C8807A419FECA605023
+                )
+                + R(
+                    value=0x000000000000000000000000000000004319055358E8617B0C46353D039CDAAB
+                )
+                + S(
+                    value=0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC63254E
+                )
+                + X(
+                    value=0x0AD99500288D466940031D72A9F5445A4D43784640855BF0A69874D2DE5FE103
+                )
+                + Y(
+                    value=0xC5011E6EF2C42DCD50D5D3D29F99AE6EBA2C80C9244F4C5422F0979FF0C3BA5E
+                )
             ),
             id="p256verify_modular_comp_x_coordinate_exceeds_n",
         ),
@@ -101,14 +115,12 @@ def test_p256verify(
     [
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            concatenate_parameters(
-                [
-                    p256verify_spec.Spec.H0,
-                    p256verify_spec.Spec.R0,
-                    p256verify_spec.Spec.S0,
-                    p256verify_spec.Spec.X0,
-                    p256verify_spec.Spec.Y0,
-                ]
+            bytes(
+                p256verify_spec.Spec.H0
+                + p256verify_spec.Spec.R0
+                + p256verify_spec.Spec.S0
+                + p256verify_spec.Spec.X0
+                + p256verify_spec.Spec.Y0
             ),
             id="p256verify",
         ),

--- a/tests/benchmark/compute/precompile/test_p256verify.py
+++ b/tests/benchmark/compute/precompile/test_p256verify.py
@@ -24,13 +24,11 @@ from tests.osaka.eip7951_p256verify_precompiles.spec import H, R, S, X, Y
     [
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            bytes(
-                p256verify_spec.Spec.H0
-                + p256verify_spec.Spec.R0
-                + p256verify_spec.Spec.S0
-                + p256verify_spec.Spec.X0
-                + p256verify_spec.Spec.Y0
-            ),
+            p256verify_spec.Spec.H0
+            + p256verify_spec.Spec.R0
+            + p256verify_spec.Spec.S0
+            + p256verify_spec.Spec.X0
+            + p256verify_spec.Spec.Y0,
             id="p256verify",
             marks=[
                 pytest.mark.eip_checklist(
@@ -41,43 +39,39 @@ from tests.osaka.eip7951_p256verify_precompiles.spec import H, R, S, X, Y
         ),
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            bytes(
-                H(
-                    value=0x235060CAFE19A407880C272BC3E73600E3A12294F56143ED61929C2FF4525ABB
-                )
-                + R(
-                    value=0x182E5CBDF96ACCB859E8EEA1850DE5FF6E430A19D1D9A680ECD5946BBEA8A32B
-                )
-                + S(
-                    value=0x76DDFAE6797FA6777CAAB9FA10E75F52E70A4E6CEB117B3C5B2F445D850BD64C
-                )
-                + X(
-                    value=0x3828736CDFC4C8696008F71999260329AD8B12287846FEDCEDE3BA1205B12729
-                )
-                + Y(
-                    value=0x3E5141734E971A8D55015068D9B3666760F4608A49B11F92E500ACEA647978C7
-                )
+            H(
+                value=0x235060CAFE19A407880C272BC3E73600E3A12294F56143ED61929C2FF4525ABB
+            )
+            + R(
+                value=0x182E5CBDF96ACCB859E8EEA1850DE5FF6E430A19D1D9A680ECD5946BBEA8A32B
+            )
+            + S(
+                value=0x76DDFAE6797FA6777CAAB9FA10E75F52E70A4E6CEB117B3C5B2F445D850BD64C
+            )
+            + X(
+                value=0x3828736CDFC4C8696008F71999260329AD8B12287846FEDCEDE3BA1205B12729
+            )
+            + Y(
+                value=0x3E5141734E971A8D55015068D9B3666760F4608A49B11F92E500ACEA647978C7
             ),
             id="p256verify_wrong_endianness",
         ),
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            bytes(
-                H(
-                    value=0xBB5A52F42F9C9261ED4361F59422A1E30036E7C32B270C8807A419FECA605023
-                )
-                + R(
-                    value=0x000000000000000000000000000000004319055358E8617B0C46353D039CDAAB
-                )
-                + S(
-                    value=0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC63254E
-                )
-                + X(
-                    value=0x0AD99500288D466940031D72A9F5445A4D43784640855BF0A69874D2DE5FE103
-                )
-                + Y(
-                    value=0xC5011E6EF2C42DCD50D5D3D29F99AE6EBA2C80C9244F4C5422F0979FF0C3BA5E
-                )
+            H(
+                value=0xBB5A52F42F9C9261ED4361F59422A1E30036E7C32B270C8807A419FECA605023
+            )
+            + R(
+                value=0x000000000000000000000000000000004319055358E8617B0C46353D039CDAAB
+            )
+            + S(
+                value=0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC63254E
+            )
+            + X(
+                value=0x0AD99500288D466940031D72A9F5445A4D43784640855BF0A69874D2DE5FE103
+            )
+            + Y(
+                value=0xC5011E6EF2C42DCD50D5D3D29F99AE6EBA2C80C9244F4C5422F0979FF0C3BA5E
             ),
             id="p256verify_modular_comp_x_coordinate_exceeds_n",
         ),
@@ -115,13 +109,11 @@ def test_p256verify(
     [
         pytest.param(
             p256verify_spec.Spec.P256VERIFY,
-            bytes(
-                p256verify_spec.Spec.H0
-                + p256verify_spec.Spec.R0
-                + p256verify_spec.Spec.S0
-                + p256verify_spec.Spec.X0
-                + p256verify_spec.Spec.Y0
-            ),
+            p256verify_spec.Spec.H0
+            + p256verify_spec.Spec.R0
+            + p256verify_spec.Spec.S0
+            + p256verify_spec.Spec.X0
+            + p256verify_spec.Spec.Y0,
             id="p256verify",
         ),
     ],

--- a/tests/benchmark/compute/precompile/test_point_evaluation.py
+++ b/tests/benchmark/compute/precompile/test_point_evaluation.py
@@ -18,9 +18,9 @@ from execution_testing import (
 )
 from execution_testing.test_types.blob_types import Blob
 
+from tests.benchmark.compute.helpers import Precompile
+from tests.cancun.eip4844_blobs.spec import PointEvaluationInput
 from tests.cancun.eip4844_blobs.spec import Spec as BlobsSpec
-
-from ..helpers import Precompile, concatenate_parameters
 
 INPUT_SIZE = 192
 
@@ -31,14 +31,23 @@ INPUT_SIZE = 192
     [
         pytest.param(
             BlobsSpec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-            concatenate_parameters(
-                [
-                    "01E798154708FE7789429634053CBF9F99B619F9F084048927333FCE637F549B",
-                    "564C0A11A0F704F4FC3E8ACFE0F8245F0AD1347B378FBF96E206DA11A5D36306",
-                    "24D25032E67A7E6A4910DF5834B8FE70E6BCFEEAC0352434196BDF4B2485D5A1",
-                    "8F59A8D2A1A625A17F3FEA0FE5EB8C896DB3764F3185481BC22F91B4AAFFCCA25F26936857BC3A7C2539EA8EC3A952B7",
-                    "873033E038326E87ED3E1276FD140253FA08E9FC25FB2D9A98527FC22A2C9612FBEAFDAD446CBC7BCDBDCD780AF2C16A",
-                ]
+            bytes(
+                PointEvaluationInput(
+                    versioned_hash=bytes.fromhex(
+                        "01E798154708FE7789429634053CBF9F"
+                        "99B619F9F084048927333FCE637F549B"
+                    ),
+                    z=0x564C0A11A0F704F4FC3E8ACFE0F8245F0AD1347B378FBF96E206DA11A5D36306,
+                    y=0x24D25032E67A7E6A4910DF5834B8FE70E6BCFEEAC0352434196BDF4B2485D5A1,
+                    commitment=bytes.fromhex(
+                        "8F59A8D2A1A625A17F3FEA0FE5EB8C896DB3764F3185481BC22F91B4AAFFCCA2"
+                        "5F26936857BC3A7C2539EA8EC3A952B7"
+                    ),
+                    proof=bytes.fromhex(
+                        "873033E038326E87ED3E1276FD140253FA08E9FC25FB2D9A98527FC22A2C9612"
+                        "FBEAFDAD446CBC7BCDBDCD780AF2C16A"
+                    ),
+                )
             ),
             id="point_evaluation",
         ),
@@ -85,7 +94,15 @@ def _generate_point_evaluation_input(
     proof_bytes, y_bytes = ckzg.compute_kzg_proof(
         blob_data, z_bytes, trusted_setup
     )
-    return versioned_hash + z_bytes + y_bytes + commitment + proof_bytes
+    return bytes(
+        PointEvaluationInput(
+            versioned_hash=versioned_hash,
+            z=z,
+            y=int.from_bytes(y_bytes, "big"),
+            commitment=commitment,
+            proof=proof_bytes,
+        )
+    )
 
 
 @pytest.mark.repricing

--- a/tests/benchmark/compute/precompile/test_point_evaluation.py
+++ b/tests/benchmark/compute/precompile/test_point_evaluation.py
@@ -31,23 +31,21 @@ INPUT_SIZE = 192
     [
         pytest.param(
             BlobsSpec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-            bytes(
-                PointEvaluationInput(
-                    versioned_hash=bytes.fromhex(
-                        "01E798154708FE7789429634053CBF9F"
-                        "99B619F9F084048927333FCE637F549B"
-                    ),
-                    z=0x564C0A11A0F704F4FC3E8ACFE0F8245F0AD1347B378FBF96E206DA11A5D36306,
-                    y=0x24D25032E67A7E6A4910DF5834B8FE70E6BCFEEAC0352434196BDF4B2485D5A1,
-                    commitment=bytes.fromhex(
-                        "8F59A8D2A1A625A17F3FEA0FE5EB8C896DB3764F3185481BC22F91B4AAFFCCA2"
-                        "5F26936857BC3A7C2539EA8EC3A952B7"
-                    ),
-                    proof=bytes.fromhex(
-                        "873033E038326E87ED3E1276FD140253FA08E9FC25FB2D9A98527FC22A2C9612"
-                        "FBEAFDAD446CBC7BCDBDCD780AF2C16A"
-                    ),
-                )
+            PointEvaluationInput(
+                versioned_hash=bytes.fromhex(
+                    "01E798154708FE7789429634053CBF9F"
+                    "99B619F9F084048927333FCE637F549B"
+                ),
+                z=0x564C0A11A0F704F4FC3E8ACFE0F8245F0AD1347B378FBF96E206DA11A5D36306,
+                y=0x24D25032E67A7E6A4910DF5834B8FE70E6BCFEEAC0352434196BDF4B2485D5A1,
+                commitment=bytes.fromhex(
+                    "8F59A8D2A1A625A17F3FEA0FE5EB8C896DB3764F3185481BC22F91B4AAFFCCA2"
+                    "5F26936857BC3A7C2539EA8EC3A952B7"
+                ),
+                proof=bytes.fromhex(
+                    "873033E038326E87ED3E1276FD140253FA08E9FC25FB2D9A98527FC22A2C9612"
+                    "FBEAFDAD446CBC7BCDBDCD780AF2C16A"
+                ),
             ),
             id="point_evaluation",
         ),

--- a/tests/benchmark/compute/precompile/test_ripemd160.py
+++ b/tests/benchmark/compute/precompile/test_ripemd160.py
@@ -16,7 +16,11 @@ from execution_testing import (
     WhileGas,
 )
 
-from ..helpers import Precompile, calculate_optimal_input_length
+from tests.benchmark.compute.helpers import (
+    Precompile,
+    calculate_optimal_input_length,
+)
+from tests.frontier.precompiles.spec import Spec as PrecompilesSpec
 
 
 def test_ripemd160(
@@ -39,7 +43,12 @@ def test_ripemd160(
 
     attack_block = Op.POP(
         Op.STATICCALL(
-            Op.GAS, 0x03, Op.PUSH0, optimal_input_length, Op.PUSH0, Op.PUSH0
+            Op.GAS,
+            PrecompilesSpec.RIPEMD160,
+            Op.PUSH0,
+            optimal_input_length,
+            Op.PUSH0,
+            Op.PUSH0,
         )
     )
 
@@ -59,7 +68,14 @@ def test_ripemd160_fixed_size(
 ) -> None:
     """Benchmark RIPEMD160 with fixed size input."""
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x03, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+        Op.STATICCALL(
+            Op.GAS,
+            PrecompilesSpec.RIPEMD160,
+            Op.PUSH0,
+            size,
+            Op.PUSH0,
+            Op.PUSH0,
+        )
     )
 
     benchmark_test(
@@ -94,7 +110,7 @@ def test_ripemd160_uncachable(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x03,
+            address=PrecompilesSpec.RIPEMD160,
             args_size=size,
             ret_size=0x20,
             # gas accounting

--- a/tests/benchmark/compute/precompile/test_sha256.py
+++ b/tests/benchmark/compute/precompile/test_sha256.py
@@ -16,7 +16,11 @@ from execution_testing import (
     WhileGas,
 )
 
-from ..helpers import Precompile, calculate_optimal_input_length
+from tests.benchmark.compute.helpers import (
+    Precompile,
+    calculate_optimal_input_length,
+)
+from tests.frontier.precompiles.spec import Spec as PrecompilesSpec
 
 
 def test_sha256(
@@ -39,7 +43,12 @@ def test_sha256(
 
     attack_block = Op.POP(
         Op.STATICCALL(
-            Op.GAS, 0x02, Op.PUSH0, optimal_input_length, Op.PUSH0, Op.PUSH0
+            Op.GAS,
+            PrecompilesSpec.SHA256,
+            Op.PUSH0,
+            optimal_input_length,
+            Op.PUSH0,
+            Op.PUSH0,
         )
     )
 
@@ -59,7 +68,14 @@ def test_sha256_fixed_size(
 ) -> None:
     """Benchmark SHA256 with fixed size input."""
     attack_block = Op.POP(
-        Op.STATICCALL(Op.GAS, 0x02, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+        Op.STATICCALL(
+            Op.GAS,
+            PrecompilesSpec.SHA256,
+            Op.PUSH0,
+            size,
+            Op.PUSH0,
+            Op.PUSH0,
+        )
     )
 
     benchmark_test(
@@ -93,7 +109,7 @@ def test_sha256_uncachable(
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
-            address=0x02,
+            address=PrecompilesSpec.SHA256,
             args_size=size,
             ret_size=0x20,
             # gas accounting

--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -7,7 +7,36 @@ from hashlib import sha256
 from typing import List, Optional, Set, Tuple
 
 import pytest
-from execution_testing import Fork, ParameterSet, Transaction
+from execution_testing import (
+    BytesConcatenation,
+    Fork,
+    ParameterSet,
+    Transaction,
+)
+
+
+@dataclass(frozen=True)
+class PointEvaluationInput(BytesConcatenation):
+    """
+    EIP-4844 KZG point-evaluation precompile input (192 bytes):
+    versioned_hash (32) || z (32) || y (32) || commitment (48) || proof (48).
+    """
+
+    versioned_hash: bytes
+    z: int
+    y: int
+    commitment: bytes
+    proof: bytes
+
+    def __bytes__(self) -> bytes:
+        """Convert input to bytes."""
+        return (
+            self.versioned_hash
+            + self.z.to_bytes(32, byteorder="big")
+            + self.y.to_bytes(32, byteorder="big")
+            + self.commitment
+            + self.proof
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/frontier/identity_precompile/spec.py
+++ b/tests/frontier/identity_precompile/spec.py
@@ -1,0 +1,12 @@
+"""Defines spec constants for the IDENTITY precompile."""
+
+from dataclasses import dataclass
+
+from execution_testing import Address
+
+
+@dataclass(frozen=True)
+class Spec:
+    """Parameters for the IDENTITY precompile (frontier)."""
+
+    IDENTITY = Address(0x04)

--- a/tests/frontier/precompiles/spec.py
+++ b/tests/frontier/precompiles/spec.py
@@ -1,0 +1,34 @@
+"""Defines spec constants and input types for the ECRECOVER precompile."""
+
+from dataclasses import dataclass
+
+from execution_testing import Address, BytesConcatenation
+
+
+@dataclass(frozen=True)
+class EcrecoverInput(BytesConcatenation):
+    """
+    ECRECOVER precompile input: 32-byte message hash, 32-byte v, 32-byte r,
+    32-byte s — concatenated big-endian (128 bytes total).
+    """
+
+    msg_hash: int
+    v: int
+    r: int
+    s: int
+
+    def __bytes__(self) -> bytes:
+        """Convert input to bytes."""
+        return b"".join(
+            x.to_bytes(32, byteorder="big")
+            for x in (self.msg_hash, self.v, self.r, self.s)
+        )
+
+
+@dataclass(frozen=True)
+class Spec:
+    """Parameters for the frontier precompiles."""
+
+    ECRECOVER = Address(0x01)
+    SHA256 = Address(0x02)
+    RIPEMD160 = Address(0x03)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Refactor precompile benchmark inputs so each field is named by a typed dataclass instead of an opaque list of hex strings.

Before:

```python
concatenate_parameters(
    [
        "38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E",
        "000000000000000000000000000000000000000000000000000000000000001B",
        "38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E",
        "789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02",
    ]
)
```

After:

```python
bytes(
    EcrecoverInput(
        msg_hash=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
        v=0x1B,
        r=0x38D18ACB67D25C8BB9942764B62F18E17054F66A817BD4295423ADF9ED98873E,
        s=0x789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02,
    )
)
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #2739

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
