### PR TITLE
feat(zkevm): avoid stateless fields generation for fixtures that use RLP-modifiers

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1028,6 +1028,76 @@ test_module_execution_witness_missing_expected = textwrap.dedent(
 )
 
 
+test_module_execution_witness_rlp_modifier = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Account,
+        Alloc,
+        Block,
+        BlockchainTestFiller,
+        Header,
+        Op,
+        Transaction,
+    )
+
+    @pytest.mark.valid_at("Amsterdam")
+    def test_execution_witness_rlp_modifier(
+        pre: Alloc,
+        blockchain_test: BlockchainTestFiller,
+    ) -> None:
+        contract = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.STOP)
+        sender = pre.fund_eoa()
+        tx = Transaction(to=contract, gas_limit=100_000, sender=sender)
+
+        blockchain_test(
+            pre=pre,
+            post={
+                contract: Account(storage={0: 1}),
+                sender: Account(nonce=1),
+            },
+            blocks=[
+                Block(
+                    txs=[tx],
+                    rlp_modifier=Header(extra_data=b"mutated"),
+                )
+            ],
+        )
+    """
+)
+
+
+test_module_execution_witness_rlp_modifier_stateless_intent = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Alloc,
+        Block,
+        BlockchainTestFiller,
+        Header,
+    )
+
+    @pytest.mark.valid_at("Amsterdam")
+    def test_execution_witness_rlp_modifier_stateless_intent(
+        pre: Alloc,
+        blockchain_test: BlockchainTestFiller,
+    ) -> None:
+        blockchain_test(
+            pre=pre,
+            post={},
+            blocks=[
+                Block(
+                    rlp_modifier=Header(extra_data=b"mutated"),
+                    expected_stateless_validation_success=True,
+                )
+            ],
+        )
+    """
+)
+
+
 def test_execution_witness_in_blockchain_fixture(
     testdir: pytest.Testdir,
 ) -> None:
