### PR TITLE
feat(tests): EIP-4844 point evaluation -G1 and G1 doubling vectors

### DIFF
--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -3,6 +3,13 @@
 from typing import Literal
 
 INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
+# BLS12-381 G1 generator in compressed form (48 bytes, big-endian).
+G1_GENERATOR = bytes.fromhex(
+    "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac58"
+    "6c55e83ff97a1aeffb3af00adb22c6bb"
+)
+# Negation flips the y-sign bit (0x20) in the leading byte.
+NEG_G1_GENERATOR = bytes([G1_GENERATOR[0] ^ 0x20]) + G1_GENERATOR[1:]
 Z = 0x623CE31CF9759A5C8DAF3A357992F9F3DD7F9339D8998BC8E68373E54F00B75E
 Z_Y_INVALID_ENDIANNESS: Literal["little", "big"] = "little"
 Z_Y_VALID_ENDIANNESS: Literal["little", "big"] = "big"

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -55,7 +55,13 @@ from execution_testing import (
     call_return_code,
 )
 
-from .common import INF_POINT, Z_Y_VALID_ENDIANNESS, Z
+from .common import (
+    G1_GENERATOR,
+    INF_POINT,
+    NEG_G1_GENERATOR,
+    Z_Y_VALID_ENDIANNESS,
+    Z,
+)
 from .spec import Spec, ref_spec_4844
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_4844.git_path
@@ -405,6 +411,25 @@ def test_valid_inputs(
             INF_POINT,
             Spec.kzg_to_versioned_hash(INF_POINT, 0xFF),
             id="correct_proof_1_incorrect_versioned_hash_version_0xff",
+        ),
+        # Proof is the negation of G1_generator.
+        pytest.param(
+            0,
+            0,
+            G1_GENERATOR,
+            NEG_G1_GENERATOR,
+            None,
+            id="proof_neg_g1_generator",
+        ),
+        # P+P doubling in the final G1 add: verifier computes
+        # `C - [y]_1 = [-1]_1 + [-1]_1`, forcing the doubling path.
+        pytest.param(
+            0,
+            1,
+            NEG_G1_GENERATOR,
+            INF_POINT,
+            None,
+            id="g1_doubling_in_final_add",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description

Add two failure cases to test_invalid_inputs:

- proof_neg_g1_generator: `proof = -G1_generator`.
- g1_doubling_in_final_add: `z=0, y=1, proof=G1_infinity, commitment=-G1_generator`; verifier computes `C - [y]_1 = [-1]_1 + [-1]_1`, forcing the P+P doubling path.

## 🔗 Related Issues or PRs

Closes #2909.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.