### PR TITLE
fix(ci): devnet-7 linting issue

### DIFF
--- a/.github/actions/build-evm-base/action.yaml
+++ b/.github/actions/build-evm-base/action.yaml
@@ -74,3 +74,9 @@ runs:
       with:
         repo: ${{ steps.config-evm-reader.outputs.repo }}
         ref: ${{ steps.config-evm-reader.outputs.ref }}
+    - name: Build the EVM using revm action
+      if: steps.config-evm-reader.outputs.impl == 'revm'
+      uses: ./.github/actions/build-evm-client/revm
+      with:
+        repo: ${{ steps.config-evm-reader.outputs.repo }}
+        ref: ${{ steps.config-evm-reader.outputs.ref }}

--- a/.github/actions/build-evm-client/revm/action.yaml
+++ b/.github/actions/build-evm-client/revm/action.yaml
@@ -1,0 +1,59 @@
+name: 'Build revm revme'
+description: 'Builds the revme t8n binary from bluealloy/revm (or a fork)'
+inputs:
+  repo:
+    description: 'Source repository to use to build the EVM binary'
+    required: true
+    default: 'bluealloy/revm'
+  ref:
+    description: 'Reference to branch, commit, or tag to use to build the EVM binary'
+    required: true
+    default: 'main'
+runs:
+  using: "composite"
+  steps:
+    - name: Get latest revm commit
+      id: revm-sha
+      shell: bash
+      run: |
+        SHA=$(git ls-remote https://github.com/${{ inputs.repo }}.git refs/heads/${{ inputs.ref }} | cut -f1)
+        echo "sha=$SHA" >> $GITHUB_OUTPUT
+        echo "Latest revm commit: $SHA"
+    - name: Restore build cache
+      id: cache-restore
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          ${{ github.workspace }}/revm/target/release/revme
+        key: revm-revme-build-sha=${{ steps.revm-sha.outputs.sha }}
+        restore-keys: |
+          revm-revme-build-
+    - name: Checkout revm
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: ${{ inputs.repo }}
+        ref: ${{ steps.revm-sha.outputs.sha }}
+        path: revm
+    - name: Install Rust
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential rustup
+        rustup update --no-self-update 1.94.0 && rustup default 1.94.0
+    - name: Build revme
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd $GITHUB_WORKSPACE/revm
+        cargo build --release -p revme
+    - name: Add revme to PATH
+      shell: bash
+      run: echo $GITHUB_WORKSPACE/revm/target/release >> $GITHUB_PATH
+    - name: Save build cache
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          ${{ github.workspace }}/revm/target/release/revme
+        key: revm-revme-build-sha=${{ steps.revm-sha.outputs.sha }}

--- a/.github/configs/evm-impl.yaml
+++ b/.github/configs/evm-impl.yaml
@@ -13,3 +13,6 @@ besu:
 ethjs:
   evm-bin: ethereumjs-t8ntool.sh
   x-dist: auto
+revm:
+  evm-bin: revme
+  x-dist: auto

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -8,6 +8,6 @@ static:
   ref: master
   targets: ["evmone-t8n"]
 benchmark:
-  impl: geth
-  repo: ethereum/go-ethereum
-  ref: master
+  impl: revm
+  repo: spencer-tb/revm
+  ref: t8n-subcommand

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -5,12 +5,7 @@ mainnet:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
-  feature_only: true
-
-benchmark_fast:
-  evm-type: benchmark
-  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
+  fill-params: --fork=Amsterdam --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
   feature_only: true
 
 bal:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -83,18 +83,3 @@ jobs:
 
   # TODO: Add execute remote tests with --gas-benchmark-values
   # TODO: Add execute remote tests with --fixed-opcode-count
-
-  build-artifact:
-    name: Build Benchmark Fixture Artifact
-    needs: [sanity-checks] # TODO: Add execute remote jobs when implemented
-    if: github.event_name == 'push'
-    runs-on: [self-hosted-ghr, size-gigachungus-x64]
-    timeout-minutes: 720
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-
-      - uses: ./.github/actions/build-fixtures
-        with:
-          release_name: benchmark_fast

--- a/Justfile
+++ b/Justfile
@@ -220,7 +220,7 @@ bench-gas *args:
         --evm-bin="{{ evm_bin }}" \
         --gas-benchmark-values 1 \
         --generate-all-formats \
-        --fork Osaka \
+        --fork {{ latest_fork }} \
         -m "not slow" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --output="{{ output_dir }}/bench-gas/fixtures" \
@@ -237,7 +237,7 @@ bench-opcode *args:
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
         --fixed-opcode-count 1 \
-        --fork Osaka \
+        --fork {{ latest_fork }} \
         -m repricing \
         -n auto --maxprocesses 10 --dist=loadgroup \
         -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not uncachable" \
@@ -256,7 +256,7 @@ bench-opcode-config *args:
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
         --fixed-opcode-count \
-        --fork Osaka \
+        --fork {{ latest_fork }} \
         -m repricing \
         -n auto --maxprocesses 10 --dist=loadgroup \
         -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not test_point_evaluation_uncachable" \

--- a/packages/testing/src/execution_testing/client_clis/__init__.py
+++ b/packages/testing/src/execution_testing/client_clis/__init__.py
@@ -24,6 +24,7 @@ from .clis.execution_specs import ExecutionSpecsTransitionTool
 from .clis.geth import GethFixtureConsumer, GethTransitionTool
 from .clis.nethermind import Nethtest, NethtestFixtureConsumer
 from .clis.nimbus import NimbusTransitionTool
+from .clis.revm import RevmExceptionMapper, RevmTransitionTool
 from .ethereum_cli import CLINotFoundInPathError, UnknownCLIError
 from .fixture_consumer_tool import FixtureConsumerTool
 from .trace_comparators import (
@@ -62,6 +63,8 @@ __all__ = (
     "NethtestFixtureConsumer",
     "NimbusTransitionTool",
     "Result",
+    "RevmExceptionMapper",
+    "RevmTransitionTool",
     "TraceComparator",
     "TraceComparatorType",
     "TraceComparisonResult",

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -1,43 +1,50 @@
-"""Reth execution client transition tool."""
+"""
+Reth execution client transition tool — exception mapper only.
 
+Reth's EVM is revm, so all the EVM-level error strings reth surfaces
+match revm's `Display for InvalidTransaction` output and live in the
+shared [`RevmExceptionMapper`] base. This module only contains the
+strings that come from layers *above* revm — reth's payload validator,
+its consensus engine, its tx pool, and its BAL validator — because
+those wrap or replace revm's errors with reth-specific phrasing.
+"""
+
+from execution_testing.client_clis.clis.revm import RevmExceptionMapper
 from execution_testing.exceptions import (
     BlockException,
-    ExceptionMapper,
     TransactionException,
 )
 
 
-class RethExceptionMapper(ExceptionMapper):
-    """Reth exception mapper."""
+class RethExceptionMapper(RevmExceptionMapper):
+    """
+    Reth-specific overrides on top of the revm base mapper.
+
+    Only entries that diverge from revm's `Display for
+    InvalidTransaction` belong here. Anything matching revm's core
+    error vocabulary lives in [`RevmExceptionMapper`].
+    """
 
     mapping_substring = {
-        TransactionException.SENDER_NOT_EOA: (
-            "reject transactions from senders with deployed code"
+        **RevmExceptionMapper.mapping_substring,
+        # Reth's payload validator wording (revm itself says
+        # "blob versioned hashes not supported" — that's the base).
+        TransactionException.TYPE_3_TX_PRE_FORK: (
+            "blob transactions present in pre-cancun payload"
         ),
-        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "lack of funds",
-        TransactionException.INITCODE_SIZE_EXCEEDED: (
-            "create initcode size limit"
-        ),
-        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
-            "gas price is less than basefee"
-        ),
-        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
-            "priority fee is greater than max fee"
-        ),
-        TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW: "overflow",
-        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
-        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
-        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
-            "blob version not supported"
-        ),
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: "empty blobs",
-        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
-            "empty authorization list"
-        ),
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
+        # Reth's payload validator wording for EIP-7702 pre-Prague.
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "eip 7702 transactions present in pre-prague payload"
         ),
