### PR TITLE
feat(tests, spec-specs): eip8037 sstore/collision clear dynamics

### DIFF
--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -621,7 +621,6 @@ def gas_test(
             LEGACY_CALL_SUCCESS
         )
 
-    gas_sstore = Op.SSTORE(1, 1).gas_cost(fork=fork)
     if tx_gas is None:
         tx_gas = gas_single_gas_run + cold_gas + 1_000_000
     tx = Transaction(

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1084,8 +1084,6 @@ def process_transaction(
     tx_output = process_message_call(message)
 
     if tx_output.error is not None:
-        # State rolled back: restore reservoir via the
-        # `state_gas_left + state_gas_used` invariant.
         tx_output.state_gas_left = Uint(
             int(tx_output.state_gas_left) + tx_output.state_gas_used
         )
@@ -1159,8 +1157,6 @@ def process_transaction(
         destroy_account(tx_state, block_env.coinbase)
 
     tx_regular_gas = tx_env.intrinsic_regular_gas + tx_output.regular_gas_used
-    # `state_gas_used` may be negative when inline refunds exceed
-    # gross charges; clamp the block contribution at zero.
     tx_state_gas = (
         int(tx_env.intrinsic_state_gas)
         + tx_output.state_gas_used

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1084,8 +1084,12 @@ def process_transaction(
     tx_output = process_message_call(message)
 
     if tx_output.error is not None:
-        tx_output.state_gas_left += tx_output.state_gas_used
-        tx_output.state_gas_used = Uint(0)
+        # State rolled back: restore reservoir via the
+        # `state_gas_left + state_gas_used` invariant.
+        tx_output.state_gas_left = Uint(
+            int(tx_output.state_gas_left) + tx_output.state_gas_used
+        )
+        tx_output.state_gas_used = 0
         if isinstance(tx.to, Bytes0):
             new_account_refund = (
                 STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
@@ -1155,15 +1159,17 @@ def process_transaction(
         destroy_account(tx_state, block_env.coinbase)
 
     tx_regular_gas = tx_env.intrinsic_regular_gas + tx_output.regular_gas_used
+    # `state_gas_used` may be negative when inline refunds exceed
+    # gross charges; clamp the block contribution at zero.
     tx_state_gas = (
-        tx_env.intrinsic_state_gas
+        int(tx_env.intrinsic_state_gas)
         + tx_output.state_gas_used
-        - tx_output.state_refund
+        - int(tx_output.state_refund)
     )
     block_output.block_gas_used += max(
         tx_regular_gas, intrinsic.calldata_floor
     )
-    block_output.block_state_gas_used += tx_state_gas
+    block_output.block_state_gas_used += Uint(max(0, tx_state_gas))
     block_output.blob_gas_used += tx_blob_gas_used
 
     block_output.cumulative_gas_used += tx_gas_used_after_refund

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -180,18 +180,15 @@ class Evm:
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     regular_gas_used: Uint = Uint(0)
-    state_gas_used: Uint = Uint(0)
-    state_gas_refund_pending: Uint = Uint(0)
+    state_gas_used: int = 0
 
 
 def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:
     """
-    Credit an inline state gas refund to `evm.state_gas_left`.
+    Credit an inline state gas refund to the local frame's reservoir.
 
-    Clamp the applied portion to this frame's `state_gas_used` — the
-    matching charge may sit in an ancestor sharing storage via
-    CALLCODE/DELEGATECALL.  Defer the unapplied remainder in
-    `state_gas_refund_pending` for propagation on success.
+    `state_gas_used` may go negative when the refund matches an
+    ancestor's charge (e.g. an `SSTORE` clearing a slot a parent set).
 
     Parameters
     ----------
@@ -201,19 +198,13 @@ def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:
         The refund amount to credit.
 
     """
-    applied = min(amount, evm.state_gas_used)
-    evm.state_gas_left += applied
-    evm.state_gas_used -= applied
-    evm.state_gas_refund_pending += amount - applied
+    evm.state_gas_left += amount
+    evm.state_gas_used -= int(amount)
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     """
     Incorporate the state of a successful `child_evm` into the parent `evm`.
-
-    Apply `state_gas_refund_pending` (the unapplied remainder of any
-    refund credited inside the child) to the parent via
-    `credit_state_gas_refund`; any leftover propagates further up.
 
     Parameters
     ----------
@@ -232,7 +223,6 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
     evm.regular_gas_used += child_evm.regular_gas_used
     evm.state_gas_used += child_evm.state_gas_used
-    credit_state_gas_refund(evm, child_evm.state_gas_refund_pending)
 
 
 def incorporate_child_on_error(
@@ -242,16 +232,10 @@ def incorporate_child_on_error(
     """
     Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
 
-    On failure (revert or exceptional halt) state changes are rolled back,
-    so no state was actually grown.  All state gas, both reservoir and any
-    that spilled into `gas_left`, is restored to the parent's reservoir and
-    the child's `state_gas_used` is not accumulated.
-
-    `state_gas_refund_pending` is discarded with the child frame: any
-    inline credits the child applied are keyed to charges (its own
-    SSTORE or CREATE pre-charge) that are themselves rolled back, so
-    the matching `state_gas_left + state_gas_used` sum already reflects
-    the correct amount to return to the parent.
+    State is rolled back, so all state gas is restored to the parent's
+    reservoir via the `state_gas_left + state_gas_used` invariant. Any
+    inline refunds the child credited net out automatically — their
+    matching charges are rolled back too.
 
     Parameters
     ----------
@@ -262,7 +246,11 @@ def incorporate_child_on_error(
 
     """
     evm.gas_left += child_evm.gas_left
-    evm.state_gas_left += child_evm.state_gas_used + child_evm.state_gas_left
+    evm.state_gas_left = Uint(
+        int(evm.state_gas_left)
+        + child_evm.state_gas_used
+        + int(child_evm.state_gas_left)
+    )
     evm.regular_gas_used += child_evm.regular_gas_used
 
 

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -303,7 +303,7 @@ def charge_state_gas(evm: Evm, amount: Uint) -> None:
     else:
         raise OutOfGasError
 
-    evm.state_gas_used += amount
+    evm.state_gas_used += int(amount)
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -244,9 +244,6 @@ def process_create_message(message: Message) -> Evm:
             restore_tx_state(tx_state, snapshot)
             evm.regular_gas_used += evm.gas_left
             evm.gas_left = Uint(0)
-            # State-gas counters preserved: the parent (or tx-level
-            # error handler) restores them via the
-            # `state_gas_left + state_gas_used` invariant.
             evm.output = b""
             evm.error = error
         else:
@@ -338,9 +335,6 @@ def process_message(message: Message) -> Evm:
         evm_trace(evm, OpException(error))
         evm.regular_gas_used += evm.gas_left
         evm.gas_left = Uint(0)
-        # State-gas counters preserved: the parent (or tx-level
-        # error handler) restores them via the
-        # `state_gas_left + state_gas_used` invariant.
         evm.output = b""
         evm.error = error
     except Revert as error:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -101,7 +101,7 @@ class MessageCallOutput:
     error: Optional[EthereumException]
     return_data: Bytes
     regular_gas_used: Uint
-    state_gas_used: Uint
+    state_gas_used: int
     state_refund: Uint
 
 
@@ -138,7 +138,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
                 regular_gas_used=message.gas,
-                state_gas_used=Uint(0),
+                state_gas_used=0,
                 state_refund=Uint(0),
             )
         else:
@@ -244,11 +244,9 @@ def process_create_message(message: Message) -> Evm:
             restore_tx_state(tx_state, snapshot)
             evm.regular_gas_used += evm.gas_left
             evm.gas_left = Uint(0)
-            # State-gas counters preserved: parent's
-            # incorporate_child_on_error (or tx-level error handler at
-            # top) folds the full state-gas charge — including any
-            # spilled portion — back into the reservoir, since no
-            # state was actually grown.
+            # State-gas counters preserved: the parent (or tx-level
+            # error handler) restores them via the
+            # `state_gas_left + state_gas_used` invariant.
             evm.output = b""
             evm.error = error
         else:
@@ -340,11 +338,9 @@ def process_message(message: Message) -> Evm:
         evm_trace(evm, OpException(error))
         evm.regular_gas_used += evm.gas_left
         evm.gas_left = Uint(0)
-        # State-gas counters preserved: parent's
-        # incorporate_child_on_error (or tx-level error handler at
-        # top) folds the full state-gas charge — including any
-        # spilled portion — back into the reservoir, since no
-        # state was actually grown.
+        # State-gas counters preserved: the parent (or tx-level
+        # error handler) restores them via the
+        # `state_gas_left + state_gas_used` invariant.
         evm.output = b""
         evm.error = error
     except Revert as error:

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -19,6 +19,7 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    AuthorizationTuple,
     Block,
     BlockchainTestFiller,
     Bytecode,
@@ -31,11 +32,14 @@ from execution_testing import (
     Transaction,
     TransactionException,
     TransactionReceipt,
+    compute_create_address,
 )
 from execution_testing import (
     Macros as Om,
 )
 from execution_testing.checklists import EIPChecklist
+
+from tests.prague.eip7702_set_code_tx.spec import Spec as Spec7702
 
 from .spec import ref_spec_8037
 
@@ -1374,6 +1378,149 @@ def test_nested_failure_resets_to_tx_reservoir(
         ],
         post={},
     )
+
+
+@pytest.mark.parametrize(
+    "refund_scenario",
+    [
+        pytest.param("sstore_restoration", id="sstore_restoration"),
+        pytest.param("create_collision", id="create_collision"),
+        pytest.param("create_initcode_revert", id="create_initcode_revert"),
+        pytest.param("auth_existing_leaf", id="auth_existing_leaf"),
+    ],
+)
+@pytest.mark.parametrize(
+    "depth",
+    [
+        pytest.param(1, id="depth_1"),
+        pytest.param(3, id="depth_3"),
+        pytest.param(10, id="depth_10"),
+    ],
+)
+@pytest.mark.parametrize(
+    "consume_at",
+    [
+        pytest.param("deepest", id="consume_deepest"),
+        pytest.param("top", id="consume_top"),
+    ],
+)
+@pytest.mark.pre_alloc_mutable
+@pytest.mark.valid_from("EIP8037")
+def test_nested_state_gas_refund_consumed_at_depth(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    refund_scenario: str,
+    depth: int,
+    consume_at: str,
+) -> None:
+    """
+    Verify state-gas refund credits propagate through a CALL chain so
+    they can be consumed at any depth.
+
+    Refund sources: SSTORE `0→1→0`, CREATE collision, CREATE initcode
+    revert (all credit deepest's reservoir), and a SetCode auth on an
+    `existing_leaf` authority (credits the top reservoir at message
+    entry).
+
+    A probe CALL sized one short of covering an SSTORE on full spill
+    runs either at the refund-source frame or back at the top after
+    the chain returns; it succeeds only when its frame holds enough
+    reservoir, so a missing or mis-propagated credit OOGs it.
+    """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    is_auth_scenario = refund_scenario == "auth_existing_leaf"
+
+    probe_address = pre.deploy_contract(code=Op.SSTORE(0, 1))
+    probe_gas = (
+        2 * gas_costs.VERY_LOW
+        + gas_costs.COLD_STORAGE_WRITE
+        + sstore_state_gas
+        - 1
+    )
+    consumer_storage = Storage()
+    consume_op = Op.SSTORE(
+        consumer_storage.store_next(1, "probe_must_succeed"),
+        Op.CALL(gas=probe_gas, address=probe_address),
+    )
+
+    if refund_scenario == "sstore_restoration":
+        refund_body = Op.SSTORE(0, 1) + Op.SSTORE.with_metadata(
+            key_warm=True,
+            original_value=0,
+            current_value=1,
+            new_value=0,
+        )(0, 0)
+    elif refund_scenario == "create_collision":
+        refund_body = Op.POP(Op.CREATE(0, 0, 0))
+    elif refund_scenario == "create_initcode_revert":
+        revert_initcode = bytes(Op.REVERT(0, 0))
+        refund_body = Om.MSTORE(revert_initcode, 0) + Op.POP(
+            Op.CREATE(0, 0, len(revert_initcode))
+        )
+    elif is_auth_scenario:
+        refund_body = Bytecode()
+    else:
+        raise ValueError(f"unknown refund_scenario: {refund_scenario!r}")
+
+    deepest_body = refund_body
+    if consume_at == "deepest":
+        deepest_body = deepest_body + consume_op
+    elif consume_at != "top":
+        raise ValueError(f"unknown consume_at: {consume_at!r}")
+
+    deepest_address = pre.deploy_contract(code=deepest_body + Op.STOP)
+    if refund_scenario == "create_collision":
+        # Deepest is reached via plain CALL, so the CREATE's sender is
+        # deepest itself with nonce 1 (fresh `deploy_contract` default).
+        collision_target = compute_create_address(
+            address=deepest_address, nonce=1
+        )
+        pre.deploy_contract(code=Op.STOP, address=collision_target)
+
+    chain_inner = deepest_address
+    for _ in range(depth):
+        chain_inner = pre.deploy_contract(
+            code=Op.POP(Op.CALL(gas=Op.GAS, address=chain_inner)) + Op.STOP
+        )
+
+    top_body = Op.POP(Op.CALL(gas=Op.GAS, address=chain_inner))
+    if consume_at == "top":
+        top_body = top_body + consume_op
+    top = pre.deploy_contract(code=top_body + Op.STOP)
+
+    authorization_list = None
+    extra_post: dict = {}
+    if is_auth_scenario:
+        signer = pre.fund_eoa()
+        auth_target = pre.deploy_contract(code=Op.STOP)
+        authorization_list = [
+            AuthorizationTuple(
+                address=auth_target,
+                nonce=0,
+                signer=signer,
+            ),
+        ]
+        extra_post[signer] = Account(
+            nonce=1,
+            code=Spec7702.delegation_designation(auth_target),
+        )
+
+    tx = Transaction(
+        to=top,
+        gas_limit=gas_limit_cap,
+        authorization_list=authorization_list,
+        sender=pre.fund_eoa(),
+    )
+
+    consumer_address = deepest_address if consume_at == "deepest" else top
+    post: dict = {consumer_address: Account(storage=consumer_storage)}
+    post.update(extra_post)
+    state_test(pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.valid_from("EIP8037")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -15,6 +15,7 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 import pytest
 from execution_testing import (
     Account,
+    Address,
     Alloc,
     Block,
     BlockchainTestFiller,
@@ -153,6 +154,74 @@ def test_sstore_zero_to_zero(
 
     post = {contract: Account(storage=storage)}
     state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "delegatecall_depth",
+    [
+        pytest.param(1, id="depth_1"),
+        pytest.param(3, id="depth_3"),
+        pytest.param(10, id="depth_10"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_sstore_restoration_refund_credits_local_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    delegatecall_depth: int,
+) -> None:
+    """
+    SSTORE 0→x→0 restoration refund credits the *local* reservoir.
+
+    Parent sets slots `0` and `1` to `1`, then DELEGATECALLs through a
+    chain that clears both slots and CREATEs an empty account from
+    the clearing frame. The two restoration refunds credit the
+    clearing frame's reservoir, funding the CREATE.
+
+    A spec that clamps the refund to the clearing frame's own
+    `state_gas_used` (zero — it does no `0→x` set) would OOG the
+    CREATE and leave both slots set.
+    """
+    state_gas = fork.sstore_state_gas()
+    create_state_gas = fork.create_state_gas()
+
+    clearing = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, 0)
+            + Op.SSTORE(1, 0)
+            + Op.POP(Op.CREATE(0, 0, 0))
+            + Op.STOP
+        )
+    )
+    inner: Address = clearing
+    for _ in range(delegatecall_depth):
+        inner = pre.deploy_contract(
+            code=(Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=inner)) + Op.STOP)
+        )
+    parent = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, 1)
+            + Op.SSTORE(1, 1)
+            + Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=inner))
+            + Op.STOP
+        )
+    )
+
+    # Guard against fork-constant drift: the two restoration refunds
+    # must cover `create_state_gas`.
+    assert state_gas == 97_920 and create_state_gas == 183_600
+    tx = Transaction(
+        to=parent,
+        gas_limit=500_000,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        pre=pre,
+        post={parent: Account(storage={0: 0, 1: 0})},
+        tx=tx,
+    )
 
 
 @EIPChecklist.GasRefundsChanges.Test.RefundCalculation()
@@ -743,6 +812,7 @@ def test_sstore_restoration_cross_frame(
         pytest.param(1, id="single_hop"),
         pytest.param(2, id="two_hops"),
         pytest.param(3, id="three_hops"),
+        pytest.param(10, id="ten_hops"),
     ],
 )
 @pytest.mark.with_all_call_opcodes(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -157,6 +157,13 @@ def test_sstore_zero_to_zero(
 
 
 @pytest.mark.parametrize(
+    "refund_sufficient",
+    [
+        pytest.param(True, id="refund_funds_create"),
+        pytest.param(False, id="no_refund_create_oogs"),
+    ],
+)
+@pytest.mark.parametrize(
     "delegatecall_depth",
     [
         pytest.param(1, id="depth_1"),
@@ -170,27 +177,32 @@ def test_sstore_restoration_refund_credits_local_reservoir(
     pre: Alloc,
     fork: Fork,
     delegatecall_depth: int,
+    refund_sufficient: bool,
 ) -> None:
     """
-    SSTORE 0→x→0 restoration refund credits the *local* reservoir.
-
-    Parent sets slots `0` and `1` to `1`, then DELEGATECALLs through a
-    chain that clears both slots and CREATEs an empty account from
-    the clearing frame. The two restoration refunds credit the
-    clearing frame's reservoir, funding the CREATE.
-
-    A spec that clamps the refund to the clearing frame's own
-    `state_gas_used` (zero — it does no `0→x` set) would OOG the
-    CREATE and leave both slots set.
+    Verify a same transaction SSTORE restoration refund credits the
+    clearing frame's own reservoir immediately so later state gas in
+    that frame is funded. Parametrized to pin the refund as necessary
+    and sufficient.
     """
-    state_gas = fork.sstore_state_gas()
+    sstore_state_gas = fork.sstore_state_gas()
     create_state_gas = fork.create_state_gas()
+    # Premise: the two restoration refunds must be able to cover the
+    # CREATE's new-account state gas for the funded path to exist.
+    # Drift-proof relationship (vs. hardcoding the constants).
+    assert 2 * sstore_state_gas >= create_state_gas
 
+    # Sentinel written only if the CREATE returned (frame did not OOG).
+    sentinel_slot = 2
+    # refund: clear (1→0, restoration refund). no refund: modify
+    # (1→2, no state growth, no refund) — same regular shape.
+    cleared_value = 0 if refund_sufficient else 2
     clearing = pre.deploy_contract(
         code=(
-            Op.SSTORE(0, 0)
-            + Op.SSTORE(1, 0)
+            Op.SSTORE(0, cleared_value)
+            + Op.SSTORE(1, cleared_value)
             + Op.POP(Op.CREATE(0, 0, 0))
+            + Op.SSTORE(sentinel_slot, 1)
             + Op.STOP
         )
     )
@@ -208,20 +220,29 @@ def test_sstore_restoration_refund_credits_local_reservoir(
         )
     )
 
-    # Guard against fork-constant drift: the two restoration refunds
-    # must cover `create_state_gas`.
-    assert state_gas == 97_920 and create_state_gas == 183_600
+    # The two parent `0→1` sets spill their state gas into `gas_left`
+    # (tx is far below the per-tx cap, so no state-gas reservoir).
+    # Budget regular headroom for the call chain plus that spill, then
+    # sit mid-window: short of also spill-funding `create_state_gas`,
+    # so only a refund-credited reservoir can cover the CREATE.
+    regular_headroom = 200_000
+    gas_limit = regular_headroom + 2 * sstore_state_gas + create_state_gas // 2
+
+    if refund_sufficient:
+        post = {parent: Account(storage={0: 0, 1: 0, sentinel_slot: 1})}
+    else:
+        # CREATE OOGs in the clearing frame; its writes (the 1→2
+        # modifications and the sentinel) revert, leaving the parent's
+        # original sets intact.
+        post = {parent: Account(storage={0: 1, 1: 1})}
+
     tx = Transaction(
         to=parent,
-        gas_limit=500_000,
+        gas_limit=gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    state_test(
-        pre=pre,
-        post={parent: Account(storage={0: 0, 1: 0})},
-        tx=tx,
-    )
+    state_test(pre=pre, post=post, tx=tx)
 
 
 @EIPChecklist.GasRefundsChanges.Test.RefundCalculation()

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py
@@ -21,6 +21,7 @@ from execution_testing import (
     Storage,
     Transaction,
 )
+
 from .spec import (
     GAS_CALCULATION_FUNCTION_MAP,
     PointG1,

--- a/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
@@ -123,7 +123,9 @@ def blocks(
             assert not block_included_requests
         blocks.append(
             Block(
-                txs=sum((r.transactions(fork) for r in block_requests), []),
+                txs=sum(
+                    (r.transactions(block_fork) for r in block_requests), []
+                ),
                 header_verify=header_verify,
                 timestamp=timestamp,
             )


### PR DESCRIPTION
## 🗒️ Description

Spec fix: EIP-8037 inline `state_gas` refunds (`SSTORE` clear, `CREATE` collision/revert) now credit the local frame's reservoir immediately, instead of being clamped to local `state_gas_used` and deferred. 

### Tests added
- Added a nested refund-propagation test in `test_state_gas_reservoir.py` modelled on `test_nested_failure_resets_to_tx_reservoir` but exercising the success path. Parametrizes for refund scenarios × depth × consume-point.
- A local-consumption `SSTORE`-restoration test and a `depth_10` case on existing ancestor-charge test

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
