### PR TITLE
feat(tests): EIP-8037 CREATE-tx collision refunds state-gas reservoir

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1933,6 +1933,66 @@ def test_create_tx_collision_refunds_intrinsic_new_account(
     )
 
 
+@pytest.mark.pre_alloc_mutable()
+@pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
+@pytest.mark.valid_from("EIP8037")
+def test_create_tx_collision_refunds_reservoir(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify the state-gas reservoir is refunded on a depth-0 CREATE-tx
+    address collision when `gas_limit > TX_MAX_GAS_LIMIT`.
+
+    EIP-8037 splits `gas_limit` into the capped regular budget and a
+    state-gas reservoir. On collision the inner regular gas is burnt
+    and `intrinsic_state_gas` is refunded; the reservoir must also
+    be refunded to the sender. `header.gas_used` is fixed at the
+    regular cap regardless of reservoir handling, so the sender's
+    post-balance is the primary discriminating assertion.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    init_code = Op.STOP
+    # +1 above intrinsic_state_gas (= create_state_gas(code_size=0)
+    # for empty-code CREATE-tx) makes message.state_gas_reservoir > 0.
+    reservoir = fork.create_state_gas(code_size=0) + 1
+    gas_limit = gas_limit_cap + reservoir
+    initial_fund = 10**18
+
+    sender = pre.fund_eoa(initial_fund)
+    collision_target = compute_create_address(address=sender, nonce=0)
+    pre[collision_target] = Account(nonce=1)
+
+    tx_gas_price = 7
+    tx = Transaction(
+        to=None,
+        data=init_code,
+        gas_limit=gas_limit,
+        sender=sender,
+        gas_price=tx_gas_price,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=gas_limit_cap),
+            ),
+        ],
+        post={
+            sender: Account(
+                balance=initial_fund - gas_limit_cap * tx_gas_price,
+                nonce=1,
+            ),
+            collision_target: Account(nonce=1, code=b"", storage={}),
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "initcode_size_delta",
     [


### PR DESCRIPTION
## 🗒️ Description

Add `test_create_tx_collision_refunds_reservoir`: a depth-0 CREATE-tx with `gas_limit > TX_MAX_GAS_LIMIT` that collides at the deterministic CREATE address. The existing collision test uses `gas_limit` near the intrinsic, so the state-gas reservoir is empty and the reservoir-preservation path is untested.

Block-level `gas_used` is the same under both buggy and correct behaviors; the sender's post-balance is the discriminator. A buggy implementation that drops the reservoir on collision overcharges the sender by `reservoir * gas_price`.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
