### PR TITLE
feat(test-fill): align `fill-stateful` with `gas-benchmarks` implementation

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -7,6 +7,7 @@ from random import randint
 from typing import Any, Dict, Generator, Iterator, List, Literal, Tuple
 
 import pytest
+from ethereum.crypto.hash import keccak256
 from filelock import FileLock
 from pydantic import PrivateAttr
 
@@ -54,6 +55,11 @@ from .contracts import (
 )
 
 logger = get_logger(__name__)
+
+UNCACHED_EOA_BASE_KEY = int.from_bytes(
+    keccak256(b"gas-repricings-private-key"), "big"
+)
+UNCACHED_EOA_POOL_SIZE = 50_000
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -301,6 +307,7 @@ class Alloc(SharedAlloc):
     )
     _block_number: int = PrivateAttr()
     _timestamp: int = PrivateAttr()
+    _uncached_eoa_count: int = PrivateAttr(0)
 
     def __init__(
         self,
@@ -740,6 +747,21 @@ class Alloc(SharedAlloc):
             f"EOA {eoa} funding tx created (label={label}):"
             f"tx_nonce={eoa.nonce}, balance={balance_str}"
         )
+        return eoa
+
+    def uncached_eoa(self) -> EOA:
+        """
+        Return the next EOA from the session-funded uncached pool.
+
+        Pool accounts are untracked in the pre-allocation so they stay
+        out of the setup block and remain uncached on the client.
+        """
+        assert self._uncached_eoa_count < UNCACHED_EOA_POOL_SIZE, (
+            f"uncached EOA pool exhausted ({UNCACHED_EOA_POOL_SIZE} "
+            "accounts); increase UNCACHED_EOA_POOL_SIZE"
+        )
+        eoa = EOA(key=UNCACHED_EOA_BASE_KEY + self._uncached_eoa_count)
+        self._uncached_eoa_count += 1
         return eoa
 
     def _fund_address(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -337,27 +337,27 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
 
     def bump_block_gas_limit(
         self,
-        block_count: int,
+        target_gas_limit: int,
     ) -> List[EnginePayloadMetadata]:
         """
         Build empty block to increase the block gas limit to target.
         """
-        if block_count <= 0:
-            return []
         assert self.testing_rpc is not None, (
             "bump_block_gas_limit requires testing_rpc"
         )
         captured: List[EnginePayloadMetadata] = []
         with self.block_building_lock:
-            for _ in range(block_count):
-                head_block = self.get_block_by_number("latest")
-                assert head_block is not None
-                next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
+            head_block = self.get_block_by_number("latest")
+            assert head_block is not None
+            parent_hash = Hash(head_block["hash"])
+            parent_timestamp = int(HexNumber(head_block["timestamp"]))
+            gas_limit = int(HexNumber(head_block["gasLimit"]))
+            while gas_limit < target_gas_limit:
                 payload_attributes = self._payload_attributes(
-                    next_timestamp=next_timestamp,
+                    next_timestamp=parent_timestamp + 1,
                 )
                 new_payload = self.testing_rpc.build_block(
-                    parent_block_hash=Hash(head_block["hash"]),
+                    parent_block_hash=parent_hash,
                     payload_attributes=payload_attributes,
                     transactions=[],
                     extra_data=Bytes(b""),
@@ -368,6 +368,14 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                         payload_attributes.parent_beacon_block_root,
                     )
                 )
