### PR TITLE
feat(zkevm): include in releases blockchain_test_engine format

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -20,5 +20,5 @@ bal:
 
 zkevm:
   evm-type: develop
-  fill-params: -m "blockchain_test" --fork=Amsterdam ./tests/
+  fill-params: -m "blockchain_test or blockchain_test_engine" --fork=Amsterdam ./tests/
   feature_only: true

--- a/src/ethereum/forks/amsterdam/witness_state.py
+++ b/src/ethereum/forks/amsterdam/witness_state.py
@@ -5,7 +5,7 @@ Implement the ``PreState`` protocol using execution witness data
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import AbstractSet, Dict, List, Optional, Tuple
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
@@ -225,6 +225,7 @@ class WitnessState:
         self,
         account_changes: Dict[Address, Optional[Account]],
         storage_changes: Dict[Address, Dict[Bytes32, U256]],
+        storage_clears: AbstractSet[Address] = frozenset(),
     ) -> Tuple[Root, List[InternalNode]]:
         """
         Compute the state root after applying changes.
@@ -235,9 +236,16 @@ class WitnessState:
         new_storage_roots: Dict[Address, Root] = {}
 
         for address, slots in storage_changes.items():
-            if address not in self._storage_root_cache:
+            if (
+                address not in storage_clears
+                and address not in self._storage_root_cache
+            ):
                 self.get_account_optional(address)
-            old_root = self._storage_root_cache.get(address, EMPTY_TRIE_ROOT)
+            old_root = (
+                EMPTY_TRIE_ROOT
+                if address in storage_clears
+                else self._storage_root_cache.get(address, EMPTY_TRIE_ROOT)
+            )
             storage_mpt: IncrementalMPT[Bytes32, U256] = decode_witness_to_mpt(
                 self._node_db,
                 old_root,
@@ -263,7 +271,8 @@ class WitnessState:
             )
         )
 
-        for address in storage_changes:
+        storage_touched = set(storage_changes) | set(storage_clears)
+        for address in storage_touched:
             if address not in account_changes:
                 account = self.get_account_optional(address)
                 if account is not None:
@@ -282,6 +291,8 @@ class WitnessState:
         def get_storage_root(addr: Address) -> Root:
             if addr in new_storage_roots:
                 return new_storage_roots[addr]
+            if addr in storage_clears:
+                return EMPTY_TRIE_ROOT
             return self._storage_root_cache.get(addr, EMPTY_TRIE_ROOT)
 
         for address, account in account_changes.items():


### PR DESCRIPTION
## 🗒️ Description
Include the `blockchain_test_engine` format in releases.

Also fixes lints fails caused by a previous rebase.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
