### PR TITLE
refactor(tests): replace runtime skip in EIP-7778 calldata test

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -370,6 +370,18 @@ class CallDataTestType(Enum):
     ],
 )
 @pytest.mark.with_all_refund_types()
+@pytest.mark.filter_combinations(
+    lambda refund_type, refund_tx_reverts, calldata_test_type, **_: not (
+        refund_type == RefundTypes.STORAGE_CLEAR
+        and refund_tx_reverts
+        and calldata_test_type
+        == CallDataTestType.DATA_FLOOR_BETWEEN_TX_GAS_BEFORE_AND_AFTER
+    ),
+    reason=(
+        "STORAGE_CLEAR refund is zero on revert, so the (post, pre) "
+        "interval that DATA_FLOOR_BETWEEN needs is empty"
+    ),
+)
 @pytest.mark.valid_from("EIP7778")
 def test_varying_calldata_costs(
     blockchain_test: BlockchainTestFiller,
@@ -388,17 +400,6 @@ def test_varying_calldata_costs(
     2. tx_gas_after_refund < calldata_floor < tx_gas_before_refund
     3. calldata_floor > tx_gas_before_refund
     """
-    if refund_type == RefundTypes.STORAGE_CLEAR:
-        if (
-            refund_tx_reverts
-            and calldata_test_type
-            == CallDataTestType.DATA_FLOOR_BETWEEN_TX_GAS_BEFORE_AND_AFTER
-        ):
-            pytest.skip(
-                "calldata_cost cannot be between pre and post refund gas"
-                "since refund is zero when execution reverts"
-            )
-
     match refund_type:
         case RefundTypes.STORAGE_CLEAR:
             bytes_to_add_per_iteration = b"00" * 2


### PR DESCRIPTION
## 🗒️ Description

This PR just refactors `test_varying_calldata_costs` to avoid runtime `pytest.skip()` and avoid console noise by using the `filter_combinations` marker from #2543. 

The `STORAGE_CLEAR` refund is zero on revert, so the `(post, pre)` interval that `DATA_FLOOR_BETWEEN_TX_GAS_BEFORE_AND_AFTER` requires is empty; the two infeasible cells per fork are now deselected at collection time instead of at runtime.

The `with_all_refund_types()` covariant marker is retained so future refund types auto-participate.

Fixtures are identical to the pre-refactor branch, verified by `uv run hasher compare`.

## 🔗 Related Issues or PRs

Follow-up review nit on #2840. Uses the `filter_combinations` marker added by #2543.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