+        # Reth's RLP decoder catches type-3/type-4 contract-creation
+        # attempts at decode time and surfaces them as "unexpected
+        # length" / "unexpected list" — revm never sees them, so these
+        # are reth-only.
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
+        # Block-envelope / consensus errors — emitted by reth's
+        # consensus engine, never by revm.
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",
         BlockException.INVALID_RECEIPTS_ROOT: "receipt root mismatch",
         BlockException.INVALID_STATE_ROOT: "mismatched block state root",
@@ -48,38 +55,24 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.EXTRA_DATA_TOO_BIG: "invalid payload extra data",
         BlockException.INVALID_LOG_BLOOM: "header bloom filter mismatch",
     }
+
     mapping_regex = {
-        TransactionException.NONCE_MISMATCH_TOO_LOW: (
-            r"nonce \d+ too low, expected \d+"
-        ),
-        TransactionException.NONCE_MISMATCH_TOO_HIGH: (
-            r"nonce \d+ too high, expected \d+"
-        ),
-        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
-            r"blob gas price \(\d+\) is greater than "
-            r"max fee per blob gas \(\d+\)"
-        ),
-        TransactionException.INTRINSIC_GAS_TOO_LOW: (
-            r"call gas cost \(\d+\) exceeds the gas limit \(\d+\)"
-        ),
-        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
-            r"gas floor \(\d+\) exceeds the gas limit \(\d+\)"
-        ),
+        **RevmExceptionMapper.mapping_regex,
+        # Reth's blob-allowance checker phrasing.
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
-        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
-            r"too many blobs, have \d+, max \d+"
-        ),
-        TransactionException.TYPE_3_TX_PRE_FORK: (
-            r"blob transactions present in pre-cancun payload|empty blobs"
-        ),
+        # Reth tx-pool phrasing for over-budget tx gas (revm's
+        # equivalent "caller gas limit exceeds the block gas limit"
+        # lives in the base).
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             r"transaction gas limit \w+ is more than blocks available gas \w+"
         ),
+        # Reth tx-pool phrasing.
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
             r"transaction gas limit.*is greater than the cap"
         ),
+        # Reth consensus / block-execution errors.
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"failed to apply .* requests contract call"
         ),
@@ -109,7 +102,7 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.GAS_USED_OVERFLOW: (
             r"transaction gas limit \w+ is more than blocks available gas \w+"
         ),
-        # BAL Exceptions
+        # BAL exceptions — reth's BAL validator.
         BlockException.INVALID_BAL_HASH: (r"block access list hash mismatch"),
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"block access list hash mismatch"
@@ -118,8 +111,8 @@ class RethExceptionMapper(ExceptionMapper):
             r"block access list hash mismatch"
         ),
         # Reth does not validate the sizes or offsets of the deposit
-        # contract logs. As a workaround we have set
-        # INVALID_DEPOSIT_EVENT_LAYOUT equal to INVALID_REQUESTS.
+        # contract logs. As a workaround we map INVALID_DEPOSIT_EVENT_LAYOUT
+        # to the same error pattern as INVALID_REQUESTS.
         #
         # Although this is out of spec, it is understood that this
         # will not cause an issue so long as the mainnet/testnet

