### PR TITLE
feat(zkevm): support external t8n stateless input/output byte generation

### DIFF
--- a/.github/workflows/benchmark-fill-parity.yaml
+++ b/.github/workflows/benchmark-fill-parity.yaml
@@ -1,0 +1,134 @@
+name: Benchmark Fill Parity
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      geth_repo:
+        description: "Geth repository to build"
+        required: false
+        type: string
+        default: "jsign/go-ethereum"
+      geth_branch:
+        description: "Geth branch to build"
+        required: false
+        type: string
+        default: "jsign-master-t8n-fill-executionwitness"
+      benchmark_file:
+        description: "Benchmark test file to fill"
+        required: false
+        type: string
+        default: "tests/benchmark/compute/instruction/test_memory.py"
+      fill_fork:
+        description: "Fork to fill"
+        required: false
+        type: string
+        default: "Amsterdam"
+      xdist_workers:
+        description: "Number of fill workers"
+        required: false
+        type: string
+        default: "auto"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
+env:
+  GETH_REPO: ${{ inputs.geth_repo || 'jsign/go-ethereum' }}
+  GETH_BRANCH: ${{ inputs.geth_branch || 'jsign-master-t8n-fill-executionwitness' }}
+  BENCHMARK_FILE: ${{ inputs.benchmark_file || 'tests/benchmark/compute/instruction/test_memory.py' }}
+  FILL_FORK: ${{ inputs.fill_fork || 'Amsterdam' }}
+  XDIST_WORKERS: ${{ inputs.xdist_workers || 'auto' }}
+
+jobs:
+  compare-fills:
+    name: Compare Python and Geth fills
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
+        with:
+          enable-cache: "false"
+
+      - name: Install dependencies
+        run: uv sync --no-progress
+
+      - name: Build Geth evm
+        uses: ./.github/actions/build-evm-client/geth
+        with:
+          repo: ${{ env.GETH_REPO }}
+          ref: ${{ env.GETH_BRANCH }}
+
+      - name: Validate benchmark file input
+        shell: bash
+        run: |
+          case "$BENCHMARK_FILE" in
+            ./*)
+              echo "benchmark_file must be relative to the repository root without a leading ./"
+              exit 1
+              ;;
+            tests/benchmark/*.py)
+              ;;
+            *)
+              echo "benchmark_file must be a Python file under tests/benchmark/"
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "$BENCHMARK_FILE" ]; then
+            echo "benchmark_file does not exist: $BENCHMARK_FILE"
+            exit 1
+          fi
+
+      - name: Prepare fill directories
+        run: mkdir -p fill_tmp/python fill_tmp/geth fill_logs/python fill_logs/geth
+
+      - name: Fill benchmark with Python spec
+        run: |
+          uv run fill \
+            --clean \
+            --gas-benchmark-values 1 \
+            --fork "$FILL_FORK" \
+            -m blockchain_test \
+            -n "$XDIST_WORKERS" \
+            --output=fixtures_python \
+            --no-html \
+            --basetemp=fill_tmp/python \
+            --log-to fill_logs/python \
+            "$BENCHMARK_FILE"
+
+      - name: Fill benchmark with Geth
+        run: |
+          uv run fill \
+            --clean \
+            --gas-benchmark-values 1 \
+            --fork "$FILL_FORK" \
+            --evm-bin=evm \
+            -m blockchain_test \
+            -n "$XDIST_WORKERS" \
+            --output=fixtures_geth \
+            --no-html \
+            --basetemp=fill_tmp/geth \
+            --log-to fill_logs/geth \
+            "$BENCHMARK_FILE"
+
+      - name: Compare fixture hashes
+        run: uv run hasher compare fixtures_python fixtures_geth
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: benchmark-fill-parity-debug
+          path: |
+            fixtures_python/
+            fixtures_geth/
+            fill_logs/
+          if-no-files-found: ignore

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -372,6 +372,249 @@ def verify_stateless_input_public_keys(
             )
 
 
+def _decode_amsterdam_header_bytes(header_rlp: Bytes) -> Any | None:
+    """
+    Decode an Amsterdam or immediate pre-Amsterdam RLP header.
+    """
+    from ethereum.forks.amsterdam.stateless import _decode_header
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    try:
+        return _decode_header(AmsterdamBytes(bytes(header_rlp)))
+    except Exception:
+        return None
+
+
+def _convert_amsterdam_execution_witness(
+    execution_witness: ExecutionWitness,
+) -> Any:
+    """
+    Convert fixture execution witness data to Amsterdam fork types.
+    """
+    from ethereum.forks.amsterdam.stateless import (
+        ExecutionWitness as AmsterdamExecutionWitness,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    return AmsterdamExecutionWitness(
+        state=tuple(
+            AmsterdamBytes(bytes(node)) for node in execution_witness.state
+        ),
+        codes=tuple(
+            AmsterdamBytes(bytes(code)) for code in execution_witness.codes
+        ),
+        headers=tuple(
+            AmsterdamBytes(bytes(header))
+            for header in execution_witness.headers
+        ),
+    )
+
+
+def _convert_amsterdam_withdrawals(
+    withdrawals: List[Withdrawal] | None,
+) -> Any:
+    """
+    Convert fixture withdrawals to Amsterdam fork withdrawals.
+    """
+    from ethereum.forks.amsterdam.blocks import (
+        Withdrawal as AmsterdamWithdrawal,
+    )
+    from ethereum.state import Address as AmsterdamAddress
+    from ethereum_types.numeric import U64, U256
+
+    if withdrawals is None:
+        return ()
+    return tuple(
+        AmsterdamWithdrawal(
+            index=U64(int(withdrawal.index)),
+            validator_index=U64(int(withdrawal.validator_index)),
+            address=AmsterdamAddress(bytes(withdrawal.address)),
+            amount=U256(int(withdrawal.amount)),
+        )
+        for withdrawal in withdrawals
+    )
+
+
+def _convert_amsterdam_block_access_list(
+    block_access_list: BlockAccessList,
+) -> Any:
+    """
+    Convert fixture BAL data to Amsterdam fork BAL data.
+    """
+    from ethereum.forks.amsterdam.block_access_lists import (
+        AccountChanges,
+        BalanceChange,
+        CodeChange,
+        NonceChange,
+        SlotChanges,
+        StorageChange,
+    )
+    from ethereum.state import Address as AmsterdamAddress
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+    from ethereum_types.numeric import U32, U64, U256
+
+    return [
+        AccountChanges(
+            address=AmsterdamAddress(bytes(account.address)),
+            storage_changes=tuple(
+                SlotChanges(
+                    slot=U256(int(slot.slot)),
+                    changes=tuple(
+                        StorageChange(
+                            block_access_index=U32(
+                                int(change.block_access_index)
+                            ),
+                            new_value=U256(int(change.post_value)),
+                        )
+                        for change in slot.slot_changes
+                    ),
+                )
+                for slot in account.storage_changes
+            ),
+            storage_reads=tuple(
+                U256(int(slot)) for slot in account.storage_reads
+            ),
+            balance_changes=tuple(
+                BalanceChange(
+                    block_access_index=U32(int(change.block_access_index)),
+                    post_balance=U256(int(change.post_balance)),
+                )
+                for change in account.balance_changes
+            ),
+            nonce_changes=tuple(
+                NonceChange(
+                    block_access_index=U32(int(change.block_access_index)),
+                    new_nonce=U64(int(change.post_nonce)),
+                )
+                for change in account.nonce_changes
+            ),
+            code_changes=tuple(
+                CodeChange(
+                    block_access_index=U32(int(change.block_access_index)),
+                    new_code=AmsterdamBytes(bytes(change.new_code)),
+                )
+                for change in account.code_changes
+            ),
+        )
+        for account in block_access_list.root
+    ]
+
+
+def build_amsterdam_stateless_artifacts_from_t8n(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    header: FixtureHeader,
+    previous_env: Environment,
+    txs: List[Transaction],
+    result: Result,
+    withdrawals: List[Withdrawal] | None,
+    requests_list: List[Bytes] | None,
+    execution_witness: ExecutionWitness,
+    block_access_list: BlockAccessList,
+    chain_id: int,
+) -> tuple[Bytes, Bytes] | None:
+    """
+    Build Amsterdam stateless input/output bytes from t8n witness artifacts.
+
+    Returns ``None`` when the finalized request list cannot be decoded into
+    the Amsterdam request container, matching the existing EELS t8n behavior.
+    """
+    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
+    if active_fork.name() != "Amsterdam" or block_number == 0:
+        return None
+
+    from ethereum.forks.amsterdam.blocks import (
+        Block as AmsterdamBlock,
+    )
+    from ethereum.forks.amsterdam.blocks import (
+        Header as AmsterdamHeader,
+    )
+    from ethereum.forks.amsterdam.execution_engine.requests import (
+        decode_execution_requests,
+    )
+    from ethereum.forks.amsterdam.stateless import (
+        StatelessValidationResult,
+        compute_new_payload_request_root,
+    )
+    from ethereum.forks.amsterdam.stateless_guest import (
+        serialize_stateless_output,
+    )
+    from ethereum.forks.amsterdam.stateless_host import (
+        build_chain_config,
+        build_stateless_input,
+        serialize_stateless_input,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+    from ethereum_types.numeric import U64
+
+    parent_number = ZeroPaddedHexNumber(block_number - 1)
+    parent_header_rlp = previous_env.block_headers.get(parent_number)
+    if parent_header_rlp is None:
+        return None
+    parent_header = _decode_amsterdam_header_bytes(parent_header_rlp)
+    if parent_header is None:
+        return None
+    if Hash(parent_header_rlp.keccak256()) != header.parent_hash:
+        return None
+
+    current_header = _decode_amsterdam_header_bytes(header.rlp)
+    if not isinstance(current_header, AmsterdamHeader):
+        return None
+
+    try:
+        execution_requests = decode_execution_requests(
+            tuple(
+                AmsterdamBytes(bytes(request))
+                for request in requests_list or []
+            )
+        )
+    except Exception:
+        return None
+
+    rejected_indices = {
+        int(rejected.index) for rejected in result.rejected_transactions
+    }
+    accepted_txs = tuple(
+        AmsterdamBytes(bytes(tx.rlp()))
+        for index, tx in enumerate(txs)
+        if index not in rejected_indices
+    )
+    block = AmsterdamBlock(
+        header=current_header,
+        transactions=accepted_txs,
+        ommers=(),
+        withdrawals=_convert_amsterdam_withdrawals(withdrawals),
+    )
+    stateless_input = build_stateless_input(
+        block,
+        execution_witness=_convert_amsterdam_execution_witness(
+            execution_witness
+        ),
+        execution_requests=execution_requests,
+        block_access_list=_convert_amsterdam_block_access_list(
+            block_access_list
+        ),
+        chain_id=U64(chain_id),
+    )
+    stateless_input_bytes = serialize_stateless_input(stateless_input)
+    # TODO: Replace this shortcut with a client-provided validation result
+    # or a real stateless guest run once Geth witness generation is complete.
+    stateless_output = StatelessValidationResult(
+        new_payload_request_root=compute_new_payload_request_root(
+            stateless_input
+        ),
+        successful_validation=True,
+        chain_config=build_chain_config(U64(chain_id)),
+    )
+    stateless_output_bytes = serialize_stateless_output(stateless_output)
+    return (
+        Bytes(bytes(stateless_input_bytes)),
+        Bytes(bytes(stateless_output_bytes)),
+    )
+
+
 def decode_amsterdam_stateless_output(
     *,
     fork: Fork,
@@ -1281,6 +1524,32 @@ class BlockchainTest(BaseTest):
         stateless_output_bytes = (
             transition_tool_output.result.stateless_output_bytes
         )
+        if (
+            not skip_stateless_for_block
+            and t8n_witness is not None
+            and bal is not None
+            and (
+                stateless_input_bytes is None or stateless_output_bytes is None
+            )
+        ):
+            stateless_artifacts = build_amsterdam_stateless_artifacts_from_t8n(
+                fork=fork,
+                block_number=int(env.number),
+                timestamp=int(env.timestamp),
+                header=header,
+                previous_env=previous_env,
+                txs=txs,
+                result=transition_tool_output.result,
+                withdrawals=env.withdrawals,
+                requests_list=requests_list,
+                execution_witness=t8n_witness,
+                block_access_list=bal,
+                chain_id=self.chain_id,
+            )
+            if stateless_artifacts is not None:
+                stateless_input_bytes, stateless_output_bytes = (
+                    stateless_artifacts
+                )
         stateless_output = decode_amsterdam_stateless_output(
             fork=fork,
             block_number=int(env.number),


### PR DESCRIPTION
## 🗒️ Description
zkEVM added three important fields to fixtures: `executionWitness`, `statelessInputBytes` and `statelessOutputBytes`. The last two are the main crucial ones since are the raw bytes received by the stateless validator (i.e. guest programs) to validate a block (and thus generate a proof).

Currently, we can fill test fixtures but not benchmark fixtures -- mainly because filling benchmarks with the Python spec is not possible given that these are quite heavy blocks and is not doable. This isn't something particular to zkEVM efforts, but a general one (e.g. for Glamsterdam efforts, benchmarks aren't filled with Python either).

This means that benchmark fixtures should be filled with an external t8n implementation, usually based on some real EL that is performant enough. Geth is currently one of the main clients used in EEST for this purpose.

This PR:
- Allows to fill any fixture (in particular, benchmark fixtures) using an external t8n tool with a minimal requirement that `executionWitness` is returned as t8n output (not necessarily `stateless{Input|Output}Bytes`)
- The `stateless{Input|Ouput}Bytes` are constructed in the testing framework.

Ideally, the t8n should also return the `stateless{Input| Output}Bytes`, and it would make this PR a simpler (i.e. basically almost no diff at all), but currently Geth doesn't have good SSZ support to do this. But, it has good support for `executionWitness` generation, thus still doing the SSZ-work on this side. Eventually, we could push `stateless{Input|Output}Bytes` generation to Geth-t8n, and remove this on EEST side, which would be nice.

I also added a GH workflow that does a quick smoke test, checking that a particular benchmark fixture target filled with Python and with Geth leads to exactly the same output. See [here](https://github.com/ethereum/execution-specs/actions/runs/26174837461/job/77002149002?pr=2889) for a run.

With this change, we could create zkEVM benchmark releases. These would target spec-compliant guest programs, plus also on the latest devnet target.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
