### PR TITLE
feat(tests): EIP-8037 reject when calldata_floor > TX_MAX_GAS_LIMIT

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -255,6 +255,12 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
             "TransactionGasLimitExceededError"
         ),
+        TransactionException.INTRINSIC_GAS_COST_EXCEEDS_MAXIMUM: (
+            "IntrinsicGasCostExceedsMaximumError"
+        ),
+        TransactionException.FLOOR_GAS_EXCEEDS_MAXIMUM: (
+            "FloorGasExceedsMaximumError"
+        ),
         BlockException.SYSTEM_CONTRACT_EMPTY: "System contract address",
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "call failed:",
         BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "deposit",

--- a/packages/testing/src/execution_testing/exceptions/exceptions/transaction.py
+++ b/packages/testing/src/execution_testing/exceptions/exceptions/transaction.py
@@ -177,6 +177,16 @@ class TransactionException(ExceptionBase):
     """
     Transaction gas limit exceeds the maximum allowed limit for the given fork.
     """
+    INTRINSIC_GAS_COST_EXCEEDS_MAXIMUM = auto()
+    """
+    Transaction intrinsic regular gas cost exceeds the maximum allowed
+    transaction gas limit for the given fork.
+    """
+    FLOOR_GAS_EXCEEDS_MAXIMUM = auto()
+    """
+    Transaction calldata floor gas cost exceeds the maximum allowed
+    transaction gas limit for the given fork.
+    """
     TYPE_3_TX_ZERO_BLOBS = auto()
     """Transaction is type 3, but has no blobs."""
     TYPE_4_EMPTY_AUTHORIZATION_LIST = auto()

