### PR TITLE
feat(spec-specs, tests): EIP-8037 tx created contracts destroyed in same tx

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1085,14 +1085,12 @@ def process_transaction(
     else:
         # Refund state gas for accounts created and destroyed in the
         # same tx (EIP-6780). Covers account, storage, and code.
+        new_account_refund = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
         for address in tx_output.accounts_to_delete:
             if address in tx_state.created_accounts:
-                selfdestruct_refund = (
-                    STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
-                )
                 storage = tx_state.storage_writes.get(address, {})
                 created_slots = sum(1 for v in storage.values() if v != 0)
-                selfdestruct_refund += (
+                non_account_refund = (
                     Uint(created_slots)
                     * STATE_BYTES_PER_STORAGE_SET
                     * COST_PER_STATE_BYTE
@@ -1103,7 +1101,27 @@ def process_transaction(
                 # pre-deletion.
                 account = get_account(tx_state, address)
                 code = get_code(tx_state, account.code_hash)
-                selfdestruct_refund += ulen(code) * COST_PER_STATE_BYTE
+                non_account_refund += ulen(code) * COST_PER_STATE_BYTE
+
+                tx_created_target = (
+                    tx.to == Bytes0(b"")
+                    and address == message.current_target
+                )
+                if tx_created_target:
+                    # NEW_ACCOUNT was paid via intrinsic, not via
+                    # state_gas_used. Refund through state_refund so
+                    # tx-level accounting subtracts it from
+                    # tx_state_gas at block aggregation.
+                    tx_output.state_refund += new_account_refund
+                    selfdestruct_refund = non_account_refund
+                else:
+                    # Inner CREATE: NEW_ACCOUNT was charged via the
+                    # parent's execution state_gas_used, so refund
+                    # through the same channel (clamped below).
+                    selfdestruct_refund = (
+                        new_account_refund + non_account_refund
+                    )
+
                 selfdestruct_refund = min(
                     selfdestruct_refund, tx_output.state_gas_used
                 )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -745,3 +745,93 @@ def test_selfdestruct_new_beneficiary_no_regular_account_creation_cost(
     )
 
     state_test(pre=pre, post={beneficiary: Account(balance=1)}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "tx_value,beneficiary_kind",
+    [
+        pytest.param(0, "self", id="value0_to_self"),
+        pytest.param(0, "existing", id="value0_to_existing"),
+        pytest.param(0, "empty", id="value0_to_empty"),
+        pytest.param(1, "self", id="value1_to_self"),
+        pytest.param(1, "existing", id="value1_to_existing"),
+        pytest.param(1, "empty", id="value1_to_empty"),
+    ],
+)
+@pytest.mark.pre_alloc_mutable()
+@pytest.mark.valid_from("EIP8037")
+def test_create_tx_selfdestruct_initcode_refunds_intrinsic(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_value: int,
+    beneficiary_kind: str,
+) -> None:
+    """
+    Verify a creation tx whose initcode SELFDESTRUCTs the new
+    contract refunds the intrinsic NEW_ACCOUNT × CPSB so the user
+    only pays state-gas for any genuinely new account that persists.
+
+    Cases:
+    - value=0 (any beneficiary): contract is destroyed, no
+      beneficiary creation. Net new state = 0; expected state-gas
+      bill = 0.
+    - value>0 to self/existing: balance burned or transferred to a
+      live account; contract destroyed. Net new state = 0; expected
+      state-gas bill = 0.
+    - value>0 to empty beneficiary: SELFDESTRUCT charges a NEW_ACCOUNT
+      for the new beneficiary which persists; contract is destroyed.
+      Net new state = 1; expected state-gas bill = NEW_ACCOUNT × CPSB.
+    """
+    new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+
+    sender = pre.fund_eoa(amount=10**18)
+    contract_addr = compute_create_address(address=sender, nonce=0)
+
+    if beneficiary_kind == "self":
+        beneficiary = contract_addr
+    elif beneficiary_kind == "existing":
+        beneficiary = pre.deploy_contract(code=Op.STOP)
+    else:
+        beneficiary = pre.fund_eoa(amount=0)
+
+    # `current_target` is added to `accessed_addresses` at message
+    # entry, so SELFDESTRUCT to self skips the cold-access surcharge.
+    if beneficiary_kind == "self":
+        init_code = Op.SELFDESTRUCT.with_metadata(address_warm=True)(
+            beneficiary
+        )
+    else:
+        init_code = Op.SELFDESTRUCT(beneficiary)
+    intrinsic_total = intrinsic_calc(
+        calldata=bytes(init_code), contract_creation=True
+    )
+    intrinsic_regular = intrinsic_total - new_account_state_gas
+
+    creates_new_beneficiary = beneficiary_kind == "empty" and tx_value > 0
+    expected_state = new_account_state_gas if creates_new_beneficiary else 0
+    expected_regular = intrinsic_regular + init_code.regular_cost(fork)
+    expected_gas_used = max(expected_regular, expected_state)
+
+    # Reservoir is empty for sub-cap txs, so SELFDESTRUCT's state-gas
+    # charge for a new beneficiary spills into gas_left. The buffer
+    # has to cover that spillover plus the regular execution costs.
+    tx = Transaction(
+        to=None,
+        data=init_code,
+        gas_limit=intrinsic_total + 100_000 + expected_state,
+        sender=sender,
+        value=tx_value,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={},
+    )


### PR DESCRIPTION
## 🗒️ Description
A create tx charges `STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE` of instrinsic state gas at the start of tx processing for contract creation. If the contract is then destroyed in the same tx via a selfdestruct, the existing refund mechanism clamps to the state gas used which does not include the intrinsic state gas charge from the start of tx processing. This means the intrinsic state gas charge for account creating stays billed even though no contract persists at end of the tx. TLDR; the user pays for state that was never written.

This PR aims to fix the inconsistency by routing the destroyed contract state gas charge by refunding then moment when the destroyed account is the create tx target.

@benaadams and Iván (ethrex) flagged this scenario class during the Soldogn interop on `bal-devnet-6`. The specific case Iván mentioned: "creation tx, initcode selfdestructs to an empty beneficiary with `value > 0`" was already correctly accounted for by accident. There was however a bug from many other scenarios:

| `value` | beneficiary | net new state | before fix | after fix |
|---|---|---|---|---|
| 0 | self | 0 | over-bills 1 NEW_ACCOUNT | 0 ✓ |
| 0 | existing | 0 | over-bills 1 NEW_ACCOUNT | 0 ✓ |
| 0 | empty | 0 | over-bills 1 NEW_ACCOUNT | 0 ✓ |
| >0 | self | 0 (balance burned) | over-bills 1 NEW_ACCOUNT | 0 ✓ |
| >0 | existing | 0 | over-bills 1 NEW_ACCOUNT | 0 ✓ |
| >0 | empty | +1 (new beneficiary) | 1 NEW_ACCOUNT | 1 NEW_ACCOUNT ✓ |

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).