### PR TITLE
feat(zkevm): prune non scheduled forks in ProtocolFork

### DIFF
--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -91,7 +91,7 @@ class ProtocolFork(StrEnum):
     TangerineWhistle = "TangerineWhistle"
     SpuriousDragon = "SpuriousDragon"
     Byzantium = "Byzantium"
-    ConstantinopleFix = "ConstantinopleFix"
+    StPetersburg = "StPetersburg"
     Istanbul = "Istanbul"
     MuirGlacier = "MuirGlacier"
     Berlin = "Berlin"

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -91,7 +91,6 @@ class ProtocolFork(StrEnum):
     TangerineWhistle = "TangerineWhistle"
     SpuriousDragon = "SpuriousDragon"
     Byzantium = "Byzantium"
-    Constantinople = "Constantinople"
     ConstantinopleFix = "ConstantinopleFix"
     Istanbul = "Istanbul"
     MuirGlacier = "MuirGlacier"
@@ -106,9 +105,6 @@ class ProtocolFork(StrEnum):
     Osaka = "Osaka"
     BPO1 = "BPO1"
     BPO2 = "BPO2"
-    BPO3 = "BPO3"
-    BPO4 = "BPO4"
-    BPO5 = "BPO5"
     Amsterdam = "Amsterdam"
 
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -212,8 +212,7 @@ ProtocolFork.DAOFork
 ProtocolFork.TangerineWhistle
 ProtocolFork.SpuriousDragon
 ProtocolFork.Byzantium
-ProtocolFork.Constantinople
-ProtocolFork.ConstantinopleFix
+ProtocolFork.StPetersburg
 ProtocolFork.Istanbul
 ProtocolFork.MuirGlacier
 ProtocolFork.Berlin


### PR DESCRIPTION
## 🗒️ Description
Remove `BPO{3,4,5}` from the enum since those aren't scheduled, and might not even apply to specs in the `amsterdam` folder. Also only leave a single Constantinople reference (although any fork before Amsterdam doesn't apply much to guest programs, but still).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
