### PR TITLE
feat(spec-specs, tests): Add EIP-7981 Increase Access List Cost

### DIFF
--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -61,7 +61,12 @@ class TransactionDataFloorCostCalculator(Protocol):
     Calculate the transaction floor cost due to its calldata for a given fork.
     """
 
-    def __call__(self, *, data: BytesConvertible) -> int:
+    def __call__(
+        self,
+        *,
+        data: BytesConvertible,
+        access_list: List[AccessList] | None = None,
+    ) -> int:
         """Return transaction gas cost of calldata given its contents."""
         pass
 

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
@@ -59,7 +59,7 @@ class EIP7981(BaseFork):
             return (
                 super_fn(data=data)
                 + cls._access_list_floor_tokens(access_list)
-                * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+                * gas_costs.TX_DATA_TOKEN_FLOOR
             )
 
         return fn
@@ -95,7 +95,7 @@ class EIP7981(BaseFork):
             )
             intrinsic_cost += (
                 cls._access_list_floor_tokens(access_list)
-                * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+                * gas_costs.TX_DATA_TOKEN_FLOOR
             )
 
             if return_cost_deducted_prior_execution:

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
@@ -1,63 +1,55 @@
 """
-EIP-7623: Increase calldata cost.
+EIP-7981: Increase Access List Cost.
 
-Increase calldata cost to reduce maximum block size.
+Price access lists for data to reduce maximum block size.
 
-https://eips.ethereum.org/EIPS/eip-7623
+https://eips.ethereum.org/EIPS/eip-7981
 """
 
-from dataclasses import replace
 from typing import List, Sized
 
-from execution_testing.base_types import AccessList, Bytes
+from execution_testing.base_types import AccessList
 from execution_testing.base_types.conversions import BytesConvertible
 
 from ....base_fork import (
     BaseFork,
-    CalldataGasCalculator,
     TransactionDataFloorCostCalculator,
     TransactionIntrinsicCostCalculator,
 )
-from ....gas_costs import GasCosts
 
 
-class EIP7623(BaseFork):
-    """EIP-7623 class."""
-
-    @classmethod
-    def gas_costs(cls) -> GasCosts:
-        """Add standard and floor token costs for calldata."""
-        return replace(
-            super(EIP7623, cls).gas_costs(),
-            TX_DATA_TOKEN_STANDARD=4,
-            TX_DATA_TOKEN_FLOOR=10,
-        )
+class EIP7981(BaseFork):
+    """EIP-7981 class."""
 
     @classmethod
-    def calldata_gas_calculator(cls) -> CalldataGasCalculator:
+    def _access_list_token_count(
+        cls, access_list: List[AccessList] | None
+    ) -> int:
         """
-        Return a callable that calculates the transaction gas cost for its
-        calldata depending on its contents.
+        Return the total number of data tokens contributed by an access list.
+
+        Tokens are counted per EIP-7981:
+        - zero byte = 1 token
+        - non-zero byte = 4 tokens
         """
-        gas_costs = cls.gas_costs()
+        if not access_list:
+            return 0
 
-        def fn(*, data: BytesConvertible, floor: bool = False) -> int:
-            raw = Bytes(data)
-            num_zeros = raw.count(0)
-            num_non_zeros = len(raw) - num_zeros
-            tokens = num_zeros + num_non_zeros * 4
-            if floor:
-                return tokens * gas_costs.TX_DATA_TOKEN_FLOOR
-            return tokens * gas_costs.TX_DATA_TOKEN_STANDARD
-
-        return fn
+        tokens = 0
+        for access in access_list:
+            for b in access.address:
+                tokens += 1 if b == 0 else 4
+            for slot in access.storage_keys:
+                for b in slot:
+                    tokens += 1 if b == 0 else 4
+        return tokens
 
     @classmethod
     def transaction_data_floor_cost_calculator(
         cls,
     ) -> TransactionDataFloorCostCalculator:
         """
-        Transaction data floor cost is introduced.
+        Floor cost includes calldata and access list tokens.
         """
         calldata_gas_calculator = cls.calldata_gas_calculator()
         gas_costs = cls.gas_costs()
@@ -67,10 +59,11 @@ class EIP7623(BaseFork):
             data: BytesConvertible,
             access_list: List[AccessList] | None = None,
         ) -> int:
-            del access_list
+            access_list_tokens = cls._access_list_token_count(access_list)
             return (
                 calldata_gas_calculator(data=data, floor=True)
-                + gas_costs.TX_BASE
+                + access_list_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+                + gas_costs.GAS_TX_BASE
             )
 
         return fn
@@ -80,10 +73,11 @@ class EIP7623(BaseFork):
         cls,
     ) -> TransactionIntrinsicCostCalculator:
         """
