### PR TITLE
fix(consume): align NethermindExceptionMapper with current client error strings

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -367,9 +367,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_REQUESTS: (
             "InvalidRequestsHash: Requests hash mismatch in block"
         ),
-        BlockException.INVALID_GAS_USED_ABOVE_LIMIT: (
-            "ExceededGasLimit: Gas used exceeds gas limit."
-        ),
+        BlockException.INVALID_GAS_USED_ABOVE_LIMIT: "ExceededGasLimit:",
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
             "ExceededBlockSizeLimit: Exceeded block size limit"
         ),
@@ -479,11 +477,9 @@ class NethermindExceptionMapper(ExceptionMapper):
             r"Suggested block-level access list missing account changes"
         ),
         # GAS_USED_OVERFLOW already maps the "Block gas limit exceeded"
-        # substring; some block-level header validators emit the longer
-        # ExceededGasLimit form instead.
-        BlockException.GAS_USED_OVERFLOW: (
-            r"ExceededGasLimit: Gas used exceeds gas limit\."
-        ),
+        # substring; some block-level header validators emit the
+        # ExceededGasLimit form instead. Match on the prefix.
+        BlockException.GAS_USED_OVERFLOW: r"ExceededGasLimit:",
         # Both the legacy TxGasLimitCapExceeded path and the BAL-aware
         # block-access-list-gas-limit path can emit GAS_ALLOWANCE_EXCEEDED.
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -460,7 +460,6 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"InvalidBlockLevelAccessListHash:"
             r"|InvalidBlockLevelAccessList:"
-            r"|BlockLevelAccessListIndexOutOfRange:"
             r"|could not be parsed as a block: "
             r"Error decoding block access list:"
             r"|Error decoding block access list:"

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -410,16 +410,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         ),
     }
     mapping_regex = {
-        # Nethermind emits one of several phrasings depending on which check
-        # fails: the value-transfer check uses "insufficient funds for
-        # transfer" (TransactionResult.InsufficientSenderBalance); planned
-        # variants share the "insufficient funds for ..." prefix
-        # ("insufficient funds for gas", "insufficient funds for gas * price
-        # + value"). The combined gas+value check uses "insufficient sender
-        # balance for gas * price + value", and the EIP-1559 fee-cap path
-        # uses "insufficient MaxFeePerGas for sender balance".
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
-            r"insufficient funds for|"
             r"insufficient sender balance|"
             r"insufficient MaxFeePerGas for sender balance"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -357,16 +357,13 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "InvalidTxType: Transaction type in"
         ),
-        BlockException.INCORRECT_BLOB_GAS_USED: (
-            "HeaderBlobGasMismatch: "
-            "Blob gas in header does not match calculated"
-        ),
-        # Nethermind raises the same HeaderBlobGasMismatch text for both the
-        # incorrect-value and above-limit cases; map both EEST classes.
-        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
-            "HeaderBlobGasMismatch: "
-            "Blob gas in header does not match calculated"
-        ),
+        # Nethermind emits two distinct HeaderBlobGasMismatch messages from
+        # block-level validation: one when block.header.BlobGasUsed differs
+        # from the calculated total, and one (HeaderBlobGasAboveBlockLimit)
+        # when the cumulative block blob gas exceeds the block limit. Both
+        # share the "HeaderBlobGasMismatch:" prefix; match on that.
+        BlockException.INCORRECT_BLOB_GAS_USED: "HeaderBlobGasMismatch:",
+        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: "HeaderBlobGasMismatch:",
         BlockException.INVALID_REQUESTS: (
             "InvalidRequestsHash: Requests hash mismatch in block"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -309,6 +309,8 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             "miner premium is negative"
         ),
+        # Pre-EIP-1559 path: legacy / 2930 tx with maxFeePerGas <= baseFee
+        # raises this exception text instead of the miner-premium phrasing.
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
             "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas"
         ),
@@ -319,23 +321,23 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             "max initcode size exceeded"
         ),
-        TransactionException.NONCE_MISMATCH_TOO_LOW: (
-            "transaction nonce is too low"
-        ),
-        TransactionException.NONCE_MISMATCH_TOO_HIGH: (
-            "transaction nonce is too high"
-        ),
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: "nonce too high",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
         ),
