### PR TITLE
chore(ci): bump hive start up timeout in CI

### DIFF
--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -81,7 +81,7 @@ jobs:
           clients: go-ethereum
           client-file: execution-specs/.github/configs/hive/latest.yaml
           hive-path: hive
-          timeout: "120"
+          timeout: "180"
 
       - name: Run execute remote E2E tests
         working-directory: execution-specs


### PR DESCRIPTION
## 🗒️ Description
Sometimes the hive E2E tests are flaky (like [here](https://github.com/ethereum/execution-specs/actions/runs/25874300870/job/76037844331)) because hive takes more than 120s to start up. Then CI fails, even though it's not hung. Bumped the timeout from 120s -> 180s.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).



#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSKSNYARo3etbXY9X9xFuM2Ml-Vq7TmXJ7ubw&s)
