### PR TITLE
feat(zkevm): fill public_keys execution witness field

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -95,6 +95,9 @@ from execution_testing.test_types.execution_witness import (
     ExecutionWitnessHeadersExpectation,
     ExecutionWitnessStateExpectation,
 )
+from execution_testing.test_types.execution_witness.modifiers import (
+    PublicKeyModifier,
+)
 
 from .base import BaseTest, FillResult, OpMode, verify_result
 from .debugging import print_traces
@@ -215,16 +218,17 @@ def with_execution_witness_implicit_codes(
     return expectation.model_copy(update={"codes_present": codes_present})
 
 
-def rerun_amsterdam_stateless_guest_with_witness(
+def rerun_amsterdam_stateless_guest_with_overrides(
     *,
     fork: Fork,
     block_number: int,
     timestamp: int,
     original_stateless_input_bytes: Bytes,
-    execution_witness: ExecutionWitness,
+    execution_witness: ExecutionWitness | None = None,
+    public_keys: Tuple[Bytes, ...] | None = None,
 ) -> tuple[Bytes, Bytes, bool]:
     """
-    Rebuild the stateless input with the emitted witness and rerun the guest.
+    Rebuild the stateless input with test overrides and rerun the guest.
 
     Amsterdam is currently the only fork with stateless guest support in this
     repository, so the rerun path is kept Amsterdam-specific.
@@ -254,23 +258,31 @@ def rerun_amsterdam_stateless_guest_with_witness(
     original_input = deserialize_stateless_input(
         AmsterdamBytes(bytes(original_stateless_input_bytes))
     )
-    rebuilt_witness = AmsterdamExecutionWitness(
-        state=tuple(
-            AmsterdamBytes(bytes(node)) for node in execution_witness.state
-        ),
-        codes=tuple(
-            AmsterdamBytes(bytes(code)) for code in execution_witness.codes
-        ),
-        headers=tuple(
-            AmsterdamBytes(bytes(header))
-            for header in execution_witness.headers
-        ),
-    )
+    rebuilt_witness = original_input.witness
+    if execution_witness is not None:
+        rebuilt_witness = AmsterdamExecutionWitness(
+            state=tuple(
+                AmsterdamBytes(bytes(node))
+                for node in execution_witness.state
+            ),
+            codes=tuple(
+                AmsterdamBytes(bytes(code))
+                for code in execution_witness.codes
+            ),
+            headers=tuple(
+                AmsterdamBytes(bytes(header))
+                for header in execution_witness.headers
+            ),
+        )
     rebuilt_input = AmsterdamStatelessInput(
         new_payload_request=original_input.new_payload_request,
         witness=rebuilt_witness,
         chain_config=original_input.chain_config,
-        public_keys=original_input.public_keys,
+        public_keys=(
+            tuple(AmsterdamBytes(bytes(key)) for key in public_keys)
+            if public_keys is not None
+            else original_input.public_keys
+        ),
     )
     rebuilt_input_bytes = serialize_stateless_input(rebuilt_input)
     rebuilt_output_bytes = run_stateless_guest(rebuilt_input_bytes)
@@ -281,6 +293,83 @@ def rerun_amsterdam_stateless_guest_with_witness(
         Bytes(bytes(rebuilt_output_bytes)),
         rebuilt_output.successful_validation,
     )
+
+
+def get_amsterdam_stateless_input_public_key_data(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    stateless_input_bytes: Bytes,
+) -> tuple[Tuple[Bytes, ...], Tuple[Bytes, ...]]:
+    """
+    Decode Amsterdam stateless input public keys and payload transactions.
+    """
+    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
+    if active_fork.name() != "Amsterdam":
+        raise Exception(
+            "Stateless input public-key decoding is only supported for "
+            "Amsterdam"
+        )
+
+    from ethereum.forks.amsterdam.stateless_guest import (
+        deserialize_stateless_input,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    stateless_input = deserialize_stateless_input(
+        AmsterdamBytes(bytes(stateless_input_bytes))
+    )
+    public_keys = tuple(
+        Bytes(bytes(public_key)) for public_key in stateless_input.public_keys
+    )
+    payload_transactions = tuple(
+        Bytes(bytes(transaction))
+        for transaction in (
+            stateless_input.new_payload_request.execution_payload.transactions
+        )
+    )
+    return public_keys, payload_transactions
+
+
+def verify_stateless_input_public_keys(
+    public_keys: Tuple[Bytes, ...],
+    payload_transactions: Tuple[Bytes, ...],
+    chain_id: int,
+) -> None:
+    """
+    Verify that every payload transaction has its recovered public key.
+    """
+    payload_transaction_count = len(payload_transactions)
+    if len(public_keys) != payload_transaction_count:
+        raise AssertionError(
+            "Stateless input public key count does not match payload "
+            f"transactions: got {len(public_keys)} public keys for "
+            f"{payload_transaction_count} transactions"
+        )
+
+    from ethereum.forks.amsterdam.transactions import (
+        decode_transaction,
+        recover_transaction_public_key,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+    from ethereum_types.numeric import U64
+
+    for index, (public_key, payload_transaction) in enumerate(
+        zip(public_keys, payload_transactions, strict=True)
+    ):
+        transaction = decode_transaction(
+            AmsterdamBytes(bytes(payload_transaction))
+        )
+        expected_public_key = recover_transaction_public_key(
+            U64(chain_id),
+            transaction,
+        )
+        if bytes(public_key) != bytes(expected_public_key):
+            raise AssertionError(
+                "Stateless input public key "
+                f"{index} does not match recovered transaction public key"
+            )
 
 
 def deserialize_amsterdam_stateless_output_success(
@@ -461,10 +550,18 @@ class Block(Header):
     If set, the execution witness headers will be verified and potentially
     modified for invalid tests.
     """
+    stateless_input_public_keys_modifier: PublicKeyModifier | None = Field(
+        default=None,
+        exclude=True,
+    )
+    """
+    If set, mutate the stateless input transaction public keys before rerunning
+    the guest for invalid tests.
+    """
     expected_stateless_validation_success: bool | None = None
     """
     If set, assert the stateless guest result matches this expectation. This
-    must be set explicitly for tests that mutate the emitted execution witness.
+    must be set explicitly for tests that mutate stateless validation input.
     """
     exception: BLOCK_EXCEPTION_TYPE = None
     # If set, the block is expected to be rejected by the client.
@@ -991,13 +1088,18 @@ class BlockchainTest(BaseTest):
             or block.expected_execution_witness_codes is not None
             or block.expected_execution_witness_headers is not None
         )
+        public_keys_modifier = block.stateless_input_public_keys_modifier
+        has_public_keys_modifier = public_keys_modifier is not None
         expected_success = block.expected_stateless_validation_success
         if self.skip_stateless_validation and (
-            has_witness_expectation or expected_success is not None
+            has_witness_expectation
+            or has_public_keys_modifier
+            or expected_success is not None
         ):
             raise AssertionError(
                 "skip_stateless_validation cannot be combined with "
-                "execution witness expectations or "
+                "execution witness expectations, stateless input public-key "
+                "modifiers, or "
                 "expected_stateless_validation_success"
             )
         state_expectation = block.expected_execution_witness_state
@@ -1069,8 +1171,39 @@ class BlockchainTest(BaseTest):
                 "Mutated execution witness tests must set "
                 "expected_stateless_validation_success explicitly"
             )
