### PR TITLE
fix(test-client-clis): detect EELS-style OutOfGasError in GasExhaustionTraceComparator

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_trace_comparators.py
@@ -1420,3 +1420,72 @@ class TestGasExhaustionTraceComparator:
         result = comparator.compare_traces(baseline, current)
         assert result.equivalent is False
         assert all(d.transaction_index == 1 for d in result.differences)
+
+    @pytest.mark.parametrize(
+        "error",
+        ["out of gas", "Out Of Gas", "OutOfGasError"],
+    )
+    def test_oog_detected_for_each_convention(
+        self,
+        comparator: GasExhaustionTraceComparator,
+        error: str,
+    ) -> None:
+        """OOG detection covers both geth-style and EELS-style errors."""
+        baseline = _make_transaction_traces(
+            [_make_trace_line(), _make_trace_line(error=error)]
+        )
+        current = _make_transaction_traces(
+            [_make_trace_line(), _make_trace_line()]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is False
+        assert len(result.differences) == 1
+        assert result.differences[0].trace_line_index == 1
+
+    def test_mixed_geth_and_eels_oog_is_equivalent(
+        self, comparator: GasExhaustionTraceComparator
+    ) -> None:
+        """
+        Baseline (geth-style "out of gas") and current (EELS-style
+        "OutOfGasError") describe the same OOG event and are equivalent.
+        """
+        baseline = _make_transaction_traces(
+            [_make_trace_line(), _make_trace_line(error="out of gas")]
+        )
+        current = _make_transaction_traces(
+            [_make_trace_line(), _make_trace_line(error="OutOfGasError")]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
+    def test_all_eels_oog_at_same_line_is_equivalent(
+        self, comparator: GasExhaustionTraceComparator
+    ) -> None:
+        """Two EELS-style traces with OOG at the same line are equivalent."""
+        oog_line = _make_trace_line(error="OutOfGasError")
+        baseline = _make_transaction_traces([_make_trace_line(), oog_line])
+        current = _make_transaction_traces([_make_trace_line(), oog_line])
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is True
+
+    def test_all_eels_oog_at_different_lines(
+        self, comparator: GasExhaustionTraceComparator
+    ) -> None:
+        """Two EELS-style traces with OOG at different lines differ."""
+        baseline = _make_transaction_traces(
+            [
+                _make_trace_line(),
+                _make_trace_line(error="OutOfGasError"),
+                _make_trace_line(),
+            ]
+        )
+        current = _make_transaction_traces(
+            [
+                _make_trace_line(),
+                _make_trace_line(),
+                _make_trace_line(error="OutOfGasError"),
+            ]
+        )
+        result = comparator.compare_transaction_traces(baseline, current, 0)
+        assert result.equivalent is False
+        assert len(result.differences) == 2

--- a/packages/testing/src/execution_testing/client_clis/trace_comparators.py
+++ b/packages/testing/src/execution_testing/client_clis/trace_comparators.py
@@ -216,7 +216,13 @@ def _is_out_of_gas_error(error: str | None) -> bool:
     """Return True if the error string indicates an out-of-gas condition."""
     if error is None:
         return False
-    return "out of gas" in error.lower()
+    s = error.lower()
+    # Two trace conventions coexist: geth-style natural-language messages
+    # ("out of gas", "contract creation code storage out of gas") and the
+    # EELS EIP-3155 emitter, which writes the Python exception class name
+    # ("OutOfGasError"). The class name has no spaces, so the substring
+    # match alone misses it — match it explicitly.
+    return "out of gas" in s or s == "outofgaserror"
 
 
 def _find_gas_exhaustion_points(


### PR DESCRIPTION
## 🗒️ Description

`_is_out_of_gas_error` in `packages/testing/src/execution_testing/client_clis/trace_comparators.py` used a substring check (`"out of gas" in error.lower()`) that matches geth-style trace error strings but misses the EELS EIP-3155 emitter's convention of writing the Python exception class name (`"OutOfGasError"`) into the trace `error` field.

Because the substring check returned `False` for EELS-style errors, `GasExhaustionTraceComparator` silently classified every EELS trace as having no gas-exhaustion points. With EELS as the default t8n in this repo, both sides of a comparison return empty OOG sets and the comparator reports `equivalent=True` for trace pairs that may actually disagree on whether a frame OOG'd — the exact thing it is meant to catch.

The comparator is opt-in (`TraceComparatorType.GAS_EXHAUSTION`), so the bug is latent rather than active in the default fill flow, but it makes the comparator effectively inert for any opt-in caller running against EELS.

Fix: also accept the bare class-name form `"OutOfGasError"` (case-insensitive exact match) alongside the existing substring check, with a comment explaining why both conventions need to be recognized.

Tests: added coverage under `TestGasExhaustionTraceComparator`:
- Parametrized positive test over `"out of gas"`, `"Out Of Gas"`, and `"OutOfGasError"`.
- Mixed-convention test (geth baseline vs. EELS current at the same line → equivalent), which is the exact mismatch this fix closes.
- Two all-EELS tests covering same-line equivalence and different-line divergence.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

<img width="588" height="429" alt="Screenshot 2569-05-19 at 21 22 48" src="https://github.com/user-attachments/assets/875018f3-19dd-4a97-bf7a-6f7843ccbc7d" />