--- a/packages/testing/src/execution_testing/client_clis/clis/revm.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/revm.py
@@ -1,0 +1,293 @@
+"""
+revm `revme` transition tool — drives the `revme t8n` subcommand.
+
+This module also owns the base [`RevmExceptionMapper`]: the substring
+and regex patterns that match `revm::context_interface::result::
+InvalidTransaction`'s `Display` output. Any client that wraps revm
+(reth, foundry, anvil, revme, …) inherits from this base and adds only
+its own node-layer / validator-layer strings on top.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional
+
+from execution_testing.client_clis.ethereum_cli import EthereumCLI
+from execution_testing.client_clis.transition_tool import TransitionTool
+from execution_testing.exceptions import (
+    BlockException,
+    ExceptionMapper,
+    TransactionException,
+)
+from execution_testing.forks import Fork
+
+
+class RevmExceptionMapper(ExceptionMapper):
+    """
+    Base mapper for any t8n / client built on revm.
+
+    Entries here match revm's [`InvalidTransaction`] `Display` output
+    (see ``revm/crates/context/interface/src/result.rs``). Clients that
+    add validator-layer error wrapping (e.g. reth's payload validator
+    or consensus engine) inherit and override the relevant entries —
+    they never need to redeclare the revm-core strings.
+    """
+
+    # revm collapses several framework exception *subtypes* onto a
+    # single Display string — most notably the EIP-7623/7976/7981
+    # intrinsic-vs-floor gas family, where the same
+    # "gas floor (X) exceeds the gas limit (Y)" message must map to
+    # either INTRINSIC_GAS_TOO_LOW or INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
+    # depending on whether the floor or the intrinsic cost is the
+    # binding constraint (a distinction revm doesn't surface). Mark the
+    # mapper not-reliable so the framework still enforces correct
+    # accept/reject and rejects undefined exceptions, but relaxes the
+    # exact-subtype check it cannot satisfy from one string.
+    reliable: ClassVar[bool] = False
+
+    mapping_substring = {
+        # revm: RejectCallerWithCode
+        TransactionException.SENDER_NOT_EOA: (
+            "reject transactions from senders with deployed code"
+        ),
+        # revm: LackOfFundForMaxFee — phrasing "lack of funds (BAL) for
+        # max fee (FEE)" — substring match handles both reth's terse
+        # "lack of funds" and revm's parenthesised form.
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "lack of funds",
+        # revm: CreateInitCodeSizeLimit
+        TransactionException.INITCODE_SIZE_EXCEEDED: (
+            "create initcode size limit"
+        ),
+        # revm: GasPriceLessThanBasefee
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
+            "gas price is less than basefee"
+        ),
+        # revm: PriorityFeeGreaterThanMaxFee
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "priority fee is greater than max fee"
+        ),
+        # revm: OverflowPaymentInTransaction — tightened from a bare
+        # "overflow" substring (which over-matched "nonce overflow")
+        # to the full Display string. Tx-fee field overflows on the
+        # builder side (e.g. tx with gas_price > u128::MAX) map here
+        # too; the underlying error in all cases is that
+        # gas_limit * gas_price doesn't fit a u128.
+        # (Moved to a regex below to cover both the validation-side
+        # and builder-side phrasings.)
+        # revm: NonceOverflowInTransaction — fires when a sender's
+        # nonce is already at u64::MAX. Maps to NONCE_IS_MAX (the
+        # framework's name for the same scenario).
+        TransactionException.NONCE_IS_MAX: "nonce overflow in transaction",
+        # revm: tx_gas_limit overflows u64 — the framework supplied
+        # gas > u64::MAX which can't fit in revm's gas counter.
+        TransactionException.GASLIMIT_OVERFLOW: "tx gas overflows u64",
+        # revme TxEnv builder rejects gas-price fields > u128::MAX with
+        # our `"<field> overflows u128"` strings. Semantically the
+        # same as OverflowPaymentInTransaction (gas_limit * gas_price
+        # would overflow), which is GASLIMIT_PRICE_PRODUCT_OVERFLOW.
+        # revm: BlobVersionNotSupported
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
+            "blob version not supported"
+        ),
+        # revm: BlobCreateTransaction ("blob create transaction") via
+        # validation OR MissingTargetForEip4844 ("missing target for
+        # EIP-4844") via the TxEnv builder — both fire for a type-3
+        # blob tx with no `to`. Moved to a regex below.
+        # revm: EmptyAuthorizationList ("empty authorization list") —
+        # moved to a regex below so the equivalent
+        # MissingAuthorizationListForEip7702 (TxEnv-builder side) is
+        # covered too.
+        # revm: DeriveTxTypeError::MissingTargetForEip7702 — fires
+        # when a type-4 tx is built without a `to` address. Maps to
+        # TYPE_4_TX_CONTRACT_CREATION (a type-4 tx must specify a
+        # target; contract creation is not allowed for set-code txs).
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "missing target for EIP-7702"
+        ),
+        # revm: Eip4844NotSupported. The actual rejection path at
+        # pre-Cancun forks goes through `Eip4844NotSupported` (which
+        # Displays "Eip4844 is not supported") rather than
+        # `BlobVersionedHashesNotSupported`. The latter is reachable in
+        # some code paths but in practice the framework hits the former.
+        TransactionException.TYPE_3_TX_PRE_FORK: ("Eip4844 is not supported"),
+        # revm: Eip7702NotSupported (pre-Prague).
+        TransactionException.TYPE_4_TX_PRE_FORK: ("Eip7702 is not supported"),
+        # revm: Eip2930NotSupported (pre-Berlin).
+        TransactionException.TYPE_1_TX_PRE_FORK: ("Eip2930 is not supported"),
+        # revm: Eip1559NotSupported (pre-London).
+        TransactionException.TYPE_2_TX_PRE_FORK: ("Eip1559 is not supported"),
+        # revm: AuthorizationListInvalidFields
+        TransactionException.TYPE_4_INVALID_AUTHORITY_SIGNATURE: (
+            "authorization list tx has invalid fields"
+        ),
+    }
+
+    mapping_regex = {
+        # revm: EmptyBlobs Display ("empty blobs") OR
+        # TxEnv builder error for a type-3 tx with no blob hashes
+        # ("missing blob hashes for EIP-4844"). Both are
+        # zero-blobs-on-a-blob-tx conditions.
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+            r"empty blobs|missing blob hashes for EIP-4844"
+        ),
+        # revm: NonceTooLow / NonceTooHigh
+        TransactionException.NONCE_MISMATCH_TOO_LOW: (
+            r"nonce \d+ too low, expected \d+"
+        ),
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: (
+            r"nonce \d+ too high, expected \d+"
+        ),
+        # revm: BlobGasPriceGreaterThanMax
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            r"blob gas price \(\d+\) is greater than "
+            r"max fee per blob gas \(\d+\)"
+        ),
+        # revm: CallGasCostMoreThanGasLimit
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"call gas cost \(\d+\) exceeds the gas limit \(\d+\)"
+        ),
+        # revm: GasFloorMoreThanGasLimit
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
+            r"gas floor \(\d+\) exceeds the gas limit \(\d+\)"
+        ),
+        # revm: OverflowPaymentInTransaction OR revme TxEnv builder
+        # field-overflow errors (gas_price/max_fee_per_gas/etc.
+        # > u128::MAX, max_fee_per_blob_gas > u128::MAX). All mean the
+        # same thing: gas_limit * gas_price would overflow.
+        TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW: (
+            r"overflow payment in transaction|"
+            r"(gas_price|max_fee_per_gas|max_priority_fee_per_gas|"
+            r"max_fee_per_blob_gas) overflows u128"
+        ),
+        # revm: TooManyBlobs
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
+            r"too many blobs, have \d+, max \d+"
+        ),
+        # revm: EmptyAuthorizationList (validation) OR
+        # MissingAuthorizationListForEip7702 (builder). Both fire for
+        # a type-4 tx with an empty authorization list.
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            r"empty authorization list|"
+            r"missing authorization list for EIP-7702"
+        ),
+        # revm: BlobCreateTransaction (validation) OR
+        # MissingTargetForEip4844 (builder). Both fire for a type-3
+        # blob tx that attempts contract creation.
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: (
+            r"blob create transaction|missing target for EIP-4844"
+        ),
+        # revme t8n's block-level blob budget rejection. Same wording
+        # as reth's blob-allowance checker so the regex can sit here in
+        # the base — reth's RethExceptionMapper still overrides it
+        # (with the identical pattern) to keep clis/reth.py
+        # self-documenting about which exceptions it cares about.
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"blob gas used \d+ exceeds maximum allowance \d+"
+        ),
+        # revme t8n emits this when an EIP-7002/EIP-7251 post-block
+        # system call reverts or halts. Mirrors geth's
+        # "system call failed to execute" path and lands in the same
+        # exception bucket reth uses.
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
+            r"failed to apply (withdrawal|consolidation) "
+            r"requests contract call"
+        ),
+        # revme t8n emits this when a Prague+ block's predeploy
+        # system contract address has no code (e.g. fork activation
+        # block before the deploy tx ran). Matches the per-client
+        # phrasing convention (evmone says "system contract empty or
+        # failed", revme says "system contract empty").
+        BlockException.SYSTEM_CONTRACT_EMPTY: (r"system contract empty"),
+        # revme t8n emits this when an EIP-6110 deposit log has a
+        # malformed ABI layout (offsets or length headers diverge from
+        # the canonical `DepositEvent(bytes,bytes,bytes,bytes,bytes)`
+        # encoding). The block is rejected with
+        # INVALID_DEPOSIT_EVENT_LAYOUT.
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            r"failed to decode deposit requests from receipts"
+        ),
+        # revme t8n emits this when the EIP-7928 block access list
+        # exceeds its size budget (`bal_items` >
+        # `block_gas_limit // BLOCK_ACCESS_LIST_ITEM`). Matches geth's
+        # phrasing for the same rejection.
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            r"block access list exceeds gas limit"
+        ),
+        # revm: TxGasLimitGreaterThanCap
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            r"transaction gas limit \(\d+\) is greater than the cap \(\d+\)"
+        ),
+        # revm: CallerGasLimitMoreThanBlock — reth's tx-pool string
+        # differs ("transaction gas limit N is more than blocks
+        # available gas M") and is overridden in RethExceptionMapper.
+        TransactionException.GAS_ALLOWANCE_EXCEEDED: (
+            r"caller gas limit exceeds the block gas limit"
+        ),
+    }
+
+
+class RevmeCLI(EthereumCLI):
+    """revme base — wraps the `revme` binary."""
+
+    default_binary = Path("revme")
+    detect_binary_pattern = re.compile(r"^revme \d+\.\d+\.\d+")
+    version_flag = "--version"
+    cached_version: Optional[str] = None
+
+    def __init__(
+        self,
+        binary: Optional[Path] = None,
+    ):
+        """Initialize the RevmeCLI class."""
+        self.binary = binary if binary else self.default_binary
+        self._info_metadata: Optional[Dict[str, object]] = {}
+
+    def _run_command(self, command: List[str]) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except Exception as e:
+            raise Exception("Unexpected exception calling revme.") from e
+
+
+class RevmTransitionTool(RevmeCLI, TransitionTool):
+    """`revme t8n` transition tool driver."""
+
+    subcommand: Optional[str] = "t8n"
+    t8n_use_stream = True
+    supports_opcode_count: ClassVar[bool] = False
+    supports_blob_params: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        *,
+        exception_mapper: Optional[ExceptionMapper] = None,
+        binary: Optional[Path] = None,
+        trace: bool = False,
+    ):
+        """Initialize the RevmTransitionTool class."""
+        if not exception_mapper:
+            exception_mapper = RevmExceptionMapper()
+        RevmeCLI.__init__(self, binary=binary)
+        TransitionTool.__init__(
+            self,
+            binary=binary,
+            exception_mapper=exception_mapper,
+            trace=trace,
+        )
+
+    def is_fork_supported(self, fork: Fork) -> bool:
+        """
+        Return True if the fork is supported by the tool.
+
+        Until revme's `t8n` subcommand stabilises its supported-fork
+        surface, accept all forks the framework asks about and let the
+        binary error out on unsupported ones.
+        """
+        del fork
+        return True

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -703,6 +703,28 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         return 0
 
     @classmethod
+    def block_gas_used_from(
+        cls,
+        *,
+        regular_gas: int,
+        state_gas: int,
+        calldata_floor: int = 0,
+        state_refund: int = 0,
+    ) -> int:
+        """
+        Return the block header ``gasUsed`` contribution of a transaction
+        under EIP-7778 two-dimensional accounting.
+
+        Mirrors EELS ``amsterdam/fork.py`` (``block_gas_used +=
+        max(tx_regular_gas, calldata_floor)``; ``block_state_gas_used +=
+        max(0, tx_state_gas)``; header ``gasUsed = max(...)``). Pre-Amsterdam
+        ``state_gas`` is zero so this degenerates to the regular cost.
+        """
+        tx_regular = max(regular_gas, calldata_floor)
+        tx_state = max(0, state_gas - state_refund)
+        return max(tx_regular, tx_state)
+
+    @classmethod
     def system_call_gas_limit(cls) -> int:
         """
         Return the total gas budget the system transaction grants the

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -316,7 +316,6 @@ class BenchmarkTest(BaseTest):
         Sequence[FixtureFormat | LabeledFixtureFormat]
     ] = [
         BlockchainFixture,
-        BlockchainEngineFixture,
         BlockchainEngineXFixture,
     ]
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -66,6 +66,7 @@ from execution_testing.fixtures.blockchain import (
     FixtureBlockBase,
     FixtureConfig,
     FixtureEngineNewPayload,
+    FixtureExecutionPayloadModifier,
     FixtureHeader,
     FixtureTransaction,
     FixtureWithdrawal,
@@ -395,6 +396,7 @@ class BuiltBlock(CamelModel):
     result: Result
     expected_exception: BLOCK_EXCEPTION_TYPE = None
     engine_api_error_code: EngineAPIError | None = None
+    rlp_modifier: Header | None = None
     fork: Fork
     block_access_list: BlockAccessList | None
 
@@ -447,6 +449,36 @@ class BuiltBlock(CamelModel):
         """Get the RLP of the block."""
         return self.get_fixture_block().rlp
 
+    @staticmethod
+    def derive_engine_payload_modifier(
+        rlp_modifier: Header | None,
+        block_access_list: BlockAccessList | None,
+    ) -> "FixtureExecutionPayloadModifier | None":
+        """
+        Propagate ``rlp_modifier``'s header changes to the engine payload.
+
+        The engine ``ExecutionPayload`` schema does not carry
+        ``block_access_list_hash`` directly; the equivalent payload field is
+        the ``block_access_list`` body. So a header modifier that touches the
+        BAL hash needs to drive a matching change on the payload body.
+        """
+        if rlp_modifier is None:
+            return None
+        bal_hash_override = rlp_modifier.block_access_list_hash
+        if bal_hash_override is None:
+            return None
+        if bal_hash_override is Header.REMOVE_FIELD:
+            return FixtureExecutionPayloadModifier(
+                block_access_list=(
+                    FixtureExecutionPayloadModifier.REMOVE_FIELD
+                ),
+            )
+        if block_access_list is None:
+            return FixtureExecutionPayloadModifier(
+                block_access_list=Bytes(b""),
+            )
+        return None
+
     def get_fixture_engine_new_payload(self) -> FixtureEngineNewPayload:
         """Get a FixtureEngineNewPayload from the built block."""
         return FixtureEngineNewPayload.from_fixture_header(
@@ -458,6 +490,9 @@ class BuiltBlock(CamelModel):
             block_access_list=self.block_access_list.rlp
             if self.block_access_list
             else None,
+            execution_payload_modifier=self.derive_engine_payload_modifier(
+                self.rlp_modifier, self.block_access_list
+            ),
             validation_error=self.expected_exception,
             error_code=self.engine_api_error_code,
         )

--- a/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
@@ -120,6 +120,21 @@ def test_iterating_subcall_gas_cost() -> None:
         iterating_subcall=5000,
     )
     assert bytecode_int.iterating_subcall_gas_cost(fork=Osaka) == 5000