@@ -1177,6 +1247,83 @@ def test_execution_witness_skip_stateless_validation(
     assert "executionWitness" not in block
     assert "statelessInputBytes" not in block
     assert "statelessOutputBytes" not in block
+
+
+def test_execution_witness_rlp_modifier_omits_stateless_artifacts(
+    testdir: pytest.Testdir,
+) -> None:
+    """RLP-mutated blocks should not expose canonical stateless artifacts."""
+    tests_dir = testdir.mkdir("tests")
+    amsterdam_tests_dir = tests_dir.mkdir("amsterdam")
+    test_module = amsterdam_tests_dir.join(
+        "test_module_execution_witness_rlp_modifier.py"
+    )
+    test_module.write(test_module_execution_witness_rlp_modifier)
+
+    testdir.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    args = [
+        "-c",
+        "pytest-fill.ini",
+        "-v",
+        "--until=Amsterdam",
+        "-m",
+        "blockchain_test",
+        "--no-html",
+    ]
+    result = testdir.runpytest(*args)
+    result.assert_outcomes(
+        passed=1,
+        failed=0,
+        skipped=0,
+        errors=0,
+    )
+
+    fixture_path = Path(
+        "fixtures/blockchain_tests/for_amsterdam/amsterdam/"
+        "module_execution_witness_rlp_modifier/"
+        "execution_witness_rlp_modifier.json"
+    )
+    assert fixture_path.exists(), f"{fixture_path} does not exist"
+
+    with open(fixture_path, "r") as f:
+        fixture_data = json.load(f)
+
+    assert len(fixture_data) == 1, "Expected exactly one fixture"
+    fixture = next(iter(fixture_data.values()))
+    block = fixture["blocks"][0]
+
+    assert "executionWitness" not in block
+    assert "statelessInputBytes" not in block
+    assert "statelessOutputBytes" not in block
+
+
+def test_execution_witness_rlp_modifier_rejects_stateless_intent(
+    testdir: pytest.Testdir,
+) -> None:
+    """RLP modifiers cannot be combined with explicit stateless assertions."""
+    tests_dir = testdir.mkdir("tests")
+    amsterdam_tests_dir = tests_dir.mkdir("amsterdam")
+    test_module = amsterdam_tests_dir.join(
+        "test_module_execution_witness_rlp_modifier_stateless_intent.py"
+    )
+    test_module.write(
+        test_module_execution_witness_rlp_modifier_stateless_intent
+    )
+
+    testdir.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    args = ["-c", "pytest-fill.ini", "-v", "--until=Amsterdam", "--no-html"]
+    result = testdir.runpytest(*args)
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(
+        [
+            "*Blocks with rlp_modifier omit stateless artifacts because "
+            "they are generated before the RLP mutation*"
+        ]
+    )
 
 
 def test_execution_witness_expected_true_reuses_canonical_stateless_result(

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -987,6 +987,40 @@ class BlockchainTest(BaseTest):
                     "exception must be the last transaction in the block"
                 )
 
+        has_witness_expectation = (
+            block.expected_execution_witness_state is not None
+            or block.expected_execution_witness_codes is not None
+            or block.expected_execution_witness_headers is not None
+        )
+        public_keys_modifier = block.stateless_input_public_keys_modifier
+        has_public_keys_modifier = public_keys_modifier is not None
+        expected_success = block.expected_stateless_validation_success
+        omit_stateless_artifacts = block.rlp_modifier is not None
+        if omit_stateless_artifacts and (
+            has_witness_expectation
+            or has_public_keys_modifier
+            or expected_success is not None
+        ):
+            raise AssertionError(
+                "Blocks with rlp_modifier omit stateless artifacts because "
+                "they are generated before the RLP mutation. SSZ/stateless "
+                "mutation tests require a separate explicit mechanism."
+            )
+        if self.skip_stateless_validation and (
+            has_witness_expectation
+            or has_public_keys_modifier
+            or expected_success is not None
+        ):
+            raise AssertionError(
+                "skip_stateless_validation cannot be combined with "
+                "execution witness expectations, stateless input public-key "
+                "modifiers, or "
+                "expected_stateless_validation_success"
+            )
+        skip_stateless_for_block = (
+            self.skip_stateless_validation or omit_stateless_artifacts
+        )
+
         transition_tool_output = t8n.evaluate(
             transition_tool_data=TransitionTool.TransitionToolData(
                 alloc=previous_alloc,
@@ -996,7 +1030,7 @@ class BlockchainTest(BaseTest):
                 chain_id=self.chain_id,
                 reward=fork.get_reward(),
                 blob_schedule=fork.blob_schedule(),
-                skip_stateless_validation=self.skip_stateless_validation,
+                skip_stateless_validation=skip_stateless_for_block,
             ),
             slow_request=self.is_tx_gas_heavy_test,
         )
@@ -1114,25 +1148,6 @@ class BlockchainTest(BaseTest):
         # If expected witness state/codes defined, verify against actual
         t8n_witness = transition_tool_output.result.execution_witness
         execution_witness = t8n_witness
-        has_witness_expectation = (
-            block.expected_execution_witness_state is not None
-            or block.expected_execution_witness_codes is not None
-            or block.expected_execution_witness_headers is not None
-        )
-        public_keys_modifier = block.stateless_input_public_keys_modifier
-        has_public_keys_modifier = public_keys_modifier is not None
-        expected_success = block.expected_stateless_validation_success
-        if self.skip_stateless_validation and (
-            has_witness_expectation
-            or has_public_keys_modifier
-            or expected_success is not None
-        ):
-            raise AssertionError(
-                "skip_stateless_validation cannot be combined with "
-                "execution witness expectations, stateless input public-key "
-                "modifiers, or "
-                "expected_stateless_validation_success"
-            )
         state_expectation = block.expected_execution_witness_state
         if state_expectation is not None and execution_witness is not None:
             state_expectation.verify_against(execution_witness)

--- a/src/ethereum/forks/amsterdam/execution_engine/get_payload.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/get_payload.py
@@ -8,7 +8,7 @@ from .types import (
 )
 
 
-def get_payload(payload_id: PayloadId) -> GetPayloadResponse:
+def get_payload(_payload_id: PayloadId) -> GetPayloadResponse:
     """
     Return a prepared payload response for a previously returned
     ``PayloadId``.

--- a/src/ethereum/forks/amsterdam/incremental_mpt.py
+++ b/src/ethereum/forks/amsterdam/incremental_mpt.py
@@ -28,7 +28,7 @@ from typing import (
 
 from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.crypto.hash import keccak256
 from ethereum.merkle_patricia_trie import (
@@ -713,9 +713,7 @@ def _delete_from_extension(
         return node
 
     old_child = node.child
-    new_child = _mpt_delete_node(
-        mpt, old_child, key, level + Uint(len(segment))
-    )
+    new_child = _mpt_delete_node(mpt, old_child, key, level + ulen(segment))
 
     if new_child is None:
         return None

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -15,7 +15,7 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.forks.bpo5.blocks import Header as PreviousForkHeader
 from ethereum.state import Root
 
-from .blocks import Block, Header
+from .blocks import Header
 from .execution_engine.new_payload import execute_new_payload_request
 from .execution_engine.requests import ExecutionRequests
 from .execution_engine.types import ExecutionPayload, NewPayloadRequest
@@ -241,15 +241,6 @@ def compute_new_payload_request_root(
 
     ssz_npr = _new_payload_request_to_ssz(stateless_input.new_payload_request)
     return Hash32(ssz_npr.hash_tree_root())
-
-
-def new_payload_request_to_block(
-    new_payload_request: NewPayloadRequest,
-) -> Block:
-    """
-    Convert a NewPayloadRequest into a block.
-    """
-    raise NotImplementedError
 
 
 def _decode_header(header_bytes: Bytes) -> Header | PreviousForkHeader:

--- a/src/ethereum/forks/amsterdam/witness_state.py
+++ b/src/ethereum/forks/amsterdam/witness_state.py
@@ -12,12 +12,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.merkle_patricia_trie import EMPTY_TRIE_ROOT
+from ethereum.merkle_patricia_trie import EMPTY_TRIE_ROOT, InternalNode
 from ethereum.state import (
     EMPTY_CODE_HASH,
     Account,
     Address,
-    InternalNode,
     Root,
 )
 

--- a/tests/json_loader/test_incremental_mpt.py
+++ b/tests/json_loader/test_incremental_mpt.py
@@ -3,6 +3,13 @@
 from typing import Any
 
 import pytest
+from ethereum.forks.amsterdam.trie import (
+    EMPTY_TRIE_ROOT,
+    Trie,
+    nibble_list_to_compact,
+    root,
+    trie_set,
+)
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 
@@ -18,13 +25,6 @@ from ethereum.forks.amsterdam.incremental_mpt import (
     mpt_get,
     mpt_root,
     mpt_set,
-)
-from ethereum.forks.amsterdam.trie import (
-    EMPTY_TRIE_ROOT,
-    Trie,
-    nibble_list_to_compact,
-    root,
-    trie_set,
 )
 from ethereum.state import Root
 

--- a/tests/json_loader/test_incremental_mpt.py
+++ b/tests/json_loader/test_incremental_mpt.py
@@ -3,13 +3,6 @@
 from typing import Any
 
 import pytest
-from ethereum.forks.amsterdam.trie import (
-    EMPTY_TRIE_ROOT,
-    Trie,
-    nibble_list_to_compact,
-    root,
-    trie_set,
-)
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 
@@ -25,6 +18,13 @@ from ethereum.forks.amsterdam.incremental_mpt import (
     mpt_get,
     mpt_root,
     mpt_set,
+)
+from ethereum.merkle_patricia_trie import (
+    EMPTY_TRIE_ROOT,
+    Trie,
+    nibble_list_to_compact,
+    root,
+    trie_set,
 )
 from ethereum.state import Root
 

--- a/tests/json_loader/test_witness_state.py
+++ b/tests/json_loader/test_witness_state.py
@@ -3,6 +3,11 @@
 from typing import Any, Optional
 
 import pytest
+from ethereum.forks.amsterdam.trie import (
+    EMPTY_TRIE_ROOT,
+    bytes_to_nibble_list,
+    nibble_list_to_compact,
+)
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
@@ -14,11 +19,6 @@ from ethereum.forks.amsterdam.incremental_mpt import (
     build_mpt,
     mpt_get,
     mpt_root,
-)
-from ethereum.forks.amsterdam.trie import (
-    EMPTY_TRIE_ROOT,
-    bytes_to_nibble_list,
-    nibble_list_to_compact,
 )
 from ethereum.forks.amsterdam.witness_state import (
     WitnessState,

--- a/tests/json_loader/test_witness_state.py
+++ b/tests/json_loader/test_witness_state.py
@@ -3,11 +3,6 @@
 from typing import Any, Optional
 
 import pytest
-from ethereum.forks.amsterdam.trie import (
-    EMPTY_TRIE_ROOT,
-    bytes_to_nibble_list,
-    nibble_list_to_compact,
-)
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
@@ -24,6 +19,11 @@ from ethereum.forks.amsterdam.witness_state import (
     WitnessState,
     build_code_db,
     build_node_db,
+)
+from ethereum.merkle_patricia_trie import (
+    EMPTY_TRIE_ROOT,
+    bytes_to_nibble_list,
+    nibble_list_to_compact,
 )
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, Root
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -11,6 +11,15 @@ from ethereum_spec_tools.evm_tools.t8n.transition_tool import EELST8N
 
 from ethereum.ethash import *
 from ethereum.fork_criteria import Unscheduled
+from ethereum.forks.amsterdam.execution_engine.types import (
+    BlobsBundle,
+    GetPayloadResponse,
+    PayloadAttributes,
+)
+from ethereum.forks.amsterdam.stateless import (
+    NewPayloadRequestHeader,
+    ProtocolFork,
+)
 from ethereum.trace import EvmTracer
 from ethereum.utils.hexadecimal import hex_to_bytes256
 from ethereum_optimized.state_db import State
@@ -173,3 +182,39 @@ RemoveDocstringCommand
 _configure_client_manager  # autouse fixture
 test_suite_name  # hive test suite name fixture
 genesis_header  # genesis header fixture
+
+# src/ethereum/forks/amsterdam/execution_engine/types.py - Engine API fields
+PayloadAttributes.suggested_fee_recipient
+BlobsBundle.commitments
+BlobsBundle.proofs
+BlobsBundle.blobs
+GetPayloadResponse.block_value
+GetPayloadResponse.blobs_bundle
+
+# src/ethereum/forks/amsterdam/stateless.py - stateless public API scaffolding
+NewPayloadRequestHeader
+NewPayloadRequestHeader.execution_payload_header
+ProtocolFork.Frontier
+ProtocolFork.Homestead
+ProtocolFork.DAOFork
+ProtocolFork.TangerineWhistle
+ProtocolFork.SpuriousDragon
+ProtocolFork.Byzantium
+ProtocolFork.Constantinople
+ProtocolFork.ConstantinopleFix
+ProtocolFork.Istanbul
+ProtocolFork.MuirGlacier
+ProtocolFork.Berlin
+ProtocolFork.London
+ProtocolFork.ArrowGlacier
+ProtocolFork.GrayGlacier
+ProtocolFork.Paris
+ProtocolFork.Shanghai
+ProtocolFork.Cancun
+ProtocolFork.Prague
+ProtocolFork.Osaka
+ProtocolFork.BPO1
+ProtocolFork.BPO2
+ProtocolFork.BPO3
+ProtocolFork.BPO4
+ProtocolFork.BPO5


### PR DESCRIPTION
## 🗒️ Description
Some fixtures use RLP-modifies to "corrupt" the RLP representation of blocks. Conceptually, this is an encoding-mismatch for the stateless executor since its input is SSZ-encoded. While some particular mutations might be translatable to SSZ-mutations (e.g. raw concrete field mutation), others that might target RLP-nature can't apply. Trying to automate this sounds quite tricky, so this PR auomatically skips fixtures with RLP-modifiers.

The current invalid input test cases are "semantic-invalidations" (e.g. mutate the MPT proofs or headers to be invalid by missing data, or similar). But we are also planning to add more "raw corruption" cases which is exactly the same idea of having RLP-mutators but SSZ-ones.

Edit: has also many unrelated lint fixtures since `projects/zkevm` was rebased.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
