### PR TITLE
feat(zkevm): explicitly fail stateless validation for invalid input bytes & add proper tests

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -295,6 +295,39 @@ def rerun_amsterdam_stateless_guest_with_overrides(
     )
 
 
+def rerun_amsterdam_stateless_guest_with_input_bytes(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    stateless_input_bytes: Bytes,
+) -> tuple[Bytes, Bytes, bool]:
+    """
+    Rerun the Amsterdam stateless guest with raw stateless input bytes.
+    """
+    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
+    if active_fork.name() != "Amsterdam":
+        raise Exception(
+            "Stateless guest raw input rerun is only supported for Amsterdam"
+        )
+
+    from ethereum.forks.amsterdam.stateless_guest import run_stateless_guest
+    from ethereum.forks.amsterdam.stateless_host import (
+        deserialize_stateless_output,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    guest_input_bytes = AmsterdamBytes(bytes(stateless_input_bytes))
+    stateless_output_bytes = run_stateless_guest(guest_input_bytes)
+    stateless_output = deserialize_stateless_output(stateless_output_bytes)
+
+    return (
+        Bytes(bytes(guest_input_bytes)),
+        Bytes(bytes(stateless_output_bytes)),
+        stateless_output.successful_validation,
+    )
+
+
 def get_amsterdam_stateless_input_public_key_data(
     *,
     fork: Fork,
@@ -666,6 +699,27 @@ def assert_amsterdam_stateless_output_chain_config(
         )
 
 
+def is_invalid_stateless_input_sentinel(stateless_output: Any) -> bool:
+    """
+    Return whether output is the invalid stateless input sentinel.
+    """
+    from ethereum.forks.amsterdam.stateless import ProtocolFork
+    from ethereum_types.numeric import U64
+
+    chain_config = stateless_output.chain_config
+    active_fork = chain_config.active_fork
+    activation = active_fork.activation
+    return (
+        not stateless_output.successful_validation
+        and bytes(stateless_output.new_payload_request_root) == b"\0" * 32
+        and chain_config.chain_id == U64(0)
+        and active_fork.fork == ProtocolFork.Frontier
+        and activation.block_number is None
+        and activation.timestamp is None
+        and active_fork.blob_schedule is None
+    )
+
+
 class Header(CamelModel):
     """Header type used to describe block header properties in test specs."""
 
@@ -828,6 +882,14 @@ class Block(Header):
     """
     If set, mutate the stateless input transaction public keys before rerunning
     the guest for invalid tests.
+    """
+    stateless_input_bytes_modifier: Callable[[Bytes], Bytes] | None = Field(
+        default=None,
+        exclude=True,
+    )
+    """
+    If set, mutate the serialized stateless input bytes before rerunning the
+    guest for invalid tests.
     """
     expected_stateless_validation_success: bool | None = None
     """
@@ -994,10 +1056,10 @@ class BuiltBlock(CamelModel):
             if self.execution_witness
             else None,
             stateless_input_bytes=self.stateless_input_bytes
-            if self.stateless_input_bytes
+            if self.stateless_input_bytes is not None
             else None,
             stateless_output_bytes=self.stateless_output_bytes
-            if self.stateless_output_bytes
+            if self.stateless_output_bytes is not None
             else None,
             fork=self.fork,
         ).with_rlp(txs=self.txs)
@@ -1286,11 +1348,16 @@ class BlockchainTest(BaseTest):
         )
         public_keys_modifier = block.stateless_input_public_keys_modifier
         has_public_keys_modifier = public_keys_modifier is not None
+        stateless_input_bytes_modifier = block.stateless_input_bytes_modifier
+        has_stateless_input_bytes_modifier = (
+            stateless_input_bytes_modifier is not None
+        )
         expected_success = block.expected_stateless_validation_success
         omit_stateless_artifacts = block.rlp_modifier is not None
         if omit_stateless_artifacts and (
             has_witness_expectation
             or has_public_keys_modifier
+            or has_stateless_input_bytes_modifier
             or expected_success is not None
         ):
             raise AssertionError(
@@ -1301,12 +1368,13 @@ class BlockchainTest(BaseTest):
         if self.skip_stateless_validation and (
             has_witness_expectation
             or has_public_keys_modifier
+            or has_stateless_input_bytes_modifier
             or expected_success is not None
         ):
             raise AssertionError(
                 "skip_stateless_validation cannot be combined with "
                 "execution witness expectations, stateless input public-key "
-                "modifiers, or "
+                "modifiers, stateless input byte modifiers, or "
                 "expected_stateless_validation_success"
             )
         skip_stateless_for_block = (
@@ -1566,6 +1634,11 @@ class BlockchainTest(BaseTest):
                 "Mutated stateless input public-key tests must set "
                 "expected_stateless_validation_success explicitly"
             )
+        if has_stateless_input_bytes_modifier and expected_success is None:
+            raise AssertionError(
+                "Mutated stateless input byte tests must set "
+                "expected_stateless_validation_success explicitly"
+            )
         public_keys: Tuple[Bytes, ...] | None = None
         should_verify_stateless_input_public_keys = (
             stateless_input_bytes is not None
@@ -1618,10 +1691,11 @@ class BlockchainTest(BaseTest):
                 stateless_output.successful_validation
             )
 
-        should_rerun_stateless_guest = (
+        should_rerun_structured_stateless_guest = (
             has_witness_modifier or has_public_keys_modifier
         )
-        if should_rerun_stateless_guest:
+        final_successful_validation = canonical_successful_validation
+        if should_rerun_structured_stateless_guest:
             if stateless_input_bytes is None:
                 raise Exception(
                     "Stateless guest rerun requires stateless input bytes"
@@ -1658,30 +1732,58 @@ class BlockchainTest(BaseTest):
                 timestamp=int(env.timestamp),
                 stateless_output_bytes=stateless_output_bytes,
             )
-            if (
-                expected_success is not None
-                and successful_validation != expected_success
-            ):
-                raise AssertionError(
-                    "Stateless guest validation result mismatch: "
-                    f"got {successful_validation}, "
-                    f"want {expected_success}"
+            final_successful_validation = successful_validation
+
+        if has_stateless_input_bytes_modifier:
+            if stateless_input_bytes is None:
+                raise Exception(
+                    "Stateless guest raw input rerun requires stateless "
+                    "input bytes"
                 )
-        elif (
+            if stateless_input_bytes_modifier is None:
+                raise Exception("Stateless input bytes modifier is required")
+            stateless_input_bytes = stateless_input_bytes_modifier(
+                stateless_input_bytes
+            )
+            (
+                stateless_input_bytes,
+                stateless_output_bytes,
+                successful_validation,
+            ) = rerun_amsterdam_stateless_guest_with_input_bytes(
+                fork=fork,
+                block_number=int(env.number),
+                timestamp=int(env.timestamp),
+                stateless_input_bytes=stateless_input_bytes,
+            )
+            stateless_output = decode_amsterdam_stateless_output(
+                fork=fork,
+                block_number=int(env.number),
+                timestamp=int(env.timestamp),
+                stateless_output_bytes=stateless_output_bytes,
+            )
+            final_successful_validation = successful_validation
+
+        if (
             expected_success is not None
-            and canonical_successful_validation != expected_success
+            and final_successful_validation != expected_success
         ):
             raise AssertionError(
-                "Canonical stateless guest validation result mismatch: "
-                f"got {canonical_successful_validation}, "
+                "Stateless guest validation result mismatch: "
+                f"got {final_successful_validation}, "
                 f"want {expected_success}"
             )
 
-        assert_amsterdam_stateless_output_chain_config(
-            block_number=int(env.number),
-            chain_id=self.chain_id,
-            stateless_output=stateless_output,
+        skip_chain_config_assertion = (
+            has_stateless_input_bytes_modifier
+            and stateless_output is not None
+            and is_invalid_stateless_input_sentinel(stateless_output)
         )
+        if not skip_chain_config_assertion:
+            assert_amsterdam_stateless_output_chain_config(
+                block_number=int(env.number),
+                chain_id=self.chain_id,
+                stateless_output=stateless_output,
+            )
 
         built_block = BuiltBlock(
             header=header,

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -219,13 +219,32 @@ class StatelessValidationResult:
     """
     Result returned by stateless validation.
 
-    Note: We use return values to denote "public inputs"
+    Note: We use return values to denote "public inputs".
+
+    If ``successful_validation`` is ``False``, the remaining fields are
+    only meaningful when the input bytes were decoded successfully. If
+    decoding failed before a ``StatelessInput`` existed,
+    ``run_stateless_guest`` returns a failed result with sentinel defaults.
 
     """
 
     new_payload_request_root: Hash32
+    """
+    SSZ root of the decoded ``NewPayloadRequest``. This is zero when
+    ``run_stateless_guest`` cannot decode the input bytes.
+    """
+
     successful_validation: bool
+    """
+    Whether the decoded stateless input validated successfully. ``False``
+    means validation failed or the guest input bytes could not be decoded.
+    """
+
     chain_config: ChainConfig
+    """
+    Chain configuration decoded from the input. This is a sentinel default
+    when ``run_stateless_guest`` cannot decode the input bytes.
+    """
 
 
 def compute_new_payload_request_root(

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -3,8 +3,15 @@ Stateless guest interfaces.
 """
 
 from ethereum_types.bytes import Bytes
+from ethereum_types.numeric import U64
+
+from ethereum.crypto.hash import Hash32
 
 from .stateless import (
+    ChainConfig,
+    ForkActivation,
+    ForkConfig,
+    ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
     verify_stateless_new_payload,
@@ -44,12 +51,37 @@ def deserialize_stateless_input(data: Bytes) -> StatelessInput:
     return ssz_to_stateless_input(ssz_obj)
 
 
+def _default_failed_stateless_output() -> StatelessValidationResult:
+    """
+    Return the sentinel result used when stateless input cannot be decoded.
+    """
+    return StatelessValidationResult(
+        new_payload_request_root=Hash32(b"\0" * 32),
+        successful_validation=False,
+        chain_config=ChainConfig(
+            chain_id=U64(0),
+            active_fork=ForkConfig(
+                fork=ProtocolFork.Frontier,
+                activation=ForkActivation(
+                    block_number=None,
+                    timestamp=None,
+                ),
+                blob_schedule=None,
+            ),
+        ),
+    )
+
+
 def run_stateless_guest(input_bytes: Bytes) -> Bytes:
     """
     Run the stateless guest with serialized input, return serialized output.
     """
-    stateless_input = deserialize_stateless_input(input_bytes)
-    stateless_output = verify_stateless_new_payload(stateless_input)
+    try:
+        stateless_input = deserialize_stateless_input(input_bytes)
+    except Exception:
+        stateless_output = _default_failed_stateless_output()
+    else:
+        stateless_output = verify_stateless_new_payload(stateless_input)
 
     output_bytes = serialize_stateless_output(stateless_output)
     return output_bytes

--- a/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
@@ -1,0 +1,102 @@
+"""Stateless input byte validation tests."""
+
+from typing import Callable
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytes,
+    Transaction,
+)
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+StatelessInputBytesModifier = Callable[[Bytes], Bytes]
+
+
+def empty_input_bytes(input_bytes: Bytes) -> Bytes:
+    """Replace stateless input bytes with empty input."""
+    del input_bytes
+    return Bytes(b"")
+
+
+def incomplete_schema_id(input_bytes: Bytes) -> Bytes:
+    """Keep only one byte of the schema id."""
+    return Bytes(input_bytes[:1])
+
+
+def unsupported_schema_id(input_bytes: Bytes) -> Bytes:
+    """Replace the schema id while keeping the SSZ body."""
+    return Bytes(b"\x00\x02" + input_bytes[2:])
+
+
+def missing_ssz_body(input_bytes: Bytes) -> Bytes:
+    """Keep only the schema id."""
+    return Bytes(input_bytes[:2])
+
+
+def truncated_ssz_body(input_bytes: Bytes) -> Bytes:
+    """Drop the final SSZ body byte."""
+    return Bytes(input_bytes[:-1])
+
+
+def trailing_garbage(input_bytes: Bytes) -> Bytes:
+    """Append extra bytes after the SSZ body."""
+    return Bytes(input_bytes + b"\x00")
+
+
+def invalid_first_ssz_offset(input_bytes: Bytes) -> Bytes:
+    """
+    Corrupt the first SSZ container offset.
+
+    The stateless input starts with a 2-byte schema id, followed by the
+    SSZ-encoded ``SszStatelessInput`` container. Its first four SSZ bytes
+    encode the offset to the first variable-size field. Setting that offset
+    to 1 makes it point inside the fixed-size section, so the SSZ decoder
+    must reject the input before stateless validation can run.
+    """
+    return Bytes(input_bytes[:2] + b"\x01\x00\x00\x00" + input_bytes[6:])
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        pytest.param(empty_input_bytes, id="empty_input_bytes"),
+        pytest.param(incomplete_schema_id, id="incomplete_schema_id"),
+        pytest.param(unsupported_schema_id, id="unsupported_schema_id"),
+        pytest.param(missing_ssz_body, id="missing_ssz_body"),
+        pytest.param(truncated_ssz_body, id="truncated_ssz_body"),
+        pytest.param(trailing_garbage, id="trailing_garbage"),
+        pytest.param(invalid_first_ssz_offset, id="invalid_first_ssz_offset"),
+    ],
+)
+def test_invalid_stateless_input_bytes_are_rejected(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    modifier: StatelessInputBytesModifier,
+) -> None:
+    """Invalid stateless input bytes fail guest validation."""
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    tx = Transaction(sender=sender, to=recipient, value=1, gas_limit=21_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                stateless_input_bytes_modifier=modifier,
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            recipient: Account(balance=1),
+        },
+    )

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -33,6 +33,7 @@ from ethereum.forks.amsterdam.stateless import (
 )
 from ethereum.forks.amsterdam.stateless_guest import (
     deserialize_stateless_input,
+    run_stateless_guest,
     serialize_stateless_output,
 )
 from ethereum.forks.amsterdam.stateless_host import (
@@ -340,6 +341,23 @@ class TestSerializeStatelessOutput:
         encoded = serialize_stateless_output(original)
         recovered = deserialize_stateless_output(encoded)
         assert recovered == original
+
+
+class TestRunStatelessGuest:
+    """Test stateless guest input and output handling."""
+
+    def test_invalid_input_bytes_return_failed_validation(self) -> None:
+        """Malformed input returns a failed result with sentinel fields."""
+        encoded = run_stateless_guest(Bytes(b""))
+        result = deserialize_stateless_output(encoded)
+
+        assert result.new_payload_request_root == Hash32(b"\0" * 32)
+        assert not result.successful_validation
+        assert result.chain_config.chain_id == U64(0)
+        assert result.chain_config.active_fork.fork == ProtocolFork.Frontier
+        assert result.chain_config.active_fork.activation.block_number is None
+        assert result.chain_config.active_fork.activation.timestamp is None
+        assert result.chain_config.active_fork.blob_schedule is None
 
 
 class TestComputeNewPayloadRequestRoot:


### PR DESCRIPTION
## 🗒️ Description
This PR:
- Spec:
  - Catch any exception during guest input SSZ decoding, and if so, properly return `stateless_validation=False`. `new_payload_request_root` and `chain_config` contain default values (zeroes) for this case.
- Testing:
  - Support a new `stateless_input_bytes_modifier` mutator for tests, which allows to arbitrarily mutate guest program inputs. This is a new tool for test writers.
  - Add proper tests to cover many cases reg invalid raw bytes stateless input e.g. missing/invalid/corrupted schema-id, missing/invalid SSZ bytes, trailing bytes, etc


## 🔗 Related Issues or PRs
https://github.com/ethereum/execution-specs/issues/2558

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
