### PR TITLE
chore(tests): create `spec.py` for EIP-7778

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/spec.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/spec.py
@@ -1,0 +1,24 @@
+"""Defines EIP-7778 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7778 = ReferenceSpec(
+    "EIPS/eip-7778.md", "ce17d00b8341032a946301944124c4a6013032d6"
+)
+
+
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-7778 specifications as defined at
+    https://eips.ethereum.org/EIPS/eip-7778.
+    """

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -24,8 +24,10 @@ from execution_testing import (
 from execution_testing.base_types import HashInt
 from execution_testing.vm import Op
 
-REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7778.md"
-REFERENCE_SPEC_VERSION = "ce17d00b8341032a946301944124c4a6013032d6"
+from .spec import ref_spec_7778
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7778.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7778.version
 
 
 def build_refund_tx(


### PR DESCRIPTION
## 🗒️ Description
Currently the refspec is hardcoded into `test_gas_accounting.py` but this trips my refspecfind script because it is not consistent with how we do it for all other EIPs (standalone `spec.py` file). This PR fixes this.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1337018504141864963/1504784280797053040/PNG_image_121.png?ex=6a0ed692&is=6a0d8512&hm=fe0bbe21ab295f8095f775e6b5b9d2fa118bd9256f17bc47b891e93d40ea4ae7&"
  alt="Cute Animal Picture"
  width="320">