--- a/src/ethereum/forks/amsterdam/exceptions.py
+++ b/src/ethereum/forks/amsterdam/exceptions.py
@@ -145,6 +145,30 @@ class TransactionGasLimitExceededError(InvalidTransaction):
     """
 
 
+class IntrinsicGasCostExceedsMaximumError(InvalidTransaction):
+    """
+    The transaction's intrinsic regular gas exceeds the maximum allowed
+    transaction gas limit (`TX_MAX_GAS_LIMIT`).
+
+    Per [EIP-8037], inclusion requires
+    `max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`.
+
+    [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
+    """
+
+
+class FloorGasExceedsMaximumError(InvalidTransaction):
+    """
+    The transaction's calldata floor gas cost exceeds the maximum allowed
+    transaction gas limit (`TX_MAX_GAS_LIMIT`).
+
+    Per [EIP-8037], inclusion requires
+    `max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`.
+
+    [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
+    """
+
+
 class BlockAccessListGasLimitExceededError(InvalidBlock):
     """
     The block access list exceeds the gas limit constraint.

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -22,7 +22,9 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    FloorGasExceedsMaximumError,
     InitCodeTooLargeError,
+    IntrinsicGasCostExceedsMaximumError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, RegularGas, VersionedHash
@@ -605,11 +607,11 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
     if intrinsic.regular > TX_MAX_GAS_LIMIT:
-        raise InsufficientTransactionGasError(
+        raise IntrinsicGasCostExceedsMaximumError(
             "Intrinsic regular gas exceeds TX_MAX_GAS_LIMIT"
         )
     if intrinsic.calldata_floor > TX_MAX_GAS_LIMIT:
-        raise InsufficientTransactionGasError(
+        raise FloorGasExceedsMaximumError(
             "Intrinsic calldata floor exceeds TX_MAX_GAS_LIMIT"
         )
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_intrinsic_cap_at_validation.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_intrinsic_cap_at_validation.py
@@ -1,0 +1,101 @@
+"""
+Test EIP-8037 intrinsic-or-floor cap at tx validation.
+
+Tests for [EIP-8037: State Creation Gas Cost Increase]
+(https://eips.ethereum.org/EIPS/eip-8037).
+"""
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Account,
+    Address,
+    Alloc,
+    Fork,
+    Op,
+    StateTestFiller,
+    Transaction,
+    TransactionException,
+)
+
+from .spec import ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+
+@pytest.mark.parametrize(
+    "scenario, expected_exception",
+    [
+        pytest.param(
+            "floor_binds",
+            TransactionException.INTRINSIC_GAS_TOO_LOW,
+            id="floor_binds",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(
+            "intrinsic_binds",
+            TransactionException.INTRINSIC_GAS_TOO_LOW,
+            id="intrinsic_binds",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param("neither_binds", None, id="neither_binds"),
+    ],
+)
+@pytest.mark.parametrize(
+    "tx_type",
+    [pytest.param(1, id="type_1"), pytest.param(2, id="type_2")],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_intrinsic_or_floor_cap_at_validation(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_type: int,
+    scenario: str,
+    expected_exception: TransactionException | None,
+) -> None:
+    """
+    Reject when ``max(intrinsic_regular, calldata_floor) > TX_MAX_GAS_LIMIT``.
+
+    Type 0 lacks an access list to vary intrinsic independently of floor;
+    type 4 would need thousands of signed authorizations.
+    """
+    cap = fork.transaction_gas_limit_cap()
+    assert cap is not None
+    gas_costs = fork.gas_costs()
+    floor_per_byte = (
+        gas_costs.TX_DATA_TOKEN_FLOOR * gas_costs.TX_DATA_TOKEN_STANDARD
+    )
+
+    if scenario == "floor_binds":
+        data = b"\x01" * ((cap - gas_costs.TX_BASE) // floor_per_byte + 1)
+        access_list = []
+    elif scenario == "intrinsic_binds":
+        data = b""
+        n = (cap - gas_costs.TX_BASE) // gas_costs.TX_ACCESS_LIST_ADDRESS + 1
+        access_list = [
+            AccessList(address=Address(i + 1), storage_keys=[])
+            for i in range(n)
+        ]
+    else:
+        data = b""
+        access_list = []
+
+    contract = pre.deploy_contract(Op.STOP)
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=contract,
+        data=data,
+        access_list=access_list,
+        gas_limit=cap + 1,
+        error=expected_exception,
+    )
+    post = (
+        {sender: Account(nonce=0)}
+        if expected_exception
+        else {sender: Account(nonce=1)}
+    )
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_intrinsic_cap_at_validation.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_intrinsic_cap_at_validation.py
@@ -29,13 +29,13 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
     [
         pytest.param(
             "floor_binds",
-            TransactionException.INTRINSIC_GAS_TOO_LOW,
+            TransactionException.FLOOR_GAS_EXCEEDS_MAXIMUM,
             id="floor_binds",
             marks=pytest.mark.exception_test,
         ),
         pytest.param(
             "intrinsic_binds",
-            TransactionException.INTRINSIC_GAS_TOO_LOW,
+            TransactionException.INTRINSIC_GAS_COST_EXCEEDS_MAXIMUM,
             id="intrinsic_binds",
             marks=pytest.mark.exception_test,
         ),
@@ -68,19 +68,23 @@ def test_intrinsic_or_floor_cap_at_validation(
         gas_costs.TX_DATA_TOKEN_FLOOR * gas_costs.TX_DATA_TOKEN_STANDARD
     )
 
+    gas_limit = cap + 1
+    data = b""
+    access_list: list[AccessList] = []
     if scenario == "floor_binds":
         data = b"\x01" * ((cap - gas_costs.TX_BASE) // floor_per_byte + 1)
-        access_list = []
+        gas_limit = fork.transaction_data_floor_cost_calculator()(
+            data=data, access_list=access_list
+        )
     elif scenario == "intrinsic_binds":
-        data = b""
         n = (cap - gas_costs.TX_BASE) // gas_costs.TX_ACCESS_LIST_ADDRESS + 1
         access_list = [
             AccessList(address=Address(i + 1), storage_keys=[])
             for i in range(n)
         ]
-    else:
-        data = b""
-        access_list = []
+        gas_limit = fork.transaction_intrinsic_cost_calculator()(
+            calldata=data, access_list=access_list
+        )
 
     contract = pre.deploy_contract(Op.STOP)
     sender = pre.fund_eoa()
@@ -90,7 +94,7 @@ def test_intrinsic_or_floor_cap_at_validation(
         to=contract,
         data=data,
         access_list=access_list,
-        gas_limit=cap + 1,
+        gas_limit=gas_limit,
         error=expected_exception,
     )
     post = (

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -208,7 +208,7 @@ def test_calldata_floor_exceeding_tx_gas_limit_cap(
         data=calldata,
         gas_limit=gas_limit,
         sender=pre.fund_eoa(),
-        error=TransactionException.INTRINSIC_GAS_TOO_LOW
+        error=TransactionException.FLOOR_GAS_EXCEEDS_MAXIMUM
         if exceeds_cap
         else None,
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -342,7 +342,7 @@ def test_intrinsic_regular_gas_exceeds_cap(
         gas_limit=tx_gas,
         access_list=access_list,
         sender=pre.fund_eoa(),
-        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+        error=TransactionException.INTRINSIC_GAS_COST_EXCEEDS_MAXIMUM,
     )
     state_test(pre=pre, post={}, tx=tx)
 
@@ -391,7 +391,7 @@ def test_intrinsic_regular_gas_exceeds_cap_with_floor_below_cap(
         gas_limit=tx_gas,
         access_list=access_list,
         sender=pre.fund_eoa(),
-        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+        error=TransactionException.INTRINSIC_GAS_COST_EXCEEDS_MAXIMUM,
     )
     state_test(pre=pre, post={}, tx=tx)
 

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -733,9 +733,10 @@ def test_tx_gas_limit_cap_authorized_tx(
         sender=pre.fund_eoa(),
         access_list=access_list,
         authorization_list=auth_tuples,
-        # EIP-8037 reports a cap overflow as INTRINSIC_GAS_TOO_LOW.
+        # EIP-8037 caps the intrinsic regular gas at TX_MAX_GAS_LIMIT and
+        # reports the overflow with a distinct exception.
         error=(
-            TransactionException.INTRINSIC_GAS_TOO_LOW
+            TransactionException.INTRINSIC_GAS_COST_EXCEEDS_MAXIMUM
             if fork.is_eip_enabled(8037)
             else TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM
         )


### PR DESCRIPTION
## 🗒️ Description

EIP-8037 requires max(intrinsic_regular, calldata_floor) <= TX_MAX_GAS_LIMIT. The existing `tx.gas_limit < total_intrinsic` check already covers the intrinsic-regular arm, so only the calldata_floor arm is observably untested.

Parametrize types 1 and 2 over floor_binds, intrinsic_binds, and neither_binds.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.