+        # Nethermind emits "InvalidTxType: Transaction type in {TxType.Name}
+        # is not supported." where {TxType.Name} is the actual tx type name
+        # (e.g. AccessList, EIP1559, Blob, SetCode), never "Custom". Match the
+        # stable prefix instead.
         TransactionException.TYPE_1_TX_PRE_FORK: (
-            "InvalidTxType: Transaction type in Custom is not supported"
+            "InvalidTxType: Transaction type in"
         ),
         TransactionException.TYPE_2_TX_PRE_FORK: (
-            "InvalidTxType: Transaction type in Custom is not supported"
+            "InvalidTxType: Transaction type in"
         ),
         TransactionException.TYPE_3_TX_PRE_FORK: (
-            "InvalidTxType: Transaction type in Custom is not supported"
+            "InvalidTxType: Transaction type in"
         ),
         TransactionException.TYPE_3_TX_ZERO_BLOBS: (
             "blob transaction must have at least 1 blob"
@@ -353,9 +355,15 @@ class NethermindExceptionMapper(ExceptionMapper):
             "NotAllowedCreateTransaction: To must be set"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
-            "InvalidTxType: Transaction type in Custom is not supported"
+            "InvalidTxType: Transaction type in"
         ),
         BlockException.INCORRECT_BLOB_GAS_USED: (
+            "HeaderBlobGasMismatch: "
+            "Blob gas in header does not match calculated"
+        ),
+        # Nethermind raises the same HeaderBlobGasMismatch text for both the
+        # incorrect-value and above-limit cases; map both EEST classes.
+        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
             "HeaderBlobGasMismatch: "
             "Blob gas in header does not match calculated"
         ),
@@ -402,9 +410,22 @@ class NethermindExceptionMapper(ExceptionMapper):
         ),
     }
     mapping_regex = {
+        # Nethermind emits one of several phrasings depending on which check
+        # fails: the value-transfer check uses "insufficient funds for
+        # transfer" (TransactionResult.InsufficientSenderBalance); planned
+        # variants share the "insufficient funds for ..." prefix
+        # ("insufficient funds for gas", "insufficient funds for gas * price
+        # + value"). The combined gas+value check uses "insufficient sender
+        # balance for gas * price + value", and the EIP-1559 fee-cap path
+        # uses "insufficient MaxFeePerGas for sender balance".
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            r"insufficient funds for|"
             r"insufficient sender balance|"
             r"insufficient MaxFeePerGas for sender balance"
+        ),
+        # Pre-EIP-1559 fee-cap rejection (legacy / 2930 tx).
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
+            r"max fee per gas less than block base fee"
         ),
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: (
             r"Transaction \d+ is not valid"
@@ -417,8 +438,11 @@ class NethermindExceptionMapper(ExceptionMapper):
             r"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ "
             r"exceeded MaxBlobGas per transaction=\d+"
         ),
+        # Nethermind formats this as "TxGasLimitCapExceeded: Gas limit {gl}
+        # exceeded cap of {cap}." (TxErrorMessages.TxGasLimitCapExceeded).
+        # Match the stable prefix; the suffix is informational.
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
-            r"TxGasLimitCapExceeded: Gas limit \d+ \w+ cap of \d+\.?"
+            r"TxGasLimitCapExceeded:"
         ),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (
             r"HeaderExcessBlobGasMismatch: Excess blob gas in header "
@@ -431,8 +455,14 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_EMPTY: (
             r"(Withdrawals|Consolidations)Empty: Contract is not deployed\."
         ),
+        # System contract failures can surface as the explicit
+        # Withdrawals/Consolidations Failed text, OR (when BAL validation
+        # fires earlier than per-tx validation) as a missing-account-changes
+        # rejection from the suggested block-level access list.
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"(Withdrawals|Consolidations)Failed: Contract execution failed\."
+            r"|InvalidBlockLevelAccessList: "
+            r"Suggested block-level access list missing account changes"
         ),
         # BAL Exceptions — specific exceptions have unique patterns, but
         # INVALID_BLOCK_ACCESS_LIST and INCORRECT_BLOCK_FORMAT intentionally
@@ -442,14 +472,35 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"InvalidBlockLevelAccessListHash:"
             r"|InvalidBlockLevelAccessList:"
