### PR TITLE
chore(specs): refactor code deployment functions

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -15,6 +15,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Self,
     Set,
     Tuple,
     Type,
@@ -801,12 +802,14 @@ class ValidityMarker(ABC):
         for marker in markers:
             for marker_name in ALL_VALIDITY_MARKERS:
                 if marker.name == marker_name:
-                    if marker_name in markers_dict:
-                        raise Exception(
-                            f"Too many '{marker_name}' markers applied to test"
-                        )
                     cls = ALL_VALIDITY_MARKERS[marker.name]
-                    markers_dict[marker_name] = cls(mark=marker)
+                    new_marker = cls(mark=marker)
+                    try:
+                        existing_marker = markers_dict[marker_name]
+                    except KeyError:
+                        markers_dict[marker_name] = new_marker
+                    else:
+                        existing_marker.update(new_marker)
 
         for cls in ALL_VALIDITY_MARKERS.values():
             if cls.flag and cls.marker_name not in markers_dict:
@@ -915,6 +918,26 @@ class ValidityMarker(ABC):
         """
         pass
 
+    def update(self, other: Self) -> None:
+        """
+        Update `self` to be the more strict of `self` or `other`.
+
+        For example:
+
+        >>> first = ValidFrom("Frontier")
+        >>> second = ValidFrom("Osaka")
+        >>> first.update(second)
+        >>> print(first)
+        ValidFrom("Osaka")
+
+        If `self` cannot be updated (no merging is possible/implemented),
+        raises an exception.
+        """
+        del other
+        raise Exception(
+            f"Too many '{self.marker_name}' markers applied to test"
+        )
+
 
 class ValidFrom(ValidityMarker):
     """
@@ -949,6 +972,21 @@ class ValidFrom(ValidityMarker):
         for fork in forks:
             resulting_set |= {f for f in ALL_FORKS if f >= fork}
         return resulting_set
+
+    def update(self, other: Self) -> None:
+        """Replace `self` with `other` if `other` is more restrictive."""
+        if self.mark is None:
+            self.mark = other.mark
+            return
+
+        if other.mark is None:
+            return
+
+        ours = len(self._process_with_marker_args(*self.mark.args))
+        theirs = len(other._process_with_marker_args(*other.mark.args))
+
+        if theirs < ours:
+            self.mark = other.mark
 
 
 class ValidUntil(ValidityMarker):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_bad_validity_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_bad_validity_markers.py
