### PR TITLE
feat(test-specs): Test mutators

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -27,7 +27,7 @@ from execution_testing.base_types.conversions import (
     BytesConvertible,
     NumberConvertible,
 )
-from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks import Fork, SpecTestMutator, TransitionFork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.rpc.rpc_types import TransactionByHashResponse
@@ -243,6 +243,9 @@ class Alloc(SharedAlloc):
     _deferred_fund_addresses: List[_DeferredFundAddress] = PrivateAttr(
         default_factory=list
     )
+    _spec_test_mutator: SpecTestMutator = PrivateAttr(
+        default=SpecTestMutator.NONE
+    )
     _block_number: int = PrivateAttr()
     _timestamp: int = PrivateAttr()
 
@@ -257,6 +260,7 @@ class Alloc(SharedAlloc):
         address_stubs: AddressStubs | None = None,
         block_number: int = 0,
         timestamp: int = 0,
+        spec_test_mutator: SpecTestMutator = SpecTestMutator.NONE,
         **kwargs: Any,
     ) -> None:
         """Initialize the pre-alloc with the given parameters."""
@@ -269,10 +273,7 @@ class Alloc(SharedAlloc):
         self._address_stubs = address_stubs or AddressStubs(root={})
         self._block_number = block_number
         self._timestamp = timestamp
-
-    def code_pre_processor(self, code: Bytecode) -> Bytecode:
-        """Pre-processes the code before setting it."""
-        return code
+        self._spec_test_mutator = spec_test_mutator
 
     def _add_pending_tx(
         self,
@@ -454,7 +455,6 @@ class Alloc(SharedAlloc):
         assert isinstance(code, Bytecode), (
             f"incompatible code type: {type(code)}"
         )
-        code = self.code_pre_processor(code)
 
         max_code_size = fork.max_code_size()
         if len(code) > max_code_size:
@@ -985,6 +985,7 @@ def pre(
     max_fee_per_gas: int,
     max_priority_fee_per_gas: int,
     dry_run: bool,
+    spec_test_mutator: SpecTestMutator,
     request: pytest.FixtureRequest,
 ) -> Generator[Alloc, None, None]:
     """Return default pre allocation for all tests (Empty alloc)."""
@@ -1009,6 +1010,7 @@ def pre(
         chain_id=chain_config.chain_id,
         node_id=request.node.nodeid,
         address_stubs=address_stubs,
+        spec_test_mutator=spec_test_mutator,
     )
 
     # Yield the pre-alloc for usage during the test

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -390,7 +390,7 @@ class Alloc(SharedAlloc):
         self,
         code: BytesConvertible,
         *,
-        storage: Storage | StorageRootType | None,
+        storage: Storage,
         balance: NumberConvertible,
         nonce: NumberConvertible,
         address: Address | None,
@@ -398,8 +398,6 @@ class Alloc(SharedAlloc):
         stub: str | None,
     ) -> Address:
         """Execute implementation of contract deployment."""
-        if storage is None:
-            storage = {}
         assert address is None, "address parameter is not supported"
         fork = self._fork.fork_at(
             block_number=self._block_number, timestamp=self._timestamp
@@ -409,9 +407,6 @@ class Alloc(SharedAlloc):
             fork.memory_expansion_gas_calculator()
         )
         calldata_gas_calculator = fork.calldata_gas_calculator()
-
-        if not isinstance(storage, Storage):
-            storage = Storage(storage)  # type: ignore
 
         if stub is not None:
             if stub not in self._address_stubs:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -68,6 +68,7 @@ from execution_testing.forks import (
     TransitionFork,
     get_transition_forks,
 )
+from execution_testing.forks.mutators import SpecTestMutator
 from execution_testing.specs import BaseTest
 from execution_testing.specs.base import FillResult, OpMode
 from execution_testing.test_types import EnvironmentDefaults
@@ -1648,6 +1649,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
         fixed_opcode_count: int | None,
         is_tx_gas_heavy_test: bool,
         is_exception_test: bool,