+    # Default int subcall carries no explicit state split.
+    assert bytecode_int.iterating_subcall_state_cost(fork=Osaka) == 0
+    assert bytecode_int.iterating_subcall_state_refund(fork=Osaka) == 0
+
+    # An int subcall with an explicit EIP-8037 state split returns the
+    # supplied components (combined cost via the int itself).
+    bytecode_split = IteratingBytecode(
+        iterating=Op.STOP,
+        iterating_subcall=5000,
+        iterating_subcall_state=1530,
+        iterating_subcall_state_refund=765,
+    )
+    assert bytecode_split.iterating_subcall_gas_cost(fork=Osaka) == 5000
+    assert bytecode_split.iterating_subcall_state_cost(fork=Osaka) == 1530
+    assert bytecode_split.iterating_subcall_state_refund(fork=Osaka) == 765
 
 
 def test_iterating_subcall_reserve() -> None:

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -809,6 +809,17 @@ class IteratingBytecode(Bytecode):
     The value can also be an integer, in which case it represents the gas cost
     of the subcall (e.g. the subcall is a precompiled contract)
     """
+    iterating_subcall_state: int
+    """
+    EIP-8037 state-gas component of an integer `iterating_subcall`.
+
+    When `iterating_subcall` is a `Bytecode` the split is derived from its
+    opcodes; for an integer (pre-summed combined) cost the state portion is
+    otherwise lost, so callers must supply it here to keep EIP-7778
+    `max(regular, state)` block accounting correct.
+    """
+    iterating_subcall_state_refund_value: int
+    """EIP-8037 state-refund component of an integer `iterating_subcall`."""
     cleanup: Bytecode
     """Bytecode executed once at the end after all iterations complete."""
 
@@ -820,6 +831,8 @@ class IteratingBytecode(Bytecode):
         cleanup: Bytecode | None = None,
         warm_iterating: Bytecode | None = None,
         iterating_subcall: Bytecode | int | None = None,
+        iterating_subcall_state: int = 0,
+        iterating_subcall_state_refund: int = 0,
     ) -> Self:
         """
         Create a new iterating bytecode.