+        if has_public_keys_modifier and expected_success is None:
+            raise AssertionError(
+                "Mutated stateless input public-key tests must set "
+                "expected_stateless_validation_success explicitly"
+            )
+        public_keys: Tuple[Bytes, ...] | None = None
+        if stateless_input_bytes is not None:
+            payload_transactions: Tuple[Bytes, ...]
+            (
+                public_keys,
+                payload_transactions,
+            ) = get_amsterdam_stateless_input_public_key_data(
+                fork=fork,
+                block_number=int(env.number),
+                timestamp=int(env.timestamp),
+                stateless_input_bytes=stateless_input_bytes,
+            )
+            verify_stateless_input_public_keys(
+                public_keys,
+                payload_transactions,
+                self.chain_id,
+            )
+        elif has_public_keys_modifier:
+            raise Exception(
+                "Stateless input public-key mutation requires stateless "
+                "input bytes"
+            )
         canonical_successful_validation: bool | None = None
-        if has_witness_modifier or expected_success is not None:
+        if (
+            has_witness_modifier
+            or has_public_keys_modifier
+            or expected_success is not None
+        ):
             if stateless_output_bytes is None:
                 raise Exception(
                     "Stateless guest verification requires stateless output "
@@ -1085,23 +1218,39 @@ class BlockchainTest(BaseTest):
                 )
             )
 
-        should_rerun_stateless_guest = has_witness_modifier
+        should_rerun_stateless_guest = (
+            has_witness_modifier or has_public_keys_modifier
+        )
         if should_rerun_stateless_guest:
-            if execution_witness is None or stateless_input_bytes is None:
+            if stateless_input_bytes is None:
                 raise Exception(
-                    "Stateless guest rerun requires execution witness and "
-                    "stateless input bytes"
+                    "Stateless guest rerun requires stateless input bytes"
                 )