+        spec_test_mutator: SpecTestMutator,
     ) -> Any:
         """
         Fixture used to instantiate an auto-fillable BaseTest object from
@@ -1683,6 +1685,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                 kwargs["operation_mode"] = op_mode
                 kwargs["is_tx_gas_heavy_test"] = is_tx_gas_heavy_test
                 kwargs["is_exception_test"] = is_exception_test
+                kwargs["spec_test_mutator"] = spec_test_mutator
                 if (
                     op_mode == OpMode.OPTIMIZE_GAS
                     or op_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -65,10 +65,10 @@ from execution_testing.fixtures.pre_alloc_groups import (
 )
 from execution_testing.forks import (
     Fork,
+    SpecTestMutator,
     TransitionFork,
     get_transition_forks,
 )
-from execution_testing.forks.mutators import SpecTestMutator
 from execution_testing.specs import BaseTest
 from execution_testing.specs.base import FillResult, OpMode
 from execution_testing.test_types import EnvironmentDefaults

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -25,7 +25,7 @@ from execution_testing.base_types.conversions import (
     NumberConvertible,
 )
 from execution_testing.fixtures import LabeledFixtureFormat
-from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks import Fork, SpecTestMutator, TransitionFork
 from execution_testing.specs import BaseTest
 from execution_testing.test_types import (
     DETERMINISTIC_FACTORY_ADDRESS,
@@ -69,6 +69,9 @@ class Alloc(SharedAlloc):
     _eoa_fund_amount_default: int = PrivateAttr(10**21)
     _account_salt: Dict[Hash, int] = PrivateAttr(default_factory=dict)
     _stub_accounts: Dict[str, Account] = PrivateAttr(default_factory=dict)
+    _spec_test_mutator: SpecTestMutator = PrivateAttr(
+        default=SpecTestMutator.NONE
+    )
 
     def __init__(
         self,
@@ -77,6 +80,7 @@ class Alloc(SharedAlloc):
         flags: AllocFlags,
         stub_accounts: Dict[str, Account] | None = None,
         stub_eoas: Dict[str, EOA] | None = None,
+        spec_test_mutator: SpecTestMutator = SpecTestMutator.NONE,
         **kwargs: Any,
     ) -> None:
         """Initialize the pre-alloc."""
@@ -89,16 +93,13 @@ class Alloc(SharedAlloc):
         )
         if stub_accounts is not None:
             self._stub_accounts = stub_accounts
+        self._spec_test_mutator = spec_test_mutator
 
     def get_next_account_salt(self, account_hash: Hash) -> int:
         """Retrieve the next salt for this account."""
         salt = self._account_salt.get(account_hash, 0)
         self._account_salt[account_hash] = salt + 1
         return salt
-
-    def code_pre_processor(self, code: BytesConvertible) -> BytesConvertible:
-        """Pre-processes the code before setting it."""
-        return code
 
     def modified_accounts_salt(self) -> int:
         """
@@ -264,7 +265,6 @@ class Alloc(SharedAlloc):
         else:
             if storage is None:
                 storage = {}
-            code = self.code_pre_processor(code)
             code_bytes = (
                 bytes(code) if not isinstance(code, (bytes, str)) else code
             )
@@ -499,6 +499,7 @@ def pre(
     request: pytest.FixtureRequest,
     stub_accounts: Dict[str, Account],
     stub_eoas: Dict[str, EOA],
+    spec_test_mutator: SpecTestMutator,
 ) -> Alloc:
     """Return default pre allocation for all tests (Empty alloc)."""
     # FIXME: Static tests don't have a fork so we need to get it from the node.