@@ -838,6 +851,11 @@ class IteratingBytecode(Bytecode):
                 calculation. The value can also be an integer, in which case it
                 represents the gas cost of the subcall (e.g. the subcall is a
                 precompiled contract).
+            iterating_subcall_state: EIP-8037 state-gas component of an
+                integer `iterating_subcall` (ignored when it is a
+                `Bytecode`, where the split is derived from opcodes).
+            iterating_subcall_state_refund: EIP-8037 state-refund
+                component of an integer `iterating_subcall`.
 
         Returns:
             A new IteratingBytecode instance.
@@ -862,6 +880,10 @@ class IteratingBytecode(Bytecode):
             instance.iterating_subcall = Bytecode()
         else:
             instance.iterating_subcall = iterating_subcall
+        instance.iterating_subcall_state = iterating_subcall_state
+        instance.iterating_subcall_state_refund_value = (
+            iterating_subcall_state_refund
+        )
         if cleanup is None:
             cleanup = Bytecode()
         instance.cleanup = cleanup
@@ -881,11 +903,12 @@ class IteratingBytecode(Bytecode):
         """
         Return the EIP-8037 state-gas cost of the iterating subcall.
 
-        An integer subcall cost models a flat regular charge (e.g. a
-        precompile) and carries no state-gas dimension.
+        An integer subcall cost is a pre-summed combined value; its
+        state portion (otherwise lost) is supplied via the
+        `iterating_subcall_state` constructor kwarg.
         """
         if isinstance(self.iterating_subcall, int):
-            return 0
+            return self.iterating_subcall_state
         return self.iterating_subcall.state_cost(fork=fork)
 
     def iterating_subcall_state_refund(
@@ -893,7 +916,7 @@ class IteratingBytecode(Bytecode):
     ) -> int:
         """Return the EIP-8037 state refund of the iterating subcall."""
         if isinstance(self.iterating_subcall, int):