+            if has_witness_modifier and execution_witness is None:
+                raise Exception(
+                    "Stateless guest witness mutation rerun requires "
+                    "execution witness"
+                )
+            modified_public_keys: Tuple[Bytes, ...] | None = None
+            if public_keys_modifier is not None:
+                if public_keys is None:
+                    raise Exception(
+                        "Stateless guest rerun requires public keys"
+                    )
+                modified_public_keys = public_keys_modifier(public_keys)
             (
                 stateless_input_bytes,
                 stateless_output_bytes,
                 successful_validation,
-            ) = rerun_amsterdam_stateless_guest_with_witness(
+            ) = rerun_amsterdam_stateless_guest_with_overrides(
                 fork=fork,
                 block_number=int(env.number),
                 timestamp=int(env.timestamp),
                 original_stateless_input_bytes=stateless_input_bytes,
-                execution_witness=execution_witness,
+                execution_witness=(
+                    execution_witness if has_witness_modifier else None
+                ),
+                public_keys=modified_public_keys,
             )
             if (
                 expected_success is not None

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1180,7 +1180,7 @@ class BlockchainTest(BaseTest):
         should_verify_stateless_input_public_keys = (
             stateless_input_bytes is not None
             # The block could be invalid because of invalid txs, thus
-            # the public keys might not be properly constructed given they 
+            # the public keys might not be properly constructed given they
             # can't be decoded and thus provided in the execution witness.
             and block.exception is None
         )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1177,7 +1177,17 @@ class BlockchainTest(BaseTest):
                 "expected_stateless_validation_success explicitly"
             )
         public_keys: Tuple[Bytes, ...] | None = None
-        if stateless_input_bytes is not None:
+        should_verify_stateless_input_public_keys = (
+            stateless_input_bytes is not None
+            # The block could be invalid because of invalid txs, thus
+            # the public keys might not be properly constructed given they 
+            # can't be decoded and thus provided in the execution witness.
+            and block.exception is None
+        )
+        if stateless_input_bytes is not None and (
+            should_verify_stateless_input_public_keys
+            or has_public_keys_modifier
+        ):
             payload_transactions: Tuple[Bytes, ...]
             (
                 public_keys,
@@ -1188,11 +1198,12 @@ class BlockchainTest(BaseTest):
                 timestamp=int(env.timestamp),
                 stateless_input_bytes=stateless_input_bytes,
             )