@@ -8,19 +8,6 @@ invalid_merge_marker = "Marge"  # codespell:ignore marge
 
 invalid_validity_marker_test_cases = (
     (
-        "too_many_valid_from_markers",
-        (
-            """
-            import pytest
-            @pytest.mark.valid_from("Paris")
-            @pytest.mark.valid_from("Paris")
-            def test_case(state_test):
-                assert 0
-            """,
-            "Too many 'valid_from' markers applied to test",
-        ),
-    ),
-    (
         "too_many_valid_until_markers",
         (
             """
@@ -248,24 +235,6 @@ def test_invalid_validity_markers(
 
 
 param_level_marker_error_test_cases = (
-    (
-        "param_level_valid_from_with_function_level_valid_from",
-        (
-            """
-            import pytest
-            @pytest.mark.parametrize(
-                "value",
-                [
-                    pytest.param(True, marks=pytest.mark.valid_from("Paris")),
-                ],
-            )
-            @pytest.mark.valid_from("Berlin")
-            def test_case(state_test, value):
-                assert 1
-            """,
-            "Too many 'valid_from' markers applied to test",
-        ),
-    ),
     (
         "param_level_valid_until_with_function_level_valid_until",
         (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -22,6 +22,19 @@ def test_case(state_test):
     "test_function,pytest_args,outcomes",
     [
         pytest.param(
+            """
+import pytest
+@pytest.mark.valid_from("Paris")
+@pytest.mark.valid_from("Berlin")
+@pytest.mark.state_test_only
+def test_case(state_test):
+    pass
+""",
+            [],
+            {"passed": 5, "failed": 0, "skipped": 0, "errors": 0},
+            id="two_valid_from",
+        ),
+        pytest.param(
             generate_test(
                 valid_until='"Cancun"',
             ),

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -280,28 +280,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -122,9 +121,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        tx_state, contract_address
-    ) or account_has_storage(tx_state, contract_address):
+    if not account_deployable(tx_state, contract_address):
         increment_nonce(tx_state, evm.message.current_target)
         evm.regular_gas_used += create_message_gas
         evm.state_gas_left += create_message_state_gas_reservoir

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -33,8 +33,7 @@ from ethereum.utils.numeric import ceil32
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -126,10 +125,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     refund_counter = U256(0)
     state_refund = Uint(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -142,8 +140,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 state_gas_used=0,
                 state_refund=Uint(0),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             state_refund += set_delegation(message)

--- a/src/ethereum/forks/arrow_glacier/state_tracker.py
+++ b/src/ethereum/forks/arrow_glacier/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -91,9 +90,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/arrow_glacier/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -107,10 +106,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -119,8 +117,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/berlin/state_tracker.py
+++ b/src/ethereum/forks/berlin/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/berlin/vm/instructions/system.py
+++ b/src/ethereum/forks/berlin/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -91,9 +90,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/berlin/vm/interpreter.py
+++ b/src/ethereum/forks/berlin/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -106,10 +105,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -118,8 +116,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/bpo1/state_tracker.py
+++ b/src/ethereum/forks/bpo1/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/bpo1/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/bpo1/vm/interpreter.py
+++ b/src/ethereum/forks/bpo1/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/bpo2/state_tracker.py
+++ b/src/ethereum/forks/bpo2/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/bpo2/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/bpo2/vm/interpreter.py
+++ b/src/ethereum/forks/bpo2/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/bpo3/state_tracker.py
+++ b/src/ethereum/forks/bpo3/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/bpo3/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/bpo3/vm/interpreter.py
+++ b/src/ethereum/forks/bpo3/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/bpo4/state_tracker.py
+++ b/src/ethereum/forks/bpo4/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/bpo4/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/bpo4/vm/interpreter.py
+++ b/src/ethereum/forks/bpo4/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/bpo5/state_tracker.py
+++ b/src/ethereum/forks/bpo5/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/bpo5/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/bpo5/vm/interpreter.py
+++ b/src/ethereum/forks/bpo5/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/byzantium/state_tracker.py
+++ b/src/ethereum/forks/byzantium/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/byzantium/vm/instructions/system.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/system.py
@@ -20,9 +20,8 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -98,9 +97,7 @@ def create(evm: Evm) -> None:
     ):
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    elif not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/byzantium/vm/interpreter.py
+++ b/src/ethereum/forks/byzantium/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -105,10 +104,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -117,8 +115,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/cancun/state_tracker.py
+++ b/src/ethereum/forks/cancun/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/cancun/vm/instructions/system.py
+++ b/src/ethereum/forks/cancun/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/cancun/vm/interpreter.py
+++ b/src/ethereum/forks/cancun/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -104,10 +103,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -115,8 +113,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/src/ethereum/forks/constantinople/state_tracker.py
+++ b/src/ethereum/forks/constantinople/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/constantinople/vm/instructions/system.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -89,9 +88,7 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/constantinople/vm/interpreter.py
+++ b/src/ethereum/forks/constantinople/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -105,10 +104,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -117,8 +115,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/dao_fork/state_tracker.py
+++ b/src/ethereum/forks/dao_fork/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/system.py
@@ -20,8 +20,7 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -92,9 +91,7 @@ def create(evm: Evm) -> None:
     ):
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    elif not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/dao_fork/vm/interpreter.py
+++ b/src/ethereum/forks/dao_fork/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     move_ether,
@@ -98,10 +97,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -109,8 +107,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/src/ethereum/forks/frontier/state_tracker.py
+++ b/src/ethereum/forks/frontier/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/frontier/vm/instructions/system.py
+++ b/src/ethereum/forks/frontier/vm/instructions/system.py
@@ -20,8 +20,7 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -92,9 +91,7 @@ def create(evm: Evm) -> None:
     ):
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    elif not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/frontier/vm/interpreter.py
+++ b/src/ethereum/forks/frontier/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     move_ether,
@@ -98,10 +97,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -109,8 +107,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/src/ethereum/forks/gray_glacier/state_tracker.py
+++ b/src/ethereum/forks/gray_glacier/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -91,9 +90,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/gray_glacier/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -107,10 +106,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -119,8 +117,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/homestead/state_tracker.py
+++ b/src/ethereum/forks/homestead/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/homestead/vm/instructions/system.py
+++ b/src/ethereum/forks/homestead/vm/instructions/system.py
@@ -20,8 +20,7 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -92,9 +91,7 @@ def create(evm: Evm) -> None:
     ):
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    elif not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/homestead/vm/interpreter.py
+++ b/src/ethereum/forks/homestead/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     move_ether,
@@ -98,10 +97,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -109,8 +107,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/src/ethereum/forks/istanbul/state_tracker.py
+++ b/src/ethereum/forks/istanbul/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/istanbul/vm/instructions/system.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -89,9 +88,7 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/istanbul/vm/interpreter.py
+++ b/src/ethereum/forks/istanbul/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -106,10 +105,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -118,8 +116,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/london/state_tracker.py
+++ b/src/ethereum/forks/london/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/london/vm/instructions/system.py
+++ b/src/ethereum/forks/london/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -91,9 +90,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/london/vm/interpreter.py
+++ b/src/ethereum/forks/london/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -107,10 +106,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -119,8 +117,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/muir_glacier/state_tracker.py
+++ b/src/ethereum/forks/muir_glacier/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/system.py
@@ -21,9 +21,8 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -89,9 +88,7 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/muir_glacier/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -106,10 +105,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -118,8 +116,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/osaka/state_tracker.py
+++ b/src/ethereum/forks/osaka/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/osaka/vm/instructions/system.py
+++ b/src/ethereum/forks/osaka/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/osaka/vm/interpreter.py
+++ b/src/ethereum/forks/osaka/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/paris/state_tracker.py
+++ b/src/ethereum/forks/paris/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/paris/vm/instructions/system.py
+++ b/src/ethereum/forks/paris/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -90,9 +89,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/paris/vm/interpreter.py
+++ b/src/ethereum/forks/paris/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -103,10 +102,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -114,8 +112,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/src/ethereum/forks/prague/state_tracker.py
+++ b/src/ethereum/forks/prague/state_tracker.py
@@ -264,28 +264,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/prague/vm/instructions/system.py
+++ b/src/ethereum/forks/prague/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     increment_nonce,
     is_account_alive,
@@ -98,9 +97,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/prague/vm/interpreter.py
+++ b/src/ethereum/forks/prague/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     get_account,
@@ -109,10 +108,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -121,8 +119,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
             )
-        else:
-            evm = process_create_message(message)
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)

--- a/src/ethereum/forks/shanghai/state_tracker.py
+++ b/src/ethereum/forks/shanghai/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/shanghai/vm/instructions/system.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/system.py
@@ -21,8 +21,7 @@ from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
 from ...state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     get_account,
     get_code,
     increment_nonce,
@@ -97,9 +96,7 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    if not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/shanghai/vm/interpreter.py
+++ b/src/ethereum/forks/shanghai/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -104,10 +103,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -115,8 +113,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/src/ethereum/forks/spurious_dragon/state_tracker.py
+++ b/src/ethereum/forks/spurious_dragon/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
@@ -20,9 +20,8 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 
 from ...state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -95,9 +94,7 @@ def create(evm: Evm) -> None:
     ):
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    elif not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/forks/spurious_dragon/vm/interpreter.py
@@ -32,9 +32,8 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
+    account_deployable,
     account_exists_and_is_empty,
-    account_has_code_or_nonce,
-    account_has_storage,
     copy_tx_state,
     destroy_storage,
     increment_nonce,
@@ -104,10 +103,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -116,8 +114,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 touched_accounts=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
         if account_exists_and_is_empty(tx_state, Address(message.target)):

--- a/src/ethereum/forks/tangerine_whistle/state_tracker.py
+++ b/src/ethereum/forks/tangerine_whistle/state_tracker.py
@@ -276,28 +276,18 @@ def account_exists(tx_state: TransactionState, address: Address) -> bool:
     return get_account_optional(tx_state, address) is not None
 
 
-def account_has_code_or_nonce(
-    tx_state: TransactionState, address: Address
-) -> bool:
+def account_deployable(tx_state: TransactionState, address: Address) -> bool:
     """
-    Check if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : ``bool``
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
+    Check if an account's code can be written to.
     """
     account = get_account(tx_state, address)
-    return account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH
+    if account.nonce != Uint(0) or account.code_hash != EMPTY_CODE_HASH:
+        return False
+
+    if account_has_storage(tx_state, address):
+        return False
+
+    return True
 
 
 def account_has_storage(tx_state: TransactionState, address: Address) -> bool:

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
@@ -20,9 +20,8 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 
 from ...state_tracker import (
+    account_deployable,
     account_exists,
-    account_has_code_or_nonce,
-    account_has_storage,
     get_account,
     get_code,
     increment_nonce,
@@ -94,9 +93,7 @@ def create(evm: Evm) -> None:
     ):
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(
-        evm.message.tx_env.state, contract_address
-    ) or account_has_storage(evm.message.tx_env.state, contract_address):
+    elif not account_deployable(evm.message.tx_env.state, contract_address):
         increment_nonce(evm.message.tx_env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
@@ -32,8 +32,7 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..state_tracker import (
-    account_has_code_or_nonce,
-    account_has_storage,
+    account_deployable,
     copy_tx_state,
     destroy_storage,
     move_ether,
@@ -98,10 +97,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
-        is_collision = account_has_code_or_nonce(
-            tx_state, message.current_target
-        ) or account_has_storage(tx_state, message.current_target)
-        if is_collision:
+        if account_deployable(tx_state, message.current_target):
+            evm = process_create_message(message)
+        else:
             return MessageCallOutput(
                 gas_left=Uint(0),
                 refund_counter=U256(0),
@@ -109,8 +107,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 accounts_to_delete=set(),
                 error=AddressCollision(),
             )
-        else:
-            evm = process_create_message(message)
     else:
         evm = process_message(message)
 

--- a/tests/paris/eip7610_create_collision/test_initcollision.py
+++ b/tests/paris/eip7610_create_collision/test_initcollision.py
@@ -22,7 +22,7 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7610.md"
 REFERENCE_SPEC_VERSION = "80ef48d0bbb5a4939ade51caaaac57b5df6acd4e"
 
 pytestmark = [
-    pytest.mark.valid_from("Paris"),
+    pytest.mark.valid_from("Frontier"),
     pytest.mark.ported_from(
         [
             "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stSStoreTest/InitCollisionFiller.json",
@@ -81,6 +81,7 @@ def test_init_collision_create_tx(
         ty=tx_type,
         to=None,
         data=initcode,
+        protected=False,
     )
 
     created_contract_address = tx.created_contract
@@ -113,7 +114,15 @@ def test_init_collision_create_tx(
     )
 
 
-@pytest.mark.parametrize("opcode", [Op.CREATE, Op.CREATE2])
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.CREATE,
+        pytest.param(
+            Op.CREATE2, marks=pytest.mark.valid_from("Constantinople")
+        ),
+    ],
+)
 def test_init_collision_create_opcode(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -129,14 +138,37 @@ def test_init_collision_create_opcode(
     """
     assert len(initcode) <= 32
     contract_creator_code = (
+        # Reverts if and only if contract creation fails. In Frontier/Homestead
+        # this runs out of gas, and every other fork jumps to a non-JUMPDEST.
         Op.MSTORE(0, Op.PUSH32(bytes(initcode).ljust(32, b"\0")))
-        + Op.SSTORE(0x01, opcode(value=0, offset=0, size=len(initcode)))
+        + Op.JUMPI(
+            condition=Op.ISZERO(opcode(value=0, offset=0, size=len(initcode))),
+            pc=0,
+        )
         + Op.STOP
     )
-    contract_creator_address = pre.deploy_contract(
-        contract_creator_code,
-        storage={0x01: 0x01},
+    contract_creator_address = pre.deploy_contract(contract_creator_code)
+
+    gas_limiter_code = (
+        # Calls the contract creator, reserving some gas to SSTORE the result.
+        Op.SSTORE(
+            0x01,
+            Op.CALL(
+                gas=Op.SUB(Op.GAS, 50_000),
+                address=contract_creator_address,
+                value=0,
+                args_offset=0,
+                args_size=0,
+                ret_offset=0,
+                ret_size=0,
+            ),
+        )
     )
+    gas_limiter_address = pre.deploy_contract(
+        gas_limiter_code,
+        storage={0x01: 0x02},
+    )
+
     created_contract_address = compute_create_address(
         address=contract_creator_address,
         nonce=1,
@@ -147,8 +179,8 @@ def test_init_collision_create_opcode(
 
     tx = Transaction(
         sender=pre.fund_eoa(),
-        to=contract_creator_address,
-        data=initcode,
+        to=gas_limiter_address,
+        protected=False,
     )
 
     pre[created_contract_address] = Account(
@@ -164,7 +196,7 @@ def test_init_collision_create_opcode(
             created_contract_address: Account(
                 storage={0x01: 0x01},
             ),
-            contract_creator_address: Account(storage={0x01: 0x00}),
+            gas_limiter_address: Account(storage={0x01: 0x00}),
         },
         tx=tx,
     )


### PR DESCRIPTION
## 🗒️ Description

- Combines `account_has_code_or_nonce` and `account_has_storage` into a single function, `account_deployable`.
- Expands an EIP-7610 test to cover Frontier+
- Adds support to EEST for multiple `valid_from` marks (taking the more strict mark).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/a28e59f5-63a9-4a61-a6ff-eb652d94f31d.jpeg)
