### PR TITLE
feat(github): add devnet test release tracker issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -1,0 +1,161 @@
+---
+name: Devnet Tracker
+about: Track EL test release readiness for a devnet (tests-<feat>-devnet@vX.Y.Z)
+title: '<feat>-devnet@vX.Y.Z Tracker'
+labels: C-tracker, P-high
+assignees: ''
+
+---
+
+## `<feat>`-devnet@v`X.Y.Z`
+
+> [!NOTE]
+> This is an **execution layer (EL) only** tracker — it does not cover
+> consensus layer (CL) readiness.
+
+### Overview
+
+<!--
+    Briefly describe the purpose of this devnet test release, its scope, and any
+    relevant links (devnet specs repo, ACD notes, configuration / genesis).
+
+    The `<feat>` keyword is typically the fork name or headliner feature
+    (e.g. `bal`, `glamsterdam`). The release fills all forks until the
+    development fork (e.g. `fill --until Amsterdam`) so clients can guard
+    against regressions, and is run in Hive CI under the standard naming scheme.
+-->
+
+- **Target release tag**: <!-- e.g. tests-glamsterdam-devnet@v5.0.0 -->
+- **EELS branch**: <!-- link to the `feat-devnet-N` branch being used for this devnet -->
+- **Test release date**: <!-- YYYY-MM-DD or "TBD" — aim for 5 days before the devnet -->
+- **Devnet launch date**: <!-- YYYY-MM-DD or "TBD" -->
+
+> [!NOTE]
+> **Versioning** (`vX.Y.Z`): `X` is the devnet number (e.g. `5` for
+> `glamsterdam-devnet-5`), making the targeted devnet explicit. `Y`/`Z` follow
+> the same semantics as the consensus test releases: `Y` (minor) is bumped for
+> new or changed tests that add/modify fixtures, and `Z` (patch) is bumped for
+> backward-compatible fixes that do not change existing fixtures.
+
+> [!NOTE]
+> Aim to cut the test (fixture) release **at least 5 days before** the devnet
+> launch, to give client teams time to integrate and run them.
+
+### Follows On From _(optional)_
+
+<!--
+    Optional. If there is a previous devnet release tracker, link it here for
+    context — even if the scope has changed. If this is a test-only follow-up
+    (most updates are test additions and the scope is semantically unchanged),
+    keep this issue small and list only what is new below. If there is no
+    predecessor (a brand new `<feat>` / first devnet), remove this section.
+-->
+
+This is a follow-up to the `tests-<feat>-devnet@vX.Y.Z` tracker (#`<issue>`),
+with test additions only.
+
+> [!TIP]
+> For a test-only follow-up, the sections below can be trimmed to just what
+> changed since the previous tracker.
+
+### Aim
+
+<!--
+    A short statement of what we're aiming for in this devnet test release.
+    Be explicit that the scope is tentative and will change.
+-->
+
+We aim to include the following EIPs in the first `<feat>-devnet-N` EELS test
+release (`tests-<feat>-devnet@vX.Y.Z`). This scope is tentative — EIPs may be
+added, dropped, or deferred as decisions land in ACD and during implementation.
+
+### Instructions
+
+- [ ] Assign issue to the devnet coordination owner(s).
+- [ ] Add the issue to the target fork milestone if applicable.
+- [ ] Link each included EIP's [EIP Implementation Tracker](https://github.com/ethereum/execution-specs/issues/new?template=eip-tracker.md) below.
+
+> [!IMPORTANT]
+> Per-EIP specification and testing progress is tracked in the individual EIP
+> Implementation Tracker issues. This issue tracks devnet-level readiness only.
+
+### Proposed Scope
+
+<!--
+    Group EIPs by confidence. Move EIPs between groups as decisions are made,
+    and check an EIP off in "Confirmed" once its tracker issue is stable.
+-->
+
+#### Confirmed
+
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — #<tracker-issue>
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — #<tracker-issue>
+
+#### To Be Discussed
+
+<!-- Items pending an ACD / owner decision. Link the relevant EIP PR. -->
+
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — <reason / link to discussion PR>
+
+#### At Risk / Likely Dropped
+
+<!-- EIPs that may not make this devnet. -->
+
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — <reason>
+
+### Notes & Risks
+
+<!--
+    Call out the integration challenges and known hard spots, e.g. cross-EIP
+    alignment, ordering dependencies, framework changes.
+-->
+
+The most difficult changes are expected to be `<...>`. Highlight any cross-EIP
+alignment, ordering dependencies, or testing-framework work that could block the
+release here.
+
+### Specification + Testing Status
+
+- [ ] All included EIP specifications merged to the corresponding `feat-devnet-N` branch.
+- [ ] Devnet branch (`feat-devnet-N`) created and rebased on the target `forks/<fork>` branch.
+- [ ] Required testing framework modifications implemented.
+- [ ] Test suites for all included EIPs implemented.
+- [ ] No regressions or failures in tests from prior forks (including static tests).
+- [ ] Fixtures generated and released for the devnet.
+- [ ] [`hive-tests`](https://github.com/ethpandaops/hive-tests/tree/master/.github/workflows) repo checked/updated to run the latest set of fixtures.
+- [ ] [`hive-ui`](https://github.com/ethpandaops/hive-ui/blob/master/public/discovery.json) discovery checked/updated to the latest devnet workflow file within the `hive-tests` repo.
+
+### Client Readiness
+
+<!--
+    Track which client implementations are ready for the devnet. Link each
+    client's devnet branch / PR in the parentheses.
+-->
+
+- [ ] [geth]()
+- [ ] [erigon]()
+- [ ] [besu]()
+- [ ] [nethermind]()
+- [ ] [reth]()
+- [ ] [ethrex]()
+- [ ] [nimbus-el]()
+
+### Process Status
+
+- [ ] Hive tests passing on at least two implementations.
+- [ ] Interop / cross-client testing completed.
+- [ ] Devnet launched.
+- [ ] Post-launch issues triaged and tracked.
+
+### Closure
+
+<!--
+    Before closing this issue, link the test fixture release tag that shipped
+    for this devnet.
+-->
+
+- [ ] Linked the test fixture release tag used for this devnet: <!-- e.g. https://github.com/ethereum/execution-spec-tests/releases/tag/<tag> -->
+
+> [!IMPORTANT]
+> After tagging, any future changes must be added to a newly created devnet
+> tracker rather than reopening or amending this one.

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -1,7 +1,7 @@
 ---
-name: Devnet Tracker
+name: Devnet Test Release Tracker
 about: Track EL test release readiness for a devnet (tests-<feat>-devnet@vX.Y.Z)
-title: '<feat>-devnet@vX.Y.Z Tracker'
+title: '<feat>-devnet@vX.Y.Z Test Release Tracker'
 labels: C-tracker, P-high
 assignees: ''
 
@@ -34,8 +34,8 @@ assignees: ''
 > **Versioning** (`vX.Y.Z`): `X` is the devnet number (e.g. `5` for
 > `glamsterdam-devnet-5`), making the targeted devnet explicit. `Y`/`Z` follow
 > the same semantics as the consensus test releases: `Y` (minor) is bumped for
-> new or changed tests that add/modify fixtures, and `Z` (patch) is bumped for
-> backward-compatible fixes that do not change existing fixtures.
+> a change in behaviour (a spec/test change that alters existing fixtures), and
+> `Z` (patch) is bumped for new test additions only.
 
 > [!NOTE]
 > Aim to cut the test (fixture) release **at least 5 days before** the devnet
@@ -71,7 +71,6 @@ added, dropped, or deferred as decisions land in ACD and during implementation.
 
 ### Instructions
 
-- [ ] Assign issue to the devnet coordination owner(s).
 - [ ] Add the issue to the target fork milestone if applicable.
 - [ ] Link each included EIP's [EIP Implementation Tracker](https://github.com/ethereum/execution-specs/issues/new?template=eip-tracker.md) below.
 
@@ -84,24 +83,32 @@ added, dropped, or deferred as decisions land in ACD and during implementation.
 <!--
     Group EIPs by confidence. Move EIPs between groups as decisions are made,
     and check an EIP off in "Confirmed" once its tracker issue is stable.
+
+    Always pin the exact spec version each devnet targets — `eips.ethereum.org`
+    renders the latest EIP, but a devnet freezes a specific version, and that
+    skew is a common source of cross-client divergence. Pin via a commit
+    permalink to the EIP markdown (github.com/ethereum/EIPs/blob/<sha>/EIPS/eip-<n>.md)
+    and/or the open EIP PR(s) — a SHA and PR(s) ideally, but either works.
+    Devnets routinely run ahead of the merged EIP, and a single EIP may have
+    several relevant PRs — list them all.
 -->
 
 #### Confirmed
 
-- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — #<tracker-issue>
-- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — #<tracker-issue>
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) ([ethereum/EIPs#<pr>](https://github.com/ethereum/EIPs/pull/<pr>), [#<pr>](https://github.com/ethereum/EIPs/pull/<pr>)) — #<tracker-issue>
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) ([ethereum/EIPs#<pr>](https://github.com/ethereum/EIPs/pull/<pr>)) — #<tracker-issue>
 
 #### To Be Discussed
 
-<!-- Items pending an ACD / owner decision. Link the relevant EIP PR. -->
+<!-- Items pending an ACD / owner decision. Link the relevant EIP PR(s). -->
 
-- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — <reason / link to discussion PR>
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) ([ethereum/EIPs#<pr>](https://github.com/ethereum/EIPs/pull/<pr>)) — <reason / link to discussion PR>
 
 #### At Risk / Likely Dropped
 
 <!-- EIPs that may not make this devnet. -->
 
-- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — <reason>
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) ([ethereum/EIPs#<pr>](https://github.com/ethereum/EIPs/pull/<pr>)) — <reason>
 
 ### Notes & Risks
 
@@ -119,26 +126,11 @@ release here.
 - [ ] All included EIP specifications merged to the corresponding `feat-devnet-N` branch.
 - [ ] Devnet branch (`feat-devnet-N`) created and rebased on the target `forks/<fork>` branch.
 - [ ] Required testing framework modifications implemented.
-- [ ] Test suites for all included EIPs implemented.
+- [ ] Sufficient test suites for the included EIPs implemented.
 - [ ] No regressions or failures in tests from prior forks (including static tests).
 - [ ] Fixtures generated and released for the devnet.
 - [ ] [`hive-tests`](https://github.com/ethpandaops/hive-tests/tree/master/.github/workflows) repo checked/updated to run the latest set of fixtures.
 - [ ] [`hive-ui`](https://github.com/ethpandaops/hive-ui/blob/master/public/discovery.json) discovery checked/updated to the latest devnet workflow file within the `hive-tests` repo.
-
-### Client Readiness
-
-<!--
-    Track which client implementations are ready for the devnet. Link each
-    client's devnet branch / PR in the parentheses.
--->
-
-- [ ] [geth]()
-- [ ] [erigon]()
-- [ ] [besu]()
-- [ ] [nethermind]()
-- [ ] [reth]()
-- [ ] [ethrex]()
-- [ ] [nimbus-el]()
 
 ### Process Status
 
@@ -154,7 +146,7 @@ release here.
     for this devnet.
 -->
 
-- [ ] Linked the test fixture release tag used for this devnet: <!-- e.g. https://github.com/ethereum/execution-spec-tests/releases/tag/<tag> -->
+- [ ] Linked the test fixture release tag used for this devnet: <!-- e.g. https://github.com/ethereum/execution-specs/releases/tag/<tag> -->
 
 > [!IMPORTANT]
 > After tagging, any future changes must be added to a newly created devnet


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Adds a devnet test release tracker issue template , **EL only**. The aim of this tracker is to give us a process that signals to clients early on what is going in the next test release, and help us plan the next test releases more evenly across the team. I propose we start with something like this tracker template and update it in the future once we see what should be visualized and denoted more clearly.

Each test release must start with a devnet tracker, i.e for each `<feat>-devnet@vX.Y.Z `, even the small test version bumps. This tracker will be constantly updated, and used to prepare the test fixture devnet release notes.

If we followed this process today, we would have a tracker for `bal-devnet@v7.3.0`:
https://discord.com/channels/1359927674746835211/1386730600333054122/1507339893595050156,
and a tracker for `glamsterdam-devnet@v5.0.0`:
https://discord.com/channels/595666850260713488/1503770570829856898/1507344484352921712.

The trackers will be posted in the STEEL discord upon creation, and our website will have redirect links to the correct issue tracker, using both cc @danceratopz  on how to do this:
- https://steel.ethereum.foundation/<feat>-devnet/vX.Y.Z
- https://steel.ethereum.foundation/<feat>-devnet/latest

As part of our future process we should always have a devnet N and devnet N+1 trackers open. This unblocks client teams, and helps them work ahead if they have spare bandwidth, opening up spec issues/questions earlier. In an ideal world we would have N+M trackers with a devnet plan for the entire fork lifecycle but N/N+1 is a good first start!

#### Open Question

- Testnets? Should they use the same tracker, testnets will use a `consensus@vX.Y.Z` release and be tagged from `forks/amsterdam`, not a `feat-devnet@vX.Y.Z` release tagged from a `feat-devnet-X` branch.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.chzbgr.com/full/9781271296/h014229CA/dog)
