### PR TITLE
fix(consume): add ethereum/execution-specs to SUPPORTED_REPOS

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/releases.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/releases.py
@@ -20,6 +20,7 @@ CACHED_RELEASE_INFORMATION_FILE = (
 
 SUPPORTED_REPOS = [
     "ethereum/execution-spec-tests",
+    "ethereum/execution-specs",
     "ethereum/tests",
     "ethereum/legacytests",
 ]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_releases.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_releases.py
@@ -7,8 +7,10 @@ from typing import List
 import pytest
 
 from ..releases import (
+    SUPPORTED_REPOS,
     ReleaseInformation,
     get_release_url_from_release_information,
+    is_release_url,
     parse_release_information_from_file,
 )
 
@@ -61,3 +63,62 @@ def test_release_parsing(
     ) == get_release_url_from_release_information(
         release_name, release_information
     )
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # All currently supported release-hosting repos must be recognized so
+        # `FixtureDownloader.get_cache_path` versions the cache directory by
+        # release tag. A repo missing from `SUPPORTED_REPOS` falls through to
+        # the unversioned `cache_folder / "other" / archive_name` path, which
+        # silently shadows newer releases with the same archive filename.
+        (
+            "https://github.com/ethereum/execution-spec-tests/releases/download/v3.0.0/fixtures_stable.tar.gz",
+            True,
+        ),
+        (
+            "https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.1.0/fixtures_bal.tar.gz",
+            True,
+        ),
+        (
+            "https://github.com/ethereum/tests/releases/download/v14.0/some.tar.gz",
+            True,
+        ),
+        (
+            "https://github.com/ethereum/legacytests/releases/download/v1.0/some.tar.gz",
+            True,
+        ),
+        (
+            # Not a recognized repo; must NOT match.
+            "https://github.com/some-fork/execution-spec-tests/releases/download/v1/foo.tar.gz",
+            False,
+        ),
+        (
+            # Local path, not a URL.
+            "./fixtures",
+            False,
+        ),
+    ],
+)
+def test_is_release_url_covers_supported_repos(
+    url: str, expected: bool
+) -> None:
+    """
+    All entries in `SUPPORTED_REPOS` must be matched by `is_release_url`.
+
+    Regression test for bal-devnet-7: when the BAL fixture URL moved from
+    `execution-spec-tests` to `execution-specs`, the new URL stopped being
+    recognized as a release URL, so the cache key dropped the version tag and
+    a `tests-bal@v7.0.0` download from a prior session silently shadowed
+    `tests-bal@v7.1.0`.
+    """
+    assert is_release_url(url) is expected
+
+
+def test_supported_repos_contains_execution_specs() -> None:
+    """
+    `ethereum/execution-specs` hosts the BAL fixture releases (from
+    `tests-bal@v7.1.0` onward) and must be in `SUPPORTED_REPOS`.
+    """
+    assert "ethereum/execution-specs" in SUPPORTED_REPOS


### PR DESCRIPTION
### Summary

`FixtureDownloader.get_cache_path` versions the on-disk cache directory by release tag only when the release URL's owner/repo appears in `SUPPORTED_REPOS`. Otherwise it falls through to the unversioned `cache_folder / "other" / <archive_name>` path.

When the BAL fixture release was moved from `ethereum/execution-spec-tests` to `ethereum/execution-specs` for `tests-bal@v7.1.0`, the new URL stopped being recognized as a release URL. A v7.0.0 download from a prior session, cached at `other/fixtures_bal/`, kept satisfying every subsequent `consume` request, including ones explicitly pointing at v7.1.0. Consumers got stale fixtures with no warning.

This PR adds `ethereum/execution-specs` to `SUPPORTED_REPOS` so its release URLs hit the versioned cache path (`execution-specs/tests-bal@v7.1.0/fixtures_bal/`).

### How this was found

While validating ethrex's bal-devnet-7 branch against `tests-bal@v7.1.0`:

* The downloaded tarball at `https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.1.0/fixtures_bal.tar.gz` has the correct v7.1.0 BAL (sender post-balance reflects no SD-refund per #2845).
* The on-disk cache used by `consume` had the v7.0.0 BAL (still applied the SD refund).
* 76 SD-related Amsterdam tests appeared to fail with a `+1,836,000 wei = +1× NEW_ACCOUNT × cpsb × gas_price` mismatch; the exact amount of the removed v7.0.0 SD refund.
* The fixture file extracted from a fresh v7.1.0 tarball download matched ethrex's execution exactly. The wire-BAL the consume harness sent matched a v7.0.0 tarball's `_info.url`.
* Clearing `~/.cache/ethereum-execution-spec-tests/cached_downloads/` made all 2,145 amsterdam tests pass on the same ethrex commit.

So this was a stale-cache issue, not a spec or client bug. The fix prevents it from recurring once `execution-specs`-hosted releases become standard.

### Changes

* `releases.py`: add `ethereum/execution-specs` to `SUPPORTED_REPOS`.
* `tests/test_releases.py`: add parametrized regression test for `is_release_url` covering every entry in `SUPPORTED_REPOS`, plus an explicit assertion that `ethereum/execution-specs` is present.

### Follow-up worth considering (not in this PR)

The `cache_folder / "other" / <archive_name>` fallback in `get_cache_path` is a latent footgun: any future release hosted on a repo not in `SUPPORTED_REPOS` will silently collide with prior downloads sharing an archive filename. A defensive change, e.g. incorporating a hash of the URL into the "other" path, would close the door entirely. Happy to follow up in a separate PR if maintainers agree it's worth doing.

### Test plan

* [x] `uv run pytest packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_releases.py`: 12/12 pass.
* [x] `uv run ruff check && uv run ruff format --check`: clean.
* [x] Manual: clear cache, re-run `consume` against `tests-bal@v7.1.0`, observe 2,145/2,145 pass on ethrex bal-devnet-7.