### PR TITLE
bug(spec-specs, tests): EIP-8037 strict block-gas inclusion rule

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -569,7 +569,7 @@ def check_transaction(
         raise GasUsedExceedsLimitError("regular gas used exceeds limit")
 
     if tx.gas > state_gas_available:
-        raise GasUsedExceedsLimitError("gas used exceeds limit")
+        raise GasUsedExceedsLimitError("state gas used exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -83,7 +83,6 @@ from .transactions import (
     TX_MAX_GAS_LIMIT,
     BlobTransaction,
     FeeMarketCapableTransaction,
-    IntrinsicGasCost,
     LegacyTransaction,
     SetCodeTransaction,
     Transaction,
@@ -496,7 +495,6 @@ def check_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     tx_state: TransactionState,
-    intrinsic: IntrinsicGasCost,
 ) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
@@ -511,9 +509,6 @@ def check_transaction(
         The transaction.
     tx_state :
         The transaction state tracker.
-    intrinsic :
-        The transaction's intrinsic gas cost, split into regular and
-        state components.
 
     Returns
     -------
@@ -569,17 +564,12 @@ def check_transaction(
     )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
-    # Worst-case regular contribution: tx.gas minus the portion that
-    # must go to intrinsic state gas, capped at TX_MAX_GAS_LIMIT.
-    worst_case_regular = min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state)
-    if worst_case_regular > regular_gas_available:
-        raise GasUsedExceedsLimitError("regular gas used exceeds limit")
+    # EIP-8037 per-dimension inclusion check.
+    if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
 
-    # Worst-case state contribution: tx.gas minus the portion that
-    # must go to intrinsic regular gas.
-    worst_case_state = tx.gas - intrinsic.regular
-    if worst_case_state > state_gas_available:
-        raise GasUsedExceedsLimitError("state gas used exceeds limit")
+    if tx.gas > state_gas_available:
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:
@@ -1014,7 +1004,6 @@ def process_transaction(
         block_output=block_output,
         tx=tx,
         tx_state=tx_state,
-        intrinsic=intrinsic,
     )
 
     sender_account = get_account(tx_state, sender)

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -566,7 +566,7 @@ def check_transaction(
 
     # EIP-8037 per-dimension inclusion check.
     if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
-        raise GasUsedExceedsLimitError("gas used exceeds limit")
+        raise GasUsedExceedsLimitError("regular gas used exceeds limit")
 
     if tx.gas > state_gas_available:
         raise GasUsedExceedsLimitError("gas used exceeds limit")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -11,21 +11,27 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
+    Address,
     Alloc,
+    AuthorizationTuple,
     Block,
     BlockchainTestFiller,
     Bytecode,
     Environment,
     Fork,
+    Hash,
     Header,
     Op,
     Storage,
     Transaction,
     TransactionException,
     TransactionReceipt,
+    add_kzg_version,
 )
 
+from ...cancun.eip4844_blobs.spec import Spec as EIP4844_Spec
 from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
@@ -474,6 +480,121 @@ def test_multi_block_dimension_flip(
             ),
         ],
         post=post_2,