+                new_gas_limit = int(new_payload.execution_payload.gas_limit)
+                assert new_gas_limit > gas_limit, (
+                    f"block gas limit stalled at {new_gas_limit} before "
+                    f"reaching target {target_gas_limit};"
+                )
+                gas_limit = new_gas_limit
+                parent_hash = new_payload.execution_payload.block_hash
+                parent_timestamp = int(new_payload.execution_payload.timestamp)
         return captured
 
     def set_canonical_head(self, head_block_hash: Hash) -> None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -19,6 +19,7 @@ from execution_testing.base_types import (
 )
 from execution_testing.client_clis.cli_types import EnginePayloadMetadata
 from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks.transition_base_fork import TransitionBaseClass
 from execution_testing.rpc import EngineRPC, TestingRPC
 from execution_testing.rpc import EthRPC as BaseEthRPC
 from execution_testing.rpc.rpc_types import (
@@ -38,7 +39,10 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
     pending transactions or a block generation interval.
     """
 
-    fork: Fork | TransitionFork
+    fork: Fork
+    fcu_version: int
+    new_payload_version: int
+    get_payload_version: int
     engine_rpc: EngineRPC
     get_payload_wait_time: float
     block_building_lock: FileLock
@@ -63,7 +67,25 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             transaction_wait_timeout=transaction_wait_timeout,
             max_transactions_per_batch=max_transactions_per_batch,
         )
+        assert not issubclass(fork, TransitionBaseClass), (
+            "ChainBuilderEthRPC does not support transition forks"
+        )
         self.fork = fork
+        fcu_version = fork.engine_forkchoice_updated_version()
+        assert fcu_version is not None, (
+            "Fork does not support engine forkchoice_updated"
+        )
+        self.fcu_version = fcu_version
+        new_payload_version = fork.engine_new_payload_version()
+        assert new_payload_version is not None, (
+            "Fork does not support engine new_payload"
+        )
+        self.new_payload_version = new_payload_version
+        get_payload_version = fork.engine_get_payload_version()
+        assert get_payload_version is not None, (
+            "Fork does not support engine get_payload"
+        )
+        self.get_payload_version = get_payload_version
         self.engine_rpc = engine_rpc
         parsed = urlparse(rpc_endpoint)
         self.block_building_lock = FileLock(
@@ -87,26 +109,15 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                 # Get the head block hash
                 head_block = self.get_block_by_number("latest")
                 assert head_block is not None
-                block_number = HexNumber(head_block["number"])
-                timestamp = HexNumber(head_block["timestamp"])
-                head_fork = self.fork.fork_at(
-                    block_number=block_number, timestamp=timestamp
-                )
                 # Send initial forkchoice updated
                 forkchoice_state = ForkchoiceState(
                     head_block_hash=head_block["hash"],
-                )
-                forkchoice_version = (
-                    head_fork.engine_forkchoice_updated_version()
-                )
-                assert forkchoice_version is not None, (
-                    "Fork does not support engine forkchoice_updated"
                 )
                 for _ in range(initial_forkchoice_update_retries):
                     response = self.engine_rpc.forkchoice_updated(
                         forkchoice_state,
                         None,
-                        version=forkchoice_version,
+                        version=self.fcu_version,
                     )
                     if (
                         response.payload_status.status
@@ -137,9 +148,8 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         withdrawals: List[Withdrawal] | None = None,
     ) -> PayloadAttributes:
         """Build payload attributes for a block at ``next_timestamp``."""
-        next_fork = self.fork.fork_at(block_number=0, timestamp=next_timestamp)
         return PayloadAttributes.for_fork(
-            next_fork,
+            self.fork,
             timestamp=next_timestamp,
             withdrawals=withdrawals,
         )
@@ -164,40 +174,28 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             new_payload_args.append(parent_beacon_block_root)
         if payload.execution_requests is not None:
             new_payload_args.append(payload.execution_requests)
-        payload_fork = self.fork.fork_at(
-            block_number=payload.execution_payload.number,
-            timestamp=payload.execution_payload.timestamp,
-        )
-        new_payload_version = payload_fork.engine_new_payload_version()
-        assert new_payload_version is not None, (
-            "Fork does not support engine new_payload"
-        )
         new_payload_response = self.engine_rpc.new_payload(
-            *new_payload_args, version=new_payload_version
+            *new_payload_args, version=self.new_payload_version
         )
         assert new_payload_response.status == PayloadStatusEnum.VALID, (
             "Payload was invalid"
         )
 
-        fcu_version = payload_fork.engine_forkchoice_updated_version()
-        assert fcu_version is not None, (
-            "Fork does not support engine forkchoice_updated"
-        )
         new_forkchoice_state = ForkchoiceState(
             head_block_hash=(payload.execution_payload.block_hash),
         )
         response = self.engine_rpc.forkchoice_updated(
             new_forkchoice_state,
             None,
-            version=fcu_version,
+            version=self.fcu_version,
         )
         assert response.payload_status.status == PayloadStatusEnum.VALID, (
             "Payload was invalid"
         )
         return EnginePayloadMetadata(
             payload_response=payload,
-            new_payload_version=new_payload_version,
-            forkchoice_updated_version=fcu_version,
+            new_payload_version=self.new_payload_version,
+            forkchoice_updated_version=self.fcu_version,
             parent_beacon_block_root=parent_beacon_block_root,
         )
 
@@ -210,20 +208,13 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             head_block_hash=head_block["hash"],
         )
         next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
-        next_fork = self.fork.fork_at(block_number=0, timestamp=next_timestamp)
         payload_attributes = self._payload_attributes(
             next_timestamp=next_timestamp
-        )
-        forkchoice_updated_version = (
-            next_fork.engine_forkchoice_updated_version()
-        )
-        assert forkchoice_updated_version is not None, (
-            "Fork does not support engine forkchoice_updated"
         )
         response = self.engine_rpc.forkchoice_updated(
             forkchoice_state,
             payload_attributes,
-            version=forkchoice_updated_version,
+            version=self.fcu_version,
         )
         assert response.payload_status.status == PayloadStatusEnum.VALID, (
             "Payload was invalid"
@@ -232,13 +223,9 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             "payload_id was not returned by the client"
         )
         time.sleep(self.get_payload_wait_time)
-        get_payload_version = next_fork.engine_get_payload_version()
-        assert get_payload_version is not None, (
-            "Fork does not support engine get_payload"
-        )
         new_payload = self.engine_rpc.get_payload(
             response.payload_id,
-            version=get_payload_version,
+            version=self.get_payload_version,
         )
         self._finalize_payload(
             new_payload,
@@ -388,24 +375,13 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         Reorg the canonical head to head_block_hash via
         ``engine_forkchoiceUpdated``.
         """
-        head_block = self.get_block_by_hash(head_block_hash)
-        assert head_block is not None, (
-            f"cannot reset head to unknown block {head_block_hash}"
-        )
-        head_fork = self.fork.fork_at(
-            block_number=HexNumber(head_block["number"]),
-            timestamp=HexNumber(head_block["timestamp"]),
-        )
-        fcu_version = head_fork.engine_forkchoice_updated_version()
-        assert fcu_version is not None, (
-            "Fork does not support engine forkchoice_updated"
-        )
         response = self.engine_rpc.forkchoice_updated(
             ForkchoiceState(head_block_hash=head_block_hash),
             None,
-            version=fcu_version,
+            version=self.fcu_version,
         )
         assert response.payload_status.status == PayloadStatusEnum.VALID, (
             f"forkchoice_updated reset to {head_block_hash} was not VALID "
-            f"(got {response.payload_status.status})"
+            f"(got {response.payload_status.status}; SYNCING usually means "
+            "the block is unknown to the client)"
         )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -348,6 +348,41 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                 payload_attributes.parent_beacon_block_root,
             )
 