-            verify_stateless_input_public_keys(
-                public_keys,
-                payload_transactions,
-                self.chain_id,
-            )
+            if should_verify_stateless_input_public_keys:
+                verify_stateless_input_public_keys(
+                    public_keys,
+                    payload_transactions,
+                    self.chain_id,
+                )
         elif has_public_keys_modifier:
             raise Exception(
                 "Stateless input public-key mutation requires stateless "

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -262,12 +262,10 @@ def rerun_amsterdam_stateless_guest_with_overrides(
     if execution_witness is not None:
         rebuilt_witness = AmsterdamExecutionWitness(
             state=tuple(
-                AmsterdamBytes(bytes(node))
-                for node in execution_witness.state
+                AmsterdamBytes(bytes(node)) for node in execution_witness.state
             ),
             codes=tuple(
-                AmsterdamBytes(bytes(code))
-                for code in execution_witness.codes
+                AmsterdamBytes(bytes(code)) for code in execution_witness.codes
             ),
             headers=tuple(
                 AmsterdamBytes(bytes(header))

--- a/packages/testing/src/execution_testing/test_types/execution_witness/modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/execution_witness/modifiers.py
@@ -5,11 +5,13 @@ This module provides modifier functions that can be used to modify
 execution witnesses for testing invalid block scenarios.
 """
 
-from typing import Callable
+from typing import Callable, Tuple
 
 from execution_testing.base_types import Bytes
 
 from .types import ExecutionWitness
+
+PublicKeyModifier = Callable[[Tuple[Bytes, ...]], Tuple[Bytes, ...]]
 
 
 def add_code(
@@ -206,10 +208,32 @@ def replace_header_at(
     return transform
 
 
+def replace_public_key_at(
+    index: int,
+    public_key: Bytes,
+) -> PublicKeyModifier:
+    """Replace the transaction public key at `index`."""
+
+    def transform(
+        public_keys: Tuple[Bytes, ...],
+    ) -> Tuple[Bytes, ...]:
+        new_public_keys = list(public_keys)
+        try:
+            new_public_keys[index] = public_key
+        except IndexError as exc:
+            raise IndexError(
+                f"Public key index {index} out of range for stateless input"
+            ) from exc
+        return tuple(new_public_keys)
+
+    return transform
+
+
 __all__ = [
     "add_state_node",
     "add_code",
     "clear_headers",
+    "PublicKeyModifier",
     "remove_state_node",
     "remove_code",
     "remove_code_at",
@@ -219,4 +243,5 @@ __all__ = [
     "remove_header_at",
     "reverse_headers",
     "replace_header_at",
+    "replace_public_key_at",
 ]

--- a/src/ethereum/forks/amsterdam/execution_engine/new_payload.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/new_payload.py
@@ -105,13 +105,6 @@ def execute_new_payload_request(
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root
     execution_requests = new_payload_request.execution_requests
 
-    if transaction_public_keys is not None and len(
-        transaction_public_keys
-    ) != len(payload.transactions):
-        raise InvalidBlock(
-            "Transaction public key count does not match payload transactions"
-        )
-
     if b"" in payload.transactions:
         raise InvalidBlock("Empty transaction in payload")
 

--- a/src/ethereum/forks/amsterdam/execution_engine/new_payload.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/new_payload.py
@@ -2,9 +2,10 @@
 Payload verification.
 """
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes
 
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidBlock
@@ -71,6 +72,7 @@ def execute_new_payload_request(
     new_payload_request: NewPayloadRequest,
     pre_state: PreState,
     chain_context: ChainContext,
+    transaction_public_keys: Optional[Tuple[Bytes, ...]] = None,
 ) -> Tuple[BlockDiff, Block]:
     """
     Validate and execute a payload against ``pre_state``.
@@ -88,6 +90,8 @@ def execute_new_payload_request(
         Pre-execution state provider.
     chain_context :
         Chain context needed for block execution.
+    transaction_public_keys :
+        Optional transaction public keys in payload order.
 
     Returns
     -------
@@ -100,6 +104,13 @@ def execute_new_payload_request(
     payload = new_payload_request.execution_payload
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root
     execution_requests = new_payload_request.execution_requests
+
+    if transaction_public_keys is not None and len(
+        transaction_public_keys
+    ) != len(payload.transactions):
+        raise InvalidBlock(
+            "Transaction public key count does not match payload transactions"
+        )
 
     if b"" in payload.transactions:
         raise InvalidBlock("Empty transaction in payload")
@@ -119,7 +130,12 @@ def execute_new_payload_request(
         parent_beacon_block_root,
         execution_requests,
     )
-    block_diff = execute_block(block, pre_state, chain_context)
+    block_diff = execute_block(
+        block,
+        pre_state,
+        chain_context,
+        transaction_public_keys=transaction_public_keys,
+    )
     return block_diff, block
 
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -88,6 +88,7 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
+    recover_sender_from_public_key,
     validate_transaction,
 )
 from .trie import root, trie_set
@@ -269,6 +270,7 @@ def execute_block(
     block: Block,
     pre_state: PreState,
     chain_context: ChainContext,
+    transaction_public_keys: Optional[Tuple[Bytes, ...]] = None,
 ) -> BlockDiff:
     """
     Execute a block and validate the resulting roots against the header.
@@ -283,6 +285,8 @@ def execute_block(
         Pre-execution state provider.
     chain_context :
         Chain context that the block may need during execution.
+    transaction_public_keys :
+        Optional transaction public keys in block order.
 
     Returns
     -------
@@ -292,6 +296,13 @@ def execute_block(
     """
     if len(rlp.encode(block)) > MAX_RLP_BLOCK_SIZE:
         raise InvalidBlock("Block rlp size exceeds MAX_RLP_BLOCK_SIZE")
+
+    if transaction_public_keys is not None and len(
+        transaction_public_keys
+    ) != len(block.transactions):
+        raise InvalidBlock(
+            "Transaction public key count does not match block transactions"
+        )
 
     parent_header = chain_context.parent_header
     validate_header(parent_header, block.header)
@@ -314,6 +325,7 @@ def execute_block(
         excess_blob_gas=block.header.excess_blob_gas,
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
+        transaction_public_keys=transaction_public_keys,
     )
 
     block_output = apply_body(
@@ -483,6 +495,7 @@ def check_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     tx_state: TransactionState,
+    sender_public_key: Optional[Bytes] = None,
 ) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
@@ -497,6 +510,8 @@ def check_transaction(
         The transaction.
     tx_state :
         The transaction state tracker.
+    sender_public_key :
+        Optional sender public key to verify instead of recovering.
 
     Returns
     -------
@@ -554,7 +569,12 @@ def check_transaction(
     if tx_blob_gas_used > blob_gas_available:
         raise BlobGasLimitExceededError("blob gas limit exceeded")
 
-    sender_address = recover_sender(block_env.chain_id, tx)
+    if sender_public_key is None:
+        sender_address = recover_sender(block_env.chain_id, tx)
+    else:
+        sender_address = recover_sender_from_public_key(
+            block_env.chain_id, tx, sender_public_key
+        )
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(
@@ -975,6 +995,9 @@ def process_transaction(
     )
 
     intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    sender_public_key = None
+    if block_env.transaction_public_keys is not None:
+        sender_public_key = block_env.transaction_public_keys[int(index)]
 
     (
         sender,
@@ -986,6 +1009,7 @@ def process_transaction(
         block_output=block_output,
         tx=tx,
         tx_state=tx_state,
+        sender_public_key=sender_public_key,
     )
 
     sender_account = get_account(tx_state, sender)

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -114,7 +114,7 @@ class StatelessInput:
 
     public_keys: Tuple[Bytes, ...]
     """
-    Recovered transaction public keys, in transaction order.
+    65-byte uncompressed transaction public keys, in payload order.
     """
 
 
@@ -203,6 +203,8 @@ def verify_stateless_new_payload(
     witness = stateless_input.witness
 
     try:
+        validate_transaction_public_keys(stateless_input)
+
         # Validate the headers are contiguous and compute their
         # blockhashes.
         decoded_headers, block_hashes = validate_headers(witness.headers)
@@ -224,6 +226,7 @@ def verify_stateless_new_payload(
             stateless_input.new_payload_request,
             pre_state,
             chain_context,
+            transaction_public_keys=stateless_input.public_keys,
         )
         successful_validation = True
     except Exception:
@@ -234,3 +237,18 @@ def verify_stateless_new_payload(
         successful_validation=successful_validation,
         chain_config=stateless_input.chain_config,
     )
+
+
+def validate_transaction_public_keys(
+    stateless_input: StatelessInput,
+) -> None:
+    """
+    Validate that the transaction public key witness matches the payload.
+    """
+    transaction_count = len(
+        stateless_input.new_payload_request.execution_payload.transactions
+    )
+    if len(stateless_input.public_keys) != transaction_count:
+        raise ValueError(
+            "Transaction public key count does not match payload transactions"
+        )

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -203,8 +203,6 @@ def verify_stateless_new_payload(
     witness = stateless_input.witness
 
     try:
-        validate_transaction_public_keys(stateless_input)
-
         # Validate the headers are contiguous and compute their
         # blockhashes.
         decoded_headers, block_hashes = validate_headers(witness.headers)
@@ -237,18 +235,3 @@ def verify_stateless_new_payload(
         successful_validation=successful_validation,
         chain_config=stateless_input.chain_config,
     )
-
-
-def validate_transaction_public_keys(
-    stateless_input: StatelessInput,
-) -> None:
-    """
-    Validate that the transaction public key witness matches the payload.
-    """
-    transaction_count = len(
-        stateless_input.new_payload_request.execution_payload.transactions
-    )
-    if len(stateless_input.public_keys) != transaction_count:
-        raise ValueError(
-            "Transaction public key count does not match payload transactions"
-        )

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -30,6 +30,7 @@ from .transactions import (
     BlobTransaction,
     LegacyTransaction,
     decode_transaction,
+    recover_transaction_public_key,
 )
 
 
@@ -65,12 +66,15 @@ def build_stateless_input(
     header = block.header
     block_hash = Hash32(keccak256(rlp.encode(header)))
 
-    # Encode transactions to bytes and collect versioned hashes.
+    # Encode transactions to bytes, recover public keys, and collect
+    # versioned hashes.
     tx_bytes_list: List[Bytes] = []
+    public_keys: List[Bytes] = []
     versioned_hashes: List[VersionedHash] = []
     for tx in block.transactions:
         if isinstance(tx, LegacyTransaction):
             tx_bytes_list.append(Bytes(rlp.encode(tx)))
+            tx_obj = tx
         else:
             tx_bytes_list.append(Bytes(tx))
             # A typed tx may be malformed (pre-execution-rejected by
@@ -80,8 +84,9 @@ def build_stateless_input(
                 tx_obj = decode_transaction(tx)
             except Exception:
                 continue
-            if isinstance(tx_obj, BlobTransaction):
-                versioned_hashes.extend(tx_obj.blob_versioned_hashes)
+        public_keys.append(recover_transaction_public_key(chain_id, tx_obj))
+        if isinstance(tx_obj, BlobTransaction):
+            versioned_hashes.extend(tx_obj.blob_versioned_hashes)
 
     # Block access list as RLP bytes.
     bal_bytes = Bytes(rlp.encode(block_access_list))
@@ -118,5 +123,5 @@ def build_stateless_input(
         new_payload_request=new_payload,
         witness=execution_witness,
         chain_config=ChainConfig(chain_id=chain_id),
-        public_keys=(),
+        public_keys=tuple(public_keys),
     )

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -29,6 +29,7 @@ from .stateless_ssz import (
 from .transactions import (
     BlobTransaction,
     LegacyTransaction,
+    Transaction,
     decode_transaction,
     recover_transaction_public_key,
 )
@@ -72,6 +73,7 @@ def build_stateless_input(
     public_keys: List[Bytes] = []
     versioned_hashes: List[VersionedHash] = []
     for tx in block.transactions:
+        tx_obj: Transaction
         if isinstance(tx, LegacyTransaction):
             tx_bytes_list.append(Bytes(rlp.encode(tx)))
             tx_obj = tx

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -438,8 +438,7 @@ def stateless_input_to_ssz(
         witness=_witness_to_ssz(si.witness),
         chain_config=_chain_config_to_ssz(si.chain_config),
         public_keys=SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS](
-            ByteVector[PUBLIC_KEY_BYTES](bytes(pk))
-            for pk in si.public_keys
+            ByteVector[PUBLIC_KEY_BYTES](bytes(pk)) for pk in si.public_keys
         ),
     )
 

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -50,7 +50,7 @@ MAX_BYTES_PER_WITNESS_NODE = 2**20
 MAX_BYTES_PER_CODE = 2**24
 MAX_BYTES_PER_HEADER = 2**10
 MAX_PUBLIC_KEYS = 2**20
-MAX_BYTES_PER_PUBLIC_KEY = 65
+PUBLIC_KEY_BYTES = 65
 
 
 # --- SSZ Container types ---
@@ -157,7 +157,7 @@ class SszStatelessInput(Container):
     new_payload_request: SszNewPayloadRequest
     witness: SszExecutionWitness
     chain_config: SszChainConfig
-    public_keys: SszList[ByteList[MAX_BYTES_PER_PUBLIC_KEY], MAX_PUBLIC_KEYS]
+    public_keys: SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
 
 
 class SszStatelessValidationResult(Container):
@@ -425,16 +425,20 @@ def stateless_input_to_ssz(
     si: StatelessInput,
 ) -> SszStatelessInput:
     """Convert a StatelessInput to its SSZ form."""
+    for public_key in si.public_keys:
+        if len(public_key) != PUBLIC_KEY_BYTES:
+            raise ValueError(
+                f"Transaction public key must be {PUBLIC_KEY_BYTES} bytes"
+            )
+
     return SszStatelessInput(
         new_payload_request=_new_payload_request_to_ssz(
             si.new_payload_request
         ),
         witness=_witness_to_ssz(si.witness),
         chain_config=_chain_config_to_ssz(si.chain_config),
-        public_keys=SszList[
-            ByteList[MAX_BYTES_PER_PUBLIC_KEY], MAX_PUBLIC_KEYS
-        ](
-            ByteList[MAX_BYTES_PER_PUBLIC_KEY](bytes(pk))
+        public_keys=SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS](
+            ByteVector[PUBLIC_KEY_BYTES](bytes(pk))
             for pk in si.public_keys
         ),
     )

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -12,7 +12,10 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint, ulen
 
-from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
+from ethereum.crypto.elliptic_curve import (
+    SECP256K1N,
+    secp256k1_recover,
+)
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import (
     InsufficientTransactionGasError,
@@ -66,6 +69,7 @@ Gas cost for including a storage key in the access list of a transaction.
 """
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+SECP256K1_UNCOMPRESSED_PUBLIC_KEY_PREFIX = b"\x04"
 
 
 @slotted_freezable
@@ -676,6 +680,57 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     the address of the sender of the transaction. It raises an
     `InvalidSignatureError` if the signature values (r, s, v) are invalid.
     """
+    public_key = recover_transaction_public_key(chain_id, tx)
+    return _sender_address_from_public_key(public_key)
+
+
+def recover_transaction_public_key(chain_id: U64, tx: Transaction) -> Bytes:
+    """
+    Recover the canonical uncompressed SEC1 public key for a transaction.
+    """
+    r, s, recovery_id, signing_hash = _signature_recovery_parameters(
+        chain_id, tx
+    )
+    return Bytes(
+        SECP256K1_UNCOMPRESSED_PUBLIC_KEY_PREFIX
+        + secp256k1_recover(r, s, recovery_id, signing_hash)
+    )
+
+
+def recover_sender_from_public_key(
+    chain_id: U64, tx: Transaction, public_key: Bytes
+) -> Address:
+    """
+    Verify that ``public_key`` is the transaction sender's canonical
+    uncompressed SEC1 public key.
+
+    This reference implementation verifies the supplied key by recovering the
+    canonical public key from the transaction signature and comparing the two.
+    Optimized implementations may avoid full public-key recovery, but must
+    still verify that the supplied key validates the signature and is
+    consistent with the transaction's recovery id / y-parity bit. Otherwise,
+    another valid recovery candidate could derive a different sender address.
+
+    Returns the sender address derived from the verified public key.
+    """
+    if public_key != recover_transaction_public_key(chain_id, tx):
+        raise InvalidSignatureError
+    return _sender_address_from_public_key(public_key)
+
+
+def _sender_address_from_public_key(public_key: Bytes) -> Address:
+    """
+    Derive the sender address from an uncompressed SEC1 public key.
+    """
+    return Address(keccak256(bytes(public_key)[1:])[12:32])
+
+
+def _signature_recovery_parameters(
+    chain_id: U64, tx: Transaction
+) -> Tuple[U256, U256, U256, Hash32]:
+    """
+    Validate the transaction signature fields and return recovery inputs.
+    """
     r, s = tx.r, tx.s
     if U256(0) >= r or r >= SECP256K1N:
         raise InvalidSignatureError("bad r")
@@ -685,14 +740,17 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     if isinstance(tx, LegacyTransaction):
         v = tx.v
         if v == 27 or v == 28:
-            public_key = secp256k1_recover(
-                r, s, v - U256(27), signing_hash_pre155(tx)
+            return (
+                r,
+                s,
+                v - U256(27),
+                signing_hash_pre155(tx),
             )
         else:
             chain_id_x2 = U256(chain_id) * U256(2)
             if v != U256(35) + chain_id_x2 and v != U256(36) + chain_id_x2:
                 raise InvalidSignatureError("bad v")
-            public_key = secp256k1_recover(
+            return (
                 r,
                 s,
                 v - U256(35) - chain_id_x2,
@@ -701,29 +759,41 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     elif isinstance(tx, AccessListTransaction):
         if tx.y_parity not in (U256(0), U256(1)):
             raise InvalidSignatureError("bad y_parity")
-        public_key = secp256k1_recover(
-            r, s, tx.y_parity, signing_hash_2930(tx)
+        return (
+            r,
+            s,
+            tx.y_parity,
+            signing_hash_2930(tx),
         )
     elif isinstance(tx, FeeMarketTransaction):
         if tx.y_parity not in (U256(0), U256(1)):
             raise InvalidSignatureError("bad y_parity")
-        public_key = secp256k1_recover(
-            r, s, tx.y_parity, signing_hash_1559(tx)
+        return (
+            r,
+            s,
+            tx.y_parity,
+            signing_hash_1559(tx),
         )
     elif isinstance(tx, BlobTransaction):
         if tx.y_parity not in (U256(0), U256(1)):
             raise InvalidSignatureError("bad y_parity")
-        public_key = secp256k1_recover(
-            r, s, tx.y_parity, signing_hash_4844(tx)
+        return (
+            r,
+            s,
+            tx.y_parity,
+            signing_hash_4844(tx),
         )
     elif isinstance(tx, SetCodeTransaction):
         if tx.y_parity not in (U256(0), U256(1)):
             raise InvalidSignatureError("bad y_parity")
-        public_key = secp256k1_recover(
-            r, s, tx.y_parity, signing_hash_7702(tx)
+        return (
+            r,
+            s,
+            tx.y_parity,
+            signing_hash_7702(tx),
         )
-
-    return Address(keccak256(public_key)[12:32])
+    else:
+        raise InvalidSignatureError("unsupported transaction type")
 
 
 def signing_hash_pre155(tx: LegacyTransaction) -> Hash32:

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -50,6 +50,7 @@ class BlockEnvironment:
     excess_blob_gas: U64
     parent_beacon_block_root: Hash32
     block_access_list_builder: BlockAccessListBuilder
+    transaction_public_keys: Optional[Tuple[Bytes, ...]] = None
 
 
 @dataclass

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
@@ -45,8 +45,8 @@ def test_stateless_input_public_keys_are_constructed(
         blocks=[
             Block(
                 txs=[tx_a, tx_b],
-                # The filler automatically verifies stateless input public
-                # keys against the recovered payload transaction keys.
+                # For accepted blocks, the filler verifies stateless input
+                # public keys against the recovered payload transaction keys.
                 expected_stateless_validation_success=True,
             )
         ],

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
@@ -1,0 +1,89 @@
+"""Stateless input transaction public-key tests."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytes,
+    Transaction,
+)
+from execution_testing.test_types.execution_witness.modifiers import (
+    replace_public_key_at,
+)
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+
+def test_stateless_input_public_keys_are_constructed(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """A public key is included for each payload transaction."""
+    recipient = pre.fund_eoa()
+    sender_a = pre.fund_eoa()
+    sender_b = pre.fund_eoa()
+    tx_a = Transaction(
+        sender=sender_a,
+        to=recipient,
+        value=0,
+        gas_limit=500_000,
+    )
+    tx_b = Transaction(
+        sender=sender_b,
+        to=recipient,
+        value=0,
+        gas_limit=500_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx_a, tx_b],
+                # The filler automatically verifies stateless input public
+                # keys against the recovered payload transaction keys.
+                expected_stateless_validation_success=True,
+            )
+        ],
+        post={
+            sender_a: Account(nonce=1),
+            sender_b: Account(nonce=1),
+        },
+    )
+
+
+def test_stateless_input_invalid_public_key_is_rejected(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """A wrong but SSZ-valid public key fails stateless validation."""
+    recipient = pre.fund_eoa()
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=recipient,
+        value=0,
+        gas_limit=500_000,
+    )
+    invalid_public_key = Bytes(b"\x04" + b"\x00" * 64)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                stateless_input_public_keys_modifier=(
+                    replace_public_key_at(0, invalid_public_key)
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -23,7 +23,6 @@ from ethereum.forks.amsterdam.stateless import (
     StatelessInput,
     StatelessValidationResult,
     compute_new_payload_request_root,
-    validate_transaction_public_keys,
     verify_stateless_new_payload,
 )
 from ethereum.forks.amsterdam.stateless_guest import (
@@ -229,25 +228,6 @@ class TestComputeNewPayloadRequestRoot:
 
 class TestTransactionPublicKeys:
     """Test stateless transaction public-key validation."""
-
-    def test_count_must_match_payload_transactions(self) -> None:
-        """Count validation should require exactly one key per transaction."""
-        original = _make_stateless_input()
-        invalid = StatelessInput(
-            new_payload_request=original.new_payload_request,
-            witness=original.witness,
-            chain_config=original.chain_config,
-            public_keys=(original.public_keys[0],),
-        )
-
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Transaction public key count does not match payload "
-                "transactions"
-            ),
-        ):
-            validate_transaction_public_keys(invalid)
 
     def test_too_few_public_keys_fail_validation(self) -> None:
         """Stateless validation should fail with too few public keys."""

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -3,6 +3,7 @@
 import random
 from typing import Tuple
 
+import pytest
 from ethereum_types.bytes import Bytes, Bytes32, Bytes48, Bytes96
 from ethereum_types.numeric import U64, U256, Uint
 
@@ -22,6 +23,8 @@ from ethereum.forks.amsterdam.stateless import (
     StatelessInput,
     StatelessValidationResult,
     compute_new_payload_request_root,
+    validate_transaction_public_keys,
+    verify_stateless_new_payload,
 )
 from ethereum.forks.amsterdam.stateless_guest import (
     deserialize_stateless_input,
@@ -96,7 +99,7 @@ def _make_stateless_input() -> StatelessInput:
             headers=(Bytes(_rb(512)), Bytes(_rb(512))),
         ),
         chain_config=ChainConfig(chain_id=U64(1)),
-        public_keys=(Bytes(_rb(33)), Bytes(_rb(33))),
+        public_keys=(Bytes(_rb(65)), Bytes(_rb(65))),
     )
 
 
@@ -138,6 +141,19 @@ class TestSerializeStatelessInput:
         encoded = serialize_stateless_input(original)
         recovered = deserialize_stateless_input(encoded)
         assert recovered == original
+
+    def test_rejects_non_65_byte_public_key(self) -> None:
+        """Public keys must be 65-byte uncompressed SEC1 points."""
+        original = _make_stateless_input()
+        invalid = StatelessInput(
+            new_payload_request=original.new_payload_request,
+            witness=original.witness,
+            chain_config=original.chain_config,
+            public_keys=(Bytes(_rb(64)), Bytes(_rb(65))),
+        )
+
+        with pytest.raises(ValueError):
+            serialize_stateless_input(invalid)
 
 
 class TestDeserializeStatelessInput:
@@ -209,3 +225,56 @@ class TestComputeNewPayloadRequestRoot:
         si = _make_stateless_input()
         root = compute_new_payload_request_root(si)
         assert len(root) == 32
+
+
+class TestTransactionPublicKeys:
+    """Test stateless transaction public-key validation."""
+
+    def test_count_must_match_payload_transactions(self) -> None:
+        """Count validation should require exactly one key per transaction."""
+        original = _make_stateless_input()
+        invalid = StatelessInput(
+            new_payload_request=original.new_payload_request,
+            witness=original.witness,
+            chain_config=original.chain_config,
+            public_keys=(original.public_keys[0],),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Transaction public key count does not match payload "
+                "transactions"
+            ),
+        ):
+            validate_transaction_public_keys(invalid)
+
+    def test_too_few_public_keys_fail_validation(self) -> None:
+        """Stateless validation should fail with too few public keys."""
+        original = _make_stateless_input()
+        invalid = StatelessInput(
+            new_payload_request=original.new_payload_request,
+            witness=original.witness,
+            chain_config=original.chain_config,
+            public_keys=(original.public_keys[0],),
+        )
+
+        result = verify_stateless_new_payload(invalid)
+        assert not result.successful_validation
+
+    def test_too_many_public_keys_fail_validation(self) -> None:
+        """Stateless validation should fail with too many public keys."""
+        original = _make_stateless_input()
+        invalid = StatelessInput(
+            new_payload_request=original.new_payload_request,
+            witness=original.witness,
+            chain_config=original.chain_config,
+            public_keys=(
+                original.public_keys[0],
+                original.public_keys[1],
+                Bytes(_rb(65)),
+            ),
+        )
+
+        result = verify_stateless_new_payload(invalid)
+        assert not result.successful_validation


### PR DESCRIPTION
## 🗒️ Description

Adds transaction public keys to Amsterdam stateless validation input and threads them through payload/block execution.

- Populate `StatelessInput.public_keys` with one 65-byte uncompressed SEC1 public key per payload transaction.
- Validate public-key count and SSZ public-key length before stateless execution.
- Allow Amsterdam execution to verify sender derivation from supplied transaction public keys.
- Extend the blockchain filler with public-key verification/mutation hooks for stateless input tests.
- Add coverage for valid public-key construction, invalid public-key rejection, SSZ length checks, and public-key count mismatches.

So, although I added some test cases to check tha valid construction works fine, and basic invalid public key are rejected by the guest program, I believe we need to add some extra tests here. Mainly regarding potential wrong public keys reg ECDSA parity checks, and probably other cases. We will do that in other upcoming PRs.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
