### PR TITLE
feat(tests): EIP-7976 reject exact-balance tx in Prague/Amsterdam floor gap

### DIFF
--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
@@ -1,6 +1,6 @@
 """
-Test [EIP-7976: Increase calldata floor cost](https://eips.ethereum.org/EIPS/eip-7976).
-"""
+abstract: Tests for floor-boundary rejection with exact-balance funding in [EIP-7976: Increase Calldata Floor Cost](https://eips.ethereum.org/EIPS/eip-7976).
+"""  # noqa: E501
 
 import pytest
 from execution_testing import (
@@ -18,7 +18,7 @@ from .spec import ref_spec_7976
 REFERENCE_SPEC_GIT_PATH = ref_spec_7976.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7976.version
 
-pytestmark = pytest.mark.valid_from("EIP7976")
+pytestmark = pytest.mark.valid_at("EIP7976")
 
 
 @pytest.mark.exception_test
@@ -43,6 +43,9 @@ def test_below_amsterdam_floor_with_exact_balance_sender(
     with `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`. The sender is funded
     with exactly `gas_limit * gas_price` so an implementation that
     uses the Prague floor cannot fall back to silent execution.
+
+    Type-0 only on purpose; broader type-1/2/3/4 coverage lives in
+    `test_transaction_validity.py`.
     """
     tx_data = Bytes(b"\x00" * zero_bytes)
     intrinsic_regular = fork.transaction_intrinsic_cost_calculator()(
@@ -52,6 +55,10 @@ def test_below_amsterdam_floor_with_exact_balance_sender(
     amsterdam_floor = fork.transaction_data_floor_cost_calculator()(
         data=tx_data,
     )
+    # Prague counts each zero byte as one token at TX_DATA_TOKEN_FLOOR
+    # gas/token. Cannot be derived from amsterdam_floor because EIP-7976
+    # changes both the per-token rate (10->16) and the floor tokenization
+    # (zero/nonzero both weighted by 4).
     prague_floor = 21000 + Spec7623.TX_DATA_TOKEN_FLOOR * zero_bytes
     gas_limit = (prague_floor + amsterdam_floor) // 2
     assert intrinsic_regular <= gas_limit

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
@@ -1,0 +1,71 @@
+"""
+Test [EIP-7976: Increase calldata floor cost](https://eips.ethereum.org/EIPS/eip-7976).
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Bytes,
+    Fork,
+    StateTestFiller,
+    Transaction,
+    TransactionException,
+)
+
+from ...prague.eip7623_increase_calldata_cost.spec import Spec as Spec7623
+from .spec import ref_spec_7976
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7976.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7976.version
+
+pytestmark = pytest.mark.valid_from("EIP7976")
+
+
+@pytest.mark.exception_test
+@pytest.mark.parametrize(
+    "zero_bytes",
+    [
+        pytest.param(100, id="100_zero_bytes"),
+        pytest.param(1000, id="1000_zero_bytes"),
+    ],
+)
+def test_below_amsterdam_floor_with_exact_balance_sender(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    zero_bytes: int,
+) -> None:
+    """
+    Reject when gas_limit sits between Prague and Amsterdam floor.
+
+    EIP-7976 raises the per-byte calldata floor cost. A transaction
+    with `gas_limit` in `[Prague_floor, Amsterdam_floor)` must reject
+    with `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`. The sender is funded
+    with exactly `gas_limit * gas_price` so an implementation that
+    uses the Prague floor cannot fall back to silent execution.
+    """
+    tx_data = Bytes(b"\x00" * zero_bytes)
+    intrinsic_regular = fork.transaction_intrinsic_cost_calculator()(
+        calldata=tx_data,
+        return_cost_deducted_prior_execution=True,
+    )
+    amsterdam_floor = fork.transaction_data_floor_cost_calculator()(
+        data=tx_data,
+    )
+    prague_floor = 21000 + Spec7623.TX_DATA_TOKEN_FLOOR * zero_bytes
+    gas_limit = (prague_floor + amsterdam_floor) // 2
+    assert intrinsic_regular <= gas_limit
+    assert prague_floor <= gas_limit < amsterdam_floor
+
+    gas_price = 10
+    sender = pre.fund_eoa(amount=gas_limit * gas_price)
+    tx = Transaction(
+        sender=sender,
+        to=pre.fund_eoa(amount=0),
+        data=tx_data,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+        error=TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

EIP-7976 raises the per-byte calldata floor cost. A transaction whose `gas_limit` lies in `[Prague_floor, Amsterdam_floor)` must reject at pre-validate with `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`. This test pins gas_limit at the midpoint of that gap for 100 and 1000 zero-byte calldata transactions. Sender balance equals `gas_limit * gas_price`, so an implementation that defaults to the Prague floor cannot fall through to a silent "accept and execute"—any pre-validate divergence produces a different post-state.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.
