### PR TITLE
feat(tests,ci): Verify filled benchmark fixtures against EELS via json_loader

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,6 +71,11 @@ jobs:
         with:
           enable-cache: "false"
 
+      - name: Install PyPy for bench-gas json_loader verify
+        if: matrix.recipe == 'bench-gas'
+        shell: bash
+        run: uv python install pypy3.11
+
       - uses: ./.github/actions/build-evm-base
         id: evm-builder
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ pip-delete-this-directory.txt
 
 .tox/
 .just/
+tests/json_loader/bench_gas_fixtures
 
 /doc/_autosummary
 

--- a/Justfile
+++ b/Justfile
@@ -212,10 +212,11 @@ test-ci-scripts *args:
 
 # --- Benchmarks ---
 
-# Fill benchmark tests with --gas-benchmark-values
+# Fill benchmark tests with --gas-benchmark-values, then verify with EELS
 [group('benchmark tests')]
 bench-gas *args:
     @mkdir -p "{{ output_dir }}/bench-gas/tmp" "{{ output_dir }}/bench-gas/logs"
+    @echo "==> Step 1/2: Filling benchmark fixtures with configured EVM (EVM_BIN={{ evm_bin }})"
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
         --gas-benchmark-values 1 \
@@ -229,6 +230,15 @@ bench-gas *args:
         --clean \
         "$@" \
         tests/benchmark/compute
+    @echo "==> Step 2/2: Running filled fixtures against EELS via json_loader"
+    @rm -rf tests/json_loader/bench_gas_fixtures
+    ln -sfn "{{ output_dir }}/bench-gas/fixtures" tests/json_loader/bench_gas_fixtures
+    cd tests/json_loader && uv run --python pypy3.11 pytest \
+        --fork Osaka \
+        --allow-post-state-hash \
+        -n auto --maxprocesses 10 --dist=loadfile \
+        --basetemp="{{ output_dir }}/bench-gas/json-loader-tmp" \
+        bench_gas_fixtures
 
 # Fill benchmark tests with --fixed-opcode-count 1
 [group('benchmark tests')]

--- a/tests/json_loader/conftest.py
+++ b/tests/json_loader/conftest.py
@@ -94,6 +94,20 @@ def pytest_addoption(parser: Parser) -> None:
         help="Path to a file containing test ids, one per line",
     )
 
+    parser.addoption(
+        "--allow-post-state-hash",
+        dest="allow_post_state_hash",
+        default=False,
+        action="store_const",
+        const=True,
+        help=(
+            "Verify blockchain fixtures that only include `postStateHash` "
+            "(not the full `postState` dict). The EELS state transition's "
+            "internal state-root check plus the `lastblockhash` assertion "
+            "are cryptographically sufficient."
+        ),
+    )
+
 
 def pytest_configure(config: Config) -> None:
     """

--- a/tests/json_loader/helpers/load_blockchain_tests.py
+++ b/tests/json_loader/helpers/load_blockchain_tests.py
@@ -103,7 +103,16 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
     def runtest(self) -> None:
         """Run a blockchain state test from JSON test case data."""
         json_data = self.test_dict
-        if "postState" not in json_data:
+        has_post_state = "postState" in json_data
+        allow_post_state_hash = self.config.getoption(
+            "allow_post_state_hash", False
+        )
+        post_state_hash_only = (
+            not has_post_state
+            and "postStateHash" in json_data
+            and allow_post_state_hash
+        )
+        if not has_post_state and not post_state_hash_only:
             pytest.xfail(
                 f"{self.test_file}[{self.test_key}] doesn't have post state"
             )
@@ -187,10 +196,11 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
             keccak256(rlp.encode(chain.blocks[-1].header)) == last_block_hash
         )
 
-        expected_post_state = load.json_to_state(json_data["postState"])
-        assert chain.state == expected_post_state
+        if has_post_state:
+            expected_post_state = load.json_to_state(json_data["postState"])
+            assert chain.state == expected_post_state
+            close_state(expected_post_state)
         close_state(chain.state)
-        close_state(expected_post_state)
 
     def reportinfo(self) -> Tuple[Path, int, str]:
         """Return information for test reporting."""


### PR DESCRIPTION
## 🗒️ Description

Benchmark tests are filled with an external EVM (geth, evmone,...) as the EELS EVM is extremely slow at filling these compute-heavy tests. This has led to a consensus testing gap: The canonical spec (EELS) is not part of the benchmark workflow.

This PR updates the `bench-gas` recipe to additionally run the externally generated fixtures against EELS via the `json_loader`; this is then verified upon push in CI.

It does not update the target fork used for benchmarks (currently Osaka); this should be bumped!

### `bench-gas` recipe / `benchmark.yaml` workflow

This PR adds a Step 2 to `bench-gas`: after filling with geth, re-execute the resulting `blockchain_test` fixtures against EELS via the `json_loader`. EELS' `state_transition` validates each block's state root against the header internally (`src/ethereum/forks/osaka/fork.py:266`), and the `lastblockhash` assertion provides the final cryptographic check. Any gas, state, or opcode-behavior divergence between geth and EELS will now fail the verify step.

Modifications:

1. `feat(tests): Add --allow-post-state-hash option to json_loader`: previously the json_loader xfailed any fixture without a full `postState` dict. Benchmark fixtures only carry `postStateHash` (since `include_full_post_state_in_output` defaults to `False`). With the new flag, EELS' state transition runs against these fixtures and `lastblockhash` validates the resulting state root via the block header. Behavior is unchanged when the flag is absent, so the existing `json-loader` recipe is unaffected.
2. `feat(bench-gas): Verify filled fixtures against EELS via json_loader`: extends the recipe with a clearly-labeled Step 2. Symlinks the filled output under `tests/json_loader/` so the path-scoped conftest applies, then runs pytest with `--allow-post-state-hash --fork Osaka` under PyPy 3.11.
3. `ci(bench): Install PyPy for bench-gas json_loader verify`: pre-installs PyPy 3.11 in the CI job so the recipe doesn't pay the on-demand download cost. Gated to the `bench-gas` matrix entry.

PyPy gives a ~9x speedup over CPython on this workload (`1082 passed in 2:08` vs `19:32` locally), so the verification adds about two minutes to the existing CI job rather than twenty. The bottleneck is pure-Python Merkle Patricia Trie hashing and RLP encoding inside EELS' state transition, which is exactly the workload PyPy's JIT was designed for; the `fill` step still runs on CPython since it bottlenecks on subprocess I/O to the EVM binary, not on hot Python loops.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="1262" height="780" alt="image" src="https://github.com/user-attachments/assets/33d2303c-4f47-4aff-a35b-a1a4357bcead" />