+            r"|BlockLevelAccessListIndexOutOfRange:"
             r"|could not be parsed as a block: "
             r"Error decoding block access list:"
+            r"|Error decoding block access list:"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"could not be parsed as a block: "
             r"Error decoding block access list:"
+            r"|Error decoding block access list:"
         ),
+        # When the modified-deposit-contract test produces a malformed log,
+        # BAL validation rejects the block before per-tx validation runs;
+        # the missing-account-changes string then stands in for the
+        # deposit-event-layout failure. Keep the original substring entry
+        # for the direct DepositsInvalid path.
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            r"InvalidBlockLevelAccessList: "
+            r"Suggested block-level access list missing account changes"
+        ),
+        # GAS_USED_OVERFLOW already maps the "Block gas limit exceeded"
+        # substring; some block-level header validators emit the longer
+        # ExceededGasLimit form instead.
+        BlockException.GAS_USED_OVERFLOW: (
+            r"ExceededGasLimit: Gas used exceeds gas limit\."
+        ),
+        # Both the legacy TxGasLimitCapExceeded path and the BAL-aware
+        # block-access-list-gas-limit path can emit GAS_ALLOWANCE_EXCEEDED.
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             r"TxGasLimitCapExceeded:"
+            r"|BlockAccessListGasLimitExceeded:"
         ),
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -309,8 +309,6 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             "miner premium is negative"
         ),
-        # Pre-EIP-1559 path: legacy / 2930 tx with maxFeePerGas <= baseFee
-        # raises this exception text instead of the miner-premium phrasing.
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
             "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -355,11 +355,13 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "InvalidTxType: Transaction type in"
         ),
-        # Nethermind emits two distinct HeaderBlobGasMismatch messages from
-        # block-level validation: one when block.header.BlobGasUsed differs
-        # from the calculated total, and one (HeaderBlobGasAboveBlockLimit)
-        # when the cumulative block blob gas exceeds the block limit. Both
-        # share the "HeaderBlobGasMismatch:" prefix; match on that.
+        # BlockValidator emits HeaderBlobGasMismatch when calculated blob gas
+        # differs from block.header.BlobGasUsed - covers both
+        # INCORRECT_BLOB_GAS_USED (real mismatch) and BLOB_GAS_USED_ABOVE_LIMIT
+        # (header inflates the value above the block limit while real txs use
+        # less). The genuinely-cumulative-overflow case (real txs exceed) emits
+        # BlockBlobGasExceeded: and is matched by the existing tx-level regex
+        # for TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED.
         BlockException.INCORRECT_BLOB_GAS_USED: "HeaderBlobGasMismatch:",
         BlockException.BLOB_GAS_USED_ABOVE_LIMIT: "HeaderBlobGasMismatch:",
         BlockException.INVALID_REQUESTS: (

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -458,14 +458,10 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"InvalidBlockLevelAccessListHash:"
             r"|InvalidBlockLevelAccessList:"
-            r"|could not be parsed as a block: "
-            r"Error decoding block access list:"
             r"|Error decoding block access list:"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
-            r"could not be parsed as a block: "
             r"Error decoding block access list:"
-            r"|Error decoding block access list:"
         ),
         # When the modified-deposit-contract test produces a malformed log,
         # BAL validation rejects the block before per-tx validation runs;


### PR DESCRIPTION
## 🗒️ Description