-            return 0
+            return self.iterating_subcall_state_refund_value
         return self.iterating_subcall.state_refund(fork=fork)
 
     def iterating_subcall_reserve(
@@ -993,6 +1016,10 @@ class IteratingBytecode(Bytecode):
             cleanup=self.cleanup,
             warm_iterating=self.warm_iterating,
             iterating_subcall=self.iterating_subcall,
+            iterating_subcall_state=self.iterating_subcall_state,
+            iterating_subcall_state_refund=(
+                self.iterating_subcall_state_refund_value
+            ),
             iteration_count=iteration_count,
         )
 
@@ -1046,6 +1073,7 @@ class IteratingBytecode(Bytecode):
         fork: Fork,
         iteration_count: int,
         start_iteration: int = 0,
+        extra_regular_gas: int = 0,
         **intrinsic_cost_kwargs: Any,
     ) -> int:
         """
@@ -1058,6 +1086,11 @@ class IteratingBytecode(Bytecode):
         returns `max(regular, state)` per Amsterdam EIP-7778 block
         accounting. Pre-Amsterdam the state dimension is zero so this
         equals the combined cost.
+
+        `extra_regular_gas` is added to the regular dimension only (used by
+        `tx_gas_limit_by_iteration_count` for the 63/64 subcall reserve,
+        which is a regular-gas concept — state gas is a separate reservoir
+        not subject to the 63/64 rule).
         """
         intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
         if "data" in intrinsic_cost_kwargs:
@@ -1110,7 +1143,7 @@ class IteratingBytecode(Bytecode):
         )
 
         return fork.block_gas_used_from(
-            regular_gas=regular_loop + intrinsic_regular,
+            regular_gas=regular_loop + intrinsic_regular + extra_regular_gas,
             state_gas=state_loop + intrinsic_state,
             calldata_floor=calldata_floor,
             state_refund=state_refund_loop,
@@ -1130,13 +1163,21 @@ class IteratingBytecode(Bytecode):
 
         The gas limit is calculated by adding the required extra gas for the
         last iteration due to the 63/64 rule.
+
+        Iteration fitting must size against the EIP-7778 block-gas the tx
+        actually consumes (`max(regular, state)`), not the combined sum;
+        otherwise loops are packed too sparsely on Amsterdam. The 63/64
+        subcall reserve is regular gas and is added to the regular
+        dimension. Pre-Amsterdam (state == 0) this equals the previous
+        `combined + reserve`.
         """
-        return self.tx_gas_cost_by_iteration_count(
+        return self.tx_block_gas_used_by_iteration_count(
             fork=fork,
             iteration_count=iteration_count,
             start_iteration=start_iteration,
+            extra_regular_gas=self.iterating_subcall_reserve(fork=fork),
             **intrinsic_cost_kwargs,
-        ) + self.iterating_subcall_reserve(fork=fork)
+        )
 
     def _binary_search_iterations(
         self,
@@ -1481,6 +1522,8 @@ class FixedIterationsBytecode(IteratingBytecode):
         iteration_count: int,
         warm_iterating: Bytecode | None = None,
         iterating_subcall: Bytecode | int | None = None,
+        iterating_subcall_state: int = 0,
+        iterating_subcall_state_refund: int = 0,
     ) -> Self:
         """
         Create a new FixedIterationsBytecode instance.
@@ -1502,6 +1545,10 @@ class FixedIterationsBytecode(IteratingBytecode):
                 calculation. The value can also be an integer, in which case it
                 represents the gas cost of the subcall (e.g. the subcall is a
                 precompiled contract).
+            iterating_subcall_state: EIP-8037 state-gas component of an
+                integer `iterating_subcall`.
+            iterating_subcall_state_refund: EIP-8037 state-refund
+                component of an integer `iterating_subcall`.
 
         Returns:
             A new FixedIterationsBytecode instance.
@@ -1514,6 +1561,8 @@ class FixedIterationsBytecode(IteratingBytecode):
             cleanup=cleanup,
             warm_iterating=warm_iterating,
             iterating_subcall=iterating_subcall,
+            iterating_subcall_state=iterating_subcall_state,
+            iterating_subcall_state_refund=iterating_subcall_state_refund,
         )
         instance.iteration_count = iteration_count
         return instance

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -771,6 +771,11 @@ class TransactionWithCost(Transaction):
     """Transaction object that can include the expected gas to be consumed."""
 
     gas_cost: int = Field(..., exclude=True)
+    block_gas_used: int = Field(default=0, exclude=True)
+    """
+    EIP-7778 block header ``gasUsed`` contribution of this transaction
+    (``max(regular, state)``). Equals ``gas_cost`` pre-Amsterdam.
+    """
 
 
 class IteratingBytecode(Bytecode):
@@ -870,6 +875,27 @@ class IteratingBytecode(Bytecode):
             return self.iterating_subcall
         return self.iterating_subcall.gas_cost(fork=fork)
 
+    def iterating_subcall_state_cost(
+        self, *, fork: Type[ForkOpcodeInterface]
+    ) -> int:
+        """
+        Return the EIP-8037 state-gas cost of the iterating subcall.
+
+        An integer subcall cost models a flat regular charge (e.g. a
+        precompile) and carries no state-gas dimension.
+        """
+        if isinstance(self.iterating_subcall, int):
+            return 0
+        return self.iterating_subcall.state_cost(fork=fork)
+
+    def iterating_subcall_state_refund(
+        self, *, fork: Type[ForkOpcodeInterface]
+    ) -> int:
+        """Return the EIP-8037 state refund of the iterating subcall."""
+        if isinstance(self.iterating_subcall, int):
+            return 0
+        return self.iterating_subcall.state_refund(fork=fork)
+
     def iterating_subcall_reserve(
         self, *, fork: Type[ForkOpcodeInterface]
     ) -> int:
@@ -902,6 +928,57 @@ class IteratingBytecode(Bytecode):
             self.setup.gas_cost(fork=fork)
             + loop_gas_cost
             + self.cleanup.gas_cost(fork=fork)
