### PR TITLE
fix(traces): tracing consistency between input and output alloc formatting

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/spec.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/spec.py
@@ -1,0 +1,24 @@
+"""Defines EIP-7778 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7778 = ReferenceSpec(
+    "EIPS/eip-7778.md", "ce17d00b8341032a946301944124c4a6013032d6"
+)
+
+
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-7778 specifications as defined at
+    https://eips.ethereum.org/EIPS/eip-7778.
+    """

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -24,8 +24,10 @@ from execution_testing import (
 from execution_testing.base_types import HashInt
 from execution_testing.vm import Op
 
-REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7778.md"
-REFERENCE_SPEC_VERSION = "ce17d00b8341032a946301944124c4a6013032d6"
+from .spec import ref_spec_7778
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7778.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7778.version
 
 
 def build_refund_tx(


### PR DESCRIPTION
## 🗒️ Description
while looking into how our different tracing flags work I noticed that the same values are represented differently in input vs output alloc. for instance, a storage key would be `0x22` in the input (no padding) but `0x000..22` in the output (32 byte padded). another example is how an empty storage in the input would be shown as `{}` whereas empty fields are completely emitted in the output (same for empty balances and empty code). also nonces in the input are shown like e.g. `0x01` (always at least two chars)  but shown as `0x1` in the output (minimal representation)

this PR fixes all these inconsistencies and adds a unit tests that ensures input and output alloc formatting remains consistent. the output of course can still be different, this PR is only about the format in which values are shown

i think this is a good feature because if we ever want to actually look at the diff between input and output alloc we currently would have a lot of noise, after the PR only the actual differences would be left (less bloating of our human context windows)

i don't think this PR breaks anything, because it only changes the input alloc formatting and leaves the output alloc (that might be read be client software) exactly as is

## Command to run the new unit test

`uv run pytest packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_alloc_dump_canonical.py::test_input_alloc_matches_output_alloc_format -v`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://media.discordapp.net/attachments/1349696533922320478/1491808384129699941/PNG_image_56.png?ex=6a029193&is=6a014013&hm=c4dd8b3c9adf5ffa4fb19cef93292daa248b1023d37be6994dcd5b3ac57d28bf&=&format=webp&quality=lossless&width=828&height=831"
  alt="Cute Animal Picture"
  width="320">
