### PR TITLE
feat(test-consume): Validate RPC header fields in consume rlp

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_rlp.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_rlp.py
@@ -7,18 +7,39 @@ start-up.
 """
 
 import logging
+from typing import Any, Dict
+
+from pydantic import ValidationError
 
 from execution_testing.fixtures import BlockchainFixture
 from execution_testing.fixtures.blockchain import (
     FixtureBlock,
     FixtureHeader,
 )
+from execution_testing.forks import Fork, TransitionFork
 from execution_testing.rpc import EthRPC
 
 from ..helpers.exceptions import GenesisBlockMismatchExceptionError
 from ..helpers.timing import TimingData
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_rpc_header_fields(
+    block: Dict[str, Any],
+    fixture_fork: Fork | TransitionFork,
+) -> None:
+    applicable_fork = fixture_fork.fork_at(
+        block_number=int(block["number"], 16),
+        timestamp=int(block["timestamp"], 16),
+    )
+    try:
+        FixtureHeader.model_validate({**block, "fork": applicable_fork})
+    except ValidationError as e:
+        raise AssertionError(
+            f"RPC response missing required header field for "
+            f"block {block['number']}: {e}"
+        ) from e
 
 
 def test_via_rlp(
@@ -44,6 +65,7 @@ def test_via_rlp(
         logger.info("Calling getBlockByNumber to get latest block...")
         block = eth_rpc.get_block_by_number("latest")
         assert block, "`getBlockByNumber` didn't return a block."
+        _validate_rpc_header_fields(block, fixture.fork)
         if block["hash"] != str(fixture.last_block_hash):
             try:
                 block_header = FixtureHeader.model_validate(block).model_dump()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_rlp.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_rlp.py
@@ -11,6 +11,7 @@ from typing import Any, Dict
 
 from pydantic import ValidationError
 
+from execution_testing.base_types import HexNumber
 from execution_testing.fixtures import BlockchainFixture
 from execution_testing.fixtures.blockchain import (
     FixtureBlock,
@@ -30,14 +31,14 @@ def _validate_rpc_header_fields(
     fixture_fork: Fork | TransitionFork,
 ) -> None:
     applicable_fork = fixture_fork.fork_at(
-        block_number=int(block["number"], 16),
-        timestamp=int(block["timestamp"], 16),
+        block_number=HexNumber(block["number"]),
+        timestamp=HexNumber(block["timestamp"]),
     )
     try:
         FixtureHeader.model_validate({**block, "fork": applicable_fork})
     except ValidationError as e:
         raise AssertionError(
-            f"RPC response missing required header field for "
+            f"Invalid or missing required header field for "
             f"block {block['number']}: {e}"
         ) from e
 
@@ -93,6 +94,8 @@ def test_via_rlp(
                     "blockHash mismatch in last block - field mismatches:"
                     "\n" + "\n".join(mismatches)
                 )
+            except AssertionError:
+                raise
             except Exception:
                 raise AssertionError(
                     f"blockHash mismatch in last block: "


### PR DESCRIPTION
## 🗒️ Description
Uses existing Pydantic validation to check header fields in the rlp. 

Also fixes a bug where a generic AssertionError was being raised instead of a nice error message that had been previously generated. 

I did validate that this fails for nimbus-el who was not returning BAL headers via RPC.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- ~~[ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.~~
- ~~[ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.~~

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1738252333834-c213bd67cfde?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTl8fGN1dGUlMjBiaXJkfGVufDB8fDB8fHww)