@@ -512,4 +513,5 @@ def pre(
         fork=actual_fork,
         stub_accounts=stub_accounts,
         stub_eoas=stub_eoas,
+        spec_test_mutator=spec_test_mutator,
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -243,11 +243,28 @@ class Alloc(SharedAlloc):
         contract_address.label = label
         return contract_address
 
+    def _set_account(
+        self, account: Account, address: Address | None = None
+    ) -> Address:
+        """Set an account to an address calculated from its account hash."""
+        if address is not None:
+            assert address not in self, (
+                f"address {address} already in allocation"
+            )
+            account_address = address
+        else:
+            account_hash = account.hash()
+            salt = self.get_next_account_salt(account_hash)
+            account_address = contract_address_from_hash(account_hash, salt)
+
+        self.__internal_setitem__(account_address, account)
+        return account_address
+
     def _deploy_contract(
         self,
         code: BytesConvertible,
         *,
-        storage: Storage | StorageRootType | None,
+        storage: Storage,
         balance: NumberConvertible,
         nonce: NumberConvertible,
         address: Address | None,
@@ -263,8 +280,6 @@ class Alloc(SharedAlloc):
                 )
             account = self._stub_accounts[stub]
         else:
-            if storage is None:
-                storage = {}
             code_bytes = (
                 bytes(code) if not isinstance(code, (bytes, str)) else code
             )
@@ -280,17 +295,6 @@ class Alloc(SharedAlloc):
                 storage=storage,
             )
 
-        if address is not None:
-            assert address not in self, (
-                f"address {address} already in allocation"
-            )
-            contract_address = address
-        else:
-            account_hash = account.hash()
-            salt = self.get_next_account_salt(account_hash)
-            contract_address = contract_address_from_hash(account_hash, salt)
-
-        self.__internal_setitem__(contract_address, account)
         if label is None:
             # Try to deduce the label from the code
             frame = inspect.currentframe()
@@ -304,6 +308,33 @@ class Alloc(SharedAlloc):
                         line = code_context[0].strip()
                         if "=" in line:
                             label = line.split("=")[0].strip()