+    )
+
+
+@pytest.mark.parametrize(
+    "tx_gas_delta, expected_exception",
+    [
+        pytest.param(0, None, id="gas_equal"),
+        pytest.param(
+            1,
+            TransactionException.GAS_ALLOWANCE_EXCEEDED,
+            id="gas_one_above",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(
+            2,
+            TransactionException.GAS_ALLOWANCE_EXCEEDED,
+            id="gas_two_above",
+            marks=pytest.mark.exception_test,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "block_gas_limit",
+    [
+        pytest.param(0x0FFFFFD, id="bgl_0x0fffffd"),
+        pytest.param(0x01FFFFE, id="bgl_0x01ffffe"),
+    ],
+)
+@pytest.mark.parametrize(
+    "tx_type, contract_creation",
+    [
+        pytest.param(0, False, id="type_0_call"),
+        pytest.param(0, True, id="type_0_create"),
+        pytest.param(1, False, id="type_1_call"),
+        pytest.param(1, True, id="type_1_create"),
+        pytest.param(2, False, id="type_2_call"),
+        pytest.param(2, True, id="type_2_create"),
+        pytest.param(3, False, id="type_3_blob"),
+        pytest.param(4, False, id="type_4_set_code"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_tx_gas_limit_block_boundary(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    tx_type: int,
+    contract_creation: bool,
+    block_gas_limit: int,
+    tx_gas_delta: int,
+    expected_exception: TransactionException | None,
+) -> None:
+    """
+    Reject tx whose ``gas_limit`` exceeds the block ``gas_limit``.
+
+    EIP-8037 inclusion rule: ``min(TX_MAX_GAS_LIMIT, tx.gas) <=
+    regular_gas_available`` and ``tx.gas <= state_gas_available``.
+    At block start both budgets equal ``block_gas_limit``.
+    """
+    gas_limit = block_gas_limit + tx_gas_delta
+    gas_price = 10
+    sender = pre.fund_eoa(amount=gas_limit * gas_price + 10**18)
+
+    to = None if contract_creation else pre.fund_eoa(amount=0)
+    access_list = None
+    authorization_list = None
+    blob_versioned_hashes = None
+    extra_fee_args: dict = {}
+    if tx_type == 1:
+        access_list = [AccessList(address=Address(1), storage_keys=[Hash(0)])]
+    elif tx_type == 2:
+        access_list = []
+    elif tx_type == 3:
+        blob_versioned_hashes = add_kzg_version(
+            [Hash(1)], EIP4844_Spec.BLOB_COMMITMENT_VERSION_KZG
+        )
+        extra_fee_args["max_fee_per_blob_gas"] = 1
+    elif tx_type == 4:
+        authorization_list = [
+            AuthorizationTuple(
+                signer=pre.fund_eoa(amount=0), address=Address(1)
+            )
+        ]
+
+    if tx_type in (0, 1):
+        fee_args: dict = {"gas_price": gas_price}
+    else:
+        fee_args = {
+            "max_fee_per_gas": gas_price,
+            "max_priority_fee_per_gas": 0,
+        }
+    fee_args.update(extra_fee_args)
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=to,
+        gas_limit=gas_limit,
+        access_list=access_list,
+        authorization_list=authorization_list,
+        blob_versioned_hashes=blob_versioned_hashes,
+        error=expected_exception,
+        **fee_args,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                gas_limit=block_gas_limit,
+                exception=expected_exception,
+            )
+        ],
+        post={},
     )
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -266,10 +266,9 @@ def test_block_state_gas_limit_boundary(
     Verify the per-tx state check at the strict-greater-than boundary.
 
     tx1 consumes `tx1_state` via cold SSTOREs. tx2 is sized so that
-    its worst-case state contribution `tx.gas - intrinsic_regular`
-    equals `state_available` (delta=0, accepted because the check is
-    strict `>`) or exceeds it by 1 (delta=1, rejected with
-    `GAS_ALLOWANCE_EXCEEDED`).
+    its worst-case state contribution `tx.gas` equals `state_available`
+    (delta=0, accepted because the check is strict `>`) or exceeds it
+    by 1 (delta=1, rejected with `GAS_ALLOWANCE_EXCEEDED`).
 
     The regular check is asserted to pass so rejection on delta=1 is
     pinned to the state dimension.
@@ -291,11 +290,10 @@ def test_block_state_gas_limit_boundary(
     tx1_regular = intrinsic_cost() + tx1_code.gas_cost(fork) - tx1_state
     tx1_gas = gas_limit_cap + tx1_state
 
-    # tx2: worst-case state contribution = tx.gas - intrinsic_regular.
+    # tx2: worst-case state contribution = tx.gas (strict EIP rule).
     # Plain call, so intrinsic_state is zero.
-    tx2_intrinsic_regular = intrinsic_cost()
     state_available = block_gas_limit - tx1_state
-    tx2_gas = tx2_intrinsic_regular + state_available + delta
+    tx2_gas = state_available + delta
 
     # Pin the rejection (when delta > 0) to the state check: the
     # regular check must not fire.
@@ -335,22 +333,21 @@ def test_block_state_gas_limit_boundary(
     )
 
 
+@pytest.mark.exception_test
 @pytest.mark.valid_from("EIP8037")
-def test_creation_tx_regular_check_subtracts_intrinsic_state(
+def test_creation_tx_regular_check_uses_full_tx_gas(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Verify the regular check subtracts `intrinsic.state` from tx.gas.
+    Verify the regular check uses the full `tx.gas` (no subtraction).
 
-    The EIP regular check is
-    `min(TX_MAX, tx.gas - intrinsic.state) > regular_available`. For a
-    creation tx, `intrinsic.state = GAS_NEW_ACCOUNT`. This test sizes a
-    creation tx whose raw `tx.gas` exceeds `regular_available` but
-    `tx.gas - intrinsic.state` fits; it must be accepted. The old
-    formula `min(TX_MAX, tx.gas)` would reject the same tx, proving
-    the subtraction is honored.
+    The EIP regular check is `min(TX_MAX, tx.gas) > regular_available`.
+    For a creation tx, `intrinsic.state = GAS_NEW_ACCOUNT`. This test
+    sizes a creation tx whose raw `tx.gas` exceeds `regular_available`
+    while `tx.gas - intrinsic.state` would fit; it must be rejected. A
+    formula subtracting `intrinsic.state` would have wrongly accepted.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -364,10 +361,10 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
     ) - fork.transaction_intrinsic_state_gas(contract_creation=True)
 
     # Tight boundary: after the filler consumes gas_limit_cap, the
-    # remaining regular is exactly intrinsic_regular + 1. The old
+    # remaining regular is exactly intrinsic_regular + 1. The strict
     # formula `min(TX_MAX, tx.gas)` rejects (tx.gas = intrinsic_total
-    # > intrinsic_regular + 1); the new formula `min(TX_MAX, tx.gas
-    # - intrinsic.state)` accepts (equals intrinsic_regular).
+    # > intrinsic_regular + 1); a formula subtracting `intrinsic.state`
+    # would accept (tx.gas - intrinsic.state == intrinsic_regular).
     block_gas_limit = gas_limit_cap + intrinsic_regular + 1
 
     intrinsic_state = fork.transaction_intrinsic_state_gas(
@@ -383,10 +380,10 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
     remaining_regular = block_gas_limit - gas_limit_cap
 
     assert create_tx_gas > remaining_regular, (
-        "old formula must reject to prove new formula differs"
+        "strict formula must reject: full tx.gas exceeds remaining regular"
     )
     assert create_tx_gas - intrinsic_state <= remaining_regular, (
-        "new formula must accept"
+        "a subtracting formula would have accepted"
     )
 
     filler_tx = Transaction(
@@ -398,6 +395,7 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
         to=None,
         gas_limit=create_tx_gas,
         sender=pre.fund_eoa(),
+        error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
     )
 
     blockchain_test(
@@ -407,6 +405,7 @@ def test_creation_tx_regular_check_subtracts_intrinsic_state(
             Block(
                 txs=[filler_tx, create_tx],
                 gas_limit=block_gas_limit,
+                exception=TransactionException.GAS_ALLOWANCE_EXCEEDED,
             )
         ],
         post={},
@@ -421,19 +420,18 @@ def test_single_tx_state_check_exceeds_block_limit(
     fork: Fork,
 ) -> None:
     """
-    Verify a single tx is rejected when its state contribution exceeds
-    the entire block gas limit.
+    Verify a single tx is rejected when its gas limit exceeds the
+    entire block gas limit in the state dimension.
 
-    No prior txs needed. A tx whose tx.gas - intrinsic_regular exceeds
-    block_gas_limit must be rejected at inclusion.
+    No prior txs needed. The state check uses the full `tx.gas`, so a
+    tx whose `tx.gas` exceeds `block_gas_limit` must be rejected at
+    inclusion.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
-    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_regular = intrinsic_cost()
 
     block_gas_limit = gas_limit_cap + 100
-    tx_gas = block_gas_limit + intrinsic_regular + 1
+    tx_gas = block_gas_limit + 1
 
     tx = Transaction(
         to=pre.deploy_contract(code=Op.STOP),
@@ -466,15 +464,11 @@ def test_creation_tx_state_check_exceeded(
     """
     Verify a creation tx is rejected by the state check.
 
-    A creation tx has non-zero intrinsic_state (new account) AND
-    intrinsic_regular (base + CREATE cost). Both formulas are
-    exercised: the regular check subtracts intrinsic_state, the state
-    check subtracts intrinsic_regular.
-
-    A filler tx consumes state budget. The creation tx's state
-    contribution (tx.gas - intrinsic_regular) exceeds the remaining
-    state budget while its regular contribution
-    (tx.gas - intrinsic_state) fits the regular budget.
+    A creation tx (`to=None`) goes through the per-dimension inclusion
+    check like any other tx. A filler tx consumes state budget; the
+    creation tx's `tx.gas` then exceeds the remaining state budget by
+    one while its regular contribution still fits, pinning the
+    rejection to the state dimension.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -482,11 +476,6 @@ def test_creation_tx_state_check_exceeded(
     block_gas_limit = 100_000_000
 
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    create_intrinsic_total = intrinsic_cost(contract_creation=True)
-    create_intrinsic_state = fork.transaction_intrinsic_state_gas(
-        contract_creation=True,
-    )
-    create_intrinsic_regular = create_intrinsic_total - create_intrinsic_state
 
     num_sstores = 50
     tx1_code = Bytecode()
@@ -499,14 +488,12 @@ def test_creation_tx_state_check_exceeded(
     tx1_gas = gas_limit_cap + tx1_state
     state_available = block_gas_limit - tx1_state
 
-    # tx2 state contribution = state_available + 1 → rejected
-    tx2_gas = create_intrinsic_regular + state_available + 1
+    # tx2: full tx.gas exceeds state_available by 1, so rejected.
+    tx2_gas = state_available + 1
 
     # Regular check must pass so rejection is pinned to state.
     regular_available = block_gas_limit - tx1_regular
-    assert min(gas_limit_cap, tx2_gas - create_intrinsic_state) < (
-        regular_available
-    )
+    assert min(gas_limit_cap, tx2_gas) < regular_available
 
     tx1 = Transaction(
         to=tx1_contract,
@@ -635,16 +622,16 @@ def test_block_2d_gas_valid_when_cumulative_exceeds_limit(
     assert tx_state > tx_regular
     block_gas_used = tx_state
 
-    # num_txs sized so `one_d_bound > block_gas_limit > two_d_bound`:
-    # per-dimension maxes fit (accepted under 2D-max) but the 1D sum
-    # exceeds the limit (would be rejected by a summing client).
-    num_txs = block_gas_limit // block_gas_used
+    env = Environment(gas_limit=block_gas_limit)
+    tx_limit = tx_gas_used + 1000
+
+    # Strict rule counts full `tx.gas` per dimension; state is the
+    # binding one (tx_state > tx_regular), so every `tx_limit` must
+    # fit the remaining state gas.
+    num_txs = (block_gas_limit - tx_limit) // tx_state + 1
     two_d_bound = num_txs * block_gas_used
     one_d_bound = num_txs * tx_gas_used
     assert two_d_bound <= block_gas_limit < one_d_bound
-
-    env = Environment(gas_limit=block_gas_limit)
-    tx_limit = tx_gas_used + 1000
 
     txs = []
     post = {}


### PR DESCRIPTION
## 🗒️ Description

EIP-8037 specifies the per-dimension inclusion check at block start as:

    min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available
    tx.gas <= state_gas_available

EELS Amsterdam was subtracting intrinsic.state / intrinsic.regular from tx.gas in each dimension, which let a transaction with non-zero state intrinsic (CREATE, EIP-7702 set_code) be included when tx.gas exceeded block.gas_limit by up to intrinsic.regular (state-dim) or intrinsic.state (regular-dim). evmone, revm, and erigon enforce the EIP literally and reject; pre-bump geth rejects too.

Add a parametrized test under EIP-8037 covering the boundary across all post-EIP-7702 tx types and contract-creation kinds, at two block-gas-limit values to avoid hard-coded-cap false-positives.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.


