### PR TITLE
feat(tests): EIP-7981 reject in access-list-byte floor gap with exact balance

### DIFF
--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
@@ -1,0 +1,87 @@
+"""
+abstract: Tests for floor-boundary rejection with exact-balance funding in [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Bytes,
+    Fork,
+    Hash,
+    StateTestFiller,
+    Transaction,
+    TransactionException,
+)
+
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = pytest.mark.valid_at("EIP7981")
+
+
+@pytest.mark.exception_test
+@pytest.mark.parametrize(
+    "tx_type",
+    [pytest.param(1, id="type_1"), pytest.param(2, id="type_2")],
+)
+@pytest.mark.parametrize(
+    "nonzero_bytes",
+    [
+        pytest.param(1000, id="1000_nonzero_bytes"),
+        pytest.param(2000, id="2000_nonzero_bytes"),
+    ],
+)
+def test_below_amsterdam_floor_with_access_list_exact_balance(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_type: int,
+    nonzero_bytes: int,
+) -> None:
+    """Reject when gas_limit sits in EIP-7981 access-list-byte floor gap."""
+    access_list = [
+        AccessList(
+            address=Address(1),
+            storage_keys=[Hash(k) for k in range(10)],
+        )
+    ]
+    tx_data = Bytes(b"\x01" * nonzero_bytes)
+    intrinsic_regular = fork.transaction_intrinsic_cost_calculator()(
+        calldata=tx_data,
+        access_list=access_list,
+        return_cost_deducted_prior_execution=True,
+    )
+    floor_calc = fork.transaction_data_floor_cost_calculator()
+    amsterdam_floor = floor_calc(data=tx_data, access_list=access_list)
+    amsterdam_floor_no_al = floor_calc(data=tx_data)
+    # Pin gas_limit inside the access-list-byte uplift gap so an
+    # implementation that omits this term from its floor accepts.
+    gas_limit = (amsterdam_floor_no_al + amsterdam_floor) // 2
+    assert intrinsic_regular <= gas_limit < amsterdam_floor
+    assert gas_limit >= amsterdam_floor_no_al
+
+    gas_price = 10
+    sender = pre.fund_eoa(amount=gas_limit * gas_price)
+    if tx_type == 1:
+        fee_args: dict = {"gas_price": gas_price}
+    else:
+        fee_args = {
+            "max_fee_per_gas": gas_price,
+            "max_priority_fee_per_gas": 0,
+        }
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=pre.fund_eoa(amount=0),
+        data=tx_data,
+        gas_limit=gas_limit,
+        access_list=access_list,
+        error=TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+        **fee_args,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

EIP-7981 charges every access-list byte (20 per address, 32 per storage key) at the floor token cost. A transaction whose `gas_limit` lies in `[Amsterdam_floor_without_AL_term, Amsterdam_floor)` must reject at pre-validate with `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`; an implementation that omits the access-list-byte term from its floor computes a smaller floor and accepts.

This test pins `gas_limit` at the midpoint of that uplift gap for Type-1 and Type-2 transactions carrying 1000 / 2000 nonzero data bytes plus a 1-address / 10-storage-key access list. The sender is funded with exactly `gas_limit * gas_price`, so a buggy implementation cannot fall back to a silent "accept and execute"—any acceptance produces a divergent post-state.

Complements `test_insufficient_gas_for_access_list` and `test_floor_cost_validation_with_access_list`, which exercise this boundary at `gas_limit = floor - 1` with default sender funding.

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
