### PR TITLE
refactor(test-benchmark): support 8037 for `SSTORE` benchmark (NEVER MERGE)

### DIFF
--- a/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
@@ -325,7 +325,8 @@ def test_tx_iterations_by_total_iteration_count_raises_on_impossible() -> None:
 
     with pytest.raises(
         ValueError,
-        match="Single iteration gas cost is greater than gas limit.",
+        match="Single iteration gas cost exceeds gas_limit "
+        "or compute_gas_limit.",
     ):
         list(
             bytecode.tx_iterations_by_total_iteration_count(

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -806,6 +806,10 @@ class IteratingBytecode(Bytecode):
     """
     cleanup: Bytecode
     """Bytecode executed once at the end after all iterations complete."""
+    iterating_state_gas: int
+    """
+    State-gas portion (EIP-8037) charged per loop iteration.
+    """
 
     def __new__(
         cls,
@@ -815,6 +819,7 @@ class IteratingBytecode(Bytecode):
         cleanup: Bytecode | None = None,
         warm_iterating: Bytecode | None = None,
         iterating_subcall: Bytecode | int | None = None,
+        iterating_state_gas: int = 0,
     ) -> Self:
         """
         Create a new iterating bytecode.
@@ -833,6 +838,8 @@ class IteratingBytecode(Bytecode):
                 calculation. The value can also be an integer, in which case it
                 represents the gas cost of the subcall (e.g. the subcall is a
                 precompiled contract).
+            iterating_state_gas: EIP-8037 state-gas portion charged
+                per iteration, defaults to 0.
 
         Returns:
             A new IteratingBytecode instance.
@@ -860,6 +867,7 @@ class IteratingBytecode(Bytecode):
         if cleanup is None:
             cleanup = Bytecode()
         instance.cleanup = cleanup
+        instance.iterating_state_gas = iterating_state_gas
         return instance
 
     def iterating_subcall_gas_cost(
@@ -985,60 +993,85 @@ class IteratingBytecode(Bytecode):
             **intrinsic_cost_kwargs,
         ) + self.iterating_subcall_reserve(fork=fork)
 
+    def _iterations_fit_within_gas_limits(
+        self,
+        *,
+        fork: Fork,
+        iteration_count: int,
+        start_iteration: int,
+        gas_limit: int,
+        compute_gas_limit: int | None = None,
+        **intrinsic_cost_kwargs: Any,
+    ) -> bool:
+        """
+        Check whether iteration_count iterations fit within the gas limits.
+
+        Returns True when both:
+          - The combined regular+state gas (i.e. tx.gas) is <=
+            gas_limit (block-budget constraint).
+          - The regular gas, computed as
+            combined - iteration_count * iterating_state_gas,
+            respects the compute_gas_limit.
+        """
+        if iteration_count <= 0:
+            return True
+        combined = self.tx_gas_limit_by_iteration_count(
+            fork=fork,
+            iteration_count=iteration_count,
+            start_iteration=start_iteration,
+            **intrinsic_cost_kwargs,
+        )
+        if combined > gas_limit:
+            return False
+        if compute_gas_limit is not None:
+            compute = combined - iteration_count * self.iterating_state_gas
+            if compute > compute_gas_limit:
+                return False
+        return True
+
     def _binary_search_iterations(
         self,
         *,
         fork: Fork,
         gas_limit: int,
         start_iteration: int,
+        compute_gas_limit: int | None = None,
         **intrinsic_cost_kwargs: Any,
     ) -> Tuple[int, int]:
         """
         Binary search for the maximum iterations that fit within a gas limit.
         """
-        single_iteration_gas = self.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=1,
-            start_iteration=start_iteration,
+        fits_kwargs: Dict[str, Any] = {
+            "fork": fork,
+            "start_iteration": start_iteration,
+            "gas_limit": gas_limit,
+            "compute_gas_limit": compute_gas_limit,
             **intrinsic_cost_kwargs,
-        )
-        if single_iteration_gas > gas_limit:
+        }
+
+        if not self._iterations_fit_within_gas_limits(
+            iteration_count=1, **fits_kwargs
+        ):
             raise ValueError(
-                "Single iteration gas cost is greater than gas limit."
+                "Single iteration gas cost exceeds gas_limit "
+                "or compute_gas_limit."
             )
+
         low = 1
         high = 2
 
         # Exponential search to find upper bound
-        high_gas_cost = self.tx_gas_limit_by_iteration_count(
-            fork=fork,
-            iteration_count=high,
-            start_iteration=start_iteration,
-            **intrinsic_cost_kwargs,
-        )
-        while high_gas_cost < gas_limit:
+        while self._iterations_fit_within_gas_limits(
+            iteration_count=high, **fits_kwargs
+        ):
             low = high
             high *= 2
-            high_gas_cost = self.tx_gas_limit_by_iteration_count(
-                fork=fork,
-                iteration_count=high,
-                start_iteration=start_iteration,
-                **intrinsic_cost_kwargs,
-            )
 
         # Binary search for exact fit
-        best_iterations = 0
         while low < high:
             mid = (low + high) // 2
-
-            if (
-                self.tx_gas_limit_by_iteration_count(
-                    fork=fork,
-                    iteration_count=mid,
-                    start_iteration=start_iteration,
-                    **intrinsic_cost_kwargs,
-                )
-                > gas_limit
+            if not self._iterations_fit_within_gas_limits(
+                iteration_count=mid, **fits_kwargs
             ):
                 high = mid
             else:
@@ -1082,17 +1115,11 @@ class IteratingBytecode(Bytecode):
             start_iteration=start_iteration,
             **intrinsic_cost_kwargs,
         ):
-            # Binary search for the maximum number of iterations that fits
-            # within remaining_gas
-            max_gas_limit = (
-                min(remaining_gas, gas_limit_cap)
-                if gas_limit_cap is not None
-                else remaining_gas
-            )
             best_iterations, best_iterations_gas = (
                 self._binary_search_iterations(
                     fork=fork,
-                    gas_limit=max_gas_limit,
+                    gas_limit=remaining_gas,
+                    compute_gas_limit=gas_limit_cap,
                     start_iteration=start_iteration,
                     **intrinsic_cost_kwargs,
                 )
@@ -1142,6 +1169,7 @@ class IteratingBytecode(Bytecode):
                 best_iterations, _ = self._binary_search_iterations(
                     fork=fork,
                     gas_limit=gas_limit_cap,
+                    compute_gas_limit=gas_limit_cap,
                     start_iteration=start_iteration,
                     **intrinsic_cost_kwargs,
                 )

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -84,8 +84,7 @@ BITTREX_CONTROLLER_ADDRESS = Address(
 
 
 # Ether reception cost for Bittrex-created contracts
-# Exact: 51 gas, rounded up to 60.
-RECEIVER_CONTRACT_EXECUTION_GAS = 60
+RECEIVER_CONTRACT_EXECUTION_GAS = 51
 
 
 def get_distinct_contract_receiver_list() -> Generator[Address, None, None]:
@@ -284,7 +283,6 @@ def test_ether_transfers(
     ],
 )
 @pytest.mark.parametrize("transfer_amount", [0, 1])
-@pytest.mark.parametrize("warm_access", [False, True])
 def test_ether_transfers_onchain_receivers(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -292,7 +290,6 @@ def test_ether_transfers_onchain_receivers(
     transfer_amount: int,
     fork: Fork,
     gas_benchmark_value: int,
-    warm_access: bool,
 ) -> None:
     """
     Ether transfers to receivers that exist on-chain at run time.
@@ -325,7 +322,7 @@ def test_ether_transfers_onchain_receivers(
         senders=senders,
         receivers=receivers,
         transfer_amount=transfer_amount,
-        warm_access=warm_access,
+        warm_access=False,
         receiver_initial_balance=0,
         track_post_state=False,
         receiver_execution_gas=receiver_execution_gas,

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -1,10 +1,9 @@
 """Benchmark different transaction types."""
 
-import itertools
 import math
 import random
 from dataclasses import dataclass
-from typing import Generator, List
+from typing import Generator, List, Tuple
 
 import pytest
 from execution_testing import (
@@ -74,42 +73,6 @@ def get_single_receiver_list(
         yield receiver
 
 
-# Bitterex controller mainnet address
-# Creates 1.5M contracts with deterministic address via CREATE
-# It is guaranteed no contract is destructed
-# Used for existing contract targets in benchmark
-BITTREX_CONTROLLER_ADDRESS = Address(
-    0xA3C1E324CA1CE40DB73ED6026C4A177F099B5770
-)
-
-
-# Ether reception cost for Bittrex-created contracts
-RECEIVER_CONTRACT_EXECUTION_GAS = 51
-
-
-def get_distinct_contract_receiver_list() -> Generator[Address, None, None]:
-    """Yield contract account created by Bitterex controller via CREATE."""
-    for nonce in itertools.count(1):
-        yield compute_create_address(
-            address=BITTREX_CONTROLLER_ADDRESS, nonce=nonce
-        )
-
-
-def get_distinct_existent_receiver_list() -> Generator[Address, None, None]:
-    """
-    Yield existing balance-only EOA on bloatnet. pre-funded by Spamoor
-    (https://github.com/CPerezz/spamoor/pull/12).
-    """
-    for address in itertools.count(0x1000):
-        yield Address(address)
-
-
-def get_distinct_nonexistent_receiver_list() -> Generator[Address, None, None]:
-    """Yield non-existent accounts starting from keccak256('random')."""
-    for address in itertools.count(0xF3CF193BB4AF1022AF7D2089F37D8BAE7157B85F):
-        yield Address(address)
-
-
 @dataclass(frozen=True)
 class ReceiverAccountType:
     """Receiver account type for ether transfer benchmarks."""
@@ -118,72 +81,49 @@ class ReceiverAccountType:
     delegated: bool
 
 
-def _run_ether_transfer_benchmark(
-    benchmark_test: BenchmarkTestFiller,
+@pytest.fixture
+def ether_transfer_case(
+    case_id: str,
     pre: Alloc,
-    fork: Fork,
-    gas_benchmark_value: int,
-    senders: Generator[Address, None, None],
-    receivers: Generator[Address, None, None],
-    transfer_amount: int,
-    warm_access: bool,
-    receiver_initial_balance: int,
-    track_post_state: bool,
-    receiver_execution_gas: int = 0,
-) -> None:
-    """Fill a block with ether transfers between the given generators."""
-    iteration_cost = (
-        fork.transaction_intrinsic_cost_calculator()(
-            access_list=(
-                [AccessList(address=Address(0x100), storage_keys=[])]
-                if warm_access
-                else None
-            ),
-        )
-        + receiver_execution_gas
-    )
-    iteration_count = gas_benchmark_value // iteration_cost
-
-    txs = []
-    token_transfers: dict[Address, int] = {}
-    for _ in range(iteration_count):
-        receiver = next(receivers)
-        token_transfers[receiver] = (
-            token_transfers.get(receiver, 0) + transfer_amount
-        )
-        access_list = (
-            [AccessList(address=receiver, storage_keys=[])]
-            if warm_access
-            else None
-        )
-        txs.append(
-            Transaction(
-                to=receiver,
-                value=transfer_amount,
-                gas_limit=iteration_cost,
-                sender=next(senders),
-                access_list=access_list,
-            )
-        )
-
-    post_state = (
-        {
-            receiver: Account(
-                balance=receiver_initial_balance + transferred_amount
-            )
-            for receiver, transferred_amount in token_transfers.items()
-            if receiver_initial_balance + transferred_amount > 0
-        }
-        if track_post_state
-        else {}
+    receiver_account_type: ReceiverAccountType,
+) -> Tuple[Generator[Address, None, None], Generator[Address, None, None]]:
+    """Generate sender and receiver generators based on the test case."""
+    balance = receiver_account_type.balance
+    delegation = (
+        pre.deploy_contract(code=Op.STOP)
+        if receiver_account_type.delegated
+        else None
     )
 
-    benchmark_test(
-        pre=pre,
-        post=post_state,
-        blocks=[Block(txs=txs)],
-        expected_benchmark_gas_used=iteration_count * iteration_cost,
-    )
+    if case_id == "a_to_a":
+        """Sending to self."""
+        senders = get_single_sender_list(pre)
+        receivers = senders
+
+    elif case_id == "a_to_b":
+        """One sender → one receiver."""
+        senders = get_single_sender_list(pre)
+        receivers = get_single_receiver_list(pre, balance, delegation)
+
+    elif case_id == "diff_acc_to_b":
+        """Multiple senders → one receiver."""
+        senders = get_distinct_sender_list(pre)
+        receivers = get_single_receiver_list(pre, balance, delegation)
+
+    elif case_id == "a_to_diff_acc":
+        """One sender → multiple receivers."""
+        senders = get_single_sender_list(pre)
+        receivers = get_distinct_receiver_list(pre, balance, delegation)
+
+    elif case_id == "diff_acc_to_diff_acc":
+        """Multiple senders → multiple receivers."""
+        senders = get_distinct_sender_list(pre)
+        receivers = get_distinct_receiver_list(pre, balance, delegation)
+
+    else:
+        raise ValueError(f"Unknown case: {case_id}")
+
+    return senders, receivers
 
 
 @pytest.mark.parametrize(
@@ -224,108 +164,74 @@ def test_ether_transfers(
     fork: Fork,
     gas_benchmark_value: int,
     warm_access: bool,
+    ether_transfer_case: Tuple[
+        Generator[Address, None, None], Generator[Address, None, None]
+    ],
 ) -> None:
     """
-    Ether transfers where receivers constructed in pre-allocation.
+    Single test for ether transfer scenarios.
 
     Scenarios:
-    - a_to_a: self-transfer
+    - a_to_a: one sender → one sender
     - a_to_b: one sender → one receiver
     - diff_acc_to_b: multiple senders → one receiver
     - a_to_diff_acc: one sender → multiple receivers
     - diff_acc_to_diff_acc: multiple senders → multiple receivers
+
+    When warm_access is True, each transaction includes an access list
+    entry for the receiver to warm the account before the transfer.
     """
+    senders, receivers = ether_transfer_case
+
     balance = receiver_account_type.balance
-    delegation = (
-        pre.deploy_contract(code=Op.STOP)
-        if receiver_account_type.delegated
-        else None
+
+    txs = []
+    token_transfers: dict[Address, int] = {}
+
+    iteration_cost = fork.transaction_intrinsic_cost_calculator()(
+        access_list=(
+            [AccessList(address=Address(0x100), storage_keys=[])]
+            if warm_access
+            else None
+        ),
+    )
+    iteration_count = gas_benchmark_value // iteration_cost
+
+    for _ in range(iteration_count):
+        receiver = next(receivers)
+        token_transfers[receiver] = (
+            token_transfers.get(receiver, 0) + transfer_amount
+        )
+        access_list = (
+            [AccessList(address=receiver, storage_keys=[])]
+            if warm_access
+            else None
+        )
+        txs.append(
+            Transaction(
+                to=receiver,
+                value=transfer_amount,
+                gas_limit=iteration_cost,
+                sender=next(senders),
+                access_list=access_list,
+            )
+        )
+
+    post_state = (
+        {}
+        if case_id == "a_to_a"
+        else {
+            receiver: Account(balance=balance + transferred_amount)
+            for receiver, transferred_amount in token_transfers.items()
+            if balance + transferred_amount > 0
+        }
     )
 
-    if case_id == "a_to_a":
-        senders = get_single_sender_list(pre)
-        receivers = senders
-    elif case_id == "a_to_b":
-        senders = get_single_sender_list(pre)
-        receivers = get_single_receiver_list(pre, balance, delegation)
-    elif case_id == "diff_acc_to_b":
-        senders = get_distinct_sender_list(pre)
-        receivers = get_single_receiver_list(pre, balance, delegation)
-    elif case_id == "a_to_diff_acc":
-        senders = get_single_sender_list(pre)
-        receivers = get_distinct_receiver_list(pre, balance, delegation)
-    elif case_id == "diff_acc_to_diff_acc":
-        senders = get_distinct_sender_list(pre)
-        receivers = get_distinct_receiver_list(pre, balance, delegation)
-    else:
-        raise ValueError(f"Unknown case: {case_id}")
-
-    _run_ether_transfer_benchmark(
-        benchmark_test=benchmark_test,
+    benchmark_test(
         pre=pre,
-        fork=fork,
-        gas_benchmark_value=gas_benchmark_value,
-        senders=senders,
-        receivers=receivers,
-        transfer_amount=transfer_amount,
-        warm_access=warm_access,
-        receiver_initial_balance=balance,
-        track_post_state=(case_id != "a_to_a"),
-    )
-
-
-@pytest.mark.parametrize(
-    "case_id",
-    [
-        "diff_to_nonexistent",
-        "diff_to_existent",
-        "diff_to_contract",
-    ],
-)
-@pytest.mark.parametrize("transfer_amount", [0, 1])
-def test_ether_transfers_onchain_receivers(
-    benchmark_test: BenchmarkTestFiller,
-    pre: Alloc,
-    case_id: str,
-    transfer_amount: int,
-    fork: Fork,
-    gas_benchmark_value: int,
-) -> None:
-    """
-    Ether transfers to receivers that exist on-chain at run time.
-
-    Scenarios:
-    - diff_to_nonexistent: distinct nonexistent receivers
-      (matches AccountMode.NON_EXISTING_ACCOUNT)
-    - diff_to_existent: distinct existent EOA receivers
-      (matches AccountMode.EXISTING_EOA)
-    - diff_to_contract: distinct contract receivers
-      (matches AccountMode.EXISTING_CONTRACT)
-    """
-    senders = get_distinct_sender_list(pre)
-    receiver_execution_gas = 0
-    if case_id == "diff_to_nonexistent":
-        receivers = get_distinct_nonexistent_receiver_list()
-    elif case_id == "diff_to_existent":
-        receivers = get_distinct_existent_receiver_list()
-    elif case_id == "diff_to_contract":
-        receivers = get_distinct_contract_receiver_list()
-        receiver_execution_gas = RECEIVER_CONTRACT_EXECUTION_GAS
-    else:
-        raise ValueError(f"Unknown case: {case_id}")
-
-    _run_ether_transfer_benchmark(
-        benchmark_test=benchmark_test,
-        pre=pre,
-        fork=fork,
-        gas_benchmark_value=gas_benchmark_value,
-        senders=senders,
-        receivers=receivers,
-        transfer_amount=transfer_amount,
-        warm_access=False,
-        receiver_initial_balance=0,
-        track_post_state=False,
-        receiver_execution_gas=receiver_execution_gas,
+        post=post_state,
+        blocks=[Block(txs=txs)],
+        expected_benchmark_gas_used=iteration_count * iteration_cost,
     )
 
 

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -19,6 +19,7 @@ from execution_testing import (
     Op,
     Transaction,
     compute_create_address,
+    keccak256,
 )
 
 
@@ -73,6 +74,61 @@ def get_single_receiver_list(
         yield receiver
 
 
+# Bittrex Controller: created 1,586,350 contracts on mainnet that cannot
+# selfdestruct, so they are guaranteed to be on-chain. Safe for benchmarks
+# up to ~300M gas (at 2000 gas per cold address).
+BITTREX_CONTROLLER_ADDRESS = Address(
+    0xA3C1E324CA1CE40DB73ED6026C4A177F099B5770
+)
+
+
+def get_distinct_contract_receiver_list() -> Generator[Address, None, None]:
+    """
+    Yield addresses of contracts created by the Bittrex Controller,
+    starting at nonce 1.
+    """
+    nonce = 1
+    while True:
+        yield compute_create_address(
+            address=BITTREX_CONTROLLER_ADDRESS, nonce=nonce
+        )
+        nonce += 1
+
+
+def get_distinct_existent_receiver_list() -> Generator[Address, None, None]:
+    """
+    Yield sequential EOA addresses starting at 0x1000.
+
+    The Spamoor EOA creator
+    (https://github.com/CPerezz/spamoor/pull/12) funded these addresses
+    on bloatnet.
+    """
+    address = 0x1000
+    while True:
+        yield Address(address)
+        address += 1
+
+
+def get_distinct_nonexistent_receiver_list() -> Generator[
+    Address, None, None
+]:
+    """Yield sequential addresses starting at keccak256("random")."""
+    address = int.from_bytes(keccak256(b"random")[-20:], "big")
+    while True:
+        yield Address(address)
+        address += 1
+
+
+# Cases where the receiver address is determined by case_id rather than
+# being constructed in pre-state. The receiver_account_type parametrization
+# is not multiplied with these.
+RECEIVER_TYPED_CASES: set[str] = {
+    "diff_to_nonexistent",
+    "diff_to_existent",
+    "diff_to_contract",
+}
+
+
 @dataclass(frozen=True)
 class ReceiverAccountType:
     """Receiver account type for ether transfer benchmarks."""
@@ -120,6 +176,21 @@ def ether_transfer_case(
         senders = get_distinct_sender_list(pre)
         receivers = get_distinct_receiver_list(pre, balance, delegation)
 
+    elif case_id == "diff_to_nonexistent":
+        """Multiple senders → distinct nonexistent receivers."""
+        senders = get_distinct_sender_list(pre)
+        receivers = get_distinct_nonexistent_receiver_list()
+
+    elif case_id == "diff_to_existent":
+        """Multiple senders → distinct existent EOA receivers."""
+        senders = get_distinct_sender_list(pre)
+        receivers = get_distinct_existent_receiver_list()
+
+    elif case_id == "diff_to_contract":
+        """Multiple senders → distinct contract receivers."""
+        senders = get_distinct_sender_list(pre)
+        receivers = get_distinct_contract_receiver_list()
+
     else:
         raise ValueError(f"Unknown case: {case_id}")
 
@@ -134,6 +205,9 @@ def ether_transfer_case(
         "diff_acc_to_b",
         "a_to_diff_acc",
         "diff_acc_to_diff_acc",
+        "diff_to_nonexistent",
+        "diff_to_existent",
+        "diff_to_contract",
     ],
 )
 @pytest.mark.parametrize("transfer_amount", [0, 1])
@@ -177,13 +251,34 @@ def test_ether_transfers(
     - diff_acc_to_b: multiple senders → one receiver
     - a_to_diff_acc: one sender → multiple receivers
     - diff_acc_to_diff_acc: multiple senders → multiple receivers
+    - diff_to_nonexistent: multiple senders → distinct nonexistent
+      receivers (matches AccountMode.NON_EXISTING_ACCOUNT)
+    - diff_to_existent: multiple senders → distinct existent EOA
+      receivers (matches AccountMode.EXISTING_EOA)
+    - diff_to_contract: multiple senders → distinct contract receivers
+      (matches AccountMode.EXISTING_CONTRACT)
 
     When warm_access is True, each transaction includes an access list
     entry for the receiver to warm the account before the transfer.
     """
-    senders, receivers = ether_transfer_case
+    if case_id in RECEIVER_TYPED_CASES:
+        # Receiver address is determined by case_id; avoid multiplying with
+        # receiver_account_type and only run for the default variant.
+        if receiver_account_type != ReceiverAccountType(
+            balance=0, delegated=False
+        ):
+            pytest.skip(
+                "Receiver address is determined by case_id; skipping "
+                "non-default receiver_account_type."
+            )
+        # Receivers are not allocated in pre-state during fill (they are
+        # expected to already exist on-chain at run time, e.g. on bloatnet),
+        # so their initial balance during fill is 0.
+        balance = 0
+    else:
+        balance = receiver_account_type.balance
 
-    balance = receiver_account_type.balance
+    senders, receivers = ether_transfer_case
 
     txs = []
     token_transfers: dict[Address, int] = {}

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -1,9 +1,10 @@
 """Benchmark different transaction types."""
 
+import itertools
 import math
 import random
 from dataclasses import dataclass
-from typing import Generator, List, Tuple
+from typing import Generator, List
 
 import pytest
 from execution_testing import (
@@ -19,7 +20,6 @@ from execution_testing import (
     Op,
     Transaction,
     compute_create_address,
-    keccak256,
 )
 
 
@@ -74,59 +74,36 @@ def get_single_receiver_list(
         yield receiver
 
 
-# Bittrex Controller: created 1,586,350 contracts on mainnet that cannot
-# selfdestruct, so they are guaranteed to be on-chain. Safe for benchmarks
-# up to ~300M gas (at 2000 gas per cold address).
+# Bitterex controller mainnet address
+# Creates 1.5M contracts with deterministic address via CREATE
+# It is guaranteed no contract is destructed
+# Used for existing contract targets in benchmark
 BITTREX_CONTROLLER_ADDRESS = Address(
     0xA3C1E324CA1CE40DB73ED6026C4A177F099B5770
 )
 
 
 def get_distinct_contract_receiver_list() -> Generator[Address, None, None]:
-    """
-    Yield addresses of contracts created by the Bittrex Controller,
-    starting at nonce 1.
-    """
-    nonce = 1
-    while True:
+    """Yield contract account created by Bitterex controller via CREATE."""
+    for nonce in itertools.count(1):
         yield compute_create_address(
             address=BITTREX_CONTROLLER_ADDRESS, nonce=nonce
         )
-        nonce += 1
 
 
 def get_distinct_existent_receiver_list() -> Generator[Address, None, None]:
     """
-    Yield sequential EOA addresses starting at 0x1000.
-
-    The Spamoor EOA creator
-    (https://github.com/CPerezz/spamoor/pull/12) funded these addresses
-    on bloatnet.
+    Yield existing balance-only EOA on bloatnet. pre-funded by Spamoor
+    (https://github.com/CPerezz/spamoor/pull/12).
     """
-    address = 0x1000
-    while True:
+    for address in itertools.count(0x1000):
         yield Address(address)
-        address += 1
 
 
-def get_distinct_nonexistent_receiver_list() -> Generator[
-    Address, None, None
-]:
-    """Yield sequential addresses starting at keccak256("random")."""
-    address = int.from_bytes(keccak256(b"random")[-20:], "big")
-    while True:
+def get_distinct_nonexistent_receiver_list() -> Generator[Address, None, None]:
+    """Yield non-existent accounts starting from keccak256('random')."""
+    for address in itertools.count(0xF3CF193BB4AF1022AF7D2089F37D8BAE7157B85F):
         yield Address(address)
-        address += 1
-
-
-# Cases where the receiver address is determined by case_id rather than
-# being constructed in pre-state. The receiver_account_type parametrization
-# is not multiplied with these.
-RECEIVER_TYPED_CASES: set[str] = {
-    "diff_to_nonexistent",
-    "diff_to_existent",
-    "diff_to_contract",
-}
 
 
 @dataclass(frozen=True)
@@ -137,64 +114,68 @@ class ReceiverAccountType:
     delegated: bool
 
 
-@pytest.fixture
-def ether_transfer_case(
-    case_id: str,
+def _run_ether_transfer_benchmark(
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
-    receiver_account_type: ReceiverAccountType,
-) -> Tuple[Generator[Address, None, None], Generator[Address, None, None]]:
-    """Generate sender and receiver generators based on the test case."""
-    balance = receiver_account_type.balance
-    delegation = (
-        pre.deploy_contract(code=Op.STOP)
-        if receiver_account_type.delegated
-        else None
+    fork: Fork,
+    gas_benchmark_value: int,
+    senders: Generator[Address, None, None],
+    receivers: Generator[Address, None, None],
+    transfer_amount: int,
+    warm_access: bool,
+    receiver_initial_balance: int,
+    track_post_state: bool,
+) -> None:
+    """Fill a block with ether transfers between the given generators."""
+    iteration_cost = fork.transaction_intrinsic_cost_calculator()(
+        access_list=(
+            [AccessList(address=Address(0x100), storage_keys=[])]
+            if warm_access
+            else None
+        ),
+    )
+    iteration_count = gas_benchmark_value // iteration_cost
+
+    txs = []
+    token_transfers: dict[Address, int] = {}
+    for _ in range(iteration_count):
+        receiver = next(receivers)
+        token_transfers[receiver] = (
+            token_transfers.get(receiver, 0) + transfer_amount
+        )
+        access_list = (
+            [AccessList(address=receiver, storage_keys=[])]
+            if warm_access
+            else None
+        )
+        txs.append(
+            Transaction(
+                to=receiver,
+                value=transfer_amount,
+                gas_limit=iteration_cost,
+                sender=next(senders),
+                access_list=access_list,
+            )
+        )
+
+    post_state = (
+        {
+            receiver: Account(
+                balance=receiver_initial_balance + transferred_amount
+            )
+            for receiver, transferred_amount in token_transfers.items()
+            if receiver_initial_balance + transferred_amount > 0
+        }
+        if track_post_state
+        else {}
     )
 
-    if case_id == "a_to_a":
-        """Sending to self."""
-        senders = get_single_sender_list(pre)
-        receivers = senders
-
-    elif case_id == "a_to_b":
-        """One sender → one receiver."""
-        senders = get_single_sender_list(pre)
-        receivers = get_single_receiver_list(pre, balance, delegation)
-
-    elif case_id == "diff_acc_to_b":
-        """Multiple senders → one receiver."""
-        senders = get_distinct_sender_list(pre)
-        receivers = get_single_receiver_list(pre, balance, delegation)
-
-    elif case_id == "a_to_diff_acc":
-        """One sender → multiple receivers."""
-        senders = get_single_sender_list(pre)
-        receivers = get_distinct_receiver_list(pre, balance, delegation)
-
-    elif case_id == "diff_acc_to_diff_acc":
-        """Multiple senders → multiple receivers."""
-        senders = get_distinct_sender_list(pre)
-        receivers = get_distinct_receiver_list(pre, balance, delegation)
-
-    elif case_id == "diff_to_nonexistent":
-        """Multiple senders → distinct nonexistent receivers."""
-        senders = get_distinct_sender_list(pre)
-        receivers = get_distinct_nonexistent_receiver_list()
-
-    elif case_id == "diff_to_existent":
-        """Multiple senders → distinct existent EOA receivers."""
-        senders = get_distinct_sender_list(pre)
-        receivers = get_distinct_existent_receiver_list()
-
-    elif case_id == "diff_to_contract":
-        """Multiple senders → distinct contract receivers."""
-        senders = get_distinct_sender_list(pre)
-        receivers = get_distinct_contract_receiver_list()
-
-    else:
-        raise ValueError(f"Unknown case: {case_id}")
-
-    return senders, receivers
+    benchmark_test(
+        pre=pre,
+        post=post_state,
+        blocks=[Block(txs=txs)],
+        expected_benchmark_gas_used=iteration_count * iteration_cost,
+    )
 
 
 @pytest.mark.parametrize(
@@ -205,9 +186,6 @@ def ether_transfer_case(
         "diff_acc_to_b",
         "a_to_diff_acc",
         "diff_acc_to_diff_acc",
-        "diff_to_nonexistent",
-        "diff_to_existent",
-        "diff_to_contract",
     ],
 )
 @pytest.mark.parametrize("transfer_amount", [0, 1])
@@ -238,95 +216,107 @@ def test_ether_transfers(
     fork: Fork,
     gas_benchmark_value: int,
     warm_access: bool,
-    ether_transfer_case: Tuple[
-        Generator[Address, None, None], Generator[Address, None, None]
-    ],
 ) -> None:
     """
-    Single test for ether transfer scenarios.
+    Ether transfers where receivers constructed in pre-allocation.
 
     Scenarios:
-    - a_to_a: one sender → one sender
+    - a_to_a: self-transfer
     - a_to_b: one sender → one receiver
     - diff_acc_to_b: multiple senders → one receiver
     - a_to_diff_acc: one sender → multiple receivers
     - diff_acc_to_diff_acc: multiple senders → multiple receivers
-    - diff_to_nonexistent: multiple senders → distinct nonexistent
-      receivers (matches AccountMode.NON_EXISTING_ACCOUNT)
-    - diff_to_existent: multiple senders → distinct existent EOA
-      receivers (matches AccountMode.EXISTING_EOA)
-    - diff_to_contract: multiple senders → distinct contract receivers
-      (matches AccountMode.EXISTING_CONTRACT)
-
-    When warm_access is True, each transaction includes an access list
-    entry for the receiver to warm the account before the transfer.
     """
-    if case_id in RECEIVER_TYPED_CASES:
-        # Receiver address is determined by case_id; avoid multiplying with
-        # receiver_account_type and only run for the default variant.
-        if receiver_account_type != ReceiverAccountType(
-            balance=0, delegated=False
-        ):
-            pytest.skip(
-                "Receiver address is determined by case_id; skipping "
-                "non-default receiver_account_type."
-            )
-        # Receivers are not allocated in pre-state during fill (they are
-        # expected to already exist on-chain at run time, e.g. on bloatnet),
-        # so their initial balance during fill is 0.
-        balance = 0
+    balance = receiver_account_type.balance
+    delegation = (
+        pre.deploy_contract(code=Op.STOP)
+        if receiver_account_type.delegated
+        else None
+    )
+
+    if case_id == "a_to_a":
+        senders = get_single_sender_list(pre)
+        receivers = senders
+    elif case_id == "a_to_b":
+        senders = get_single_sender_list(pre)
+        receivers = get_single_receiver_list(pre, balance, delegation)
+    elif case_id == "diff_acc_to_b":
+        senders = get_distinct_sender_list(pre)
+        receivers = get_single_receiver_list(pre, balance, delegation)
+    elif case_id == "a_to_diff_acc":
+        senders = get_single_sender_list(pre)
+        receivers = get_distinct_receiver_list(pre, balance, delegation)
+    elif case_id == "diff_acc_to_diff_acc":
+        senders = get_distinct_sender_list(pre)
+        receivers = get_distinct_receiver_list(pre, balance, delegation)
     else:
-        balance = receiver_account_type.balance
+        raise ValueError(f"Unknown case: {case_id}")
 
-    senders, receivers = ether_transfer_case
-
-    txs = []
-    token_transfers: dict[Address, int] = {}
-
-    iteration_cost = fork.transaction_intrinsic_cost_calculator()(
-        access_list=(
-            [AccessList(address=Address(0x100), storage_keys=[])]
-            if warm_access
-            else None
-        ),
-    )
-    iteration_count = gas_benchmark_value // iteration_cost
-
-    for _ in range(iteration_count):
-        receiver = next(receivers)
-        token_transfers[receiver] = (
-            token_transfers.get(receiver, 0) + transfer_amount
-        )
-        access_list = (
-            [AccessList(address=receiver, storage_keys=[])]
-            if warm_access
-            else None
-        )
-        txs.append(
-            Transaction(
-                to=receiver,
-                value=transfer_amount,
-                gas_limit=iteration_cost,
-                sender=next(senders),
-                access_list=access_list,
-            )
-        )
-
-    post_state = (
-        {}
-        if case_id == "a_to_a"
-        else {
-            receiver: Account(balance=balance + transferred_amount)
-            for receiver, transferred_amount in token_transfers.items()
-            if balance + transferred_amount > 0
-        }
-    )
-
-    benchmark_test(
+    _run_ether_transfer_benchmark(
+        benchmark_test=benchmark_test,
         pre=pre,
-        post=post_state,
-        blocks=[Block(txs=txs)],
-        expected_benchmark_gas_used=iteration_count * iteration_cost,
+        fork=fork,
+        gas_benchmark_value=gas_benchmark_value,
+        senders=senders,
+        receivers=receivers,
+        transfer_amount=transfer_amount,
+        warm_access=warm_access,
+        receiver_initial_balance=balance,
+        track_post_state=(case_id != "a_to_a"),
+    )
+
+
+@pytest.mark.parametrize(
+    "case_id",
+    [
+        "diff_to_nonexistent",
+        "diff_to_existent",
+        "diff_to_contract",
+    ],
+)
+@pytest.mark.parametrize("transfer_amount", [0, 1])
+@pytest.mark.parametrize("warm_access", [False, True])
+def test_ether_transfers_onchain_receivers(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    case_id: str,
+    transfer_amount: int,
+    fork: Fork,
+    gas_benchmark_value: int,
+    warm_access: bool,
+) -> None:
+    """
+    Ether transfers to receivers that exist on-chain at run time.
+
+    Scenarios:
+    - diff_to_nonexistent: distinct nonexistent receivers
+      (matches AccountMode.NON_EXISTING_ACCOUNT)
+    - diff_to_existent: distinct existent EOA receivers
+      (matches AccountMode.EXISTING_EOA)
+    - diff_to_contract: distinct contract receivers
+      (matches AccountMode.EXISTING_CONTRACT)
+    """
+    senders = get_distinct_sender_list(pre)
+    if case_id == "diff_to_nonexistent":
+        receivers = get_distinct_nonexistent_receiver_list()
+    elif case_id == "diff_to_existent":
+        receivers = get_distinct_existent_receiver_list()
+    elif case_id == "diff_to_contract":
+        receivers = get_distinct_contract_receiver_list()
+    else:
+        raise ValueError(f"Unknown case: {case_id}")
+
+    _run_ether_transfer_benchmark(
+        benchmark_test=benchmark_test,
+        pre=pre,
+        fork=fork,
+        gas_benchmark_value=gas_benchmark_value,
+        senders=senders,
+        receivers=receivers,
+        transfer_amount=transfer_amount,
+        warm_access=warm_access,
+        receiver_initial_balance=0,
+        track_post_state=False,
     )
 
 

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -83,6 +83,11 @@ BITTREX_CONTROLLER_ADDRESS = Address(
 )
 
 
+# Ether reception cost for Bittrex-created contracts
+# Exact: 51 gas, rounded up to 60.
+RECEIVER_CONTRACT_EXECUTION_GAS = 60
+
+
 def get_distinct_contract_receiver_list() -> Generator[Address, None, None]:
     """Yield contract account created by Bitterex controller via CREATE."""
     for nonce in itertools.count(1):
@@ -125,14 +130,18 @@ def _run_ether_transfer_benchmark(
     warm_access: bool,
     receiver_initial_balance: int,
     track_post_state: bool,
+    receiver_execution_gas: int = 0,
 ) -> None:
     """Fill a block with ether transfers between the given generators."""
-    iteration_cost = fork.transaction_intrinsic_cost_calculator()(
-        access_list=(
-            [AccessList(address=Address(0x100), storage_keys=[])]
-            if warm_access
-            else None
-        ),
+    iteration_cost = (
+        fork.transaction_intrinsic_cost_calculator()(
+            access_list=(
+                [AccessList(address=Address(0x100), storage_keys=[])]
+                if warm_access
+                else None
+            ),
+        )
+        + receiver_execution_gas
     )
     iteration_count = gas_benchmark_value // iteration_cost
 
@@ -297,12 +306,14 @@ def test_ether_transfers_onchain_receivers(
       (matches AccountMode.EXISTING_CONTRACT)
     """
     senders = get_distinct_sender_list(pre)
+    receiver_execution_gas = 0
     if case_id == "diff_to_nonexistent":
         receivers = get_distinct_nonexistent_receiver_list()
     elif case_id == "diff_to_existent":
         receivers = get_distinct_existent_receiver_list()
     elif case_id == "diff_to_contract":
         receivers = get_distinct_contract_receiver_list()
+        receiver_execution_gas = RECEIVER_CONTRACT_EXECUTION_GAS
     else:
         raise ValueError(f"Unknown case: {case_id}")
 
@@ -317,6 +328,7 @@ def test_ether_transfers_onchain_receivers(
         warm_access=warm_access,
         receiver_initial_balance=0,
         track_post_state=False,
+        receiver_execution_gas=receiver_execution_gas,
     )
 
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -9,7 +9,7 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
 
 from enum import Enum, auto
 from functools import partial
-from typing import Callable, Generator, List
+from typing import Any, Callable, Generator, List
 
 import pytest
 from execution_testing import (
@@ -130,12 +130,10 @@ def run_bloated_eoa_benchmark(
     existing_slots: bool,
     runtime_code: Bytecode,
     cache_strategy: CacheStrategy,
+    tx_generator: Callable[[EOA], list[Transaction]] | None = None,
 ) -> None:
     """
     Run a bloated-EOA benchmark with the given runtime delegation code.
-
-    Handles authority setup, slot 0 initialization, delegation to
-    runtime code, benchmark tx generation, and test invocation.
     """
     slot_0_value = Hash(1) if existing_slots else Hash(START_SLOT)
 
@@ -151,22 +149,25 @@ def run_bloated_eoa_benchmark(
 
     blocks: list[Block] = [Block(txs=[init_tx, runtime_tx])]
 
-    gas_available = gas_benchmark_value
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     sender = pre.fund_eoa()
 
     txs: list[Transaction] = []
     with TestPhaseManager.execution():
-        while gas_available >= intrinsic_gas:
-            tx_gas = min(gas_available, tx_gas_limit)
-            txs.append(
-                Transaction(
-                    gas_limit=tx_gas,
-                    to=authority,
-                    sender=sender,
+        if tx_generator is not None:
+            txs = tx_generator(sender)
+        else:
+            gas_available = gas_benchmark_value
+            intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+            while gas_available >= intrinsic_gas:
+                tx_gas = min(gas_available, tx_gas_limit)
+                txs.append(
+                    Transaction(
+                        gas_limit=tx_gas,
+                        to=authority,
+                        sender=sender,
+                    )
                 )
-            )
-            gas_available -= tx_gas
+                gas_available -= tx_gas
 
     cache_txs: list[Transaction] = []
     if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
@@ -176,6 +177,7 @@ def run_bloated_eoa_benchmark(
                 cache_txs.append(
                     Transaction(
                         gas_limit=tx.gas_limit,
+                        data=tx.data,
                         to=authority,
                         sender=cache_sender,
                     )
@@ -589,62 +591,107 @@ def test_sstore_bloated(
 ) -> None:
     """
     Benchmark SSTORE opcodes targeting an EOA with storage bloated.
-
-    The storage is assumed to be filled from 0-N linearly, where
-    each slot has the value of the key. Except slot 0, this is the
-    pointer to the next free (empty) storage slot.
-
-    For this test to work correctly under all parameters then above
-    has to be true. If this is not the case then some tests will not
-    test what they claim to do. For instance, for `write_new_value`
-    set to False we need to know the current value of the slots.
     """
+    sstore_metadata: dict[str, Any] = {}
+    # If CACHE_TX, there would be one cold SLOAD before SSTORE
+    sstore_metadata["key_warm"] = cache_strategy == CacheStrategy.CACHE_TX
+
+    # SSTORE metadata matrix:
+    #
+    # existing_slots | write_new_value | original | current | new
+    # ---------------+-----------------+----------+---------+-----
+    # True           | True            | 1        | 1       | 2
+    # True           | False           | 1        | 1       | 1
+    # False          | True            | 0        | 0       | 1
+    # False          | False           | 0        | 0       | 0
+
+    initial_value = int(existing_slots)
+
+    # When existing_slots is False, the initial value is always 0
+    # Otherwise, the initial value starts at 1 instead.
+    sstore_metadata["original_value"] = initial_value
+    sstore_metadata["current_value"] = initial_value
+
+    # If not writing a new value, the new value is the same as the current one
+    # If writing a new value, the new value is current value + 1
+    sstore_metadata["new_value"] = (
+        initial_value if not write_new_value else initial_value + 1
+    )
+
     setup = (
-        Op.PUSH0  # [0]
-        + Op.SLOAD  # [key], s[0] = key
-        + Op.DUP1  # [key, key]
+        Op.CALLDATALOAD(32)  # [end_slot]
+        + Op.CALLDATALOAD(0)  # [counter, end_slot]
     )
 
-    if write_new_value:
-        setup += (
-            Op.PUSH1(1)  # [1, key, key]
-            + Op.ADD  # [key+1, key]
-            + Op.SWAP1  # [key, key+1]
-        )
+    # stack element: [counter, end_slot]
 
-    # After setup phase, the stack element represents
-    # [slot, value], slot to write and value to write
+    loop = Bytecode()
+    loop += Op.JUMPDEST  # jump target
 
-    cache_op = Bytecode()
+    # If CACHE_TX, warm the slot with a cold SLOAD before the SSTORE loop
     if cache_strategy == CacheStrategy.CACHE_TX:
-        cache_op = (
-            Op.DUP1  # [slot, slot, value]
-            + Op.SLOAD  # [s[slot], slot, value]
-            + Op.POP  # [slot, value]
+        loop += Op.POP(Op.SLOAD(Op.DUP1, key_warm=False))
+
+    sstore_op: Bytecode = Bytecode()
+    if write_new_value:
+        # s[counter] = counter + 1
+        sstore_op = (
+            Op.DUP1  # [counter, counter, end_slot]
+            + Op.DUP1  # [counter, counter, counter, end_slot]
+            + Op.PUSH1(1)  # [1, counter, counter, counter, end_slot]
+            + Op.ADD  # [counter+1, counter, counter, end_slot]
+            + Op.SWAP1  # [counter, counter+1, counter, end_slot]
+            + Op.SSTORE(**sstore_metadata)  # [counter, end_slot]
+        )
+    else:
+        # s[counter] = counter (existing slot) or 0 (non existing slot)
+        push_value = Op.DUP1 if existing_slots else Op.PUSH1(0)
+        sstore_op = (
+            push_value  # [value, counter, end_slot]
+            + Op.DUP2  # [counter, value, counter, end_slot]
+            + Op.SSTORE(**sstore_metadata)  # [counter, end_slot]
         )
 
-    # The cache mechanism touches the slot before SSTORE
+    loop += sstore_op
 
-    runtime_code = (
-        setup
-        + While(
-            body=(
-                cache_op  # [slot, value]
-                + Op.DUP2  # [value, slot, value]
-                + Op.DUP2  # [slot, value, slot, value]
-                + Op.SSTORE  # [slot, value], s[slot] = value
-                + Op.PUSH1(1)  # [1, slot, value]
-                + Op.ADD  # [slot+1, value]
-                + Op.SWAP1  # [value, slot+1]
-                + Op.PUSH1(1)  # [1, value, slot+1]
-                + Op.ADD  # [value+1, slot+1]
-                + Op.SWAP1  # [slot+1, value+1]
-            ),
-            condition=Op.GT(Op.GAS, 0xFFFF),
-        )
-        + Op.PUSH0  # [0, slot+1, value+1]
-        + Op.SSTORE  # s[0] = slot+1
+    # stack element: [counter, end_slot]
+
+    loop += (
+        Op.PUSH1(1)  # [1, counter, end_slot]
+        + Op.ADD  # [counter+1, end_slot]
+        + Op.DUP2  # [end_slot, counter+1, end_slot]
+        + Op.DUP2  # [counter+1, end_slot, counter+1, end_slot]
+        + Op.LT  # [counter+1<end_slot, counter+1, end_slot]
+        + Op.PUSH1(len(setup))  # [dest, condition, counter+1, end_slot]
+        + Op.JUMPI  # [counter+1, end_slot]
     )
+
+    runtime_code = IteratingBytecode(
+        setup=setup,
+        iterating=loop,
+        cleanup=Op.STOP,
+        iterating_state_gas=fork.sstore_state_gas()
+        if (not existing_slots and write_new_value)
+        else 0,
+    )
+
+    authority = pre.stub_eoa(token_name)
+    start_slot = 1 if existing_slots else START_SLOT
+
+    def calldata_gen(iteration_count: int, start_iteration: int) -> bytes:
+        return Hash(start_iteration) + Hash(start_iteration + iteration_count)
+
+    def tx_generator(sender: EOA) -> list[Transaction]:
+        return list(
+            runtime_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                sender=sender,
+                to=authority,
+                start_iteration=start_slot,
+                calldata=calldata_gen,
+            )
+        )
 
     run_bloated_eoa_benchmark(
         benchmark_test=benchmark_test,
@@ -652,10 +699,11 @@ def test_sstore_bloated(
         fork=fork,
         gas_benchmark_value=gas_benchmark_value,
         tx_gas_limit=tx_gas_limit,
-        authority=pre.stub_eoa(token_name),
+        authority=authority,
         existing_slots=existing_slots,
         runtime_code=runtime_code,
         cache_strategy=cache_strategy,
+        tx_generator=tx_generator,
     )
 
 

--- a/tests/benchmark/stateful/bloatnet/test_transaction_types.py
+++ b/tests/benchmark/stateful/bloatnet/test_transaction_types.py
@@ -1,0 +1,120 @@
+"""Benchmark ether transfers to receivers that exist on-chain."""
+
+import itertools
+from typing import Generator
+
+import pytest
+from execution_testing import (
+    Address,
+    Alloc,
+    BenchmarkTestFiller,
+    Block,
+    Fork,
+    Transaction,
+    compute_create_address,
+)
+
+
+def get_distinct_sender_list(pre: Alloc) -> Generator[Address, None, None]:
+    """Get a list of distinct sender accounts."""
+    while True:
+        yield pre.fund_eoa()
+
+
+# Bitterex controller mainnet address
+# Creates 1.5M contracts with deterministic address via CREATE
+# It is guaranteed no contract is destructed
+# Used for existing contract targets in benchmark
+BITTREX_CONTROLLER_ADDRESS = Address(
+    0xA3C1E324CA1CE40DB73ED6026C4A177F099B5770
+)
+
+
+# Ether reception cost for Bittrex-created contracts
+RECEIVER_CONTRACT_EXECUTION_GAS = 51
+
+
+def get_distinct_contract_receiver_list() -> Generator[Address, None, None]:
+    """Yield contract account created by Bitterex controller via CREATE."""
+    for nonce in itertools.count(1):
+        yield compute_create_address(
+            address=BITTREX_CONTROLLER_ADDRESS, nonce=nonce
+        )
+
+
+def get_distinct_existent_receiver_list() -> Generator[Address, None, None]:
+    """
+    Yield existing balance-only EOA on bloatnet. pre-funded by Spamoor
+    (https://github.com/CPerezz/spamoor/pull/12).
+    """
+    for address in itertools.count(0x1000):
+        yield Address(address)
+
+
+def get_distinct_nonexistent_receiver_list() -> Generator[Address, None, None]:
+    """Yield non-existent accounts starting from keccak256('random')."""
+    for address in itertools.count(0xF3CF193BB4AF1022AF7D2089F37D8BAE7157B85F):
+        yield Address(address)
+
+
+@pytest.mark.parametrize(
+    "case_id",
+    [
+        "diff_to_nonexistent",
+        "diff_to_existent",
+        "diff_to_contract",
+    ],
+)
+@pytest.mark.parametrize("transfer_amount", [0, 1])
+def test_ether_transfers_onchain_receivers(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    case_id: str,
+    transfer_amount: int,
+    fork: Fork,
+    gas_benchmark_value: int,
+) -> None:
+    """
+    Ether transfers to receivers that exist on-chain at run time.
+
+    Scenarios:
+    - diff_to_nonexistent: distinct nonexistent receivers
+      (matches AccountMode.NON_EXISTING_ACCOUNT)
+    - diff_to_existent: distinct existent EOA receivers
+      (matches AccountMode.EXISTING_EOA)
+    - diff_to_contract: distinct contract receivers
+      (matches AccountMode.EXISTING_CONTRACT)
+    """
+    senders = get_distinct_sender_list(pre)
+    receiver_execution_gas = 0
+    if case_id == "diff_to_nonexistent":
+        receivers = get_distinct_nonexistent_receiver_list()
+    elif case_id == "diff_to_existent":
+        receivers = get_distinct_existent_receiver_list()
+    elif case_id == "diff_to_contract":
+        receivers = get_distinct_contract_receiver_list()
+        receiver_execution_gas = RECEIVER_CONTRACT_EXECUTION_GAS
+    else:
+        raise ValueError(f"Unknown case: {case_id}")
+
+    iteration_cost = (
+        fork.transaction_intrinsic_cost_calculator()() + receiver_execution_gas
+    )
+    iteration_count = gas_benchmark_value // iteration_cost
+
+    txs = [
+        Transaction(
+            to=next(receivers),
+            value=transfer_amount,
+            gas_limit=iteration_cost,
+            sender=next(senders),
+        )
+        for _ in range(iteration_count)
+    ]
+
+    benchmark_test(
+        pre=pre,
+        post={},
+        blocks=[Block(txs=txs)],
+        expected_benchmark_gas_used=iteration_count * iteration_cost,
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Temporary branch for benchmarking purpose.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
