### PR TITLE
docs(spec-specs): fix `TransactionEnvironment` docstring

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -109,7 +109,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/forks/arrow_glacier/vm/__init__.py
@@ -86,7 +86,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/berlin/vm/__init__.py
+++ b/src/ethereum/forks/berlin/vm/__init__.py
@@ -85,7 +85,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/bpo1/vm/__init__.py
+++ b/src/ethereum/forks/bpo1/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/bpo2/vm/__init__.py
+++ b/src/ethereum/forks/bpo2/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/bpo3/vm/__init__.py
+++ b/src/ethereum/forks/bpo3/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/bpo4/vm/__init__.py
+++ b/src/ethereum/forks/bpo4/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/bpo5/vm/__init__.py
+++ b/src/ethereum/forks/bpo5/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/byzantium/vm/__init__.py
+++ b/src/ethereum/forks/byzantium/vm/__init__.py
@@ -85,7 +85,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/cancun/vm/__init__.py
+++ b/src/ethereum/forks/cancun/vm/__init__.py
@@ -92,7 +92,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/constantinople/vm/__init__.py
+++ b/src/ethereum/forks/constantinople/vm/__init__.py
@@ -85,7 +85,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/dao_fork/vm/__init__.py
+++ b/src/ethereum/forks/dao_fork/vm/__init__.py
@@ -80,7 +80,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/frontier/vm/__init__.py
+++ b/src/ethereum/forks/frontier/vm/__init__.py
@@ -80,7 +80,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/gray_glacier/vm/__init__.py
+++ b/src/ethereum/forks/gray_glacier/vm/__init__.py
@@ -86,7 +86,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/homestead/vm/__init__.py
+++ b/src/ethereum/forks/homestead/vm/__init__.py
@@ -80,7 +80,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/istanbul/vm/__init__.py
+++ b/src/ethereum/forks/istanbul/vm/__init__.py
@@ -85,7 +85,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/london/vm/__init__.py
+++ b/src/ethereum/forks/london/vm/__init__.py
@@ -86,7 +86,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/muir_glacier/vm/__init__.py
+++ b/src/ethereum/forks/muir_glacier/vm/__init__.py
@@ -85,7 +85,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/osaka/vm/__init__.py
+++ b/src/ethereum/forks/osaka/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/paris/vm/__init__.py
+++ b/src/ethereum/forks/paris/vm/__init__.py
@@ -81,7 +81,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/prague/vm/__init__.py
+++ b/src/ethereum/forks/prague/vm/__init__.py
@@ -95,7 +95,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/shanghai/vm/__init__.py
+++ b/src/ethereum/forks/shanghai/vm/__init__.py
@@ -86,7 +86,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/forks/spurious_dragon/vm/__init__.py
@@ -85,7 +85,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address

--- a/src/ethereum/forks/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/__init__.py
@@ -80,7 +80,7 @@ class BlockOutput:
 @dataclass
 class TransactionEnvironment:
     """
-    Items that are used by contract creation or message call.
+    Items that are used while processing a transaction.
     """
 
     origin: Address


### PR DESCRIPTION
## Summary

Fixes the `TransactionEnvironment` docstring in the Berlin VM module so it describes transaction-level processing instead of repeating the `Message` wording about contract creation or message calls.

The issue points to this as a copy-paste error from `Message`; this PR keeps the change scoped to that documented Berlin fork location and leaves behavior untouched.

Closes #2929

## Verification

- `uv run ruff format --check src/ethereum/forks/berlin/vm/__init__.py`
- `uv run ruff check src/ethereum/forks/berlin/vm/__init__.py`
- `git diff --check`