+
+        if (
+            SpecTestMutator.EIP_7702_ALL_CONTRACTS_AS_DELEGATIONS
+            in self._spec_test_mutator
+            and address is None
+        ):
+            code_address = self._set_account(
+                Account(
+                    nonce=1,
+                    balance=0,
+                    code=account.code,
+                    storage={},
+                ),
+                address,
+            )
+            contract_address = Address(
+                self._fund_eoa(
+                    amount=balance,
+                    label=label,
+                    storage=storage,
+                    code=None,
+                    delegation=code_address,
+                    nonce=nonce,
+                )
+            )
+        else:
+            contract_address = self._set_account(account, address)
 
         contract_address.label = label
         return contract_address

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_spec_test_mutators.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_spec_test_mutators.py
@@ -1,0 +1,154 @@
+"""Test the spec-test mutator integration with the filler plugin."""
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+DELEGATION_PREFIX = "0xef0100"
+
+
+test_module_contract = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Alloc,
+        Environment,
+        Op,
+        StateTestFiller,
+        Transaction,
+    )
+
+
+    @pytest.mark.valid_from("Paris")
+    @pytest.mark.valid_until("Prague")
+    def test_with_contract(state_test: StateTestFiller, pre: Alloc) -> None:
+        sender = pre.fund_eoa()
+        contract = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.STOP)
+        tx = Transaction(to=contract, gas_limit=200_000, sender=sender)
+        state_test(env=Environment(), pre=pre, post={}, tx=tx)
+    """
+)
+
+
+def load_pre_alloc(fixture_path: Path) -> Dict[str, Dict[str, Any]]:
+    """Merge the ``pre`` sections of every fixture in the file."""
+    data = json.loads(fixture_path.read_text())
+    merged: Dict[str, Dict[str, Any]] = {}
+    for fixture in data.values():
+        merged.update(fixture["pre"])
+    return merged
+
+
+@pytest.fixture()
+def contract_test_dir(testdir: pytest.Testdir) -> Any:
+    """Create tests/contract_test/test_module.py with a state test."""
+    tests_dir = testdir.mkdir("tests")
+    contract_dir = tests_dir.mkdir("contract_test")
+    contract_dir.join("test_module.py").write(test_module_contract)
+    return contract_dir
+
+
+@pytest.fixture()
+def fill_args(testdir: pytest.Testdir) -> list[str]:
+    """Copy fill ini and return base pytest args."""
+    testdir.copy_example(
+        name=(
+            "src/execution_testing/cli/pytest_commands"
+            "/pytest_ini_files/pytest-fill.ini"
+        )
+    )
+    return [
+        "-c",
+        "pytest-fill.ini",
+        "--no-html",
+        "--skip-index",
+        "-m",
+        "state_test",
+        "--until=Prague",
+        "--test-mutators=EIP_7702_ALL_CONTRACTS_AS_DELEGATIONS",
+    ]
+
+
+def test_eip_7702_mutator_applied_at_prague(
+    testdir: pytest.Testdir,
+    contract_test_dir: Any,
+    fill_args: list[str],
+) -> None:
+    """
+    Verify the EIP-7702 mutator turns every deployed contract into a
+    delegated EOA when filling for Prague.
+
+    The mutated fixture must contain at least one account whose code is a
+    delegation designator (``0xef0100`` followed by an address), and the
+    original contract bytecode must still appear in a separate account so
+    the delegation can resolve to it.
+    """
+    del contract_test_dir
+    result = testdir.runpytest(*fill_args)
+    assert result.ret == 0, f"fill exited with non-zero status: {result.ret}"
+
+    fixture_path = Path(
+        "fixtures/state_tests/for_prague/contract_test/module/with_contract.json"
+    )
+    assert fixture_path.exists(), f"{fixture_path} does not exist"
+
+    pre = load_pre_alloc(fixture_path)
+    delegations = {
+        addr: account["code"]
+        for addr, account in pre.items()
+        if account.get("code", "0x").startswith(DELEGATION_PREFIX)
+    }
+    assert delegations, (
+        "Expected at least one delegated EOA in the Prague pre-alloc, "
+        f"got pre={pre}"
+    )
+
+    target_address = (
+        "0x" + next(iter(delegations.values()))[len(DELEGATION_PREFIX) :]
+    )
+    target_account = pre.get(target_address.lower())
+    assert target_account is not None, (
+        f"Delegation target {target_address} not present in pre-alloc"
+    )
+    assert target_account.get("code", "0x") != "0x", (
+        "Delegation target should hold the original contract bytecode"
+    )
+
+
+@pytest.mark.parametrize("fork", ["paris", "shanghai", "cancun"])
+def test_eip_7702_mutator_not_applied_before_prague(
+    testdir: pytest.Testdir,
+    contract_test_dir: Any,
+    fill_args: list[str],
+    fork: str,
+) -> None:
+    """
+    Verify the EIP-7702 mutator has no effect on forks that don't support
+    it, even when the user enables it via ``--test-mutators``.
+
+    The pre-alloc for Paris/Shanghai/Cancun must contain no delegation
+    designators, so contracts remain plain contract accounts.
+    """
+    del contract_test_dir
+    result = testdir.runpytest(*fill_args)
+    assert result.ret == 0, f"fill exited with non-zero status: {result.ret}"
+
+    fixture_path = Path(
+        f"fixtures/state_tests/for_{fork}/contract_test/module/"
+        "with_contract.json"
+    )
+    assert fixture_path.exists(), f"{fixture_path} does not exist"
+
+    pre = load_pre_alloc(fixture_path)
+    delegations = [
+        account["code"]
+        for account in pre.values()
+        if account.get("code", "0x").startswith(DELEGATION_PREFIX)
+    ]
+    assert not delegations, (
+        f"Unexpected delegation designators in {fork} pre-alloc: {delegations}"
+    )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -15,6 +15,8 @@ from execution_testing.execution import (
     LabeledExecuteFormat,
 )
 from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
+from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks.mutators import SpecTestMutator
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.specs import BaseTest
@@ -415,4 +417,64 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         dest="fill_static_tests_enabled",
         default=None,
         help=("Enable reading and filling from static test files."),
+    )
+    test_mutators_group = parser.getgroup(
+        "test_mutators", "Arguments to specify spec test mutators"
+    )
+    test_mutators_group.addoption(
+        "--spec-test-mutators",
+        action="store",
+        dest="spec_test_mutators",
+        default=None,
+        help="Parametrize spec tests with the given comma-separated list of "
+        "mutators.",
+    )
+
+
+@pytest.fixture(scope="session")
+def spec_test_mutator_parameter(
+    request: pytest.FixtureRequest,
+) -> SpecTestMutator:
+    """
+    Parse the ``--spec-test-mutators`` option value into a single
+    ``SpecTestMutator`` value with every named mutator OR'd in.
+
+    Exits with a usage error if an entry does not match an existing mutator.
+    """
+    value: str | None = request.config.getoption("spec_test_mutators")
+    if not value:
+        return SpecTestMutator.NONE
+    combined: SpecTestMutator = SpecTestMutator.NONE
+    value = value.strip()
+    if value.lower() == "all":
+        for mutator in SpecTestMutator:
+            combined |= mutator
+    else:
+        for raw in value.split(","):
+            name = raw.strip()
+            if not name:
+                continue
+            if name.upper() not in SpecTestMutator.__members__:
+                available = ", ".join(
+                    m.name for m in SpecTestMutator if m.name is not None
+                )
+                pytest.exit(
+                    f"Error: Unknown spec test mutator: {name}.\n"
+                    f"Available mutators: {available}",
+                    returncode=pytest.ExitCode.USAGE_ERROR,
+                )
+            mutator = SpecTestMutator[name.upper()]
+            combined |= mutator
+    return combined
+
+
+@pytest.fixture(scope="function")
+def spec_test_mutator(
+    spec_test_mutator_parameter: SpecTestMutator,
+    fork: Fork | TransitionFork,
+) -> SpecTestMutator:
+    """Return the mutator for the current test."""
+    return (
+        spec_test_mutator_parameter
+        | fork.transitions_from().spec_test_mutators()
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -475,5 +475,5 @@ def spec_test_mutator(
     """Return the mutator for the current test."""
     return (
         spec_test_mutator_parameter
-        | fork.transitions_from().spec_test_mutators()
+        & fork.transitions_from().spec_test_mutators()
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -15,8 +15,7 @@ from execution_testing.execution import (
     LabeledExecuteFormat,
 )
 from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
-from execution_testing.forks import Fork, TransitionFork
-from execution_testing.forks.mutators import SpecTestMutator
+from execution_testing.forks import Fork, SpecTestMutator, TransitionFork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.specs import BaseTest

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -421,9 +421,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "test_mutators", "Arguments to specify spec test mutators"
     )
     test_mutators_group.addoption(
-        "--spec-test-mutators",
+        "--test-mutators",
         action="store",
-        dest="spec_test_mutators",
+        dest="test_mutators",
         default=None,
         help="Parametrize spec tests with the given comma-separated list of "
         "mutators.",
@@ -435,12 +435,12 @@ def spec_test_mutator_parameter(
     request: pytest.FixtureRequest,
 ) -> SpecTestMutator:
     """
