### PR TITLE
chore(tests): stop mutating parametrize values in EL request helpers

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7002.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7002.py
@@ -542,18 +542,18 @@ def test_bal_7002_request_from_contract(
     )
 
     # Set up pre-state using helper
-    interaction.update_pre(pre)
+    prepared = interaction.update_pre(pre)
 
-    alice = interaction.sender_account
-    relay_contract = interaction.contract_address
+    alice = prepared.sender_account
+    relay_contract = prepared.contract_address
 
     # Build queue storage slots with contract as source
     queue_writes, queue_reads = _build_queue_storage_slots(
-        [relay_contract], interaction.requests
+        [relay_contract], prepared.requests
     )
 
     block = Block(
-        txs=interaction.transactions(),
+        txs=prepared.transactions(),
         expected_block_access_list=BlockAccessListExpectation(
             account_expectations={
                 alice: BalAccountExpectation(
@@ -766,9 +766,9 @@ def test_bal_7002_request_invalid(
     - No withdrawal request is queued
     """
     # Use helper to set up pre-state and get transaction
-    interaction.update_pre(pre)
-    tx = interaction.transactions()[0]
-    alice = interaction.sender_account
+    prepared = interaction.update_pre(pre)
+    tx = prepared.transactions()[0]
+    alice = prepared.sender_account
 
     # Build account expectations
     account_expectations = {
@@ -801,8 +801,8 @@ def test_bal_7002_request_invalid(
     }
 
     # Add relay contract to post-state for contract scenarios
-    if isinstance(interaction, WithdrawalRequestContract):
-        post[interaction.contract_address] = Account()
+    if isinstance(prepared, WithdrawalRequestContract):
+        post[prepared.contract_address] = Account()
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7251.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7251.py
@@ -102,8 +102,8 @@ def test_bal_system_dequeue_consolidations_eip7251(
     txs = []
 
     for request in blocks_consolidation_requests:
-        request.update_pre(pre=pre)
-        txs += request.transactions()
+        prepared = request.update_pre(pre=pre)
+        txs += prepared.transactions()
 
     num = len(txs)
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
@@ -276,9 +276,9 @@ def test_reentrant_selfdestructing_call(
         data=data,
     )
 
-    expected_storage[0] = callee_address
+    post_storage = {**expected_storage, 0: callee_address}
 
-    post: Dict = {caller_address: Account(storage=expected_storage)}
+    post: Dict = {caller_address: Account(storage=post_storage)}
 
     if pre_existing_contract:
         post[callee_address] = Account(code=callee_bytecode)

--- a/tests/prague/eip6110_deposits/conftest.py
+++ b/tests/prague/eip6110_deposits/conftest.py
@@ -17,23 +17,24 @@ from .helpers import DepositInteractionBase, DepositRequest
 
 
 @pytest.fixture
-def update_pre(pre: Alloc, requests: List[DepositInteractionBase]) -> None:
+def prepared_requests(
+    pre: Alloc, requests: List[DepositInteractionBase]
+) -> List[DepositInteractionBase]:
     """
-    Init state of the accounts. Every deposit transaction defines their own
-    pre-state requirements, and this fixture aggregates them all.
+    Allocate accounts/contracts for each request in `pre` and return copies
+    with the allocated state populated. The parametrize value `requests` is
+    not mutated, so it stays pristine across fixture format runs.
     """
-    for d in requests:
-        d.update_pre(pre)
+    return [r.update_pre(pre) for r in requests]
 
 
 @pytest.fixture
 def txs(
-    requests: List[DepositInteractionBase],
-    update_pre: None,  # Fixture is used for its side effects
+    prepared_requests: List[DepositInteractionBase],
 ) -> List[Transaction]:
     """List of transactions to include in the block."""
     txs = []
-    for r in requests:
+    for r in prepared_requests:
         txs += r.transactions()
     return txs
 
@@ -55,14 +56,14 @@ def exception() -> BlockException | None:
 
 @pytest.fixture
 def included_requests(
-    requests: List[DepositInteractionBase],
+    prepared_requests: List[DepositInteractionBase],
 ) -> List[DepositRequest]:
     """
     Return the list of deposit requests that should be included in each block.
     """
     valid_requests: List[DepositRequest] = []
 
-    for d in requests:
+    for d in prepared_requests:
         valid_requests += d.valid_requests(10**18)
 
     return valid_requests

--- a/tests/prague/eip6110_deposits/helpers.py
+++ b/tests/prague/eip6110_deposits/helpers.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field, replace
 from functools import cached_property
 from hashlib import sha256 as sha256_hashlib
-from typing import Callable, ClassVar, List
+from typing import Callable, ClassVar, List, Self
 
 from execution_testing import (
     EOA,
@@ -214,7 +214,7 @@ class DepositRequest(DepositRequestBase):
         return self.copy()
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class DepositInteractionBase:
     """Base class for all types of deposit transactions we want to test."""
 
@@ -229,7 +229,7 @@ class DepositInteractionBase:
         """Return a transaction for the deposit request."""
         raise NotImplementedError
 
-    def update_pre(self, pre: Alloc) -> "DepositInteractionBase":
+    def update_pre(self, pre: Alloc) -> Self:
         """
         Allocate accounts/contracts in `pre` and return a new instance with
         the allocated state populated. Does not mutate `self`, so the
@@ -245,7 +245,7 @@ class DepositInteractionBase:
         raise NotImplementedError
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class DepositTransaction(DepositInteractionBase):
     """
     Class used to describe a deposit originated from an externally owned
@@ -269,7 +269,7 @@ class DepositTransaction(DepositInteractionBase):
             for request in self.requests
         ]
 
-    def update_pre(self, pre: Alloc) -> "DepositTransaction":
+    def update_pre(self, pre: Alloc) -> Self:
         """Return a copy of self with `sender_account` populated."""
         return replace(self, sender_account=pre.fund_eoa(self.sender_balance))
 
@@ -285,7 +285,7 @@ class DepositTransaction(DepositInteractionBase):
         ]
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class DepositContract(DepositInteractionBase):
     """Class used to describe a deposit originated from a contract."""
 
@@ -351,7 +351,7 @@ class DepositContract(DepositInteractionBase):
             )
         ]
 
-    def update_pre(self, pre: Alloc) -> "DepositContract":
+    def update_pre(self, pre: Alloc) -> Self:
         """
         Return a copy of self with the allocated sender/contract/entry
         addresses populated.

--- a/tests/prague/eip6110_deposits/helpers.py
+++ b/tests/prague/eip6110_deposits/helpers.py
@@ -1,6 +1,6 @@
 """Helpers for the EIP-6110 deposit tests."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import cached_property
 from hashlib import sha256 as sha256_hashlib
 from typing import Callable, ClassVar, List
@@ -229,8 +229,12 @@ class DepositInteractionBase:
         """Return a transaction for the deposit request."""
         raise NotImplementedError
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
+    def update_pre(self, pre: Alloc) -> "DepositInteractionBase":
+        """
+        Allocate accounts/contracts in `pre` and return a new instance with
+        the allocated state populated. Does not mutate `self`, so the
+        parametrize value remains pristine across fixture format runs.
+        """
         raise NotImplementedError
 
     def valid_requests(self, current_minimum_fee: int) -> List[DepositRequest]:
@@ -265,9 +269,9 @@ class DepositTransaction(DepositInteractionBase):
             for request in self.requests
         ]
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
-        self.sender_account = pre.fund_eoa(self.sender_balance)
+    def update_pre(self, pre: Alloc) -> "DepositTransaction":
+        """Return a copy of self with `sender_account` populated."""
+        return replace(self, sender_account=pre.fund_eoa(self.sender_balance))
 
     def valid_requests(self, current_minimum_fee: int) -> List[DepositRequest]:
         """
@@ -347,26 +351,29 @@ class DepositContract(DepositInteractionBase):
             )
         ]
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
+    def update_pre(self, pre: Alloc) -> "DepositContract":
+        """
+        Return a copy of self with the allocated sender/contract/entry
+        addresses populated.
+        """
         required_balance = self.sender_balance
         if self.tx_value > 0:
             required_balance = max(
                 required_balance, self.tx_value + self.tx_gas_limit * 7
             )
-        self.sender_account = pre.fund_eoa(required_balance)
-        self.contract_address = pre.deploy_contract(
+        sender_account = pre.fund_eoa(required_balance)
+        contract_address = pre.deploy_contract(
             code=self.contract_code, balance=self.contract_balance
         )
-        self.entry_address = self.contract_address
+        entry_address = contract_address
         if self.call_depth > 2:
             for _ in range(1, self.call_depth - 1):
-                self.entry_address = pre.deploy_contract(
+                entry_address = pre.deploy_contract(
                     code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
                     + Op.POP(
                         Op.CALL(
                             Op.GAS,
-                            self.entry_address,
+                            entry_address,
                             0,
                             0,
                             Op.CALLDATASIZE,
@@ -375,6 +382,12 @@ class DepositContract(DepositInteractionBase):
                         )
                     ),
                 )
+        return replace(
+            self,
+            sender_account=sender_account,
+            contract_address=contract_address,
+            entry_address=entry_address,
+        )
 
     def valid_requests(self, current_minimum_fee: int) -> List[DepositRequest]:
         """

--- a/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
@@ -18,23 +18,27 @@ from .spec import Spec
 
 
 @pytest.fixture
-def update_pre(
+def prepared_blocks_withdrawal_requests(
     pre: Alloc,
     blocks_withdrawal_requests: List[List[WithdrawalRequestInteractionBase]],
-) -> None:
+) -> List[List[WithdrawalRequestInteractionBase]]:
     """
-    Init state of the accounts. Every deposit transaction defines their own
-    pre-state requirements, and this fixture aggregates them all.
+    Allocate accounts/contracts for each interaction in `pre` and return
+    copies with the allocated state populated. The parametrize value
+    `blocks_withdrawal_requests` is not mutated, so it stays pristine across
+    fixture format runs.
     """
-    for requests in blocks_withdrawal_requests:
-        for r in requests:
-            r.update_pre(pre)
+    return [
+        [r.update_pre(pre) for r in block_requests]
+        for block_requests in blocks_withdrawal_requests
+    ]
 
 
 @pytest.fixture
 def included_requests(
-    update_pre: None,  # Fixture is used for its side effects
-    blocks_withdrawal_requests: List[List[WithdrawalRequestInteractionBase]],
+    prepared_blocks_withdrawal_requests: List[
+        List[WithdrawalRequestInteractionBase]
+    ],
 ) -> List[List[WithdrawalRequest]]:
     """
     Return the list of withdrawal requests that should be included in each
@@ -43,7 +47,7 @@ def included_requests(
     excess_withdrawal_requests = 0
     carry_over_requests: List[WithdrawalRequest] = []
     per_block_included_requests: List[List[WithdrawalRequest]] = []
-    for block_withdrawal_requests in blocks_withdrawal_requests:
+    for block_withdrawal_requests in prepared_blocks_withdrawal_requests:
         # Get fee for the current block
         current_minimum_fee = Spec.get_fee(excess_withdrawal_requests)
 
@@ -87,8 +91,9 @@ def timestamp() -> int:
 @pytest.fixture
 def blocks(
     fork: Fork | TransitionFork,
-    update_pre: None,  # Fixture is used for its side effects
-    blocks_withdrawal_requests: List[List[WithdrawalRequestInteractionBase]],
+    prepared_blocks_withdrawal_requests: List[
+        List[WithdrawalRequestInteractionBase]
+    ],
     included_requests: List[List[WithdrawalRequest]],
     timestamp: int,
 ) -> List[Block]:
@@ -96,7 +101,7 @@ def blocks(
     blocks: List[Block] = []
 
     for block_requests, block_included_requests in zip_longest(  # type: ignore
-        blocks_withdrawal_requests,
+        prepared_blocks_withdrawal_requests,
         included_requests,
         fillvalue=[],
     ):

--- a/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field, replace
 from functools import cached_property
 from itertools import count
-from typing import Callable, ClassVar, List
+from typing import Callable, ClassVar, List, Self
 
 from execution_testing import (
     EOA,
@@ -69,7 +69,7 @@ class WithdrawalRequest(WithdrawalRequestBase):
         return self.copy(source_address=source_address)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class WithdrawalRequestInteractionBase:
     """Base class for all types of withdrawal transactions we want to test."""
 
@@ -84,7 +84,7 @@ class WithdrawalRequestInteractionBase:
         """Return a transaction for the withdrawal request."""
         raise NotImplementedError
 
-    def update_pre(self, pre: Alloc) -> "WithdrawalRequestInteractionBase":
+    def update_pre(self, pre: Alloc) -> Self:
         """
         Allocate accounts/contracts in `pre` and return a new instance with
         the allocated state populated. Does not mutate `self`, so the
@@ -102,7 +102,7 @@ class WithdrawalRequestInteractionBase:
         raise NotImplementedError
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class WithdrawalRequestTransaction(WithdrawalRequestInteractionBase):
     """
     Class used to describe a withdrawal request originated from an externally
@@ -126,7 +126,7 @@ class WithdrawalRequestTransaction(WithdrawalRequestInteractionBase):
             for request in self.requests
         ]
 
-    def update_pre(self, pre: Alloc) -> "WithdrawalRequestTransaction":
+    def update_pre(self, pre: Alloc) -> Self:
         """Return a copy of self with `sender_account` populated."""
         return replace(self, sender_account=pre.fund_eoa(self.sender_balance))
 
@@ -144,7 +144,7 @@ class WithdrawalRequestTransaction(WithdrawalRequestInteractionBase):
         ]
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
     """Class used to describe a withdrawal originated from a contract."""
 
@@ -208,7 +208,7 @@ class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
             )
         ]
 
-    def update_pre(self, pre: Alloc) -> "WithdrawalRequestContract":
+    def update_pre(self, pre: Alloc) -> Self:
         """
         Return a copy of self with the allocated sender/contract/entry
         addresses populated.

--- a/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
@@ -1,6 +1,6 @@
 """Helpers for the EIP-7002 withdrawal tests."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import cached_property
 from itertools import count
 from typing import Callable, ClassVar, List
@@ -84,8 +84,12 @@ class WithdrawalRequestInteractionBase:
         """Return a transaction for the withdrawal request."""
         raise NotImplementedError
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
+    def update_pre(self, pre: Alloc) -> "WithdrawalRequestInteractionBase":
+        """
+        Allocate accounts/contracts in `pre` and return a new instance with
+        the allocated state populated. Does not mutate `self`, so the
+        parametrize value remains pristine across fixture format runs.
+        """
         raise NotImplementedError
 
     def valid_requests(
@@ -122,9 +126,9 @@ class WithdrawalRequestTransaction(WithdrawalRequestInteractionBase):
             for request in self.requests
         ]
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
-        self.sender_account = pre.fund_eoa(self.sender_balance)
+    def update_pre(self, pre: Alloc) -> "WithdrawalRequestTransaction":
+        """Return a copy of self with `sender_account` populated."""
+        return replace(self, sender_account=pre.fund_eoa(self.sender_balance))
 
     def valid_requests(
         self, current_minimum_fee: int
@@ -204,21 +208,24 @@ class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
             )
         ]
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
-        self.sender_account = pre.fund_eoa(self.sender_balance)
-        self.contract_address = pre.deploy_contract(
+    def update_pre(self, pre: Alloc) -> "WithdrawalRequestContract":
+        """
+        Return a copy of self with the allocated sender/contract/entry
+        addresses populated.
+        """
+        sender_account = pre.fund_eoa(self.sender_balance)
+        contract_address = pre.deploy_contract(
             code=self.contract_code, balance=self.contract_balance
         )
-        self.entry_address = self.contract_address
+        entry_address = contract_address
         if self.call_depth > 2:
             for _ in range(1, self.call_depth - 1):
-                self.entry_address = pre.deploy_contract(
+                entry_address = pre.deploy_contract(
                     code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
                     + Op.POP(
                         Op.CALL(
                             Op.GAS,
-                            self.entry_address,
+                            entry_address,
                             0,
                             0,
                             Op.CALLDATASIZE,
@@ -227,6 +234,12 @@ class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
                         )
                     )
                 )
+        return replace(
+            self,
+            sender_account=sender_account,
+            contract_address=contract_address,
+            entry_address=entry_address,
+        )
 
     def valid_requests(
         self, current_minimum_fee: int

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
@@ -124,9 +124,9 @@ def test_extra_withdrawals(
         requests=requests_list
     )
     # prepare withdrawal senders
-    withdrawal_request_transaction.update_pre(pre=pre)
+    prepared = withdrawal_request_transaction.update_pre(pre=pre)
     # get transaction list
-    txs: List[Transaction] = withdrawal_request_transaction.transactions()
+    txs: List[Transaction] = prepared.transactions()
 
     blockchain_test(
         pre=pre,

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -847,13 +847,12 @@ def test_withdrawal_requests_negative(
     Test blocks where the requests list and the actual withdrawal requests that
     happened in the block's transactions do not match.
     """
-    for d in requests:
-        d.update_pre(pre)
+    prepared = [d.update_pre(pre) for d in requests]
 
     # No previous block so fee is the base
     fee = 1
     current_block_requests = []
-    for w in requests:
+    for w in prepared:
         current_block_requests += w.valid_requests(fee)
     included_requests = current_block_requests[
         : Spec.MAX_WITHDRAWAL_REQUESTS_PER_BLOCK
@@ -865,7 +864,7 @@ def test_withdrawal_requests_negative(
         post={},
         blocks=[
             Block(
-                txs=sum((r.transactions() for r in requests), []),
+                txs=sum((r.transactions() for r in prepared), []),
                 header_verify=Header(
                     requests_hash=Requests(
                         *included_requests,

--- a/tests/prague/eip7251_consolidations/conftest.py
+++ b/tests/prague/eip7251_consolidations/conftest.py
@@ -18,25 +18,27 @@ from .spec import Spec
 
 
 @pytest.fixture
-def update_pre(
+def prepared_blocks_consolidation_requests(
     pre: Alloc,
     blocks_consolidation_requests: List[
         List[ConsolidationRequestInteractionBase]
     ],
-) -> None:
+) -> List[List[ConsolidationRequestInteractionBase]]:
     """
-    Init state of the accounts. Every consolidation request defines its own
-    pre-state requirements, and this fixture aggregates them all.
+    Allocate accounts/contracts for each interaction in `pre` and return
+    copies with the allocated state populated. The parametrize value
+    `blocks_consolidation_requests` is not mutated, so it stays pristine
+    across fixture format runs.
     """
-    for requests in blocks_consolidation_requests:
-        for r in requests:
-            r.update_pre(pre)
+    return [
+        [r.update_pre(pre) for r in block_requests]
+        for block_requests in blocks_consolidation_requests
+    ]
 
 
 @pytest.fixture
 def included_requests(
-    update_pre: None,  # Fixture is used for its side effects
-    blocks_consolidation_requests: List[
+    prepared_blocks_consolidation_requests: List[
         List[ConsolidationRequestInteractionBase]
     ],
 ) -> List[List[ConsolidationRequest]]:
@@ -47,7 +49,7 @@ def included_requests(
     excess_consolidation_requests = 0
     carry_over_requests: List[ConsolidationRequest] = []
     per_block_included_requests: List[List[ConsolidationRequest]] = []
-    for block_consolidation_requests in blocks_consolidation_requests:
+    for block_consolidation_requests in prepared_blocks_consolidation_requests:
         # Get fee for the current block
         current_minimum_fee = Spec.get_fee(excess_consolidation_requests)
 
@@ -93,8 +95,7 @@ def timestamp() -> int:
 @pytest.fixture
 def blocks(
     fork: Fork | TransitionFork,
-    update_pre: None,  # Fixture is used for its side effects
-    blocks_consolidation_requests: List[
+    prepared_blocks_consolidation_requests: List[
         List[ConsolidationRequestInteractionBase]
     ],
     included_requests: List[List[ConsolidationRequest]],
@@ -104,7 +105,7 @@ def blocks(
     blocks: List[Block] = []
 
     for block_requests, block_included_requests in zip_longest(  # type: ignore
-        blocks_consolidation_requests,
+        prepared_blocks_consolidation_requests,
         included_requests,
         fillvalue=[],
     ):

--- a/tests/prague/eip7251_consolidations/helpers.py
+++ b/tests/prague/eip7251_consolidations/helpers.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field, replace
 from functools import cached_property
 from itertools import count
-from typing import Callable, ClassVar, List
+from typing import Callable, ClassVar, List, Self
 
 from execution_testing import (
     EOA,
@@ -62,7 +62,7 @@ class ConsolidationRequest(ConsolidationRequestBase):
         return self.copy(source_address=source_address)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ConsolidationRequestInteractionBase:
     """
     Base class for all types of consolidation transactions we want to test.
@@ -79,7 +79,7 @@ class ConsolidationRequestInteractionBase:
         """Return a transaction for the consolidation request."""
         raise NotImplementedError
 
-    def update_pre(self, pre: Alloc) -> "ConsolidationRequestInteractionBase":
+    def update_pre(self, pre: Alloc) -> Self:
         """
         Allocate accounts/contracts in `pre` and return a new instance with
         the allocated state populated. Does not mutate `self`, so the
@@ -97,7 +97,7 @@ class ConsolidationRequestInteractionBase:
         raise NotImplementedError
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ConsolidationRequestTransaction(ConsolidationRequestInteractionBase):
     """
     Class to describe a consolidation request originated from an externally
@@ -121,7 +121,7 @@ class ConsolidationRequestTransaction(ConsolidationRequestInteractionBase):
             for request in self.requests
         ]
 
-    def update_pre(self, pre: Alloc) -> "ConsolidationRequestTransaction":
+    def update_pre(self, pre: Alloc) -> Self:
         """Return a copy of self with `sender_account` populated."""
         return replace(self, sender_account=pre.fund_eoa(self.sender_balance))
 
@@ -139,7 +139,7 @@ class ConsolidationRequestTransaction(ConsolidationRequestInteractionBase):
         ]
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, frozen=True)
 class ConsolidationRequestContract(ConsolidationRequestInteractionBase):
     """Class used to describe a consolidation originated from a contract."""
 
@@ -203,7 +203,7 @@ class ConsolidationRequestContract(ConsolidationRequestInteractionBase):
             )
         ]
 
-    def update_pre(self, pre: Alloc) -> "ConsolidationRequestContract":
+    def update_pre(self, pre: Alloc) -> Self:
         """
         Return a copy of self with the allocated sender/contract/entry
         addresses populated.

--- a/tests/prague/eip7251_consolidations/helpers.py
+++ b/tests/prague/eip7251_consolidations/helpers.py
@@ -1,6 +1,6 @@
 """Helpers for the EIP-7251 consolidation tests."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import cached_property
 from itertools import count
 from typing import Callable, ClassVar, List
@@ -79,8 +79,12 @@ class ConsolidationRequestInteractionBase:
         """Return a transaction for the consolidation request."""
         raise NotImplementedError
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
+    def update_pre(self, pre: Alloc) -> "ConsolidationRequestInteractionBase":
+        """
+        Allocate accounts/contracts in `pre` and return a new instance with
+        the allocated state populated. Does not mutate `self`, so the
+        parametrize value remains pristine across fixture format runs.
+        """
         raise NotImplementedError
 
     def valid_requests(
@@ -117,9 +121,9 @@ class ConsolidationRequestTransaction(ConsolidationRequestInteractionBase):
             for request in self.requests
         ]
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
-        self.sender_account = pre.fund_eoa(self.sender_balance)
+    def update_pre(self, pre: Alloc) -> "ConsolidationRequestTransaction":
+        """Return a copy of self with `sender_account` populated."""
+        return replace(self, sender_account=pre.fund_eoa(self.sender_balance))
 
     def valid_requests(
         self, current_minimum_fee: int
@@ -199,21 +203,24 @@ class ConsolidationRequestContract(ConsolidationRequestInteractionBase):
             )
         ]
 
-    def update_pre(self, pre: Alloc) -> None:
-        """Return the pre-state of the account."""
-        self.sender_account = pre.fund_eoa(self.sender_balance)
-        self.contract_address = pre.deploy_contract(
+    def update_pre(self, pre: Alloc) -> "ConsolidationRequestContract":
+        """
+        Return a copy of self with the allocated sender/contract/entry
+        addresses populated.
+        """
+        sender_account = pre.fund_eoa(self.sender_balance)
+        contract_address = pre.deploy_contract(
             code=self.contract_code, balance=self.contract_balance
         )
-        self.entry_address = self.contract_address
+        entry_address = contract_address
         if self.call_depth > 2:
             for _ in range(1, self.call_depth - 1):
-                self.entry_address = pre.deploy_contract(
+                entry_address = pre.deploy_contract(
                     code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
                     + Op.POP(
                         Op.CALL(
                             Op.GAS,
-                            self.entry_address,
+                            entry_address,
                             0,
                             0,
                             Op.CALLDATASIZE,
@@ -222,6 +229,12 @@ class ConsolidationRequestContract(ConsolidationRequestInteractionBase):
                         )
                     )
                 )
+        return replace(
+            self,
+            sender_account=sender_account,
+            contract_address=contract_address,
+            entry_address=entry_address,
+        )
 
     def valid_requests(
         self, current_minimum_fee: int

--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -884,13 +884,12 @@ def test_consolidation_requests_negative(
     Test blocks where the requests list and the actual consolidation requests
     that happened in the block's transactions do not match.
     """
-    for d in requests:
-        d.update_pre(pre)
+    prepared = [d.update_pre(pre) for d in requests]
 
     # No previous block so fee is the base
     fee = 1
     current_block_requests = []
-    for w in requests:
+    for w in prepared:
         current_block_requests += w.valid_requests(fee)
     included_requests = current_block_requests[
         : Spec.MAX_CONSOLIDATION_REQUESTS_PER_BLOCK
@@ -902,7 +901,7 @@ def test_consolidation_requests_negative(
         post={},
         blocks=[
             Block(
-                txs=sum((r.transactions() for r in requests), []),
+                txs=sum((r.transactions() for r in prepared), []),
                 header_verify=Header(
                     requests_hash=Requests(*included_requests),
                 ),

--- a/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
+++ b/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
@@ -125,9 +125,9 @@ def test_extra_consolidations(
         requests=requests_list
     )
     # prepare consolidation senders
-    consolidation_request_transaction.update_pre(pre=pre)
+    prepared = consolidation_request_transaction.update_pre(pre=pre)
     # get transaction list
-    txs: List[Transaction] = consolidation_request_transaction.transactions()
+    txs: List[Transaction] = prepared.transactions()
 
     blockchain_test(
         pre=pre,

--- a/tests/prague/eip7685_general_purpose_el_requests/conftest.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/conftest.py
@@ -97,8 +97,8 @@ def blocks(
     # Single block therefore base fee
     withdrawal_request_fee = 1
     consolidation_request_fee = 1
-    for r in requests:
-        r.update_pre(pre)
+    prepared = [r.update_pre(pre) for r in requests]
+    for r in prepared:
         if isinstance(r, DepositInteractionBase):
             valid_requests_list += r.valid_requests(10**18)
         elif isinstance(r, WithdrawalRequestInteractionBase):
@@ -115,7 +115,7 @@ def blocks(
         )
     return [
         Block(
-            txs=sum((r.transactions() for r in requests), []),
+            txs=sum((r.transactions() for r in prepared), []),
             header_verify=Header(requests_hash=valid_requests),
             requests=block_body_override_requests,
             exception=exception,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Summary

Request helpers had `update_pre()` mutating `self.sender_account` / `contract_address` / `entry_address` on items inside `@pytest.mark.parametrize` lists, which fired the frameworks "shared parametrize value mutated" warning on 163 tests. This PR makes `update_pre()` return a fresh instance via `dataclasses.replace()` so the conftests expose a `prepared_*` fixture.

### Warnings

```text
UserWarning: Shared pytest parameter 'requests' was mutated during test
  tests/prague/eip6110_deposits/test_deposits.py::test_deposit
  tests/prague/eip6110_deposits/test_deposits.py::test_deposit_negative
  tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py::test_withdrawal_requests_negative
  tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py::test_valid_multi_type_requests

UserWarning: Shared pytest parameter 'blocks_withdrawal_requests' was mutated during test
  tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py::test_withdrawal_requests

UserWarning: Shared pytest parameter 'blocks_consolidation_requests' was mutated during test
  tests/prague/eip7251_consolidations/test_consolidations.py::test_consolidation_requests
  tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7251.py::test_bal_system_dequeue_consolidations_eip7251

UserWarning: Shared pytest parameter 'interaction' was mutated during test
  tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7002.py::test_bal_7002_request_invalid

UserWarning: Shared pytest parameter 'expected_storage' was mutated during test
  tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py::test_reentrant_selfdestructing_call
```

### Verification

Running `uv run hasher` before and after this PR on touched tests resulted in equal hashes:
```
uv run hasher compare fixtures_before/ fixtures_after/
uv run hasher hash    fixtures_before/ -r
0x9bcf99dd7add56e7a6da3cb1ce105bf74d66c5eb2003e6ca88c6475137a93149
uv run hasher hash    fixtures_after/  -r
0x9bcf99dd7add56e7a6da3cb1ce105bf74d66c5eb2003e6ca88c6475137a93149
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2F736x%2F85%2Fef%2F0e%2F85ef0eea04c71a60f508774f208e1520.jpg&f=1&nofb=1&ipt=01b5b82e2b6d033150ad10dea8edc347560f33ed688615a618f7f447ec31972d)
