### PR TITLE
fix(spec,test):  align with latest EIP-8037 auth refund changes

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -23,6 +23,7 @@ from ..state_tracker import (
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import (
     COST_PER_STATE_BYTE,
+    STATE_BYTES_PER_AUTH_BASE,
     STATE_BYTES_PER_NEW_ACCOUNT,
     GasCosts,
 )
@@ -162,10 +163,11 @@ def set_delegation(message: Message) -> Uint:
     """
     Set the delegation code for the authorities in the message.
 
-    For existing accounts, refunds the account-creation component of
-    state gas to the reservoir (no mutation of intrinsic_state_gas) and
-    accumulates the same amount as the auth state refund returned to the
-    caller, so block accounting can subtract it from `tx_state_gas`.
+    Refills the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion of
+    intrinsic state gas when the authority's account leaf already
+    exists, and the `STATE_BYTES_PER_AUTH_BASE × CPSB` portion when
+    its code slot already holds a delegation indicator. The total is
+    returned so block accounting can subtract it from `tx_state_gas`.
 
     Parameters
     ----------
@@ -175,8 +177,7 @@ def set_delegation(message: Message) -> Uint:
     Returns
     -------
     auth_state_refund : `Uint`
-        Total state gas refunded across all authorizations whose
-        authority already existed in state.
+        Total state gas refunded across all processed authorizations.
 
     """
     tx_state = message.tx_env.state
@@ -205,11 +206,15 @@ def set_delegation(message: Message) -> Uint:
         if authority_nonce != auth.nonce:
             continue
 
-        # For existing accounts, no account creation needed.
-        # Refund the account creation state gas to the reservoir.
-        # intrinsic_state_gas is immutable after validation.
         if account_exists(tx_state, authority):
             refund = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
+            message.state_gas_reservoir += refund
+            auth_state_refund += refund
+
+        # Existing delegation indicator: overwrite in place, no new
+        # state bytes added.
+        if authority_code:
+            refund = STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
             message.state_gas_reservoir += refund
             auth_state_refund += refund
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1602,10 +1602,9 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
         child_state_charge = sstore_state_gas
     else:
         fresh_target = pre.fund_eoa(amount=0)
-        child_code = (
-            Op.POP(Op.CALL(gas=Op.GAS, address=fresh_target, value=1))
-            + Op.REVERT(0, 0)
-        )
+        child_code = Op.POP(
+            Op.CALL(gas=Op.GAS, address=fresh_target, value=1)
+        ) + Op.REVERT(0, 0)
         child_balance = 1
         child_state_charge = gas_costs.NEW_ACCOUNT
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -591,48 +591,68 @@ def test_re_authorization_existing_delegation(
     fork: Fork,
 ) -> None:
     """
-    Test re-authorization of an account that already has a delegation.
+    Re-authorize an account that already has a delegation.
 
-    When an authority already has a delegation (set-code) and is
-    re-authorized in a new transaction, the account exists so the
-    new-account state gas refund applies. The new delegation replaces
-    the old one.
+    Both the new-account and auth-base state gas portions are refilled
+    (the 23 delegation bytes overwrite in place). Verified via:
+
+    * authority post-state — delegation now points at `contract_new`
+      and the nonce has incremented (catches a silently-skipped auth);
+    * receipt `cumulative_gas_used` — equals `intrinsic_regular`;
+    * `header.gas_used` — equals `intrinsic_regular`, since the full
+      `intrinsic_state_gas` is refilled.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
-    env = Environment()
-    auth_state_gas = fork.transaction_intrinsic_state_gas(
+    intrinsic_state_gas = fork.transaction_intrinsic_state_gas(
         authorization_count=1,
+    )
+    intrinsic_regular = (
+        fork.transaction_intrinsic_cost_calculator()(
+            authorization_list_or_count=1,
+        )
+        - intrinsic_state_gas
     )
 
     contract_old = pre.deploy_contract(code=Op.STOP)
-    storage = Storage()
-    contract_new = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1),
-    )
+    contract_new = pre.deploy_contract(code=Op.STOP)
 
-    # Signer already has a delegation from a previous tx
+    # `fund_eoa(delegation=...)` sets the authority's nonce to 1, so
+    # the re-authorization must use nonce=1 to be processed.
     signer = pre.fund_eoa(delegation=contract_old)
-
     authorization_list = [
         AuthorizationTuple(
             address=contract_new,
-            nonce=0,
+            nonce=1,
             signer=signer,
         ),
     ]
 
-    # Existing account — gets new-account state gas refund
+    # Existing delegation refills the full per-auth state gas.
+    expected_gas_used = max(intrinsic_regular, 0)
+
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract_new,
-        gas_limit=gas_limit_cap + auth_state_gas,
+        gas_limit=gas_limit_cap + intrinsic_state_gas,
         authorization_list=authorization_list,
         sender=sender,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used,
+        ),
     )
 
-    post = {contract_new: Account(storage=storage)}
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    state_test(
+        pre=pre,
+        post={
+            signer: Account(
+                nonce=2,
+                code=Spec7702.delegation_designation(contract_new),
+            ),
+        },
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -294,21 +294,48 @@ def test_existing_account_refund_enables_sstore(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "signer_pre_state,authorize_to_null",
+    [
+        pytest.param("nonexistent", False, id="nonexistent_authority"),
+        pytest.param("existing_leaf", False, id="existing_leaf_empty_code"),
+        pytest.param(
+            "existing_delegation",
+            False,
+            id="existing_delegation_overwrite",
+        ),
+        pytest.param(
+            "existing_delegation",
+            True,
+            id="existing_delegation_clear",
+        ),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_auth_refund_block_gas_accounting(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    signer_pre_state: str,
+    authorize_to_null: bool,
 ) -> None:
     """
-    Verify block gas accounting deducts the existing-authority refund.
+    Verify block + receipt gas accounting against per-authorization
+    state-gas refunds from `set_delegation`.
 
-    For an authorization whose authority already exists in state, the
-    new-account state gas is refunded both to the in-tx state gas
-    reservoir and from the per-tx state gas accounted into the block
-    header. block.header.gas_used therefore equals
-    `max(tx_regular_gas, intrinsic_state_gas - auth_refund)`, not the
-    full intrinsic state gas.
+    Four signer pre-states span every refund branch:
+
+    * `nonexistent` — no account leaf; no refund;
+    * `existing_leaf` — leaf, empty code; `NEW_ACCOUNT × CPSB` refilled;
+    * `existing_delegation` overwrite — leaf + delegation; full refill
+      (`NEW_ACCOUNT + AUTH_BASE`) as the 23 delegation bytes overwrite
+      in place;
+    * `existing_delegation` clear — `auth.address` =
+      `RESET_DELEGATION_ADDRESS`; same full refill, since the refill
+      keys off the *pre-state* code slot, not what we're writing.
+
+    Verified via header `gas_used`, receipt `cumulative_gas_used`, and
+    the authority post-state (catches a silently-skipped auth).
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -319,37 +346,72 @@ def test_auth_refund_block_gas_accounting(
         authorization_list_or_count=1,
     )
     intrinsic_regular = total_intrinsic - intrinsic_state_gas
-    auth_refund = fork.gas_costs().REFUND_AUTH_PER_EXISTING_ACCOUNT
+    new_account_refund = fork.gas_costs().REFUND_AUTH_PER_EXISTING_ACCOUNT
+    # Per-auth intrinsic state gas covers NEW_ACCOUNT + AUTH_BASE; the
+    # AUTH_BASE portion is what's left after stripping NEW_ACCOUNT.
+    auth_base_refund = intrinsic_state_gas - new_account_refund
 
-    contract = pre.deploy_contract(code=Op.STOP)
+    contract_old = pre.deploy_contract(code=Op.STOP)
+    contract_new = pre.deploy_contract(code=Op.STOP)
 
-    signer = pre.fund_eoa()
+    if signer_pre_state == "nonexistent":
+        signer = pre.fund_eoa(amount=0)
+        pre_nonce = 0
+        auth_refund = 0
+    elif signer_pre_state == "existing_leaf":
+        signer = pre.fund_eoa()
+        pre_nonce = 0
+        auth_refund = new_account_refund
+    elif signer_pre_state == "existing_delegation":
+        # `fund_eoa(delegation=...)` sets the authority's nonce to 1.
+        signer = pre.fund_eoa(delegation=contract_old)
+        pre_nonce = 1
+        auth_refund = new_account_refund + auth_base_refund
+    else:
+        raise ValueError(f"unknown signer_pre_state: {signer_pre_state!r}")
+
+    auth_target = (
+        Spec7702.RESET_DELEGATION_ADDRESS
+        if authorize_to_null
+        else contract_new
+    )
     authorization_list = [
         AuthorizationTuple(
-            address=contract,
-            nonce=0,
+            address=auth_target,
+            nonce=pre_nonce,
             signer=signer,
         ),
     ]
 
-    sender = pre.fund_eoa()
-    tx = Transaction(
-        to=contract,
-        gas_limit=gas_limit_cap + intrinsic_state_gas,
-        authorization_list=authorization_list,
-        sender=sender,
+    post_signer = Account(
+        nonce=pre_nonce + 1,
+        code=(
+            b""
+            if authorize_to_null
+            else Spec7702.delegation_designation(auth_target)
+        ),
     )
-
-    expected_gas_used = max(
+    header_gas_used = max(
         intrinsic_regular,
         intrinsic_state_gas - auth_refund,
+    )
+    receipt_cumulative_gas_used = total_intrinsic - auth_refund
+
+    tx = Transaction(
+        to=contract_new,
+        gas_limit=gas_limit_cap + intrinsic_state_gas,
+        authorization_list=authorization_list,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=receipt_cumulative_gas_used,
+        ),
     )
 
     state_test(
         pre=pre,
-        post={},
+        post={signer: post_signer},
         tx=tx,
-        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
+        blockchain_test_header_verify=Header(gas_used=header_gas_used),
     )
 
 
@@ -582,77 +644,6 @@ def test_auth_with_calldata_and_access_list(
 
     post = {contract: Account(storage=storage)}
     state_test(env=env, pre=pre, post=post, tx=tx)
-
-
-@pytest.mark.valid_from("EIP8037")
-def test_re_authorization_existing_delegation(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Re-authorize an account that already has a delegation.
-
-    Both the new-account and auth-base state gas portions are refilled
-    (the 23 delegation bytes overwrite in place). Verified via:
-
-    * authority post-state — delegation now points at `contract_new`
-      and the nonce has incremented (catches a silently-skipped auth);
-    * receipt `cumulative_gas_used` — equals `intrinsic_regular`;
-    * `header.gas_used` — equals `intrinsic_regular`, since the full
-      `intrinsic_state_gas` is refilled.
-    """
-    gas_limit_cap = fork.transaction_gas_limit_cap()
-    assert gas_limit_cap is not None
-    intrinsic_state_gas = fork.transaction_intrinsic_state_gas(
-        authorization_count=1,
-    )
-    intrinsic_regular = (
-        fork.transaction_intrinsic_cost_calculator()(
-            authorization_list_or_count=1,
-        )
-        - intrinsic_state_gas
-    )
-
-    contract_old = pre.deploy_contract(code=Op.STOP)
-    contract_new = pre.deploy_contract(code=Op.STOP)
-
-    # `fund_eoa(delegation=...)` sets the authority's nonce to 1, so
-    # the re-authorization must use nonce=1 to be processed.
-    signer = pre.fund_eoa(delegation=contract_old)
-    authorization_list = [
-        AuthorizationTuple(
-            address=contract_new,
-            nonce=1,
-            signer=signer,
-        ),
-    ]
-
-    # Existing delegation refills the full per-auth state gas.
-    expected_gas_used = max(intrinsic_regular, 0)
-
-    sender = pre.fund_eoa()
-    tx = Transaction(
-        to=contract_new,
-        gas_limit=gas_limit_cap + intrinsic_state_gas,
-        authorization_list=authorization_list,
-        sender=sender,
-        expected_receipt=TransactionReceipt(
-            cumulative_gas_used=expected_gas_used,
-        ),
-    )
-
-    state_test(
-        pre=pre,
-        post={
-            signer: Account(
-                nonce=2,
-                code=Spec7702.delegation_designation(contract_new),
-            ),
-        },
-        tx=tx,
-        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description

Align with https://github.com/ethereum/EIPs/pull/11611 and https://github.com/ethereum/EIPs/pull/11616

- `commit #1`:
  - Refund `AUTH_BASE` on existing delegation along with the new account cost.
  - Fix broken re-auth test with better checks that would've caught the fact that the re-auth never worked and properly check the refund in this test now.
- `commit #2`:
  - Refactor / add coverage by parametrizing all auth refund test cases together for ease of readability and keeping track of cases covered.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img width="645" height="541" alt="Screenshot 2026-05-11 at 13 36 33" src="https://github.com/user-attachments/assets/a5629c1b-f1db-40e4-8fd0-aa13f7f9e996" />
