### PR TITLE
feat(zkevm): add ChainConfig tests

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -449,10 +449,26 @@ def finalize_stateless_artifacts(
         and is_invalid_stateless_input_sentinel(stateless_output)
     )
     if not skip_chain_config_assertion:
+        expected_chain_config = None
+        if options.has_stateless_input_bytes_modifier:
+            if stateless_input_bytes is None:
+                raise Exception(
+                    "Stateless output chain_config assertion requires "
+                    "stateless input bytes"
+                )
+            expected_chain_config = (
+                decode_amsterdam_stateless_input_chain_config(
+                    fork=fork,
+                    block_number=block_number,
+                    timestamp=timestamp,
+                    stateless_input_bytes=stateless_input_bytes,
+                )
+            )
         assert_amsterdam_stateless_output_chain_config(
             block_number=block_number,
             chain_id=chain_id,
             stateless_output=stateless_output,
+            expected_chain_config=expected_chain_config,
         )
 
     return replace(
@@ -981,22 +997,50 @@ def decode_amsterdam_stateless_output(
     )
 
 
+def decode_amsterdam_stateless_input_chain_config(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    stateless_input_bytes: Bytes,
+) -> Any | None:
+    """
+    Decode the chain config from Amsterdam stateless input bytes.
+    """
+    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
+    if active_fork.name() != "Amsterdam":
+        return None
+
+    from ethereum.forks.amsterdam.stateless_guest import (
+        deserialize_stateless_input,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    stateless_input = deserialize_stateless_input(
+        AmsterdamBytes(bytes(stateless_input_bytes))
+    )
+    return stateless_input.chain_config
+
+
 def assert_amsterdam_stateless_output_chain_config(
     *,
     block_number: int,
     chain_id: int,
     stateless_output: Any | None,
+    expected_chain_config: Any | None = None,
 ) -> None:
     """
-    Assert the stateless output reports the fixed Amsterdam chain config.
+    Assert the stateless output reports the expected Amsterdam chain config.
     """
     if stateless_output is None:
         return
 
-    from ethereum.forks.amsterdam.stateless_host import build_chain_config
-    from ethereum_types.numeric import U64
+    if expected_chain_config is None:
+        from ethereum.forks.amsterdam.stateless_host import build_chain_config
+        from ethereum_types.numeric import U64
 
-    expected_chain_config = build_chain_config(U64(chain_id))
+        expected_chain_config = build_chain_config(U64(chain_id))
+
     if stateless_output.chain_config != expected_chain_config:
         raise AssertionError(
             "Stateless output chain_config mismatch for block "

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_config.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_config.py
@@ -1,0 +1,139 @@
+"""Stateless chain-config validation tests."""
+
+from dataclasses import replace
+from typing import Any, Callable
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytes,
+    Transaction,
+)
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+StatelessInputBytesModifier = Callable[[Bytes], Bytes]
+ChainConfigBuilder = Callable[[Any], Any]
+
+
+def replace_chain_config(
+    build_chain_config: ChainConfigBuilder,
+) -> StatelessInputBytesModifier:
+    """Replace only the decoded stateless input chain_config."""
+
+    def modifier(input_bytes: Bytes) -> Bytes:
+        from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+        from ethereum.forks.amsterdam.stateless_guest import (
+            deserialize_stateless_input,
+        )
+        from ethereum.forks.amsterdam.stateless_host import (
+            serialize_stateless_input,
+        )
+
+        stateless_input = deserialize_stateless_input(
+            AmsterdamBytes(bytes(input_bytes))
+        )
+        modified_input = replace(
+            stateless_input,
+            chain_config=build_chain_config(stateless_input),
+        )
+        return Bytes(bytes(serialize_stateless_input(modified_input)))
+
+    return modifier
+
+
+def future_timestamp_activation_chain_config(stateless_input: Any) -> Any:
+    """Move Amsterdam activation one second after the payload timestamp."""
+    from ethereum_types.numeric import U64
+
+    from ethereum.forks.amsterdam.stateless import (
+        ForkActivation,
+        ProtocolFork,
+    )
+
+    payload = stateless_input.new_payload_request.execution_payload
+    chain_config = stateless_input.chain_config
+    active_fork = chain_config.active_fork
+    return replace(
+        chain_config,
+        active_fork=replace(
+            active_fork,
+            fork=ProtocolFork.Amsterdam,
+            activation=ForkActivation(
+                block_number=None,
+                timestamp=U64(int(payload.timestamp) + 1),
+            ),
+        ),
+    )
+
+
+def wrong_chain_id_chain_config(stateless_input: Any) -> Any:
+    """Change chain_id from 1 to 2."""
+    from ethereum_types.numeric import U64
+
+    chain_config = stateless_input.chain_config
+    if int(chain_config.chain_id) != 1:
+        raise AssertionError(
+            f"expected canonical chain_id 1, got {chain_config.chain_id}"
+        )
+    return replace(chain_config, chain_id=U64(2))
+
+
+def test_validation_chain_config_future_timestamp_activation(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """A future Amsterdam timestamp activation fails validation."""
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[],
+                stateless_input_bytes_modifier=replace_chain_config(
+                    future_timestamp_activation_chain_config
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={},
+    )
+
+
+def test_validation_chain_config_wrong_chain_id_legacy_signature(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """A protected legacy signature for chain 1 fails under chain 2."""
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    tx = Transaction(
+        chain_id=1,
+        sender=sender,
+        to=recipient,
+        value=1,
+        gas_limit=21_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                stateless_input_bytes_modifier=replace_chain_config(
+                    wrong_chain_id_chain_config
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            recipient: Account(balance=1),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
This PR adds tests for the `ChainConfig` part of the guest program input, mainly in two cases:
- If a wrong `chain_id` is provided, the block validation must fail. e.g. transaction signatures can't be correctly validated.
- Check that the guest program is doing the check that `payload.timestamp >= ChainConfig.active_fork.timestamp` i.e. the block apparently does not correspond to the active fork

There are many other invalidity cases of `ChainConfig`, but since `ChainConfig` is fully exposed as public input, it shouldn't be possible to provide any incorrect configuration that wouldn't be rejected by the proof verifier. This is because the proof verifier will fully define what `ChainConfig` expects, so any mismatch on any field would be rejected immediately (even if the proof verifies).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