-    Parse the ``--spec-test-mutators`` option value into a single
+    Parse the ``--test-mutators`` option value into a single
     ``SpecTestMutator`` value with every named mutator OR'd in.
 
     Exits with a usage error if an entry does not match an existing mutator.
     """
-    value: str | None = request.config.getoption("spec_test_mutators")
+    value: str | None = request.config.getoption("test_mutators")
     if not value:
         return SpecTestMutator.NONE
     combined: SpecTestMutator = SpecTestMutator.NONE

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
@@ -205,6 +205,11 @@ class Alloc(BaseAlloc):
         if Number(nonce) == 0:
             self.assert_mutable()
 
+        if storage is None:
+            storage = Storage()
+        elif not isinstance(storage, Storage):
+            storage = Storage(storage)  # type: ignore
+
         return self._deploy_contract(
             code=code,
             storage=storage,
@@ -219,7 +224,7 @@ class Alloc(BaseAlloc):
         self,
         code: BytesConvertible,
         *,
-        storage: Storage | StorageRootType | None,
+        storage: Storage,
         balance: NumberConvertible,
         nonce: NumberConvertible,
         address: Address | None,

--- a/packages/testing/src/execution_testing/forks/__init__.py
+++ b/packages/testing/src/execution_testing/forks/__init__.py
@@ -74,6 +74,7 @@ from .helpers import (
     transition_fork_from_to,
     transition_fork_to,
 )
+from .mutators import SpecTestMutator
 
 __all__ = [
     "ALL_FORKS_WITH_TRANSITIONS",
@@ -85,6 +86,7 @@ __all__ = [
     "ForkOrNoneAdapter",
     "ForkSet",
     "ForkSetAdapter",
+    "SpecTestMutator",
     "TransitionFork",
     "TransitionForkAdapter",
     "TransitionForkOrNoneAdapter",

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -17,6 +17,8 @@ from typing import (
     Type,
 )
 
+from .mutators import SpecTestMutator
+
 if TYPE_CHECKING:
     from execution_testing.fixtures.blockchain import FixtureHeader
 
@@ -821,6 +823,15 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         This method must always call the `fork_to` method when transitioning,
         because the allocation can only be set at genesis, and thus cannot be
         changed at transition time.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def spec_test_mutators(cls) -> List[SpecTestMutator]:
+        """
+        Return the list of spec test mutators that can be enabled starting
+        on this fork.
         """
         pass
 

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -828,9 +828,9 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def spec_test_mutators(cls) -> List[SpecTestMutator]:
+    def spec_test_mutators(cls) -> SpecTestMutator:
         """
