### PR TITLE
feat(tests): EIP-7981 zero-byte calldata floor cost rejection

### DIFF
--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -87,6 +87,12 @@ def test_insufficient_gas_for_access_list(
             -1,
             id="large_calldata_and_access_list_insufficient_gas",
         ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            Bytes(b"\x00" * 1000),
+            -1,
+            id="large_zero_calldata_and_access_list_insufficient_gas",
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description

Add a `zero_calldata_and_access_list_insufficient_gas` parametrize to `test_floor_cost_validation_with_access_list`, exercising the `intrinsic <= gas_limit < floor` window with a 1,700-gas margin between regular intrinsic and floor (vs. ~19,700 for the existing non-zero variant).

## 🔗 Related Issues or PRs

Closes #2800.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
