### PR TITLE
fix(tests): drop gas_price from EIP-7702 txs in BAL 7702 tests

### DIFF
--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -428,6 +428,10 @@ class Transaction(
         if self.ty <= 1 and self.gas_price is None:
             self.gas_price = HexNumber(TransactionDefaults.gas_price)
             self.model_fields_set.remove("gas_price")
+        if self.ty >= 2:
+            assert self.gas_price is None, (
+                f"gas_price not supported for tx type {int(self.ty)}"
+            )
         if self.ty >= 1 and self.access_list is None:
             self.access_list = []
         if self.ty < 1:

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7702.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7702.py
@@ -67,7 +67,6 @@ def test_bal_7702_delegation_create(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle,
@@ -166,7 +165,6 @@ def test_bal_7702_delegation_update(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle1,
@@ -182,7 +180,6 @@ def test_bal_7702_delegation_update(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle2,
@@ -295,7 +292,6 @@ def test_bal_7702_delegation_clear(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle,
@@ -311,7 +307,6 @@ def test_bal_7702_delegation_clear(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=abyss,
@@ -473,7 +468,6 @@ def test_bal_7702_invalid_nonce_authorization(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle,
@@ -540,7 +534,6 @@ def test_bal_7702_invalid_authority_has_code_authorization(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle,
@@ -600,7 +593,6 @@ def test_bal_7702_invalid_chain_id_authorization(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 chain_id=999,  # Wrong chain id
@@ -744,7 +736,6 @@ def test_bal_7702_multi_hop_delegation_chain(
         sender=alice,
         to=entry_address,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=auth_b,
@@ -855,7 +846,6 @@ def test_bal_7702_cross_tx_delegation_then_call(
         to=bob,
         value=0,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=counter,
@@ -1022,7 +1012,6 @@ def test_bal_7702_double_auth_reset(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=contract_a,
@@ -1111,7 +1100,6 @@ def test_bal_7702_double_auth_swap(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=contract_a,
@@ -1213,7 +1201,6 @@ def test_bal_selfdestruct_to_7702_delegation(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle,
@@ -1346,7 +1333,6 @@ def test_bal_withdrawal_to_7702_delegation(
         to=bob,
         value=10,
         gas_limit=1_000_000,
-        gas_price=0xA,
         authorization_list=[
             AuthorizationTuple(
                 address=oracle,


### PR DESCRIPTION
## 🗒️ Description

EIP-7702 (type-4) transactions don't have a gas_price field; remove the stray gas_price=0xA from txs that include an authorization_list.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

🐛