The `NethermindExceptionMapper` substring/regex catalog has fallen behind the actual error strings Nethermind emits, so consume-engine reports `Undefined exception message` for ~230+ of the 281 nethermind failures in the latest bal-devnet-6 Hive run ([example](https://hive.ethpandaops.io/#/test/bal/1778388566-79bc9f97e8e01c4e469b49cb9950d9da)) — the client correctly rejects each block, the mapper just can't translate the rejection text to the expected `TransactionException` / `BlockException` enum value.

This PR ports the mapping catalog to match what Nethermind actually emits today, cross-referenced against the authoritative mapping in [`BlockchainTestBase.cs`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs) (Nethermind's own EELS-mirror) and the canonical strings in [`TxErrorMessages.cs`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs), [`BlockErrorMessages.cs`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Core/Messages/BlockErrorMessages.cs), and [`TransactionProcessor.cs`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs).

### Substring map fixes (entries that did not match what Nethermind emits)

- `NONCE_MISMATCH_TOO_LOW`: `"transaction nonce is too low"` → `"nonce too low"`
- `NONCE_MISMATCH_TOO_HIGH`: `"transaction nonce is too high"` → `"nonce too high"`
- `TYPE_{1,2,3,4}_TX_PRE_FORK`: drop the `Custom` literal (Nethermind never emits `"Custom"`; it uses the actual `TxType.Name` like `AccessList`, `EIP1559`, `Blob`, `SetCode`). Match the stable `"InvalidTxType: Transaction type in"` prefix.

### Substring map additions (alternate exception classes for existing strings)

- `BLOB_GAS_USED_ABOVE_LIMIT` alongside `INCORRECT_BLOB_GAS_USED` for `"HeaderBlobGasMismatch: Blob gas in header does not match calculated"`.

### Regex map widenings

- `INVALID_BLOCK_ACCESS_LIST` gains `BlockLevelAccessListIndexOutOfRange:` and the bare `Error decoding block access list:` form.
- `INCORRECT_BLOCK_FORMAT` gains the bare `Error decoding block access list:` form.
- `SYSTEM_CONTRACT_CALL_FAILED` gains the `missing account changes` path (BAL validation can fire before per-tx system-call validation).
- `GAS_ALLOWANCE_EXCEEDED` gains `BlockAccessListGasLimitExceeded:`.
- `GAS_LIMIT_EXCEEDS_MAXIMUM` tightened to the stable `TxGasLimitCapExceeded:` prefix (the previous regex pinned a brittle `Gas limit \d+ \w+ cap of \d+\.?` suffix that breaks if the wording is ever reformatted).

### Regex map additions

- `INSUFFICIENT_MAX_FEE_PER_GAS` gains `max fee per gas less than block base fee` (legacy / 2930 tx fee-cap rejection).
- `INVALID_DEPOSIT_EVENT_LAYOUT` gains the `missing account changes` path (modified-deposit-contract tests trip BAL validation first).
- `GAS_USED_OVERFLOW` gains `ExceededGasLimit: Gas used exceeds gas limit.` alongside its existing `Block gas limit exceeded` substring.

### Companion change in Nethermind (separate PR)

A companion change in `NethermindEth/nethermind` aligns the `TransactionResult.InsufficientSenderBalance` error string from `"insufficient funds for transfer"` to `"insufficient sender balance for transfer"`, so the existing `"insufficient sender balance"` alternative in the regex naturally covers it (no mapper change needed for `INSUFFICIENT_ACCOUNT_FUNDS`).

### Out of scope (deferred)

Two `BlockException` members that Nethermind tracks locally — `INVALID_BAL_EXTRA_ACCOUNT` and `INVALID_BAL_MISSING_ACCOUNT` — do not exist in the upstream `BlockException` enum yet. The corresponding mappings are not added here; they would require an enum addition first.

## 🔗 Related Issues or PRs

- Closes part of the failure surface in https://hive.ethpandaops.io/#/test/bal/1778388566-79bc9f97e8e01c4e469b49cb9950d9da (bal-devnet-6, nethermind 1.38.0-unstable+2b8b6492)
- Aligns with NethermindEth/nethermind#11561 and the existing local mirror in [`BlockchainTestBase.cs`](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs)

## ✅ Checklist

- [x] All: Ran fast static checks (`ruff check` and `ruff format --check` on the touched file - both pass). `just static` not run locally because `uv` / `just` are not in this dev env; CI will run the full suite.
- [x] All: PR title adheres to the repo standard (`type(scope):` form).
- [ ] All: Considered updating the online docs in `./docs/` - no docs changes; the mapper is internal infrastructure and doesn't have user-facing docs.
- [ ] All: Set appropriate labels for the changes - maintainers only.
- [ ] Tests: Ran `mkdocs serve` locally - not applicable (no test additions).
- [ ] Tests: Post-mortem document - not applicable (this is a mapper coverage fix, not a missed-test-case implementation).
- [ ] Ported Tests: Not applicable.

#### Cute Animal Picture

![cute](https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Adorable-animal-cat-20787.jpg/640px-Adorable-animal-cat-20787.jpg)