-        Transaction intrinsic cost wraps the parent calculator with a floor
-        cost.
+        Access list data is charged at the floor token cost and
+        contributes to the floor gas cost per EIP-7981.
         """
-        super_fn = super(EIP7623, cls).transaction_intrinsic_cost_calculator()
+        super_fn = super(EIP7981, cls).transaction_intrinsic_cost_calculator()
+        gas_costs = cls.gas_costs()
         transaction_data_floor_cost_calculator = (
             cls.transaction_data_floor_cost_calculator()
         )
@@ -101,14 +95,20 @@ class EIP7623(BaseFork):
                 contract_creation=contract_creation,
                 access_list=access_list,
                 authorization_list_or_count=authorization_list_or_count,
-                return_cost_deducted_prior_execution=False,
+                return_cost_deducted_prior_execution=True,
+            )
+            access_list_tokens = cls._access_list_token_count(access_list)
+            intrinsic_cost += (
+                access_list_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
             )
 
             if return_cost_deducted_prior_execution:
                 return intrinsic_cost
 
             transaction_floor_data_cost = (
-                transaction_data_floor_cost_calculator(data=calldata)
+                transaction_data_floor_cost_calculator(
+                    data=calldata, access_list=access_list
+                )
             )
             return max(intrinsic_cost, transaction_floor_data_cost)
 

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
@@ -22,36 +22,33 @@ class EIP7981(BaseFork):
     """EIP-7981 class."""
 
     @classmethod
-    def _access_list_token_count(
+    def _access_list_floor_tokens(
         cls, access_list: List[AccessList] | None
     ) -> int:
         """
-        Return the total number of data tokens contributed by an access list.
+        Return ``access_list_bytes * 4`` floor tokens for the access list.
 
-        Tokens are counted per EIP-7981:
-        - zero byte = 1 token
-        - non-zero byte = 4 tokens
+        Every byte of each address (20 bytes) and storage key (32 bytes)
+        contributes four floor tokens, so zero and non-zero bytes are
+        charged equally per EIP-7981.
         """
         if not access_list:
             return 0
-
-        tokens = 0
+        total_bytes = 0
         for access in access_list:
-            for b in access.address:
-                tokens += 1 if b == 0 else 4
+            total_bytes += len(access.address)
             for slot in access.storage_keys:
-                for b in slot:
-                    tokens += 1 if b == 0 else 4
-        return tokens
+                total_bytes += len(slot)
+        return total_bytes * 4
 
     @classmethod
     def transaction_data_floor_cost_calculator(
         cls,
     ) -> TransactionDataFloorCostCalculator:
         """
-        Floor cost includes calldata and access list tokens.
+        Add access list floor tokens to the inherited calldata floor cost.
         """
-        calldata_gas_calculator = cls.calldata_gas_calculator()
+        super_fn = super(EIP7981, cls).transaction_data_floor_cost_calculator()
         gas_costs = cls.gas_costs()
 
         def fn(
@@ -59,11 +56,10 @@ class EIP7981(BaseFork):
             data: BytesConvertible,
             access_list: List[AccessList] | None = None,
         ) -> int:
-            access_list_tokens = cls._access_list_token_count(access_list)
             return (
-                calldata_gas_calculator(data=data, floor=True)
-                + access_list_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
-                + gas_costs.GAS_TX_BASE
+                super_fn(data=data)
+                + cls._access_list_floor_tokens(access_list)
+                * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
             )
 
         return fn
@@ -73,12 +69,12 @@ class EIP7981(BaseFork):
         cls,
     ) -> TransactionIntrinsicCostCalculator:
         """
