### PR TITLE
feat(spec-specs, tests): remove SD state gas refunds from EIP-8037

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1091,50 +1091,6 @@ def process_transaction(
             )
             tx_output.state_gas_left += new_account_refund
             tx_output.state_refund += new_account_refund
-    else:
-        # Refund state gas for accounts created and destroyed in the
-        # same tx (EIP-6780). Covers account, storage, and code.
-        new_account_refund = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
-        for address in tx_output.accounts_to_delete:
-            if address in tx_state.created_accounts:
-                storage = tx_state.storage_writes.get(address, {})
-                created_slots = sum(1 for v in storage.values() if v != 0)
-                non_account_refund = (
-                    Uint(created_slots)
-                    * STATE_BYTES_PER_STORAGE_SET
-                    * COST_PER_STATE_BYTE
-                )
-                # EIP-6780 defers account/storage/code removal to
-                # tx-end, so `account.code_hash` still points at the
-                # deployed code here and `get_code` returns it
-                # pre-deletion.
-                account = get_account(tx_state, address)
-                code = get_code(tx_state, account.code_hash)
-                non_account_refund += ulen(code) * COST_PER_STATE_BYTE
-
-                tx_created_target = (
-                    tx.to == Bytes0(b"") and address == message.current_target
-                )
-                if tx_created_target:
-                    # NEW_ACCOUNT was paid via intrinsic, not via
-                    # state_gas_used. Refund through state_refund so
-                    # tx-level accounting subtracts it from
-                    # tx_state_gas at block aggregation.
-                    tx_output.state_refund += new_account_refund
-                    selfdestruct_refund = non_account_refund
-                else:
-                    # Inner CREATE: NEW_ACCOUNT was charged via the
-                    # parent's execution state_gas_used, so refund
-                    # through the same channel (clamped below).
-                    selfdestruct_refund = (
-                        new_account_refund + non_account_refund
-                    )
-
-                selfdestruct_refund = min(
-                    selfdestruct_refund, tx_output.state_gas_used
-                )
-                tx_output.state_gas_left += selfdestruct_refund
-                tx_output.state_gas_used -= selfdestruct_refund
 
     tx_gas_used_before_refund = (
         tx.gas - tx_output.gas_left - tx_output.state_gas_left

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2095,7 +2095,7 @@ def test_selfdestruct_in_create_tx_initcode(
         calldata=bytes(initcode), contract_creation=True
     )
 
-    expected_state = create_state_gas
+    expected_state = create_state_gas + gas_costs.NEW_ACCOUNT
 
     initcode_gas = initcode.gas_cost(fork)
     gas_limit = intrinsic_total + initcode_gas + gas_costs.NEW_ACCOUNT + 1000

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -610,20 +610,36 @@ def test_selfdestruct_via_delegatecall_chain_no_refund(
     assert gas_limit_cap is not None
     new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
     sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
 
     # Bottom of the chain does the SELFDESTRUCT; intermediate helpers
-    # just delegate further down.
-    delegate_target = pre.deploy_contract(code=Op.SELFDESTRUCT(Op.ADDRESS))
+    # just delegate further down. Track each frame's bytecode so we
+    # can sum its regular gas into `expected_gas_used` below.
+    sd_code = Op.SELFDESTRUCT.with_metadata(address_warm=True)(Op.ADDRESS)
+    chain_regular_gas = sd_code.gas_cost(fork)
+    delegate_target = pre.deploy_contract(code=sd_code)
     for _ in range(num_hops - 1):
-        delegate_target = pre.deploy_contract(
-            code=Op.POP(call_opcode(gas=Op.GAS, address=delegate_target))
-            + Op.STOP,
+        hop_code = (
+            Op.POP(
+                call_opcode.with_metadata(address_warm=False)(
+                    gas=Op.GAS, address=delegate_target
+                )
+            )
+            + Op.STOP
         )
+        chain_regular_gas += hop_code.gas_cost(fork)
+        delegate_target = pre.deploy_contract(code=hop_code)
 
     # A's deployed runtime: one delegation into the top of the chain.
-    deployed = bytes(
-        Op.POP(call_opcode(gas=Op.GAS, address=delegate_target)) + Op.STOP
+    deployed_code = (
+        Op.POP(
+            call_opcode.with_metadata(address_warm=False)(
+                gas=Op.GAS, address=delegate_target
+            )
+        )
+        + Op.STOP
     )
+    deployed = bytes(deployed_code)
     code_deposit_state_gas = fork.code_deposit_state_gas(
         code_size=len(deployed)
     )
@@ -645,36 +661,66 @@ def test_selfdestruct_via_delegatecall_chain_no_refund(
         )
         + Op.TSTORE(
             0,
-            Op.CREATE(
+            Op.CREATE.with_metadata(init_code_size=initcode_len)(
                 value=0,
                 offset=0,
                 size=Op.CALLDATASIZE,
-                init_code_size=initcode_len,
             ),
         )
-        + Op.SSTORE(
+        + Op.SSTORE.with_metadata(
+            key_warm=False,
+            original_value=0,
+            current_value=0,
+            new_value=1,
+        )(
             factory_storage.store_next(1, "create_returned_nonzero"),
             Op.ISZERO(Op.ISZERO(Op.TLOAD(0))),
         )
-        + Op.SSTORE(
+        + Op.SSTORE.with_metadata(
+            key_warm=False,
+            original_value=0,
+            current_value=0,
+            new_value=1,
+        )(
             factory_storage.store_next(1, "call_returned_success"),
-            Op.CALL(gas=Op.GAS, address=Op.TLOAD(0)),
+            Op.CALL.with_metadata(address_warm=True)(
+                gas=Op.GAS, address=Op.TLOAD(0)
+            ),
         )
     )
     factory = pre.deploy_contract(code=factory_code)
     created_address = compute_create_address(address=factory, nonce=1)
 
-    total_state_gas = new_account_state_gas + code_deposit_state_gas
+    total_state_gas = (
+        new_account_state_gas + code_deposit_state_gas + 2 * sstore_state_gas
+    )
+    regular_used = (
+        intrinsic_gas
+        + factory_code.gas_cost(fork)
+        + initcode.gas_cost(fork)
+        + deployed_code.gas_cost(fork)
+        + chain_regular_gas
+        - new_account_state_gas
+        - code_deposit_state_gas
+        - 2 * sstore_state_gas
+    )
+    expected_gas_used = max(regular_used, total_state_gas)
+
     tx = Transaction(
         to=factory,
         data=bytes(initcode),
-        gas_limit=gas_limit_cap + total_state_gas + 2 * sstore_state_gas,
+        gas_limit=gas_limit_cap + total_state_gas,
         sender=pre.fund_eoa(),
     )
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx])],
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            )
+        ],
         post={
             created_address: Account.NONEXISTENT,
             factory: Account(storage=factory_storage),

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -264,21 +264,14 @@ def test_selfdestruct_new_beneficiary_header_gas_used(
 )
 @pytest.mark.with_all_create_opcodes()
 @pytest.mark.valid_from("EIP8037")
-def test_create_selfdestruct_refunds_account_and_storage(
+def test_create_selfdestruct_no_refund_account_and_storage(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     create_opcode: Op,
     num_slots: int,
 ) -> None:
-    """
-    Verify same tx CREATE+SELFDESTRUCT refunds account and storage.
-
-    Factory CREATE/CREATE2 initcode does N cold SSTOREs then
-    SELFDESTRUCTs. Refund covers `GAS_NEW_ACCOUNT` plus each
-    created slot's state gas. Under OLD behavior the state charges
-    remain in `block_state_gas_used`. Under NEW they are refunded.
-    """
+    """Verify same tx CREATE+SELFDESTRUCT does not refund state gas."""
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
@@ -309,24 +302,26 @@ def test_create_selfdestruct_refunds_account_and_storage(
     factory_code = mstore + Op.POP(create_call)
     factory = pre.deploy_contract(code=factory_code)
 
-    total_state_refund = new_account_state_gas + num_slots * sstore_state_gas
-    # Subtract the state portion so tx_regular matches the header.
-    tx_regular = (
+    total_state_gas = new_account_state_gas + num_slots * sstore_state_gas
+    regular_used = (
         intrinsic_gas
         + factory_code.gas_cost(fork)
         + init_code.gas_cost(fork)
-        - total_state_refund
+        - total_state_gas
     )
+    expected_gas_used = max(regular_used, total_state_gas)
 
     tx = Transaction(
         to=factory,
-        gas_limit=gas_limit_cap + total_state_refund,
+        gas_limit=gas_limit_cap + total_state_gas,
         sender=pre.fund_eoa(),
     )
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_regular))],
+        blocks=[
+            Block(txs=[tx], header_verify=Header(gas_used=expected_gas_used)),
+        ],
         post={},
     )
 
@@ -340,7 +335,7 @@ def test_create_selfdestruct_refunds_account_and_storage(
     ],
 )
 @pytest.mark.valid_from("EIP8037")
