### PR TITLE
feat(tests): EIP-8037 reject tx when gas_limit covers regular but not state intrinsic

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -520,6 +520,51 @@ def test_create_tx_intrinsic_gas_boundary(
     state_test(pre=pre, post={}, tx=tx)
 
 
+@pytest.mark.exception_test
+@pytest.mark.parametrize(
+    "extra_gas",
+    [
+        pytest.param(0, id="at_regular_intrinsic"),
+        pytest.param(1, id="one_above_regular_intrinsic"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_create_tx_below_total_intrinsic(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    extra_gas: int,
+) -> None:
+    """
+    Reject CREATE tx when gas_limit covers regular but not state intrinsic.
+
+    EIP-8037 splits the CREATE intrinsic into regular and state
+    components (`STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE`).
+    `test_create_tx_intrinsic_gas_boundary` pins the upper boundary
+    (`total - 1`); this pins the lower end — `intrinsic_regular` and
+    one gas above — to catch implementations that omit the state
+    component from the pre-validate check.
+    """
+    total_intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        contract_creation=True,
+    )
+    intrinsic_state = fork.transaction_intrinsic_state_gas(
+        contract_creation=True,
+    )
+    intrinsic_regular = total_intrinsic - intrinsic_state
+    gas_limit = intrinsic_regular + extra_gas
+    assert gas_limit < total_intrinsic
+
+    tx = Transaction(
+        to=None,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
+
+
 @pytest.mark.valid_from("EIP8037")
 def test_code_deposit_oog_preserves_parent_reservoir(
     state_test: StateTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -104,6 +104,7 @@ def test_authorization_state_gas_scaling(
     [
         pytest.param(0, id="at_regular_intrinsic"),
         pytest.param(1, id="one_above_regular_intrinsic"),
+        pytest.param(-1, id="one_below_total_intrinsic"),
     ],
 )
 @pytest.mark.valid_from("EIP8037")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -90,6 +90,71 @@ def test_authorization_state_gas_scaling(
     state_test(env=env, pre=pre, post={}, tx=tx)
 
 
+@pytest.mark.exception_test
+@pytest.mark.parametrize(
+    "num_auths",
+    [
+        pytest.param(1, id="single_auth"),
+        pytest.param(2, id="two_auths"),
+        pytest.param(3, id="three_auths"),
+    ],
+)
+@pytest.mark.parametrize(
+    "extra_gas",
+    [
+        pytest.param(0, id="at_regular_intrinsic"),
+        pytest.param(1, id="one_above_regular_intrinsic"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_set_code_tx_below_total_intrinsic(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_auths: int,
+    extra_gas: int,
+) -> None:
+    """
+    Reject set_code tx when gas_limit covers regular but not state intrinsic.
+
+    EIP-8037 charges each authorization a state component
+    `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) *
+    COST_PER_STATE_BYTE`; total intrinsic = `regular + N * state` for
+    N authorizations. Sweep N = 1, 2, 3 and pin gas_limit at the
+    lower end of the rejected interval to catch implementations that
+    omit the state component from the pre-validate check.
+    """
+    intrinsic_state = fork.transaction_intrinsic_state_gas(
+        authorization_count=num_auths,
+    )
+    total_intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        authorization_list_or_count=num_auths,
+    )
+    intrinsic_regular = total_intrinsic - intrinsic_state
+    gas_limit = intrinsic_regular + extra_gas
+    assert gas_limit < total_intrinsic
+
+    contract = pre.deploy_contract(code=Op.STOP)
+    authorization_list = [
+        AuthorizationTuple(
+            address=contract,
+            nonce=1,
+            signer=pre.fund_eoa(),
+        )
+        for _ in range(num_auths)
+    ]
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        authorization_list=authorization_list,
+        sender=pre.fund_eoa(),
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
+
+
 @pytest.mark.valid_from("EIP8037")
 def test_existing_account_refund(
     state_test: StateTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -132,7 +132,9 @@ def test_set_code_tx_below_total_intrinsic(
         authorization_list_or_count=num_auths,
     )
     intrinsic_regular = total_intrinsic - intrinsic_state
-    gas_limit = intrinsic_regular + extra_gas
+    gas_limit = (
+        intrinsic_regular if extra_gas >= 0 else total_intrinsic
+    ) + extra_gas
     assert gas_limit < total_intrinsic
 
     contract = pre.deploy_contract(code=Op.STOP)


### PR DESCRIPTION
## 🗒️ Description

EIP-8037 splits a transaction's intrinsic gas into a regular component and a state component (NEW_ACCOUNT for CREATE, NEW_ACCOUNT + AUTH_BASE per authorization for set_code). The sender must cover both: any `gas_limit < regular + state` is invalid with `INTRINSIC_GAS_TOO_LOW`.

The existing `test_create_tx_intrinsic_gas_boundary` pins gas_limit at the upper boundary (`total - 1`). This change adds two functions that pin gas_limit at the lower end of the rejected interval—`regular` and `regular + 1`—where an implementation that omits the state component from its pre-validate intrinsic check would erroneously accept the transaction:

- `test_create_tx_below_total_intrinsic` (CREATE)
- `test_set_code_tx_below_total_intrinsic` (set_code, N = 1, 2, 3 auths)

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.