-        Access list data is charged at the floor token cost and
-        contributes to the floor gas cost per EIP-7981.
+        Charge access list data at the floor token cost on top of the
+        inherited intrinsic cost and enforce the combined data floor.
         """
         super_fn = super(EIP7981, cls).transaction_intrinsic_cost_calculator()
         gas_costs = cls.gas_costs()
-        transaction_data_floor_cost_calculator = (
+        data_floor_cost_calculator = (
             cls.transaction_data_floor_cost_calculator()
         )
 
@@ -97,19 +93,19 @@ class EIP7981(BaseFork):
                 authorization_list_or_count=authorization_list_or_count,
                 return_cost_deducted_prior_execution=True,
             )
-            access_list_tokens = cls._access_list_token_count(access_list)
             intrinsic_cost += (
-                access_list_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+                cls._access_list_floor_tokens(access_list)
+                * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
             )
 
             if return_cost_deducted_prior_execution:
                 return intrinsic_cost
 
-            transaction_floor_data_cost = (
-                transaction_data_floor_cost_calculator(
+            return max(
+                intrinsic_cost,
+                data_floor_cost_calculator(
                     data=calldata, access_list=access_list
-                )
+                ),
             )
-            return max(intrinsic_cost, transaction_floor_data_cost)
 
         return fn

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -812,8 +812,12 @@ class Frontier(
     ) -> TransactionDataFloorCostCalculator:
         """At frontier, the transaction data floor cost is a constant zero."""
 
-        def fn(*, data: BytesConvertible) -> int:
-            del data
+        def fn(
+            *,
+            data: BytesConvertible,
+            access_list: List[AccessList] | None = None,
+        ) -> int:
+            del data, access_list
             return 0
 
         return fn

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -38,15 +38,6 @@ from . import eips
 from .eips.amsterdam import AmsterdamEIPs
 from .helpers import ceiling_division
 
-if TYPE_CHECKING:
-
-    class _AmsterdamEIPsForTyping(BaseFork):
-        """Typing-only stand-in for Amsterdam EIP mixins."""
-
-        pass
-else:
-    from .eips.amsterdam import AmsterdamEIPs as _AmsterdamEIPsForTyping
-
 
 # All forks must be listed here !!! in the order they were introduced !!!
 class Frontier(

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -38,6 +38,15 @@ from . import eips
 from .eips.amsterdam import AmsterdamEIPs
 from .helpers import ceiling_division
 
+if TYPE_CHECKING:
+
+    class _AmsterdamEIPsForTyping(BaseFork):
+        """Typing-only stand-in for Amsterdam EIP mixins."""
+
+        pass
+else:
+    from .eips.amsterdam import AmsterdamEIPs as _AmsterdamEIPsForTyping
+
 
 # All forks must be listed here !!! in the order they were introduced !!!
 class Frontier(

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -30,6 +30,22 @@ from .fork_types import Authorization, VersionedHash
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
+ACCESS_LIST_ADDRESS_FLOOR_TOKENS = Uint(80)
+"""
+Floor data tokens contributed by a single access list address per
+[EIP-7981].
+
+[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+"""
+
+ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS = Uint(128)
+"""
+Floor data tokens contributed by a single access list storage key per
+[EIP-7981].
+
+[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+"""
+
 
 @slotted_freezable
 @dataclass
@@ -443,7 +459,6 @@ Transaction = (
 Union type representing any valid transaction type.
 """
 
-
 AccessListCapableTransaction = (
     AccessListTransaction
     | FeeMarketTransaction
@@ -575,12 +590,23 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     2. Cost for data (zero and non-zero bytes)
     3. Cost for contract creation (if applicable)
     4. Cost for access list entries (if applicable)
-    5. Cost for authorizations (if applicable)
+    5. Cost for access list data (if applicable)
+    6. Cost for authorizations (if applicable)
 
+    Access lists incur data costs in addition to storage access costs. Token
+    counting uses
+    [`CALLDATA_TOKENS_PER_ZERO_BYTE`](
+        ref:ethereum.forks.amsterdam.transactions.CALLDATA_TOKENS_PER_ZERO_BYTE
+    )
+    and
+    [`CALLDATA_TOKENS_PER_NONZERO_BYTE`](
+        ref:ethereum.forks.amsterdam.transactions.CALLDATA_TOKENS_PER_NONZERO_BYTE
+    ).
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
-    transaction based on the calldata size.
+    transaction based on the calldata and access list size.
+
     """
     from .vm.gas import GasCosts, init_code_cost
 
@@ -593,6 +619,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     else:
         create_cost = Uint(0)
 
+    # Calculate access-list tokens and costs.
     access_list_cost = Uint(0)
     tokens_in_access_list = Uint(0)
     if has_access_list(tx):
@@ -601,9 +628,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             access_list_cost += (
                 ulen(access.slots) * GasCosts.TX_ACCESS_LIST_STORAGE_KEY
             )
-
-    # Data token floor cost for access list bytes.
-    access_list_cost += tokens_in_access_list * GAS_TX_DATA_TOKEN_FLOOR
+            tokens_in_access_list += ACCESS_LIST_ADDRESS_FLOOR_TOKENS
+            tokens_in_access_list += (
+                ulen(access.slots) * ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS
+            )
 
     # Data token floor cost for access list bytes.
     access_list_cost += tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -601,6 +601,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             access_list_cost += (
                 ulen(access.slots) * GasCosts.TX_ACCESS_LIST_STORAGE_KEY
             )
+    access_list_cost += tokens_in_access_list * GAS_TX_DATA_TOKEN_FLOOR
 
     # Data token floor cost for access list bytes.
     access_list_cost += tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -459,6 +459,7 @@ Transaction = (
 Union type representing any valid transaction type.
 """
 
+
 AccessListCapableTransaction = (
     AccessListTransaction
     | FeeMarketTransaction

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -590,23 +590,12 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     2. Cost for data (zero and non-zero bytes)
     3. Cost for contract creation (if applicable)
     4. Cost for access list entries (if applicable)
-    5. Cost for access list data (if applicable)
-    6. Cost for authorizations (if applicable)
+    5. Cost for authorizations (if applicable)
 
-    Access lists incur data costs in addition to storage access costs. Token
-    counting uses
-    [`CALLDATA_TOKENS_PER_ZERO_BYTE`](
-        ref:ethereum.forks.amsterdam.transactions.CALLDATA_TOKENS_PER_ZERO_BYTE
-    )
-    and
-    [`CALLDATA_TOKENS_PER_NONZERO_BYTE`](
-        ref:ethereum.forks.amsterdam.transactions.CALLDATA_TOKENS_PER_NONZERO_BYTE
-    ).
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
-    transaction based on the calldata and access list size.
-
+    transaction based on the calldata size.
     """
     from .vm.gas import GasCosts, init_code_cost
 
@@ -619,7 +608,6 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     else:
         create_cost = Uint(0)
 
-    # Calculate access-list tokens and costs.
     access_list_cost = Uint(0)
     tokens_in_access_list = Uint(0)
     if has_access_list(tx):

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -601,6 +601,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             access_list_cost += (
                 ulen(access.slots) * GasCosts.TX_ACCESS_LIST_STORAGE_KEY
             )
+
+    # Data token floor cost for access list bytes.
     access_list_cost += tokens_in_access_list * GAS_TX_DATA_TOKEN_FLOOR
 
     # Data token floor cost for access list bytes.

--- a/tests/amsterdam/eip7981_increase_access_list_cost/__init__.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EIP-7981: Increase Access List Cost."""

--- a/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
@@ -1,0 +1,285 @@
+"""Fixtures for the EIP-7981 tests."""
+
+from typing import List, Sequence
+
+import pytest
+from execution_testing import (
+    EOA,
+    AccessList,
+    Address,
+    Alloc,
+    AuthorizationTuple,
+    Bytecode,
+    Bytes,
+    Fork,
+    Hash,
+    Op,
+    Transaction,
+    TransactionException,
+    add_kzg_version,
+)
+
+from ...cancun.eip4844_blobs.spec import Spec as EIP_4844_Spec
+
+
+@pytest.fixture
+def to(
+    request: pytest.FixtureRequest,
+    pre: Alloc,
+) -> Address | None:
+    """Create the recipient address."""
+    if hasattr(request, "param"):
+        param = request.param
+    else:
+        param = Op.STOP
+
+    if param is None:
+        return None
+    if isinstance(param, str) and param == "eoa":
+        return pre.fund_eoa(amount=0)
+    if isinstance(param, Bytecode):
+        return pre.deploy_contract(param)
+
+    raise ValueError(f"Invalid value for `to` fixture: {param}")
+
+
+@pytest.fixture
+def protected() -> bool:
+    """
+    Return whether the transaction is protected or not. Only valid for type-0
+    transactions.
+    """
+    return True
+
+
+@pytest.fixture
+def access_list() -> List[AccessList] | None:
+    """Access list for the transaction."""
+    return None
+
+
+@pytest.fixture
+def authorization_refund() -> bool:
+    """
+    Return whether the transaction has an existing authority in the
+    authorization list.
+    """
+    return False
+
+
+@pytest.fixture
+def authorization_list(
+    request: pytest.FixtureRequest,
+    pre: Alloc,
+    authorization_refund: bool,
+    tx_type: int,
+) -> List[AuthorizationTuple] | None:
+    """
+    Authorization-list for the transaction.
+
+    This fixture needs to be parametrized indirectly in order to generate the
+    authorizations with valid signers using `pre` in this function, and the
+    parametrized value should be a list of addresses.
+    """
+    if not hasattr(request, "param"):
+        if tx_type == 4:
+            return [
+                AuthorizationTuple(
+                    signer=pre.fund_eoa(1 if authorization_refund else 0),
+                    address=Address(1),
+                )
+            ]
+        return None
+    if request.param is None:
+        if tx_type == 4:
+            return [
+                AuthorizationTuple(
+                    signer=pre.fund_eoa(1 if authorization_refund else 0),
+                    address=Address(1),
+                )
+            ]
+        return None
+    return [
+        AuthorizationTuple(
+            signer=pre.fund_eoa(1 if authorization_refund else 0),
+            address=address,
+        )
+        for address in request.param
+    ]
+
+
+@pytest.fixture
+def blob_versioned_hashes(tx_type: int) -> Sequence[Hash] | None:
+    """Versioned hashes for the transaction."""
+    return (
+        add_kzg_version(
+            [Hash(1)],
+            EIP_4844_Spec.BLOB_COMMITMENT_VERSION_KZG,
+        )
+        if tx_type == 3
+        else None
+    )
+
+
+@pytest.fixture
+def contract_creating_tx(to: Address | None) -> bool:
+    """Return whether the transaction creates a contract or not."""
+    return to is None
+
+
+@pytest.fixture
+def tx_data() -> Bytes:
+    """
+    Transaction data.
+
+    Default is empty, but can be parametrized to test different scenarios.
+    """
+    return Bytes(b"")
+
+
+@pytest.fixture
+def tx_gas_delta() -> int:
+    """
+    Gas delta to modify the gas amount included with the transaction.
+
+    If negative, the transaction will be invalid because the intrinsic gas cost
+    is greater than the gas limit.
+
+    This value operates regardless of whether the floor data gas cost is
+    reached or not.
+
+    If the value is greater than zero, the transaction will also be valid and
+    the test will check that transaction processing does not consume more gas
+    than it should.
+    """
+    return 0
+
+
+@pytest.fixture
+def tx_intrinsic_gas_cost_before_execution(
+    fork: Fork,
+    tx_data: Bytes,
+    access_list: List[AccessList] | None,
+    authorization_list: List[AuthorizationTuple] | None,
+    contract_creating_tx: bool,
+) -> int:
+    """
+    Return the intrinsic gas cost that is applied before the execution start.
+
+    This value never includes the floor data gas cost.
+    """
+    intrinsic_gas_cost_calculator = (
+        fork.transaction_intrinsic_cost_calculator()
+    )
+    return intrinsic_gas_cost_calculator(
+        calldata=tx_data,
+        contract_creation=contract_creating_tx,
+        access_list=access_list,
+        authorization_list_or_count=authorization_list,
+        return_cost_deducted_prior_execution=True,
+    )
+
+
+@pytest.fixture
+def tx_intrinsic_gas_cost_including_floor_data_cost(
+    fork: Fork,
+    tx_data: Bytes,
+    access_list: List[AccessList] | None,
+    authorization_list: List[AuthorizationTuple] | None,
+    contract_creating_tx: bool,
+) -> int:
+    """
+    Transaction intrinsic gas cost.
+
+    The calculated value takes into account the normal intrinsic gas cost and
+    the floor data gas cost if it is greater than the intrinsic gas cost.
+
+    In other words, this is the value that is required for the transaction to
+    be valid.
+    """
+    intrinsic_gas_cost_calculator = (
+        fork.transaction_intrinsic_cost_calculator()
+    )
+    return intrinsic_gas_cost_calculator(
+        calldata=tx_data,
+        contract_creation=contract_creating_tx,
+        access_list=access_list,
+        authorization_list_or_count=authorization_list,
+    )
+
+
+@pytest.fixture
+def tx_floor_data_cost(
+    fork: Fork,
+    tx_data: Bytes,
+    access_list: List[AccessList] | None,
+) -> int:
+    """
+    Floor data cost for the given transaction data and access list.
+
+    This includes both calldata tokens and access list tokens.
+
+    Note: This is calculated by the fork's intrinsic cost calculator,
+    so we return the same value as
+    tx_intrinsic_gas_cost_including_floor_data_cost.
+    """
+    fork_data_floor_cost_calculator = (
+        fork.transaction_data_floor_cost_calculator()
+    )
+
+    # Calculate calldata floor cost
+    return fork_data_floor_cost_calculator(
+        data=tx_data, access_list=access_list
+    )
+
+
+@pytest.fixture
+def tx_gas_limit(
+    tx_intrinsic_gas_cost_including_floor_data_cost: int,
+    tx_gas_delta: int,
+) -> int:
+    """
+    Gas limit for the transaction.
+
+    The gas delta is added to the intrinsic gas cost to generate different test
+    scenarios.
+    """
+    return tx_intrinsic_gas_cost_including_floor_data_cost + tx_gas_delta
+
+
+@pytest.fixture
+def tx_error(
+    tx_gas_delta: int,
+) -> TransactionException | None:
+    """Transaction error, only expected if the gas delta is negative."""
+    if tx_gas_delta < 0:
+        return TransactionException.INTRINSIC_GAS_TOO_LOW
+    return None
+
+
+@pytest.fixture
+def tx(
+    sender: EOA,
+    tx_type: int,
+    tx_data: Bytes,
+    to: Address | None,
+    protected: bool,
+    access_list: List[AccessList] | None,
+    authorization_list: List[AuthorizationTuple] | None,
+    blob_versioned_hashes: Sequence[Hash] | None,
+    tx_gas_limit: int,
+    tx_error: TransactionException | None,
+) -> Transaction:
+    """Create the transaction used in each test."""
+    return Transaction(
+        ty=tx_type,
+        sender=sender,
+        data=tx_data,
+        to=to,
+        protected=protected,
+        access_list=access_list,
+        authorization_list=authorization_list,
+        gas_limit=tx_gas_limit,
+        blob_versioned_hashes=blob_versioned_hashes,
+        error=tx_error,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
@@ -209,31 +209,6 @@ def tx_intrinsic_gas_cost_including_floor_data_cost(
 
 
 @pytest.fixture
-def tx_floor_data_cost(
-    fork: Fork,
-    tx_data: Bytes,
-    access_list: List[AccessList] | None,
-) -> int:
-    """
-    Floor data cost for the given transaction data and access list.
-
-    This includes both calldata tokens and access list tokens.
-
-    Note: This is calculated by the fork's intrinsic cost calculator,
-    so we return the same value as
-    tx_intrinsic_gas_cost_including_floor_data_cost.
-    """
-    fork_data_floor_cost_calculator = (
-        fork.transaction_data_floor_cost_calculator()
-    )
-
-    # Calculate calldata floor cost
-    return fork_data_floor_cost_calculator(
-        data=tx_data, access_list=access_list
-    )
-
-
-@pytest.fixture
 def tx_gas_limit(
     tx_intrinsic_gas_cost_including_floor_data_cost: int,
     tx_gas_delta: int,

--- a/tests/amsterdam/eip7981_increase_access_list_cost/helpers.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/helpers.py
@@ -1,0 +1,30 @@
+"""Helpers for testing EIP-7981."""
+
+from typing import List
+
+from execution_testing import AccessList
+
+
+def calculate_access_list_floor_tokens(access_list: List[AccessList]) -> int:
+    """
+    Calculate the number of floor tokens in an access list.
+
+    According to EIP-7981 (aligned with EIP-7976), floor tokens are
+    calculated from the raw access list byte length:
+    floor_tokens = total_bytes * 4
+
+    Where bytes come from:
+    - 20 bytes per address
+    - 32 bytes per storage key
+    """
+    total_bytes = 0
+
+    for access in access_list:
+        # Count bytes in address (20 bytes)
+        total_bytes += len(access.address)
+
+        # Count bytes in each storage key (32 bytes each)
+        for slot in access.storage_keys:
+            total_bytes += len(slot)
+
+    return total_bytes * 4

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "be5f9861f233bfd0c0576cfa3dd027a2c4edcd4e"
+    "EIPS/eip-7981.md", "f0f874b8ed796a4e172fcaf2339c3bfaade92860"
 )
 
 
@@ -26,4 +26,3 @@ class Spec:
 
     ACCESS_LIST_ADDRESS_COST = 2400
     ACCESS_LIST_STORAGE_KEY_COST = 1900
-    TOTAL_COST_FLOOR_PER_TOKEN = 16

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "f0f874b8ed796a4e172fcaf2339c3bfaade92860"
+    "EIPS/eip-7981.md", "eb801490ef06a99d97afb2d70cfba0805d512487"
 )
 
 

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -1,0 +1,29 @@
+"""Defines EIP-7981 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7981 = ReferenceSpec(
+    "EIPS/eip-7981.md", "be5f9861f233bfd0c0576cfa3dd027a2c4edcd4e"
+)
+
+
+# Constants
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-7981 specifications as defined at
+    https://eips.ethereum.org/EIPS/eip-7981.
+    """
+
+    ACCESS_LIST_ADDRESS_COST = 2400
+    ACCESS_LIST_STORAGE_KEY_COST = 1900
+    TOTAL_COST_FLOOR_PER_TOKEN = 16

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "eb801490ef06a99d97afb2d70cfba0805d512487"
+    "EIPS/eip-7981.md", "83fdb046649608201de6eb9e028f35a2a1d15681"
 )
 
 

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "83fdb046649608201de6eb9e028f35a2a1d15681"
+    "EIPS/eip-7981.md", "954963fb6315dffadd9c40d48e4dae313e20cff5"
 )
 
 

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -20,7 +20,7 @@ from .spec import ref_spec_7981
 REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7981.version
 
-pytestmark = pytest.mark.valid_at("Amsterdam")
+pytestmark = pytest.mark.valid_at("EIP7981")
 
 
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -1,0 +1,254 @@
+"""
+abstract: Tests for access list cost calculations in [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Bytes,
+    Hash,
+    StateTestFiller,
+    Transaction,
+    TransactionReceipt,
+)
+
+from .helpers import calculate_access_list_floor_tokens
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = pytest.mark.valid_at("Amsterdam")
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,expected_floor_tokens",
+    [
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[])],
+            # 20 bytes total: 20 * 4 = 80 floor tokens
+            80,
+            id="single_zero_address_no_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[],
+                )
+            ],
+            # 20 bytes total: 20 * 4 = 80 floor tokens
+            80,
+            id="single_nonzero_address_no_keys",
+        ),
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[Hash(0)])],
+            # Total bytes: 20 + 32 = 52, floor tokens: 52 * 4 = 208
+            208,
+            id="zero_address_zero_key",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                        )
+                    ],
+                )
+            ],
+            # Total bytes: 20 + 32 = 52, floor tokens: 52 * 4 = 208
+            208,
+            id="nonzero_address_nonzero_key",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(0), Hash(1), Hash(2)],
+                )
+            ],
+            # Total bytes: 20 + (3 * 32) = 116, floor tokens: 116 * 4 = 464
+            464,
+            id="one_address_three_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+                AccessList(address=Address(2), storage_keys=[Hash(1)]),
+            ],
+            # Total bytes: 2 * (20 + 32) = 104, floor tokens: 104 * 4 = 416
+            416,
+            id="two_addresses_with_keys",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_access_list_token_calculation(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    access_list: list,
+    expected_floor_tokens: int,
+) -> None:
+    """
+    Test that access list floor tokens are calculated correctly.
+
+    This test verifies the token counting mechanism:
+    - Each access list byte contributes 4 floor tokens
+    """
+    # Verify our helper calculates floor tokens correctly
+    calculated_floor_tokens = calculate_access_list_floor_tokens(access_list)
+    assert calculated_floor_tokens == expected_floor_tokens, (
+        "Expected "
+        f"{expected_floor_tokens} tokens, got "
+        f"{calculated_floor_tokens}"
+    )
+
+    # The transaction should be valid with correct gas
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_data",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            Bytes(b"\x01" * 100),
+            id="access_list_and_calldata",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(i) for i in range(10)],
+                )
+            ],
+            Bytes(b"\x00" * 50 + b"\x01" * 50),
+            id="large_access_list_mixed_calldata",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_access_list_floor_cost_with_calldata(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    tx_intrinsic_gas_cost_including_floor_data_cost: int,
+) -> None:
+    """
+    Test that the floor cost correctly accounts for both access list
+    and calldata tokens.
+
+    According to EIP-7981:
+    - total_floor_data_tokens =
+      floor_tokens_in_calldata + floor_tokens_in_access_list
+    - floor_gas =
+      TX_BASE_COST + total_floor_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
+    """
+    tx.expected_receipt = TransactionReceipt(
+        cumulative_gas_used=tx_intrinsic_gas_cost_including_floor_data_cost
+    )
+
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(i),
+                    storage_keys=[Hash(j) for j in range(5)],
+                )
+                for i in range(1, 6)
+            ],
+            id="five_addresses_five_keys_each",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_large_access_list_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test gas costs for large access lists.
+
+    With EIP-7981, large access lists should incur:
+    1. Storage access costs (2400 per address + 1900 per key)
+    2. Data footprint costs (16 per floor token)
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+            ],
+            id="duplicate_access_list_entries",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_duplicate_access_list_entries(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that duplicate access list entries are charged multiple times.
+
+    According to EIP-2930, non-unique addresses and storage keys are allowed
+    and charged multiple times. EIP-7981 should maintain this behavior.
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -8,6 +8,7 @@ from execution_testing import (
     Address,
     Alloc,
     Bytes,
+    Fork,
     Hash,
     StateTestFiller,
     Transaction,
@@ -98,6 +99,7 @@ pytestmark = pytest.mark.valid_at("EIP7981")
 )
 def test_access_list_token_calculation(
     state_test: StateTestFiller,
+    fork: Fork,
     pre: Alloc,
     tx: Transaction,
     access_list: list,
@@ -106,18 +108,25 @@ def test_access_list_token_calculation(
     """
     Test that access list floor tokens are calculated correctly.
 
-    This test verifies the token counting mechanism:
-    - Each access list byte contributes 4 floor tokens
+    Every access list byte contributes four floor tokens regardless of
+    whether it is zero or non-zero. Verify both the reference helper and
+    the fork's floor cost calculator agree with the expected token count.
     """
-    # Verify our helper calculates floor tokens correctly
-    calculated_floor_tokens = calculate_access_list_floor_tokens(access_list)
-    assert calculated_floor_tokens == expected_floor_tokens, (
-        "Expected "
-        f"{expected_floor_tokens} tokens, got "
-        f"{calculated_floor_tokens}"
+    assert (
+        calculate_access_list_floor_tokens(access_list)
+        == expected_floor_tokens
     )
 
-    # The transaction should be valid with correct gas
+    gas_costs = fork.gas_costs()
+    expected_floor_cost = (
+        expected_floor_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+        + gas_costs.GAS_TX_BASE
+    )
+    actual_floor_cost = fork.transaction_data_floor_cost_calculator()(
+        data=b"", access_list=access_list
+    )
+    assert actual_floor_cost == expected_floor_cost
+
     state_test(
         pre=pre,
         post={},

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -119,8 +119,8 @@ def test_access_list_token_calculation(
 
     gas_costs = fork.gas_costs()
     expected_floor_cost = (
-        expected_floor_tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
-        + gas_costs.GAS_TX_BASE
+        expected_floor_tokens * gas_costs.TX_DATA_TOKEN_FLOOR
+        + gas_costs.TX_BASE
     )
     actual_floor_cost = fork.transaction_data_floor_cost_calculator()(
         data=b"", access_list=access_list

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
@@ -17,7 +17,7 @@ from .spec import ref_spec_7981
 REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7981.version
 
-pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
+pytestmark = [pytest.mark.valid_at("EIP7981"), pytest.mark.mainnet]
 
 
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
@@ -1,0 +1,149 @@
+"""
+abstract: Crafted tests for mainnet of [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Hash,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            id="single_address_single_key",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(0), Hash(1), Hash(2)],
+                )
+            ],
+            id="single_address_multiple_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+                AccessList(address=Address(2), storage_keys=[Hash(1)]),
+            ],
+            id="multiple_addresses",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xDE0B295669A9FD93D5F28D9EC85E40F4CB697BAE
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0x0000000000000000000000000000000000000000000000000000000000000003
+                        ),
+                        Hash(
+                            0x0000000000000000000000000000000000000000000000000000000000000007
+                        ),
+                    ],
+                )
+            ],
+            id="realistic_address_and_keys",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [
+        pytest.param("eoa", id="to_eoa"),
+    ],
+    indirect=True,
+)
+def test_access_list_gas_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions with access lists are charged correctly
+    according to EIP-7981.
+
+    The test verifies that:
+    1. Access lists are charged for storage access (existing behavior)
+    2. Access lists are charged for their data footprint (new in EIP-7981)
+    3. Access list data contributes to the floor gas cost
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(0),
+                    storage_keys=[Hash(0) for _ in range(10)],
+                )
+            ],
+            id="all_zero_bytes",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                        )
+                        for _ in range(5)
+                    ],
+                )
+            ],
+            id="all_nonzero_bytes",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [
+        pytest.param("eoa", id=""),
+    ],
+    indirect=True,
+)
+def test_access_list_data_cost_edge_cases(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test edge cases for access list data costs.
+
+    Tests include:
+    - All zero bytes in access list
+    - All non-zero bytes in access list
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -18,7 +18,7 @@ from .spec import ref_spec_7981
 REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7981.version
 
-pytestmark = pytest.mark.valid_at("Amsterdam")
+pytestmark = pytest.mark.valid_at("EIP7981")
 
 
 @pytest.mark.exception_test

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -1,0 +1,273 @@
+"""
+abstract: Tests for transaction validity with [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Bytes,
+    Hash,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = pytest.mark.valid_at("Amsterdam")
+
+
+@pytest.mark.exception_test
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_gas_delta",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            -1,
+            id="insufficient_gas_by_one",
+        ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            -100,
+            id="insufficient_gas_by_hundred",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(i) for i in range(10)],
+                )
+            ],
+            -1,
+            id="large_access_list_insufficient_gas",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_insufficient_gas_for_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions with insufficient gas for access list costs
+    are rejected.
+
+    With EIP-7981, the intrinsic gas must cover:
+    - Base transaction cost
+    - Calldata costs
+    - Access list storage costs
+    - Access list data costs (new in EIP-7981)
+    - Floor cost including access list tokens
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.exception_test
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_data,tx_gas_delta",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            Bytes(b"\x01" * 1000),
+            -1,
+            id="large_calldata_and_access_list_insufficient_gas",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_floor_cost_validation_with_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that the floor cost validation includes access list tokens.
+
+    According to EIP-7981:
+    - Any transaction with a gas limit below the floor cost is invalid
+    - Floor cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN *
+      total_floor_data_tokens
+    - total_floor_data_tokens =
+      floor_tokens_in_calldata + floor_tokens_in_access_list
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_gas_delta",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            0,
+            id="exact_gas",
+        ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            1,
+            id="one_extra_gas",
+        ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            1000,
+            id="plenty_extra_gas",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_valid_gas_limits_with_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions with sufficient gas are valid.
+
+    Tests various gas limit scenarios:
+    - Exact intrinsic gas
+    - Slightly more than intrinsic gas
+    - Much more than intrinsic gas
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_data",
+    [
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[Hash(0)] * 100)],
+            Bytes(b"\x00" * 1000),
+            id="zero_heavy_data_and_access_list",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                        )
+                    ]
+                    * 50,
+                )
+            ],
+            Bytes(b"\xff" * 500),
+            id="nonzero_heavy_data_and_access_list",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "tx_gas_delta",
+    [pytest.param(0, id="")],
+)
+def test_mixed_zero_nonzero_bytes_floor_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test floor cost calculation with mixed zero and non-zero bytes.
+
+    This ensures floor gas uses floor token counting:
+    - Each data byte contributes 4 floor tokens
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "tx_type,access_list",
+    [
+        pytest.param(
+            0,
+            None,
+            id="type_0_no_access_list",
+        ),
+        pytest.param(
+            1,
+            [],
+            id="type_1_empty_access_list",
+        ),
+        pytest.param(
+            2,
+            [],
+            id="type_2_empty_access_list",
+        ),
+        pytest.param(
+            3,
+            [],
+            id="type_3_empty_access_list",
+        ),
+        pytest.param(
+            4,
+            [],
+            id="type_4_empty_access_list",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "tx_gas_delta",
+    [pytest.param(0, id="")],
+)
+def test_transactions_without_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions without access lists still work correctly.
+
+    EIP-7981 should only affect transactions with non-empty access lists.
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -87,6 +87,12 @@ def test_insufficient_gas_for_access_list(
             -1,
             id="large_calldata_and_access_list_insufficient_gas",
         ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            Bytes(b"\x00" * 1000),
+            -1,
+            id="large_zero_calldata_and_access_list_insufficient_gas",
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description
Merge EIP-7981 into `forks/amsterdam`.

## 🔗 Related Issues or PRs
* SFI'd eip tracker: #2846 
* EIP-7981 tracker: #1943 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1337018504141864963/1504784279819784212/PNG_image_124.png?ex=6a0d8511&is=6a0c3391&hm=ae35d9cb6c78ac0f43acd66f5d8febd2c253d9a95374489254fbe9c55ea1066e&"
  alt="Cute Animal Picture"
  width="320">