-def test_create_selfdestruct_refunds_code_deposit_state_gas(
+def test_create_selfdestruct_no_refund_code_deposit_state_gas(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
@@ -348,13 +343,8 @@ def test_create_selfdestruct_refunds_code_deposit_state_gas(
     beneficiary_type: str,
 ) -> None:
     """
-    Verify same tx CREATE+SELFDESTRUCT refunds code deposit state gas.
-
-    Factory CREATEs a contract deploying `code_size` bytes of code
-    then CALLs it to trigger SELFDESTRUCT. Refund is account plus
-    `code_size * cost_per_state_byte`. `external` beneficiary tests
-    that the refund applies to the created account, not the
-    destination of the ETH transfer.
+    Verify same tx CREATE+SELFDESTRUCT does not refund code deposit
+    state gas.
     """
     assert code_size >= 2
     gas_limit_cap = fork.transaction_gas_limit_cap()
@@ -397,11 +387,11 @@ def test_create_selfdestruct_refunds_code_deposit_state_gas(
     factory = pre.deploy_contract(code=factory_code)
     created_address = compute_create_address(address=factory, nonce=1)
 
-    total_state_refund = new_account_state_gas + code_deposit_state_gas
+    total_state_gas = new_account_state_gas + code_deposit_state_gas
     tx = Transaction(
         to=factory,
         data=bytes(initcode),
-        gas_limit=gas_limit_cap + total_state_refund,
+        gas_limit=gas_limit_cap + total_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -413,22 +403,20 @@ def test_create_selfdestruct_refunds_code_deposit_state_gas(
 
 
 @pytest.mark.valid_from("EIP8037")
-def test_create_selfdestruct_code_deposit_refund_header_check(
+def test_create_selfdestruct_code_deposit_no_refund_header_check(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Verify block header gas reflects the code-deposit state-gas
-    refund on a same-tx CREATE plus SELFDESTRUCT.
+    Verify block header gas reflects the full account plus code-deposit
+    state-gas charge on a same-tx CREATE+SELFDESTRUCT.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     gas_costs = fork.gas_costs()
     new_account_state_gas = gas_costs.NEW_ACCOUNT
 
-    # Deployed code is sized so the code-deposit state gas would
-    # dominate block regular gas if the refund did not land.
     selfdestruct = Op.SELFDESTRUCT(Op.ADDRESS)
     sd_len = len(bytes(selfdestruct))
     code_size = 256
@@ -458,30 +446,23 @@ def test_create_selfdestruct_code_deposit_refund_header_check(
     factory = pre.deploy_contract(code=factory_code)
     created_address = compute_create_address(address=factory, nonce=1)
 
-    total_state_refund = new_account_state_gas + code_deposit_state_gas
+    total_state_gas = new_account_state_gas + code_deposit_state_gas
     tx = Transaction(
         to=factory,
         data=bytes(initcode),
-        gas_limit=gas_limit_cap + total_state_refund,
+        gas_limit=gas_limit_cap + total_state_gas,
         sender=pre.fund_eoa(),
     )
 
-    # Empirical baseline: block_state_gas refunds to zero so the
-    # header reports block regular only. Baseline regular must stay
-    # below the code-deposit state gas so a missing refund would
-    # push the header above this value.
     baseline_block_regular = 0x94C8
-    assert baseline_block_regular < code_deposit_state_gas, (
-        "Baseline regular must be below code_deposit_state_gas so "
-        "the mutation's un-refunded state_gas dominates the header."
-    )
+    expected_gas_used = max(baseline_block_regular, total_state_gas)
 
     blockchain_test(
         pre=pre,
         blocks=[
             Block(
                 txs=[tx],
-                header_verify=Header(gas_used=baseline_block_regular),
+                header_verify=Header(gas_used=expected_gas_used),
             ),
         ],
         post={created_address: Account.NONEXISTENT},
@@ -489,19 +470,14 @@ def test_create_selfdestruct_code_deposit_refund_header_check(
 
 
 @pytest.mark.valid_from("EIP8037")
-def test_create_selfdestruct_no_double_refund_with_sstore_restoration(
+def test_create_selfdestruct_sstore_restoration_refund(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Verify SSTORE restoration and SELFDESTRUCT refunds do not stack.
-
-    Initcode does SSTORE(0, 1) then SSTORE(0, 0) then SELFDESTRUCT.
-    The 0 to x to 0 restoration refunds the slot inline. The end of
-    tx selfdestruct refund scans `storage_writes[B]` and only counts
-    non zero final values, so the restored slot is excluded and the
-    end of tx refund is account only.
+    Verify SSTORE restoration still refunds its slot state gas when
+    the surrounding contract SELFDESTRUCTs.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -533,15 +509,15 @@ def test_create_selfdestruct_no_double_refund_with_sstore_restoration(
     factory_code = mstore + Op.POP(create_call)
     factory = pre.deploy_contract(code=factory_code)
 
-    # Subtract both state charges (CREATE account + cold SSTORE) to
-    # isolate the regular total.
-    tx_regular = (
+    state_used = new_account_state_gas
+    regular_used = (
         intrinsic_gas
         + factory_code.gas_cost(fork)
         + init_code.gas_cost(fork)
         - new_account_state_gas
         - sstore_state_gas
     )
+    expected_gas_used = max(regular_used, state_used)
 
     tx = Transaction(
         to=factory,
@@ -551,7 +527,9 @@ def test_create_selfdestruct_no_double_refund_with_sstore_restoration(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_regular))],
+        blocks=[
+            Block(txs=[tx], header_verify=Header(gas_used=expected_gas_used)),
+        ],
         post={},
     )
 
@@ -617,7 +595,7 @@ def test_selfdestruct_pre_existing_account_no_refund(
     selector=lambda call_opcode: call_opcode in (Op.DELEGATECALL, Op.CALLCODE)
 )
 @pytest.mark.valid_from("EIP8037")
-def test_selfdestruct_via_delegatecall_chain(
+def test_selfdestruct_via_delegatecall_chain_no_refund(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
@@ -625,15 +603,8 @@ def test_selfdestruct_via_delegatecall_chain(
     call_opcode: Op,
 ) -> None:
     """
-    Verify SELFDESTRUCT refund when the opcode executes in a nested
-    DELEGATECALL/CALLCODE frame below a same-tx-created contract.
-
-    A factory CREATEs contract A; A delegates down `num_hops` frames
-    into a helper that runs SELFDESTRUCT(Op.ADDRESS). `current_target`
-    is preserved by DELEGATECALL/CALLCODE, so A is queued for deletion
-    and its account + code-deposit state gas is refunded at tx end.
-    Exercises `accounts_to_delete` propagation across multiple
-    `incorporate_child_on_success` hops.
+    Verify SELFDESTRUCT in a nested DELEGATECALL/CALLCODE frame below
+    a same-tx-created contract does not refund state gas.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -693,12 +664,11 @@ def test_selfdestruct_via_delegatecall_chain(
     factory = pre.deploy_contract(code=factory_code)
     created_address = compute_create_address(address=factory, nonce=1)
 
-    # Reservoir must also cover the two fresh SSTORE markers.
-    total_state_refund = new_account_state_gas + code_deposit_state_gas
+    total_state_gas = new_account_state_gas + code_deposit_state_gas
     tx = Transaction(
         to=factory,
         data=bytes(initcode),
-        gas_limit=gas_limit_cap + total_state_refund + 2 * sstore_state_gas,
+        gas_limit=gas_limit_cap + total_state_gas + 2 * sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -760,7 +730,7 @@ def test_selfdestruct_new_beneficiary_no_regular_account_creation_cost(
 )
 @pytest.mark.pre_alloc_mutable()
 @pytest.mark.valid_from("EIP8037")
-def test_create_tx_selfdestruct_initcode_refunds_intrinsic(
+def test_create_tx_selfdestruct_initcode_state_gas(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
@@ -768,20 +738,8 @@ def test_create_tx_selfdestruct_initcode_refunds_intrinsic(
     beneficiary_kind: str,
 ) -> None:
     """
-    Verify a creation tx whose initcode SELFDESTRUCTs the new
-    contract refunds the intrinsic NEW_ACCOUNT × CPSB so the user
-    only pays state-gas for any genuinely new account that persists.
-
-    Cases:
-    - value=0 (any beneficiary): contract is destroyed, no
-      beneficiary creation. Net new state = 0; expected state-gas
-      bill = 0.
-    - value>0 to self/existing: balance burned or transferred to a
-      live account; contract destroyed. Net new state = 0; expected
-      state-gas bill = 0.
-    - value>0 to empty beneficiary: SELFDESTRUCT charges a NEW_ACCOUNT
-      for the new beneficiary which persists; contract is destroyed.
-      Net new state = 1; expected state-gas bill = NEW_ACCOUNT × CPSB.
+    Verify a creation tx whose initcode SELFDESTRUCTs the new contract
+    still pays the intrinsic NEW_ACCOUNT state gas.
     """
     new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
@@ -810,13 +768,12 @@ def test_create_tx_selfdestruct_initcode_refunds_intrinsic(
     intrinsic_regular = intrinsic_total - new_account_state_gas
 
     creates_new_beneficiary = beneficiary_kind == "empty" and tx_value > 0
-    expected_state = new_account_state_gas if creates_new_beneficiary else 0
+    expected_state = new_account_state_gas + (
+        new_account_state_gas if creates_new_beneficiary else 0
+    )
     expected_regular = intrinsic_regular + init_code.regular_cost(fork)
     expected_gas_used = max(expected_regular, expected_state)
 
-    # Reservoir is empty for sub-cap txs, so SELFDESTRUCT's state-gas
-    # charge for a new beneficiary spills into gas_left. The buffer
-    # has to cover that spillover plus the regular execution costs.
     tx = Transaction(
         to=None,
         data=init_code,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Remove all state gas refunds for SD in EIP-8037.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%2Fid%2FOIP.UjhPqZptrLTGs2uQ_mWbKQHaHP%3Fr%3D0%26pid%3DApi&f=1&ipt=7584cad6ff9ec44b987b8632357b3aecfdbf097b54e6cc60c0f605dfff9d3644&ipo=images)