+    def bump_block_gas_limit(
+        self,
+        block_count: int,
+    ) -> List[EnginePayloadMetadata]:
+        """
+        Build empty block to increase the block gas limit to target.
+        """
+        if block_count <= 0:
+            return []
+        assert self.testing_rpc is not None, (
+            "bump_block_gas_limit requires testing_rpc"
+        )
+        captured: List[EnginePayloadMetadata] = []
+        with self.block_building_lock:
+            for _ in range(block_count):
+                head_block = self.get_block_by_number("latest")
+                assert head_block is not None
+                next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
+                payload_attributes = self._payload_attributes(
+                    next_timestamp=next_timestamp,
+                )
+                new_payload = self.testing_rpc.build_block(
+                    parent_block_hash=Hash(head_block["hash"]),
+                    payload_attributes=payload_attributes,
+                    transactions=[],
+                    extra_data=Bytes(b""),
+                )
+                captured.append(
+                    self._finalize_payload(
+                        new_payload,
+                        payload_attributes.parent_beacon_block_root,
+                    )
+                )
+        return captured
+
     def set_canonical_head(self, head_block_hash: Hash) -> None:
         """
         Reorg the canonical head to head_block_hash via

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -347,3 +347,30 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                 new_payload,
                 payload_attributes.parent_beacon_block_root,
             )
+
+    def set_canonical_head(self, head_block_hash: Hash) -> None:
+        """
+        Reorg the canonical head to head_block_hash via
+        ``engine_forkchoiceUpdated``.
+        """
+        head_block = self.get_block_by_hash(head_block_hash)
+        assert head_block is not None, (
+            f"cannot reset head to unknown block {head_block_hash}"
+        )
+        head_fork = self.fork.fork_at(
+            block_number=HexNumber(head_block["number"]),
+            timestamp=HexNumber(head_block["timestamp"]),
+        )
+        fcu_version = head_fork.engine_forkchoice_updated_version()
+        assert fcu_version is not None, (
+            "Fork does not support engine forkchoice_updated"
+        )
+        response = self.engine_rpc.forkchoice_updated(
+            ForkchoiceState(head_block_hash=head_block_hash),
+            None,
+            version=fcu_version,
+        )
+        assert response.payload_status.status == PayloadStatusEnum.VALID, (
+            f"forkchoice_updated reset to {head_block_hash} was not VALID "
+            f"(got {response.payload_status.status})"
+        )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -20,7 +20,6 @@ from typing import Any, Generator, List, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import pytest
-from ethereum.crypto.hash import keccak256
 from filelock import FileLock
 
 from execution_testing.base_types import (
@@ -47,6 +46,10 @@ from execution_testing.specs.blockchain import (
 from execution_testing.test_types import EOA
 
 from ..execute import contracts
+from ..execute.pre_alloc import (
+    UNCACHED_EOA_BASE_KEY,
+    UNCACHED_EOA_POOL_SIZE,
+)
 from ..execute.rpc.chain_builder_eth_rpc import ChainBuilderEthRPC
 from ..shared.benchmarking import default_environment, is_benchmark_item
 from ..shared.helpers import is_help_or_collectonly_mode
@@ -56,12 +59,8 @@ from .hive_session import configure_hive, teardown_hive
 # 1B ETH for seed account
 SEED_FUNDING_WEI = 10**9 * 10**18
 
-# 1 ETH per deterministic sender-pool account.
+# 1 ETH per uncached-pool account.
 POOL_FUNDING_WEI = 10**18
-
-SENDER_BASE_KEY = int.from_bytes(
-    keccak256(b"gas-repricings-private-key"), "big"
-)
 
 logger = get_logger(__name__)
 
@@ -124,17 +123,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help=(
             "Target block gas limit (raised pre-setup via empty blocks). "
             "Defaults to benchmark limit or environment default."
-        ),
-    )
-    group.addoption(
-        "--sender-pool-size",
-        action="store",
-        dest="sender_pool_size",
-        default=15000,
-        type=int,
-        help=(
-            "Sender-pool accounts to fund via CL withdrawals for 1 ETH"
-            "Default: 15000."
         ),
     )
     group.addoption(
@@ -468,19 +456,20 @@ def _session_pre_run(
             f"{len(bump_payloads)} empty blocks"
         )
 
-    # Fund the seed key and the deterministic sender pool
-    pool_size = request.config.getoption("sender_pool_size")
+    # Fund the seed key and the deterministic uncached-EOA pool
     funding_targets: List[Tuple[Address, int]] = [
         (Address(session_worker_key), SEED_FUNDING_WEI)
     ]
     funding_targets += [
-        (Address(EOA(key=SENDER_BASE_KEY + i)), POOL_FUNDING_WEI)
-        for i in range(pool_size)
+        (Address(EOA(key=UNCACHED_EOA_BASE_KEY + i)), POOL_FUNDING_WEI)
+        for i in range(UNCACHED_EOA_POOL_SIZE)
     ]
     fund_payload = eth_rpc.fund_via_withdrawals(funding_targets)
     if fund_payload is not None:
         captured.append(fund_payload)
-    logger.info(f"Funded seed key and {pool_size} sender pool accounts")
+    logger.info(
+        f"Funded seed key and {UNCACHED_EOA_POOL_SIZE} uncached pool accounts"
+    )
 
     # 4. Deploy deterministic factory if needed.
     lock_file = session_temp_folder / "fill_stateful_setup.lock"

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -48,6 +48,7 @@ from execution_testing.test_types import EOA
 
 from ..execute import contracts
 from ..execute.rpc.chain_builder_eth_rpc import ChainBuilderEthRPC
+from ..shared.benchmarking import default_environment, is_benchmark_item
 from ..shared.helpers import is_help_or_collectonly_mode
 from ..shared.live_client_flags import FEE_BUMP_MULTIPLIER
 from .hive_session import configure_hive, teardown_hive
@@ -115,15 +116,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
     group.addoption(
-        "--gas-bump-blocks",
+        "--block-gas-limit",
         action="store",
-        dest="gas_bump_blocks",
-        default=5000,
+        dest="block_gas_limit",
+        default=None,
         type=int,
         help=(
-            "Empty blocks at start to increase block gas limit."
-            "Each block increase ≤ parent_gas_limit/1024."
-            "Default: 5000 blocks."
+            "Target block gas limit (raised pre-setup via empty blocks). "
+            "Defaults to benchmark limit or environment default."
         ),
     )
     group.addoption(
@@ -412,6 +412,21 @@ def snapshot_block(
     return block
 
 
+@pytest.fixture(scope="session")
+def target_block_gas_limit(request: pytest.FixtureRequest) -> int:
+    """
+    Determine the block gas limit for the pre-setup ramping phase.
+
+    --block-gas-limit takes precedence if provided; otherwise, uses the
+    default gas limit from the env fixture
+    """
+    explicit = request.config.getoption("block_gas_limit")
+    if explicit is not None:
+        return explicit
+    benchmark = any(is_benchmark_item(item) for item in request.session.items)
+    return int(default_environment(benchmark=benchmark).gas_limit)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _session_pre_run(
     client_backend: ClientBackend,
@@ -421,6 +436,7 @@ def _session_pre_run(
     snapshot_block: Any,
     sender_funding_transactions_gas_price: int,
     session_temp_folder: Path,
+    target_block_gas_limit: int,
     request: pytest.FixtureRequest,
 ) -> None:
     """
