### PR TITLE
feat(test): add besu main overflow test

### DIFF
--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -562,7 +563,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -586,6 +587,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/arrow_glacier/state_tracker.py
+++ b/src/ethereum/forks/arrow_glacier/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/berlin/state_tracker.py
+++ b/src/ethereum/forks/berlin/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/bpo1/state_tracker.py
+++ b/src/ethereum/forks/bpo1/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/bpo2/state_tracker.py
+++ b/src/ethereum/forks/bpo2/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/bpo3/state_tracker.py
+++ b/src/ethereum/forks/bpo3/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/bpo4/state_tracker.py
+++ b/src/ethereum/forks/bpo4/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/bpo5/state_tracker.py
+++ b/src/ethereum/forks/bpo5/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/byzantium/state_tracker.py
+++ b/src/ethereum/forks/byzantium/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/cancun/state_tracker.py
+++ b/src/ethereum/forks/cancun/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/constantinople/state_tracker.py
+++ b/src/ethereum/forks/constantinople/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/dao_fork/state_tracker.py
+++ b/src/ethereum/forks/dao_fork/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/frontier/state_tracker.py
+++ b/src/ethereum/forks/frontier/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/gray_glacier/state_tracker.py
+++ b/src/ethereum/forks/gray_glacier/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/homestead/state_tracker.py
+++ b/src/ethereum/forks/homestead/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/istanbul/state_tracker.py
+++ b/src/ethereum/forks/istanbul/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/london/state_tracker.py
+++ b/src/ethereum/forks/london/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/muir_glacier/state_tracker.py
+++ b/src/ethereum/forks/muir_glacier/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/osaka/state_tracker.py
+++ b/src/ethereum/forks/osaka/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/paris/state_tracker.py
+++ b/src/ethereum/forks/paris/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -559,7 +560,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -583,6 +584,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/prague/state_tracker.py
+++ b/src/ethereum/forks/prague/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -542,7 +543,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -566,6 +567,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/shanghai/state_tracker.py
+++ b/src/ethereum/forks/shanghai/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -559,7 +560,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -583,6 +584,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/spurious_dragon/state_tracker.py
+++ b/src/ethereum/forks/spurious_dragon/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/src/ethereum/forks/tangerine_whistle/state_tracker.py
+++ b/src/ethereum/forks/tangerine_whistle/state_tracker.py
@@ -26,6 +26,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.state import (
     EMPTY_ACCOUNT,
     EMPTY_CODE_HASH,
@@ -555,7 +556,7 @@ def move_ether(
         sender.balance -= amount
 
     def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
+        recipient.balance = recipient.balance.wrapping_add(amount)
 
     modify_state(tx_state, sender_address, reduce_sender_balance)
     modify_state(tx_state, recipient_address, increase_recipient_balance)
@@ -579,6 +580,8 @@ def create_ether(
     """
 
     def increase_balance(account: Account) -> None:
+        if Uint(account.balance) + Uint(amount) > Uint(U256.MAX_VALUE):
+            raise InvalidBlock("account balance overflow")
         account.balance += amount
 
     modify_state(tx_state, address, increase_balance)

--- a/tests/frontier/validation/test_recipient_balance_overflow.py
+++ b/tests/frontier/validation/test_recipient_balance_overflow.py
@@ -1,0 +1,67 @@
+"""
+Recipient balance overflow on value transfer.
+
+when the tx value plus the recipient's current balance would
+exceed ``2**256 - 1`` (maximum representable balance),
+besu crashes.
+
+- besu  : ``java.lang.ArithmeticException: UInt256 overflow`` is raised
+          inside ``MessageCallProcessor.transferValue`` (an internal
+          client error / stack trace, not a clean consensus rule). The
+          tx and block are rejected.
+
+- geth / nethermind / erigon / reth : silently wrap the recipient's
+          balance modulo ``2**256``. The bytecode executes normally and
+          the transaction settles with the wrapped balance.
+
+- EELS  : behavior adjusted to match geth / nethermind / erigon / reth in this
+          commit.
+
+On mainnet the case is unreachable (total ETH supply <  2**256) so it is
+more of a theoretical case
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Environment,
+    StateTestFiller,
+    Transaction,
+)
+from execution_testing.vm import Op
+
+
+@pytest.mark.eels_base_coverage
+def test_recipient_balance_overflow(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Value transfer where ``recipient.balance + tx.value`` exactly equals
+    ``2**256`` — one wei past the UINT256 ceiling.
+
+    The recipient is a normal contract whose code is a single ``STOP``,
+    so the only operation that touches the recipient's balance is the
+    transaction's value transfer. The recipient's balance must wrap to
+    zero.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.deploy_contract(
+        code=Op.STOP,
+        balance=2**256 - 2,
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=recipient,
+        value=2,
+        gas_limit=21_000,
+        protected=False,
+    )
+
+    post = {
+        recipient: Account(balance=0),
+    }
+
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
Theoretic case about max balance, not security-relevant cuz not reachable on mainnet. But I did verify via hive that only besu fails and geth/erigon/nethermind main/master all pass.

wdyt?

from eels root folder fill with:
`uv run fill tests/frontier/validation/test_recipient_balance_overflow.py --until=Osaka --clean -v -s`

use the following `clients.yaml` in hive directory:

```
- client: besu
  nametag: default
  dockerfile: git
  build_args:
    github: besu-eth/besu
    tag: main
```

set this in `~/.profile`: `export HIVE_SIMULATOR=http://127.0.0.1:3000` and source it

ensure you are on latest hive master branch, then start hive with:

`go run . --docker.nocache=besu --docker.buildoutput --docker.output --client=besu --client-file=clients.yaml --dev --loglevel=5 --sim.loglevel=5`

and from eels root folder run the tests with:
`uv run consume engine ./fixtures/blockchain_tests_engine/ -v -s`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1337018504141864963/1504784277504524288/PNG_image_127.png?ex=6a196291&is=6a181111&hm=98c8fb508f76d94ac1b945ac109fcd60a45d942a44084cfadfd6b3547e5a5bd2&"
  alt="Cute Animal Picture"
  width="320">