-        Return the list of spec test mutators that can be enabled starting
+        Return the spec test mutators that can be enabled starting
         on this fork.
         """
         pass

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7702.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7702.py
@@ -19,6 +19,7 @@ from ....base_fork import (
     TransactionIntrinsicCostCalculator,
 )
 from ....gas_costs import GasCosts
+from ....mutators import SpecTestMutator
 
 
 class EIP7702(BaseFork):
@@ -105,3 +106,14 @@ class EIP7702(BaseFork):
         refunds = super(EIP7702, cls).refund_types()
         refunds.append(RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY)
         return refunds
+
+    @classmethod
+    def spec_test_mutators(cls) -> SpecTestMutator:
+        """
+        Activate EIP-7702 mutator to convert all tests' contracts into
+        delegations.
+        """
+        return (
+            SpecTestMutator.EIP_7702_ALL_CONTRACTS_AS_DELEGATIONS
+            | super(EIP7702, cls).spec_test_mutators()
+        )

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1239,12 +1239,12 @@ class Frontier(
         return {}
 
     @classmethod
-    def spec_test_mutators(cls) -> List[SpecTestMutator]:
+    def spec_test_mutators(cls) -> SpecTestMutator:
         """
         Return the list of spec test mutators that can be enabled starting
         on this fork.
         """
-        return []
+        return SpecTestMutator.NONE
 
     @classmethod
     def build_default_block_header(

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -34,6 +34,7 @@ from ..base_fork import (
     TransactionIntrinsicCostCalculator,
 )
 from ..gas_costs import BASE, HIGH, LOW, MID, VERY_LOW, GasCosts
+from ..mutators import SpecTestMutator
 from . import eips
 from .eips.amsterdam import AmsterdamEIPs
 from .helpers import ceiling_division
@@ -1236,6 +1237,14 @@ class Frontier(
         Frontier does not require pre-allocated accounts
         """
         return {}