+        )
+
+    def state_cost_by_iteration_count(
+        self, *, fork: Type[ForkOpcodeInterface], iteration_count: int
+    ) -> int:
+        """
+        Return the EIP-8037 state-gas cost of iterating N times.
+
+        Mirrors `gas_cost_by_iteration_count` but uses the state-gas
+        dimension only, so callers can reconstruct the EIP-7778 block
+        accounting as `max(regular, state)`.
+        """
+        loop_state_cost = 0
+        if iteration_count > 0:
+            loop_state_cost = self.iterating.state_cost(fork=fork)
+            loop_state_cost += self.warm_iterating.state_cost(fork=fork) * (
+                iteration_count - 1
+            )
+            loop_state_cost += (
+                self.iterating_subcall_state_cost(fork=fork) * iteration_count
+            )
+        return (
+            self.setup.state_cost(fork=fork)
+            + loop_state_cost
+            + self.cleanup.state_cost(fork=fork)
+        )
+
+    def state_refund_by_iteration_count(
+        self, *, fork: Type[ForkOpcodeInterface], iteration_count: int
+    ) -> int:
+        """
+        Return the EIP-8037 state refund accrued by iterating N times.
+
+        Mirrors `state_cost_by_iteration_count`; the refund is netted
+        against the state dimension in EIP-7778 block accounting
+        (`block_state_gas_used += max(0, state_gas - state_refund)`).
+        """
+        loop_state_refund = 0
+        if iteration_count > 0:
+            loop_state_refund = self.iterating.state_refund(fork=fork)
+            loop_state_refund += self.warm_iterating.state_refund(
+                fork=fork
+            ) * (iteration_count - 1)
+            loop_state_refund += (
+                self.iterating_subcall_state_refund(fork=fork)
+                * iteration_count
+            )
+        return (
+            self.setup.state_refund(fork=fork)
+            + loop_state_refund
+            + self.cleanup.state_refund(fork=fork)
         )
 
     def with_fixed_iteration_count(
@@ -962,6 +1039,82 @@ class IteratingBytecode(Bytecode):
         return self.gas_cost_by_iteration_count(
             fork=fork, iteration_count=iteration_count
         ) + intrinsic_gas_cost_calc(**intrinsic_cost_kwargs)
+
+    def tx_block_gas_used_by_iteration_count(
+        self,
+        *,
+        fork: Fork,
+        iteration_count: int,
+        start_iteration: int = 0,
+        **intrinsic_cost_kwargs: Any,
+    ) -> int:
+        """
+        Calculate the EIP-7778 block header `gasUsed` contribution of a
+        transaction calling the bytecode for a given number of iterations.
+
+        Unlike `tx_gas_cost_by_iteration_count` (which returns the combined
+        regular+state cost and drives iteration fitting), this splits the
+        loop and intrinsic costs into the regular and state dimensions and
+        returns `max(regular, state)` per Amsterdam EIP-7778 block
+        accounting. Pre-Amsterdam the state dimension is zero so this
+        equals the combined cost.
+        """
+        intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+        if "data" in intrinsic_cost_kwargs:
+            intrinsic_cost_kwargs["calldata"] = intrinsic_cost_kwargs.pop(
+                "data"
+            )
+        if "authorization_list" in intrinsic_cost_kwargs:
+            intrinsic_cost_kwargs["authorization_list_or_count"] = len(
+                intrinsic_cost_kwargs.pop("authorization_list")
+            )
+        if "return_cost_deducted_prior_execution" not in intrinsic_cost_kwargs:
+            intrinsic_cost_kwargs["return_cost_deducted_prior_execution"] = (
+                True
+            )
+        for key, value in intrinsic_cost_kwargs.items():
+            if callable(value):
+                intrinsic_cost_kwargs[key] = value(
+                    iteration_count=iteration_count,
+                    start_iteration=start_iteration,
+                )
+        combined_loop = self.gas_cost_by_iteration_count(
+            fork=fork, iteration_count=iteration_count
+        )
+        state_loop = self.state_cost_by_iteration_count(
+            fork=fork, iteration_count=iteration_count
+        )
+        state_refund_loop = self.state_refund_by_iteration_count(
+            fork=fork, iteration_count=iteration_count
+        )
+        regular_loop = combined_loop - state_loop
+
+        intrinsic_combined = intrinsic_gas_cost_calc(**intrinsic_cost_kwargs)
+        contract_creation = bool(
+            intrinsic_cost_kwargs.get("contract_creation", False)
+        )
+        authorization_count = intrinsic_cost_kwargs.get(
+            "authorization_list_or_count", 0
+        )
+        if not isinstance(authorization_count, int):
+            authorization_count = len(authorization_count)
+        intrinsic_state = fork.transaction_intrinsic_state_gas(
+            contract_creation=contract_creation,
+            authorization_count=authorization_count,
+        )
+        intrinsic_regular = intrinsic_combined - intrinsic_state
+
+        floor_calc = fork.transaction_data_floor_cost_calculator()
+        calldata_floor = floor_calc(
+            data=intrinsic_cost_kwargs.get("calldata", b"")
+        )
+
+        return fork.block_gas_used_from(
+            regular_gas=regular_loop + intrinsic_regular,
+            state_gas=state_loop + intrinsic_state,
+            calldata_floor=calldata_floor,
+            state_refund=state_refund_loop,
+        )
 
     def tx_gas_limit_by_iteration_count(
         self,
@@ -1207,6 +1360,12 @@ class IteratingBytecode(Bytecode):
                 start_iteration=start_iteration,
                 **intrinsic_cost_kwargs,
             )
+            tx_block_gas_used = self.tx_block_gas_used_by_iteration_count(
+                fork=fork,
+                iteration_count=iteration_count,
+                start_iteration=start_iteration,
+                **intrinsic_cost_kwargs,
+            )
             current_tx_kwargs = tx_kwargs.copy()
 
             for key, value in current_tx_kwargs.items():
@@ -1220,6 +1379,7 @@ class IteratingBytecode(Bytecode):
                 gas_limit=tx_gas_limit + tx_gas_limit_delta,
                 sender=sender,
                 gas_cost=tx_gas_cost,
+                block_gas_used=tx_block_gas_used,
                 **current_tx_kwargs,
             )
             start_iteration += iteration_count
@@ -1275,6 +1435,12 @@ class IteratingBytecode(Bytecode):
                 start_iteration=start_iteration,
                 **intrinsic_cost_kwargs,
             )