@@ -443,14 +459,13 @@ def _session_pre_run(
 
     captured: List[EnginePayloadMetadata] = []
 
-    # Ramp gas limit (empty blocks) via empty blocks.
-    bump_payloads = eth_rpc.bump_block_gas_limit(
-        request.config.getoption("gas_bump_blocks")
-    )
+    # Ramp gas limit to the target by building empty blocks.
+    bump_payloads = eth_rpc.bump_block_gas_limit(target_block_gas_limit)
     captured.extend(bump_payloads)
     if bump_payloads:
         logger.info(
-            f"Ramped block gas limit with {len(bump_payloads)} empty blocks"
+            f"Ramped block gas limit to {target_block_gas_limit} with "
+            f"{len(bump_payloads)} empty blocks"
         )
 
     # Fund the seed key and the deterministic sender pool

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -118,6 +118,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
     group.addoption(
+        "--gas-bump-blocks",
+        action="store",
+        dest="gas_bump_blocks",
+        default=5000,
+        type=int,
+        help=(
+            "Empty blocks at start to increase block gas limit."
+            "Each block increase ≤ parent_gas_limit/1024."
+            "Default: 5000 blocks."
+        ),
+    )
+    group.addoption(
         "--snapshot-block",
         action="store",
         dest="snapshot_block",
@@ -562,32 +574,36 @@ def _session_pre_run(
     request: pytest.FixtureRequest,
 ) -> None:
     """
-    Session pre-run: capture snapshot, fund seed, deploy factory, capture
-    start block, write ``pre_run/<start_block_hash>.json``.
-
-    The file is named after the start block hash so per-test
-    ``BlockchainEngineStatefulFixture`` instances reference their setup
-    file implicitly via their own ``start_block_hash`` field — leaves
-    room for multiple pre-run files (e.g. different setup variants off
-    one snapshot) without coordinating filenames.
-
-    Pre-run helpers return their built ``EnginePayloadMetadata`` directly;
-    we collect them into ``captured`` and serialise via
-    ``payload_metadata_to_fixture``.
+    # 1. Snapshot anchor via client-returned hash (survives reorg).
+    # 2. Ramp gas limit with empty blocks before funding/setup.
+    # 3. Fund seed key via CL withdrawal.
+    # 4. Deploy deterministic factory if needed.
+    # 5. Capture start block (head after setup).
+    # 6. Write to pre_run/<start_block_hash>.json for implicit lookup.
     """
     if is_help_or_collectonly_mode(request.config):
         return
 
-    # 1. Snapshot anchor. Either way, the client-returned hash is what we
-    #    record — a later reorg can't silently re-anchor by block number.
+    # Anchor snapshot (client hash, reorg-safe).
     client_backend.snapshot_block = snapshot_block
     logger.info(
         f"Snapshot block {snapshot_block['number']} "
         f"hash={snapshot_block['hash'][:20]}..."
     )
 
-    # 2. Fund seed key via CL withdrawal; helper returns the built payload.
     captured: List[EnginePayloadMetadata] = []
+
+    # Ramp gas limit (empty blocks) via empty blocks.
+    bump_payloads = eth_rpc.bump_block_gas_limit(
+        request.config.getoption("gas_bump_blocks")
+    )
+    captured.extend(bump_payloads)
+    if bump_payloads:
+        logger.info(
+            f"Ramped block gas limit with {len(bump_payloads)} empty blocks"
+        )
+
+    # 3. Fund seed key via CL withdrawal.
     fund_payload = eth_rpc.fund_via_withdrawals(
         [(Address(session_worker_key), SEED_FUNDING_WEI)]
     )
@@ -595,7 +611,7 @@ def _session_pre_run(
         captured.append(fund_payload)
     logger.info(f"Funded {Address(session_worker_key)} via withdrawal")
 
-    # 3. Deploy deterministic factory if not already present.
+    # 4. Deploy deterministic factory if needed.
     lock_file = session_temp_folder / "fill_stateful_setup.lock"
     with FileLock(lock_file):
         if (
@@ -614,7 +630,7 @@ def _session_pre_run(
             )
             captured.extend(deploy_payloads)
 
-    # 4. Capture start block (head after global setup).
+    # 5. Capture start block.
     start_block = eth_rpc.get_block_by_number("latest")
     assert start_block is not None, "Failed to fetch start block"
     client_backend.start_block = start_block
@@ -623,9 +639,7 @@ def _session_pre_run(
         f"hash={start_block['hash'][:20]}..."
     )
 
-    # 5. Persist captured payloads to pre_run/<start_block_hash>.json.
-    #    Per-test fixtures already carry start_block_hash; naming the
-    #    pre-run file after that hash makes lookup a direct path build.
+    # Write pre_run/<start_block_hash>.json.
     if captured:
         output_dir = Path(request.config.getoption("output"))
         pre_run_dir = (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -16,10 +16,11 @@ setup-phase block prepended to ``self.blocks``.
 import os
 import secrets
 from pathlib import Path
-from typing import Any, Generator, List
+from typing import Any, Generator, List, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import pytest
+from ethereum.crypto.hash import keccak256
 from filelock import FileLock
 
 from execution_testing.base_types import (
@@ -61,9 +62,15 @@ from ..execute.rpc.hive import (
 from ..shared.helpers import is_help_or_collectonly_mode
 from ..shared.live_client_flags import FEE_BUMP_MULTIPLIER
 
-# 1 billion ETH. Withdrawals are Gwei (u64-capped); much higher risks
-# overflow on some clients, this is plenty for any single fill session.
+# 1B ETH for seed account
 SEED_FUNDING_WEI = 10**9 * 10**18
+
+# 1 ETH per deterministic sender-pool account.
+POOL_FUNDING_WEI = 10**18
+
+SENDER_BASE_KEY = int.from_bytes(
+    keccak256(b"gas-repricings-private-key"), "big"
+)
 
 logger = get_logger(__name__)
 
@@ -127,6 +134,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Empty blocks at start to increase block gas limit."
             "Each block increase ≤ parent_gas_limit/1024."
             "Default: 5000 blocks."
+        ),
+    )
+    group.addoption(
+        "--sender-pool-size",
+        action="store",
+        dest="sender_pool_size",
+        default=15000,
+        type=int,
+        help=(
+            "Sender-pool accounts to fund via CL withdrawals for 1 ETH"
+            "Default: 15000."
         ),
     )
     group.addoption(
@@ -603,13 +621,19 @@ def _session_pre_run(
             f"Ramped block gas limit with {len(bump_payloads)} empty blocks"
         )
 
-    # 3. Fund seed key via CL withdrawal.
-    fund_payload = eth_rpc.fund_via_withdrawals(
-        [(Address(session_worker_key), SEED_FUNDING_WEI)]
-    )
+    # Fund the seed key and the deterministic sender pool
+    pool_size = request.config.getoption("sender_pool_size")
+    funding_targets: List[Tuple[Address, int]] = [
+        (Address(session_worker_key), SEED_FUNDING_WEI)
+    ]
+    funding_targets += [
+        (Address(EOA(key=SENDER_BASE_KEY + i)), POOL_FUNDING_WEI)
+        for i in range(pool_size)
+    ]
+    fund_payload = eth_rpc.fund_via_withdrawals(funding_targets)
     if fund_payload is not None:
         captured.append(fund_payload)
-    logger.info(f"Funded {Address(session_worker_key)} via withdrawal")
+    logger.info(f"Funded seed key and {pool_size} sender pool accounts")
 
     # 4. Deploy deterministic factory if needed.
     lock_file = session_temp_folder / "fill_stateful_setup.lock"

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -41,7 +41,7 @@ from execution_testing.forks import (
     TransitionFork,
 )
 from execution_testing.logging import get_logger
-from execution_testing.rpc import DebugRPC, EngineRPC, EthRPC
+from execution_testing.rpc import EngineRPC, EthRPC
 from execution_testing.specs.blockchain import (
     payload_metadata_to_fixture,
 )
@@ -445,12 +445,6 @@ def max_gas_limit_per_test(
 
 
 @pytest.fixture(scope="session")
-def debug_rpc(eth_rpc: EthRPC) -> DebugRPC:
-    """DebugRPC on the same endpoint as eth_rpc (for debug_setHead)."""
-    return DebugRPC(eth_rpc.url)
-
-
-@pytest.fixture(scope="session")
 def client_backend(
     eth_rpc: ChainBuilderEthRPC,
     session_fork: Fork | TransitionFork,
@@ -693,35 +687,32 @@ def t8n(
 @pytest.fixture(autouse=True, scope="function")
 def _reset_chain_between_tests(
     client_backend: ClientBackend,
-    debug_rpc: DebugRPC,
     eth_rpc: "ChainBuilderEthRPC",
 ) -> Generator[None, None, None]:
     """
-    Rewind to start_block after each test so the chain is identical for
-    every fill. ``debug_setHead`` only takes a number, so after the
-    rewind we re-fetch ``latest`` and fail loudly if the hash drifted
-    (e.g. live reorg of a same-numbered block).
+    # Rewind to start_block after each test via engine_forkchoiceUpdated.
+    # Re-fetch latest and fail if hash drifted (detects live reorgs).
     """
     yield
     if client_backend.start_block is None:
         return
-    start_hex = client_backend.start_block["number"]
     expected_hash = client_backend.start_block["hash"]
-    # Skip when head already at start (geth rejects same-block setHead).
+
     current_head = eth_rpc.get_block_by_number("latest")
     if current_head is not None and current_head["hash"] == expected_hash:
         return
     try:
-        debug_rpc.set_head(start_hex)
+        eth_rpc.set_canonical_head(Hash(expected_hash))
     except Exception as e:
-        pytest.exit(f"debug_setHead failed — subsequent fixtures invalid: {e}")
+        pytest.exit(
+            f"forkchoice reset failed, subsequent fixtures invalid: {e}"
+        )
     head = eth_rpc.get_block_by_number("latest")
     if head is None or head["hash"] != expected_hash:
         observed = head["hash"] if head is not None else "<none>"
         pytest.exit(
-            f"debug_setHead landed on hash {observed} but expected "
-            f"{expected_hash} (start_block at number {start_hex}). The "
-            "live chain may have reorged out from under fill-stateful; "
-            "rerun against a quiescent client or use --snapshot-block "
-            "with an explicit hash."
+            f"forkchoice reset landed on hash {observed} but expected "
+            f"{expected_hash}. The live chain may have reorged out from "
+            "under fill-stateful; rerun against a quiescent client or use "
+            "--snapshot-block with an explicit hash."
         )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -37,30 +37,20 @@ from execution_testing.fixtures.blockchain import (
 )
 from execution_testing.forks import (
     Fork,
-    ForkSetAdapter,
-    InvalidForkError,
     TransitionFork,
 )
 from execution_testing.logging import get_logger
-from execution_testing.rpc import EngineRPC, EthRPC
+from execution_testing.rpc import EthRPC
 from execution_testing.specs.blockchain import (
     payload_metadata_to_fixture,
 )
 from execution_testing.test_types import EOA
-from execution_testing.test_types.chain_config_types import (
-    ChainConfigDefaults,
-)
 
 from ..execute import contracts
 from ..execute.rpc.chain_builder_eth_rpc import ChainBuilderEthRPC
-from ..execute.rpc.hive import (
-    build_client_files,
-    build_client_genesis_dict,
-    build_genesis_header,
-    build_hive_environment,
-)
 from ..shared.helpers import is_help_or_collectonly_mode
 from ..shared.live_client_flags import FEE_BUMP_MULTIPLIER
+from .hive_session import configure_hive, teardown_hive
 
 # 1B ETH for seed account
 SEED_FUNDING_WEI = 10**9 * 10**18
@@ -163,122 +153,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def _resolve_session_fork(
-    config: pytest.Config,
-) -> Fork | TransitionFork:
-    """
-    Resolve the single fork from ``--fork`` in hive mode.
-
-    Runs in ``pytest_configure`` before forks.py populates
-    ``selected_fork_set``, so we can't use ``session_fork`` here — the
-    hive genesis/ruleset must be built before remote.py's pytest_configure
-    pings the (not-yet-started) client.
-    """
-    fork_arg = config.getoption("single_fork", default="")
-    if not fork_arg:
-        pytest.exit(
-            "--fork is required in --hive-mode (single-fork only).",
-            returncode=pytest.ExitCode.USAGE_ERROR,
-        )
-    try:
-        fork_set = ForkSetAdapter.validate_python(fork_arg)
-    except InvalidForkError:
-        pytest.exit(
-            f"Unsupported fork provided to --fork: {fork_arg!r}",
-            returncode=pytest.ExitCode.USAGE_ERROR,
-        )
-    if len(fork_set) != 1:
-        pytest.exit(
-            f"Expected exactly one fork in --hive-mode, got {len(fork_set)} "
-            f"({sorted(f.name() for f in fork_set)}).",
-            returncode=pytest.ExitCode.USAGE_ERROR,
-        )
-    return next(iter(fork_set))
-
-
-def _hive_chain_id(config: pytest.Config) -> int:
-    """Resolve chain id from CLI/env, defaulting to ChainConfigDefaults."""
-    cli_value = config.getoption("chain_id", default=None)
-    if cli_value is not None:
-        return int(cli_value)
-    env_value = os.environ.get("CHAIN_ID")
-    if env_value is not None:
-        return int(env_value)
-    return ChainConfigDefaults.chain_id
-
-
-def _configure_hive(config: pytest.Config) -> None:
-    """
-    Start a hive simulator session and a single execution client, then
-    rewrite ``config.option`` so the rest of the plugin stack (remote.py
-    in particular) connects to the hive-managed client.
-    """
-    hive_simulator_url = config.getoption("hive_simulator")
-    if hive_simulator_url is None:
-        pytest.exit(
-            "The HIVE_SIMULATOR environment variable is not set.\n\n"
-            "If running locally, start hive in --dev mode, for example:\n"
-            "./hive --dev --client go-ethereum\n\n"
-            "and set the HIVE_SIMULATOR to the reported URL. For example, "
-            "in bash:\n"
-            "export HIVE_SIMULATOR=http://127.0.0.1:3000\n"
-            "or in fish:\n"
-            "set -x HIVE_SIMULATOR http://127.0.0.1:3000"
-        )
-    from hive.simulation import Simulation
-
-    session_fork = _resolve_session_fork(config)
-    chain_id = _hive_chain_id(config)
-
-    simulator = Simulation(url=hive_simulator_url)
-    suite = simulator.start_suite(
-        name="fill-stateful test suite",
-        description="Test suite used to drive a fill-stateful session",
-    )
-    config.hive_test_suite = suite  # type: ignore[attr-defined]
-    base_test = suite.start_test(
-        name="fill-stateful base test",
-        description=(
-            "Base test in the fill-stateful suite hosting the long-lived "
-            "execution client."
-        ),
-    )
-    config.hive_base_test = base_test  # type: ignore[attr-defined]
-
-    # base_pre=None: seed key funded via CL withdrawal and deterministic
-    # factory deployed on-chain by ``_session_pre_run``, so genesis only
-    # needs the fork's required system contracts.
-    pre_alloc, genesis_header = build_genesis_header(session_fork, None)
-    genesis_dict = build_client_genesis_dict(pre_alloc, genesis_header)
-
-    client_type = simulator.client_types()[0]
-    client = base_test.start_client(
-        client_type=client_type,
-        environment=build_hive_environment(session_fork, chain_id),
-        files=build_client_files(genesis_dict),
-    )
-    if client is None:
-        pytest.exit(
-            f"Unable to start hive client {client_type.name}. Check the "
-            "hive server logs for more information."
-        )
-    config.hive_client = client  # type: ignore[attr-defined]
-    logger.info(
-        f"Started hive client {client_type.name} at {client.ip} "
-        f"(fork={session_fork.name()}, chain_id={chain_id})"
-    )
-
-    config.option.rpc_endpoint = f"http://{client.ip}:8545"
-    config.option.engine_endpoint = f"http://{client.ip}:8551"
-    if (
-        config.getoption("engine_jwt_secret", default=None) is None
-        and config.getoption("engine_jwt_secret_file", default=None) is None
-    ):
-        config.option.engine_jwt_secret = EngineRPC.DEFAULT_JWT_SECRET
-    if config.getoption("chain_id", default=None) is None:
-        config.option.chain_id = chain_id
-
-
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config: pytest.Config) -> None:
     """
@@ -310,7 +184,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.hive_base_test = None  # type: ignore[attr-defined]
     config.hive_client = None  # type: ignore[attr-defined]
     if config.getoption("hive_mode", default=False):
-        _configure_hive(config)
+        configure_hive(config)
     else:
         if not config.getoption("rpc_endpoint", default=None):
             config.option.rpc_endpoint = "http://localhost:8545"
@@ -328,43 +202,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 def pytest_unconfigure(config: pytest.Config) -> None:
     """Tear down hive resources started in ``pytest_configure``."""
-    client = getattr(config, "hive_client", None)
-    if client is not None:
-        try:
-            client.stop()
-        except Exception as e:
-            logger.warning(f"Failed to stop hive client: {e}")
-        config.hive_client = None  # type: ignore[attr-defined]
-
-    base_test = getattr(config, "hive_base_test", None)
-    if base_test is not None:
-        from hive.testing import HiveTestResult
-
-        test_pass = (
-            getattr(config, "_fill_stateful_session_failed", False) is False
-        )
-        try:
-            base_test.end(
-                result=HiveTestResult(
-                    test_pass=test_pass,
-                    details=(
-                        "fill-stateful session complete"
-                        if test_pass
-                        else "fill-stateful session had failures"
-                    ),
-                )
-            )
-        except Exception as e:
-            logger.warning(f"Failed to end hive base test: {e}")
-        config.hive_base_test = None  # type: ignore[attr-defined]
-
-    suite = getattr(config, "hive_test_suite", None)
-    if suite is not None:
-        try:
-            suite.end()
-        except Exception as e:
-            logger.warning(f"Failed to end hive test suite: {e}")
-        config.hive_test_suite = None  # type: ignore[attr-defined]
+    teardown_hive(config)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
@@ -461,12 +299,6 @@ def max_gas_limit_per_test(
         return cli_value
     fork_at_genesis = session_fork.fork_at(block_number=0, timestamp=0)
     return fork_at_genesis.transaction_gas_limit_cap()
-
-
-# Other live-client fixtures (``max_transactions_per_batch``,
-# ``default_*``, fee fields, ``dry_run``, ...) come from
-# ``shared.live_client_flags``. ``skip_cleanup`` from ``execute.pre_alloc``;
-# we force it on in ``pytest_configure``.
 
 
 # ---------------------------------------------------------------------------

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/hive_session.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/hive_session.py
@@ -1,0 +1,180 @@
+"""
+Hive session bootstrap for the fill-stateful plugin.
+"""
+
+import os
+
+import pytest
+
+from execution_testing.forks import (
+    Fork,
+    ForkSetAdapter,
+    InvalidForkError,
+    TransitionFork,
+)
+from execution_testing.logging import get_logger
+from execution_testing.rpc import EngineRPC
+from execution_testing.test_types.chain_config_types import (
+    ChainConfigDefaults,
+)
+
+from ..execute.rpc.hive import (
+    build_client_files,
+    build_client_genesis_dict,
+    build_genesis_header,
+    build_hive_environment,
+)
+
+logger = get_logger(__name__)
+
+
+def _resolve_session_fork(
+    config: pytest.Config,
+) -> Fork | TransitionFork:
+    """
+    Resolve the single fork from ``--fork`` in hive mode.
+    """
+    fork_arg = config.getoption("single_fork", default="")
+    if not fork_arg:
+        pytest.exit(
+            "--fork is required in --hive-mode (single-fork only).",
+            returncode=pytest.ExitCode.USAGE_ERROR,
+        )
+    try:
+        fork_set = ForkSetAdapter.validate_python(fork_arg)
+    except InvalidForkError:
+        pytest.exit(
+            f"Unsupported fork provided to --fork: {fork_arg!r}",
+            returncode=pytest.ExitCode.USAGE_ERROR,
+        )
+    if len(fork_set) != 1:
+        pytest.exit(
+            f"Expected exactly one fork in --hive-mode, got {len(fork_set)} "
+            f"({sorted(f.name() for f in fork_set)}).",
+            returncode=pytest.ExitCode.USAGE_ERROR,
+        )
+    return next(iter(fork_set))
+
+
+def _hive_chain_id(config: pytest.Config) -> int:
+    """Resolve chain id from CLI/env, defaulting to ChainConfigDefaults."""
+    cli_value = config.getoption("chain_id", default=None)
+    if cli_value is not None:
+        return int(cli_value)
+    env_value = os.environ.get("CHAIN_ID")
+    if env_value is not None:
+        return int(env_value)
+    return ChainConfigDefaults.chain_id
+
+
+def configure_hive(config: pytest.Config) -> None:
+    """
+    Start a hive simulator session and a single execution client, then
+    rewrite ``config.option`` so the rest of the plugin stack (remote.py
+    in particular) connects to the hive-managed client.
+    """
+    hive_simulator_url = config.getoption("hive_simulator")
+    if hive_simulator_url is None:
+        pytest.exit(
+            "The HIVE_SIMULATOR environment variable is not set.\n\n"
+            "If running locally, start hive in --dev mode, for example:\n"
+            "./hive --dev --client go-ethereum\n\n"
+            "and set the HIVE_SIMULATOR to the reported URL. For example, "
+            "in bash:\n"
+            "export HIVE_SIMULATOR=http://127.0.0.1:3000\n"
+            "or in fish:\n"
+            "set -x HIVE_SIMULATOR http://127.0.0.1:3000"
+        )
+    from hive.simulation import Simulation
+
+    session_fork = _resolve_session_fork(config)
+    chain_id = _hive_chain_id(config)
+
+    simulator = Simulation(url=hive_simulator_url)
+    suite = simulator.start_suite(
+        name="fill-stateful test suite",
+        description="Test suite used to drive a fill-stateful session",
+    )
+    config.hive_test_suite = suite  # type: ignore[attr-defined]
+    base_test = suite.start_test(
+        name="fill-stateful base test",
+        description=(
+            "Base test in the fill-stateful suite hosting the long-lived "
+            "execution client."
+        ),
+    )
+    config.hive_base_test = base_test  # type: ignore[attr-defined]
+
+    # base_pre=None: seed key funded via CL withdrawal and deterministic
+    # factory deployed on-chain by ``_session_pre_run``, so genesis only
+    # needs the fork's required system contracts.
+    pre_alloc, genesis_header = build_genesis_header(session_fork, None)
+    genesis_dict = build_client_genesis_dict(pre_alloc, genesis_header)
+
+    client_type = simulator.client_types()[0]
+    client = base_test.start_client(
+        client_type=client_type,
+        environment=build_hive_environment(session_fork, chain_id),
+        files=build_client_files(genesis_dict),
+    )
+    if client is None:
+        pytest.exit(
+            f"Unable to start hive client {client_type.name}. Check the "
+            "hive server logs for more information."
+        )
+    config.hive_client = client  # type: ignore[attr-defined]
+    logger.info(
+        f"Started hive client {client_type.name} at {client.ip} "
+        f"(fork={session_fork.name()}, chain_id={chain_id})"
+    )
+
+    config.option.rpc_endpoint = f"http://{client.ip}:8545"
+    config.option.engine_endpoint = f"http://{client.ip}:8551"
+    if (
+        config.getoption("engine_jwt_secret", default=None) is None
+        and config.getoption("engine_jwt_secret_file", default=None) is None
+    ):
+        config.option.engine_jwt_secret = EngineRPC.DEFAULT_JWT_SECRET
+    if config.getoption("chain_id", default=None) is None:
+        config.option.chain_id = chain_id
+
+
+def teardown_hive(config: pytest.Config) -> None:
+    """Tear down hive resources started in ``configure_hive``."""
+    client = getattr(config, "hive_client", None)
+    if client is not None:
+        try:
+            client.stop()
+        except Exception as e:
+            logger.warning(f"Failed to stop hive client: {e}")
+        config.hive_client = None  # type: ignore[attr-defined]
+
+    base_test = getattr(config, "hive_base_test", None)
+    if base_test is not None:
+        from hive.testing import HiveTestResult
+
+        test_pass = (
+            getattr(config, "_fill_stateful_session_failed", False) is False
+        )
+        try:
+            base_test.end(
+                result=HiveTestResult(
+                    test_pass=test_pass,
+                    details=(
+                        "fill-stateful session complete"
+                        if test_pass
+                        else "fill-stateful session had failures"
+                    ),
+                )
+            )
+        except Exception as e:
+            logger.warning(f"Failed to end hive base test: {e}")
+        config.hive_base_test = None  # type: ignore[attr-defined]
+
+    suite = getattr(config, "hive_test_suite", None)
+    if suite is not None:
+        try:
+            suite.end()
+        except Exception as e:
+            logger.warning(f"Failed to end hive test suite: {e}")
+        config.hive_test_suite = None  # type: ignore[attr-defined]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -546,23 +546,26 @@ BENCHMARKING_MAX_GAS = 1_000_000_000_000
 BENCHMARK_DIR = Path("tests") / "benchmark"
 
 
-def _is_benchmark_test(request: pytest.FixtureRequest) -> bool:
-    """Check if the test is under the benchmark directory."""
-    benchmark_path = Path(request.config.rootpath) / BENCHMARK_DIR
-    return benchmark_path in Path(request.node.fspath).parents
+def is_benchmark_item(item: pytest.Item) -> bool:
+    """Check if the collected item is benchmark test."""
+    benchmark_path = Path(item.config.rootpath) / BENCHMARK_DIR
+    return benchmark_path in Path(item.fspath).parents
+
+
+def default_environment(*, benchmark: bool) -> Environment:
+    """Return the configured test Environment."""
+    if benchmark:
+        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
+    return Environment()
 
 
 @pytest.fixture
 def genesis_environment(request: pytest.FixtureRequest) -> Environment:
     """Return an Environment with appropriate gas limit."""
-    if _is_benchmark_test(request):
-        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
-    return Environment()
+    return default_environment(benchmark=is_benchmark_item(request.node))
 
 
 @pytest.fixture
 def env(request: pytest.FixtureRequest) -> Environment:
     """Return an Environment with appropriate gas limit."""
-    if _is_benchmark_test(request):
-        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
-    return Environment()
+    return default_environment(benchmark=is_benchmark_item(request.node))

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -281,10 +281,12 @@ class ClientBackend:
     def _fetch_receipts(
         self, txs: List[Transaction]
     ) -> List[TransactionReceipt]:
-        """Fetch receipts for each transaction. TODO: batch via JSON-RPC."""
+        """Fetch receipts for all block txs in one JSON-RPC batch."""
+        receipts_data = self.eth_rpc.get_transaction_receipts(
+            [tx.hash for tx in txs]
+        )
         receipts: List[TransactionReceipt] = []
-        for tx in txs:
-            receipt_data = self.eth_rpc.get_transaction_receipt(tx.hash)
+        for tx, receipt_data in zip(txs, receipts_data, strict=True):
             if receipt_data is None:
                 raise RuntimeError(
                     f"No receipt found for transaction {tx.hash}"

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -780,6 +780,30 @@ class EthRPC(BaseRPC):
             )
         ).result_or_raise()
 
+    def get_transaction_receipts(
+        self, transaction_hashes: Sequence[Hash]
+    ) -> List[dict[str, Any] | None]:
+        """
+        Get transaction receipts for a list of transaction hashes.
+        Use batch requests to avoid RPC overload.
+        """
+        if not transaction_hashes:
+            return []
+        receipts: List[dict[str, Any] | None] = []
+        batch_size = self.max_transactions_per_batch
+        for i in range(0, len(transaction_hashes), batch_size):
+            chunk = transaction_hashes[i : i + batch_size]
+            calls = [
+                RPCCall(
+                    method="getTransactionReceipt",
+                    params=[f"{tx_hash}"],
+                )
+                for tx_hash in chunk
+            ]
+            responses = self.post_batch_request(calls=calls)
+            receipts.extend(r.result_or_raise() for r in responses)
+        return receipts
+
     def get_storage_at(
         self,
         address: Address,

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -497,3 +497,9 @@ class Alloc(BaseAlloc):
         raise NotImplementedError(
             "nonexistent_account is not implemented in the base class"
         )
+
+    def uncached_eoa(self) -> EOA:
+        """Return the next EOA from the session-funded uncached pool."""
+        raise NotImplementedError(
+            "uncached_eoa is not implemented in the base class"
+        )

--- a/tests/benchmark/stateful/bloatnet/test_transaction_types.py
+++ b/tests/benchmark/stateful/bloatnet/test_transaction_types.py
@@ -6,7 +6,6 @@ from typing import Generator
 import pytest
 from execution_testing import (
     DETERMINISTIC_FACTORY_ADDRESS,
-    EOA,
     Address,
     Alloc,
     BenchmarkTestFiller,
@@ -16,21 +15,7 @@ from execution_testing import (
     Transaction,
     compute_create2_address,
     compute_create_address,
-    keccak256,
 )
-
-# Deterministic sender pool of 15K accounts.
-# Funded via system contract withdrawals (funding.txt) in payload generation.
-# Placed outside pre-allocation to ensure accounts remain uncached.
-SENDER_BASE_KEY = int.from_bytes(
-    keccak256(b"gas-repricings-private-key"), "big"
-)
-
-
-def yield_distinct_sender() -> Generator[EOA, None, None]:
-    """Yield deterministic sender EOAs pre-funded on-chain."""
-    for i in itertools.count(0):
-        yield EOA(key=SENDER_BASE_KEY + i)
 
 
 def build_unique_contract_initcode() -> bytes:
@@ -158,7 +143,6 @@ def test_ether_transfers_onchain_receivers(
     - diff_to_unique_code_jumpdest_contract: distinct CREATE2 contract
       receivers each holding unique deployed code
     """
-    senders = yield_distinct_sender()
     receiver_execution_gas = 0
     if case_id == "diff_to_nonexistent":
         receivers = yield_distinct_nonexistent_receiver()
@@ -194,7 +178,7 @@ def test_ether_transfers_onchain_receivers(
             to=next(receivers),
             value=transfer_amount,
             gas_limit=iteration_cost,
-            sender=next(senders),
+            sender=pre.uncached_eoa(),
         )
         for _ in range(iteration_count)
     ]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add a few features & refactors to the stateful filling implementation.

### Commit [d198221](https://github.com/ethereum/execution-specs/pull/2923/commits/d19822166524b988556274907a73055aea93bc69): Replace `debug_setHead` with FCU approach.

`debug_setHead` only supports in Geth, Besu and Erigon. Nethermind implements `debug_resetHead` that takes block hash as input. Reth has the method registered but not implemented ([Link](https://github.com/paradigmxyz/reth/blob/fd96cb2bd65023a0b8cc1ee328f325e64f65ebb1/crates/rpc/rpc/src/debug.rs#L1112)), Nimbus comments out the method ([Link](https://github.com/status-im/nimbus-eth1/blob/375f43fd6336feaf706bdf2c845365645356b8d2/execution_chain/rpc/debug.nim#L158)), no implementation either.

Consider some features (e.g., built-in opcode tracing) is now only supported in Nethermind master branch, this PR changes the `debug_setHead` to FCU version, in order to set the canonical chain.

### Commit [0252bec](https://github.com/ethereum/execution-specs/pull/2923/commits/0252bec93f69e85d35db564bc7493f28b2948268): Add a new CLI flag `--gas-bump-blocks`.

For perf-devnet-3 snapshot, we need to bump the block gas limit to ~1T block gas limit. This is done by sending empty blocks in gas-benchmarks. User could use `--gas-bump-blocks` to assign number of empty block to increase the block gas limit. 

In gas-benchmarks, we send 5000 empty blocks to bump the block gas limit for perf-devnet-3. For Jochmnet, we do not need to bump the gas limit, as the block gas limit is already high enough (~1 gigagas).

### Commit [05f3c16](https://github.com/ethereum/execution-specs/pull/2923/commits/05f3c16b2af478e5a87701aa3a732efb9d15f2d4): Add deterministic sender pooling.

For `test_ether_transfers_onchain_receivers` benchmark, to prevent the sender account being cached, we pre-fund the account via CL withdrawal. We inject 15K withdrawal into funding phase, starting with this pk range:

```python
SENDER_BASE_KEY = int.from_bytes(
    keccak256(b"gas-repricings-private-key"), "big"
)
```

### Commit [54f43ad](https://github.com/ethereum/execution-specs/pull/2923/commits/54f43ad277880bf82f0e9c506249df2b6ef5534c): Batch tx receipt request

Batch tx receipt RPC request, to avoid large amount of RPC request at the same time. This was a bottleneck in the past when using gas-benchmarks.

### Commit [8477bfe](https://github.com/ethereum/execution-specs/pull/2923/commits/8477bfe48b8eaeebd7727bf0efc5d3626ce40d2e): refactor `fill_stateful.py` 

Split the hive setup version from the original `fill_stateful.py` file, to keep the file small and focus on the filler feature.

These senders are then consumed by `test_ether_transfers_onchain_receivers`, this aligns changes in gas-benchmarks PR https://github.com/NethermindEth/gas-benchmarks/pull/146

### Verification
Verify the test via Hive mode, works successfully.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Issue https://github.com/ethereum/execution-specs/issues/2910

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
