### PR TITLE
refactor(src,tests): fix spelling error. KECCACK => KECCAK

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/constantinople/eip_1014.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/constantinople/eip_1014.py
@@ -26,7 +26,7 @@ class EIP1014(BaseFork):
 
         init_code_size = metadata["init_code_size"]
         init_code_words = (init_code_size + 31) // 32
-        hash_gas = gas_costs.OPCODE_KECCACK256_PER_WORD * init_code_words
+        hash_gas = gas_costs.OPCODE_KECCAK256_PER_WORD * init_code_words
 
         return gas_costs.OPCODE_CREATE_BASE + hash_gas
 

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -189,7 +189,7 @@ class Frontier(
             OPCODE_LOG_DATA_PER_BYTE=8,
             OPCODE_LOG_TOPIC=375,
             OPCODE_KECCAK256_BASE=30,
-            OPCODE_KECCACK256_PER_WORD=6,
+            OPCODE_KECCAK256_PER_WORD=6,
             # Zero-initialized: introduced in later forks, set via
             # replace() in the fork that activates them.
             TX_DATA_TOKEN_STANDARD=0,
@@ -376,7 +376,7 @@ class Frontier(
             Opcodes.SHA3: cls._with_memory_expansion(
                 lambda op: (
                     gas_costs.OPCODE_KECCAK256_BASE
-                    + gas_costs.OPCODE_KECCACK256_PER_WORD
+                    + gas_costs.OPCODE_KECCAK256_PER_WORD
                     * ((op.metadata["data_size"] + 31) // 32)
                 ),
                 memory_expansion_calculator,

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -136,7 +136,7 @@ class GasCosts:
     OPCODE_LOG_DATA_PER_BYTE: int
     OPCODE_LOG_TOPIC: int
     OPCODE_KECCAK256_BASE: int
-    OPCODE_KECCACK256_PER_WORD: int
+    OPCODE_KECCAK256_PER_WORD: int
 
     # Defined post-Frontier
     OPCODE_SHL: int = 0

--- a/packages/testing/src/execution_testing/forks/tests/test_opcode_gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_opcode_gas_costs.py
@@ -63,7 +63,7 @@ from ..helpers import Fork
             Osaka,
             Op.SHA3(data_size=64, new_memory_size=96),
             Osaka.gas_costs().OPCODE_KECCAK256_BASE
-            + Osaka.gas_costs().OPCODE_KECCACK256_PER_WORD * 2
+            + Osaka.gas_costs().OPCODE_KECCAK256_PER_WORD * 2
             + Osaka.memory_expansion_gas_calculator()(new_bytes=96),
             id="sha3_with_data_and_memory",
         ),
@@ -279,7 +279,7 @@ from ..helpers import Fork
             Op.CREATE2(init_code_size=64, new_memory_size=64),
             Osaka.gas_costs().OPCODE_CREATE_BASE
             + Osaka.gas_costs().CODE_INIT_PER_WORD * 2
-            + Osaka.gas_costs().OPCODE_KECCACK256_PER_WORD * 2
+            + Osaka.gas_costs().OPCODE_KECCAK256_PER_WORD * 2
             + Osaka.memory_expansion_gas_calculator()(new_bytes=64),
             id="create2_with_initcode_and_hash",
         ),

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -189,7 +189,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/amsterdam/vm/instructions/keccak.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -222,7 +222,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/arrow_glacier/vm/gas.py
+++ b/src/ethereum/forks/arrow_glacier/vm/gas.py
@@ -153,7 +153,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/berlin/vm/gas.py
+++ b/src/ethereum/forks/berlin/vm/gas.py
@@ -153,7 +153,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/berlin/vm/instructions/keccak.py
+++ b/src/ethereum/forks/berlin/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/berlin/vm/instructions/system.py
+++ b/src/ethereum/forks/berlin/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -181,7 +181,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/bpo1/vm/instructions/keccak.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/bpo1/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/system.py
@@ -210,7 +210,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -181,7 +181,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/bpo2/vm/instructions/keccak.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/bpo2/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/system.py
@@ -209,7 +209,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -181,7 +181,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/bpo3/vm/instructions/keccak.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/bpo3/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/system.py
@@ -209,7 +209,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -181,7 +181,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/bpo4/vm/instructions/keccak.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/bpo4/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/system.py
@@ -210,7 +210,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -181,7 +181,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/bpo5/vm/instructions/keccak.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/bpo5/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/system.py
@@ -210,7 +210,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/byzantium/vm/gas.py
+++ b/src/ethereum/forks/byzantium/vm/gas.py
@@ -143,7 +143,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/byzantium/vm/instructions/keccak.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/cancun/vm/gas.py
+++ b/src/ethereum/forks/cancun/vm/gas.py
@@ -167,7 +167,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/cancun/vm/instructions/keccak.py
+++ b/src/ethereum/forks/cancun/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/cancun/vm/instructions/system.py
+++ b/src/ethereum/forks/cancun/vm/instructions/system.py
@@ -208,7 +208,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/constantinople/vm/gas.py
+++ b/src/ethereum/forks/constantinople/vm/gas.py
@@ -147,7 +147,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/constantinople/vm/instructions/keccak.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/constantinople/vm/instructions/system.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/dao_fork/vm/gas.py
+++ b/src/ethereum/forks/dao_fork/vm/gas.py
@@ -138,7 +138,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(10)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/dao_fork/vm/instructions/keccak.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/frontier/vm/gas.py
+++ b/src/ethereum/forks/frontier/vm/gas.py
@@ -136,7 +136,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(10)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/forks/frontier/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/gray_glacier/vm/gas.py
+++ b/src/ethereum/forks/gray_glacier/vm/gas.py
@@ -153,7 +153,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/gray_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/homestead/vm/gas.py
+++ b/src/ethereum/forks/homestead/vm/gas.py
@@ -138,7 +138,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(10)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/homestead/vm/instructions/keccak.py
+++ b/src/ethereum/forks/homestead/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/istanbul/vm/gas.py
+++ b/src/ethereum/forks/istanbul/vm/gas.py
@@ -150,7 +150,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/istanbul/vm/instructions/keccak.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/istanbul/vm/instructions/system.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/london/vm/gas.py
+++ b/src/ethereum/forks/london/vm/gas.py
@@ -153,7 +153,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/london/vm/instructions/keccak.py
+++ b/src/ethereum/forks/london/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/london/vm/instructions/system.py
+++ b/src/ethereum/forks/london/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/muir_glacier/vm/gas.py
+++ b/src/ethereum/forks/muir_glacier/vm/gas.py
@@ -150,7 +150,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/muir_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/system.py
@@ -193,7 +193,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -181,7 +181,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/osaka/vm/instructions/keccak.py
+++ b/src/ethereum/forks/osaka/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/osaka/vm/instructions/system.py
+++ b/src/ethereum/forks/osaka/vm/instructions/system.py
@@ -210,7 +210,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/paris/vm/gas.py
+++ b/src/ethereum/forks/paris/vm/gas.py
@@ -153,7 +153,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/paris/vm/instructions/keccak.py
+++ b/src/ethereum/forks/paris/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/paris/vm/instructions/system.py
+++ b/src/ethereum/forks/paris/vm/instructions/system.py
@@ -192,7 +192,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost,
     )
 

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -176,7 +176,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/prague/vm/instructions/keccak.py
+++ b/src/ethereum/forks/prague/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/prague/vm/instructions/system.py
+++ b/src/ethereum/forks/prague/vm/instructions/system.py
@@ -209,7 +209,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/shanghai/vm/gas.py
+++ b/src/ethereum/forks/shanghai/vm/gas.py
@@ -155,7 +155,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/shanghai/vm/instructions/keccak.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/shanghai/vm/instructions/system.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/system.py
@@ -207,7 +207,7 @@ def create2(evm: Evm) -> None:
     charge_gas(
         evm,
         GasCosts.OPCODE_CREATE_BASE
-        + GasCosts.OPCODE_KECCACK256_PER_WORD * call_data_words
+        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
     )

--- a/src/ethereum/forks/spurious_dragon/vm/gas.py
+++ b/src/ethereum/forks/spurious_dragon/vm/gas.py
@@ -136,7 +136,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/keccak.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/gas.py
@@ -136,7 +136,7 @@ class GasCosts:
     OPCODE_EXP_BASE: Final[Uint] = Uint(10)
     OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(10)
     OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCACK256_PER_WORD: Final[Uint] = Uint(6)
+    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
     OPCODE_LOG_BASE: Final[Uint] = Uint(375)
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/keccak.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/keccak.py
@@ -45,7 +45,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCACK256_PER_WORD * words
+    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The gas constant for `OPCODE_KECCAK256_PER_WORD` was misspelt as `OPCODE_KECCACK256_PER_WORD`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/60088/pexels-photo-60088.jpeg)