+            tx_block_gas_used = self.tx_block_gas_used_by_iteration_count(
+                fork=fork,
+                iteration_count=iteration_count,
+                start_iteration=start_iteration,
+                **intrinsic_cost_kwargs,
+            )
             current_tx_kwargs = tx_kwargs.copy()
 
             for key, value in current_tx_kwargs.items():
@@ -1288,6 +1454,7 @@ class IteratingBytecode(Bytecode):
                 gas_limit=tx_gas_limit + tx_gas_limit_delta,
                 sender=sender,
                 gas_cost=tx_gas_cost,
+                block_gas_used=tx_block_gas_used,
                 **current_tx_kwargs,
             )
             start_iteration += iteration_count

--- a/src/ethereum/forks/amsterdam/blocks.py
+++ b/src/ethereum/forks/amsterdam/blocks.py
@@ -257,13 +257,6 @@ class Header:
     [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
     [cbalh]: ref:ethereum.forks.amsterdam.block_access_lists.hash_block_access_list
     """  # noqa: E501
-    slot_number: U64
-    """
-    The slot number of this block as provided by the consensus layer.
-    Introduced in [EIP-7843].
-
-    [EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
-    """
 
     slot_number: U64
     """

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -361,9 +361,12 @@ def test_storage_access_cold(
         )
         for exec_tx in exec_txs:
             if tx_result == TransactionResult.OUT_OF_GAS:
+                # Error-path state-gas handling is Phase 3.
                 expected_gas_used += exec_tx.gas_limit
             else:
-                expected_gas_used += exec_tx.gas_cost
+                # EIP-7778 block gasUsed = max(regular, state), populated
+                # on the generated tx by transactions_by_gas_limit.
+                expected_gas_used += exec_tx.block_gas_used
 
     blocks.append(Block(txs=exec_txs))
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -467,7 +467,7 @@ def test_selfdestruct_existing(
     start = 0
     total_gas_cost = 0
     for iters in iteration_counts:
-        total_gas_cost += attack_code.tx_gas_cost_by_iteration_count(
+        total_gas_cost += attack_code.tx_block_gas_used_by_iteration_count(
             fork=fork,
             iteration_count=iters,
             start_iteration=start,
@@ -601,7 +601,7 @@ def test_selfdestruct_created(
     num_iterations = sum(iteration_counts)
 
     total_gas_cost = sum(
-        attack_code.tx_gas_cost_by_iteration_count(
+        attack_code.tx_block_gas_used_by_iteration_count(
             fork=fork,
             iteration_count=iters,
             calldata=calldata,
@@ -699,7 +699,7 @@ def test_selfdestruct_initcode(
     num_iterations = sum(iteration_counts)
 
     total_gas_cost = sum(
-        attack_code.tx_gas_cost_by_iteration_count(
+        attack_code.tx_block_gas_used_by_iteration_count(
             fork=fork,
             iteration_count=iters,
             calldata=calldata,

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -584,6 +584,14 @@ def test_selfdestruct_created(
         iterating=loop,
         iterating_subcall=selfdestructable_contract.gas_cost(fork)
         + initcode.gas_cost(fork),
+        # The int subcall is a pre-summed combined cost; supply its
+        # EIP-8037 state split so block accounting stays correct.
+        iterating_subcall_state=selfdestructable_contract.state_cost(fork)
+        + initcode.state_cost(fork),
+        iterating_subcall_state_refund=(
+            selfdestructable_contract.state_refund(fork)
+            + initcode.state_refund(fork)
+        ),
         cleanup=Op.STOP,
     )
 

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -172,7 +172,7 @@ def test_unchunkified_bytecode(
                     calldata=calldata,
                 )
             )
-        total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
+        total_gas_cost = sum(tx.block_gas_used for tx in attack_txs)
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -136,13 +136,25 @@ def test_unchunkified_bytecode(
     with TestPhaseManager.setup():
         setup_sender = pre.fund_eoa()
         contracts_deployment_txs: List[ContractDeploymentTransaction] = []
-        for contract_creating_tx in (
-            custom_sized_contract_factory.transactions_by_total_contract_count(
-                fork=fork,
-                sender=setup_sender,
-                contract_count=num_contracts,
+        # On forks with a larger max code size the max-sized contract's
+        # single-iteration deploy cost can exceed any benchmark gas
+        # limit. That scenario is infeasible at this gas value rather
+        # than wrong, so skip instead of failing.
+        infeasible = "Single iteration gas cost is greater than gas limit"
+        try:
+            deployment_txs = list(
+                custom_sized_contract_factory.
+                transactions_by_total_contract_count(
+                    fork=fork,
+                    sender=setup_sender,
+                    contract_count=num_contracts,
+                )
             )
-        ):
+        except ValueError as exc:
+            if infeasible in str(exc):
+                pytest.skip(str(exc))
+            raise
+        for contract_creating_tx in deployment_txs:
             contracts_deployment_txs.append(contract_creating_tx)
             if custom_sized_contract_factory.contract_size > 0:
                 post[contract_creating_tx.deployed_contracts[-1]] = Account(

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -143,8 +143,7 @@ def test_unchunkified_bytecode(
         infeasible = "Single iteration gas cost is greater than gas limit"
         try:
             deployment_txs = list(
-                custom_sized_contract_factory.
-                transactions_by_total_contract_count(
+                custom_sized_contract_factory.transactions_by_total_contract_count(
                     fork=fork,
                     sender=setup_sender,
                     contract_count=num_contracts,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

I ran into several CI issue after rebasing my branch to upstream `devnets/bal/7` branch:

Running `just static` produced three independent failures:

### ethereum-spec-lint

```bash
ValueError: duplicate path Header.slot_number 
raised from src/ethereum_spec_tools/lint/lints/patch_hygiene.py:101
```

### mypy

```bash
src/ethereum/forks/amsterdam/blocks.py:268: error: Name "slot_number"
already defined on line 260 [no-redef]`

packages/testing/src/execution_testing/specs/tests/test_types.py
lines 159/169/178/193/207:
"type[BuiltBlock]" has no attribute "derive_engine_payload_modifier"
[attr-defined]` (5 occurrences).
```

### ruff format
```
tests/benchmark/compute/scenario/test_unchunkified_bytecode.py` would be reformatted.
```

Failures (1) and (2.a) share a root cause. Failure (2.b) shares a root cause with a different commit. Failure (3) is older and pre-existing.

this commit dffc4cfea08bdce863d54d47f932e3b67bbb22d0 might be the root cause.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
