### PR TITLE
feat(zkevm): add test for pubkey check on wrong parity case

### DIFF
--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
@@ -182,6 +182,7 @@ def _opposite_y_parity_public_key(tx: Transaction) -> Bytes:
         raise AssertionError("alternate public key does not verify signature")
     return alternate_public_key
 
+
 def _address_from_public_key(public_key: Bytes) -> Address:
     """Derive the sender address from an uncompressed SEC1 public key."""
     return Address(Bytes(public_key[1:]).keccak256()[12:])
@@ -204,4 +205,3 @@ def _signature_verifies(
         signing_hash,
         hasher=None,
     )
-

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
@@ -1,6 +1,7 @@
 """Stateless input transaction public-key tests."""
 
 import pytest
+from coincurve.keys import PublicKey
 from execution_testing import (
     Account,
     Alloc,
@@ -87,3 +88,89 @@ def test_stateless_input_invalid_public_key_is_rejected(
             sender: Account(nonce=1),
         },
     )
+
+
+def test_stateless_input_opposite_y_parity_public_key_is_rejected(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    An ECDSA-valid key from the other recovery candidate is rejected.
+
+    This catches implementations that only verify the supplied key against
+    ``(r, s, message_hash)`` without also binding it to the transaction's
+    y-parity bit.
+    """
+    recipient = pre.fund_eoa()
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=recipient,
+        value=0,
+        gas_limit=21_000,
+        max_fee_per_gas=10,
+        max_priority_fee_per_gas=0,
+    ).with_signature_and_sender()
+    invalid_public_key = _opposite_y_parity_public_key(tx)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                stateless_input_public_keys_modifier=(
+                    replace_public_key_at(0, invalid_public_key)
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )
+
+
+def _recover_public_key(
+    tx: Transaction,
+    y_parity: int,
+    signing_hash: bytes,
+) -> Bytes:
+    """Recover an uncompressed SEC1 public key for ``y_parity``."""
+    signature = (
+        int(tx.r).to_bytes(32, byteorder="big")
+        + int(tx.s).to_bytes(32, byteorder="big")
+        + bytes([y_parity])
+    )
+    public_key = PublicKey.from_signature_and_message(
+        signature,
+        signing_hash,
+        hasher=None,
+    )
+    return Bytes(public_key.format(compressed=False))
+
+
+def _opposite_y_parity_public_key(tx: Transaction) -> Bytes:
+    """Recover the other ECDSA-valid public key for a typed transaction."""
+    signed_tx = tx.with_signature_and_sender()
+    if int(signed_tx.ty) == 0:
+        raise AssertionError("expected a typed transaction")
+
+    y_parity = int(signed_tx.v)
+    if y_parity not in (0, 1):
+        raise AssertionError(f"expected y_parity 0 or 1, got {y_parity}")
+
+    signing_hash = bytes(signed_tx.rlp_signing_bytes().keccak256())
+    canonical_public_key = _recover_public_key(
+        signed_tx,
+        y_parity,
+        signing_hash,
+    )
+    alternate_public_key = _recover_public_key(
+        signed_tx,
+        y_parity ^ 1,
+        signing_hash,
+    )
+    if alternate_public_key == canonical_public_key:
+        raise AssertionError("alternate recovery id produced canonical key")
+    return alternate_public_key
+

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
@@ -1,9 +1,11 @@
 """Stateless input transaction public-key tests."""
 
 import pytest
+from coincurve import ecdsa
 from coincurve.keys import PublicKey
 from execution_testing import (
     Account,
+    Address,
     Alloc,
     Block,
     BlockchainTestFiller,
@@ -172,5 +174,34 @@ def _opposite_y_parity_public_key(tx: Transaction) -> Bytes:
     )
     if alternate_public_key == canonical_public_key:
         raise AssertionError("alternate recovery id produced canonical key")
+    if _address_from_public_key(canonical_public_key) != signed_tx.sender:
+        raise AssertionError("canonical public key does not derive sender")
+    if _address_from_public_key(alternate_public_key) == signed_tx.sender:
+        raise AssertionError("alternate public key derives sender")
+    if not _signature_verifies(signed_tx, alternate_public_key, signing_hash):
+        raise AssertionError("alternate public key does not verify signature")
     return alternate_public_key
+
+def _address_from_public_key(public_key: Bytes) -> Address:
+    """Derive the sender address from an uncompressed SEC1 public key."""
+    return Address(Bytes(public_key[1:]).keccak256()[12:])
+
+
+def _signature_verifies(
+    tx: Transaction,
+    public_key: Bytes,
+    signing_hash: bytes,
+) -> bool:
+    """Return whether ``public_key`` verifies the transaction signature."""
+    compact_signature = int(tx.r).to_bytes(32, byteorder="big") + int(
+        tx.s
+    ).to_bytes(32, byteorder="big")
+    der_signature = ecdsa.cdata_to_der(
+        ecdsa.deserialize_compact(compact_signature)
+    )
+    return PublicKey(bytes(public_key)).verify(
+        der_signature,
+        signing_hash,
+        hasher=None,
+    )
 


### PR DESCRIPTION
## 🗒️ Description
This PR adds a test case to check that stateless validation is correctly checking `pubkeys` without assuming the `pubkey` has the right parity bit, without checking it against the transaction signature parity bit.

This is a twisted border case regarding how ECDSA works.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