+
+    @classmethod
+    def spec_test_mutators(cls) -> List[SpecTestMutator]:
+        """
+        Return the list of spec test mutators that can be enabled starting
+        on this fork.
+        """
+        return []
 
     @classmethod
     def build_default_block_header(

--- a/packages/testing/src/execution_testing/forks/mutators.py
+++ b/packages/testing/src/execution_testing/forks/mutators.py
@@ -9,4 +9,4 @@ class SpecTestMutator(Flag):
     modifications on all tests depending on fork activation.
     """
 
-    pass
+    NONE = 0

--- a/packages/testing/src/execution_testing/forks/mutators.py
+++ b/packages/testing/src/execution_testing/forks/mutators.py
@@ -1,6 +1,6 @@
 """Fork specific test modifiers."""
 
-from enum import Flag
+from enum import Flag, auto
 
 
 class SpecTestMutator(Flag):
@@ -10,3 +10,4 @@ class SpecTestMutator(Flag):
     """
 
     NONE = 0
+    EIP_7702_ALL_CONTRACTS_AS_DELEGATIONS = auto()

--- a/packages/testing/src/execution_testing/forks/mutators.py
+++ b/packages/testing/src/execution_testing/forks/mutators.py
@@ -1,0 +1,12 @@
+"""Fork specific test modifiers."""
+
+from enum import Flag
+
+
+class SpecTestMutator(Flag):
+    """
+    Collection of modifiers supported by test specs which enable dynamic
+    modifications on all tests depending on fork activation.
+    """
+
+    pass

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -119,7 +119,7 @@ class BaseTest(BaseModel):
     expected_receipt_status: int | None = None
     is_tx_gas_heavy_test: bool = False
     is_exception_test: bool = False
-    spec_test_mutator: SpecTestMutator | None = None
+    spec_test_mutator: SpecTestMutator = SpecTestMutator.NONE
 
     # Class variables, to be set by subclasses
     spec_types: ClassVar[Dict[str, Type["BaseTest"]]] = {}
@@ -129,7 +129,6 @@ class BaseTest(BaseModel):
     supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = []
 
     supported_markers: ClassVar[Dict[str, str]] = {}
-    supported_mutators: ClassVar[List[SpecTestMutator]] = []
 
     def model_post_init(self, __context: Any, /) -> None:
         """

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -34,9 +34,8 @@ from execution_testing.fixtures import (
     LabeledFixtureFormat,
 )
 from execution_testing.fixtures.post_verifications import PostVerifications
-from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks import Fork, SpecTestMutator, TransitionFork
 from execution_testing.forks.base_fork import BaseFork
-from execution_testing.forks.mutators import SpecTestMutator
 from execution_testing.test_types import Environment, Withdrawal
 from execution_testing.test_types.receipt_types import (
     TransactionReceipt,

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -36,6 +36,7 @@ from execution_testing.fixtures import (
 from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.forks.base_fork import BaseFork
+from execution_testing.forks.mutators import SpecTestMutator
 from execution_testing.test_types import Environment, Withdrawal
 from execution_testing.test_types.receipt_types import (
     TransactionReceipt,
@@ -118,6 +119,7 @@ class BaseTest(BaseModel):
     expected_receipt_status: int | None = None
     is_tx_gas_heavy_test: bool = False
     is_exception_test: bool = False
+    spec_test_mutator: SpecTestMutator | None = None
 
     # Class variables, to be set by subclasses
     spec_types: ClassVar[Dict[str, Type["BaseTest"]]] = {}
@@ -127,6 +129,7 @@ class BaseTest(BaseModel):
     supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = []
 
     supported_markers: ClassVar[Dict[str, str]] = {}
+    supported_mutators: ClassVar[List[SpecTestMutator]] = []
 
     def model_post_init(self, __context: Any, /) -> None:
         """


### PR DESCRIPTION
## 🗒️ Description
Introduce a spec-test mutator framework that lets fill apply systematic mutations to existing spec tests so we can hunt for edge cases without writing new tests. Mutators are fork-gated: each fork declares which mutators it supports via `BaseFork.spec_test_mutators()`, and the user opts in per fill invocation.

### Usage

```console
fill ... --test-mutators=EIP_7702_ALL_CONTRACTS_AS_DELEGATIONS
fill ... --test-mutators=all
```

The value selected for a given test is the intersection of what the user requested with what the test's fork supports — so requesting a mutator on a fork that doesn't enable it is a no-op rather than an error, and tests under a fork range get mutated only on the forks where the mutation is meaningful.

### First mutator: EIP_7702_ALL_CONTRACTS_AS_DELEGATIONS (Prague+)

Every `pre.deploy_contract(...)` call is rewritten so that:

1. The original bytecode is placed in a separate account.
2. The address returned to the test is a delegated EOA `(0xef0100 || <code-address>)` pointing at that account.

This stresses the EIP-7702 delegation path against the full body of existing state/blockchain tests. Edge cases surfaced this way are expected to be promoted into standalone tests as a follow-up — the flag is an exploration aid, not part of regular fill runs.


## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
