### PR TITLE
feat(tests, spec-specs): refill auth state gas on delegation clear for EIP-8037

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -10,7 +10,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidBlock, InvalidSignatureError
-from ethereum.state import Address
+from ethereum.state import EMPTY_CODE_HASH, Address
 
 from ..fork_types import Authorization
 from ..state_tracker import (
@@ -214,7 +214,10 @@ def set_delegation(message: Message) -> Uint:
         # No new delegation indicator bytes are written: either the
         # authority already has one (overwrite in place / clear) or
         # this auth clears against an authority with no prior code.
-        if authority_code or auth.address == NULL_ADDRESS:
+        if (
+            authority_account.code_hash != EMPTY_CODE_HASH
+            or auth.address == NULL_ADDRESS
+        ):
             refund = STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
             message.state_gas_reservoir += refund
             auth_state_refund += refund

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -211,9 +211,10 @@ def set_delegation(message: Message) -> Uint:
             message.state_gas_reservoir += refund
             auth_state_refund += refund
 
-        # Existing delegation indicator: overwrite in place, no new
-        # state bytes added.
-        if authority_code:
+        # No new delegation indicator bytes are written: either the
+        # authority already has one (overwrite in place / clear) or
+        # this auth clears against an authority with no prior code.
+        if authority_code or auth.address == NULL_ADDRESS:
             refund = STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
             message.state_gas_reservoir += refund
             auth_state_refund += refund

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -298,7 +298,9 @@ def test_existing_account_refund_enables_sstore(
     "signer_pre_state,authorize_to_null",
     [
         pytest.param("nonexistent", False, id="nonexistent_authority"),
+        pytest.param("nonexistent", True, id="nonexistent_clear"),
         pytest.param("existing_leaf", False, id="existing_leaf_empty_code"),
+        pytest.param("existing_leaf", True, id="existing_leaf_clear"),
         pytest.param(
             "existing_delegation",
             False,
@@ -354,14 +356,19 @@ def test_auth_refund_block_gas_accounting(
     contract_old = pre.deploy_contract(code=Op.STOP)
     contract_new = pre.deploy_contract(code=Op.STOP)
 
+    # AUTH_BASE is refunded when no new delegation-indicator bytes are
+    # written: either the authority already has an indicator (overwrite
+    # in place / clear) or `auth.address` is zero (no indicator written).
     if signer_pre_state == "nonexistent":
         signer = pre.fund_eoa(amount=0)
         pre_nonce = 0
-        auth_refund = 0
+        auth_refund = auth_base_refund if authorize_to_null else 0
     elif signer_pre_state == "existing_leaf":
         signer = pre.fund_eoa()
         pre_nonce = 0
-        auth_refund = new_account_refund
+        auth_refund = new_account_refund + (
+            auth_base_refund if authorize_to_null else 0
+        )
     elif signer_pre_state == "existing_delegation":
         # `fund_eoa(delegation=...)` sets the authority's nonce to 1.
         signer = pre.fund_eoa(delegation=contract_old)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Refill `STATE_BYTES_PER_AUTH_BASE * CPSB` to the state gas reservoir when an EIP-7702 authorization clears the delegation (`auth.address == 0`).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img src="https://i.pinimg.com/736x/8e/6f/2f/8e6f2fdabe7472211b1c4dc5ba81f88c.jpg" width="500">