### PR TITLE
feat(tests): EIP-7928 catch per-tx no-op SSTORE after prior tx write

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_cross_index.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_cross_index.py
@@ -268,6 +268,79 @@ def test_bal_noop_write_filtering(
     )
 
 
+def test_bal_intra_tx_round_trip_after_prior_tx_write(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    A per-tx no-op SSTORE sequence is demoted to a read even when an
+    earlier tx in the same block already wrote to the slot.
+
+    Per EIP-7928 §Storage, "Implementations MUST check the
+    pre-transaction value to correctly distinguish between actual writes
+    and no-op writes." Pre-transaction is per-tx, not per-block, so a
+    prior tx's write to the slot does not change tx 2's classification.
+
+    Both txs call the same contract whose runtime SSTOREs 0xff then 0x42
+    to slot 1. Tx 1 changes slot 1 from 0 to 0x42 (real change). Tx 2
+    round-trips it 0x42 -> 0xff -> 0x42 (net-zero, per-tx no-op). Only
+    tx 1 must appear in `storage_changes`.
+    """
+    # Runtime: write 0xff to slot 1, then write 0x42 to slot 1, STOP.
+    # The two SSTOREs hit the journal at every call, but the net effect
+    # on the slot is `pre_value -> 0x42` — a no-op when pre_value == 0x42.
+    contract_code = Bytecode(Op.SSTORE(1, 0xFF) + Op.SSTORE(1, 0x42) + Op.STOP)
+    contract = pre.deploy_contract(code=contract_code)
+
+    sender_a = pre.fund_eoa()
+    sender_b = pre.fund_eoa()
+
+    # Both txs go into the same block; tx 1 makes the real 0 -> 0x42
+    # change, tx 2 starts from 0x42 and ends at 0x42 (per-tx no-op).
+    tx_1 = Transaction(sender=sender_a, to=contract, gas_limit=200_000)
+    tx_2 = Transaction(sender=sender_b, to=contract, gas_limit=200_000)
+
+    expected_block_access_list = BlockAccessListExpectation(
+        account_expectations={
+            contract: BalAccountExpectation(
+                # Only tx 1's real change appears. Tx 2's same-value
+                # round-trip MUST be classified as a read for tx 2.
+                storage_changes=[
+                    BalStorageSlot(
+                        slot=1,
+                        slot_changes=[
+                            BalStorageChange(
+                                block_access_index=1, post_value=0x42
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            sender_a: BalAccountExpectation(
+                nonce_changes=[
+                    BalNonceChange(block_access_index=1, post_nonce=1),
+                ],
+            ),
+            sender_b: BalAccountExpectation(
+                nonce_changes=[
+                    BalNonceChange(block_access_index=2, post_nonce=1),
+                ],
+            ),
+        }
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx_1, tx_2],
+                expected_block_access_list=expected_block_access_list,
+            ),
+        ],
+        post={contract: Account(storage={1: 0x42})},
+    )
+
+
 def test_bal_system_contract_noop_filtering(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_cross_index.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_cross_index.py
@@ -14,6 +14,7 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    BalAccountAbsentValues,
     BalAccountExpectation,
     BalBalanceChange,
     BalNonceChange,
@@ -273,18 +274,20 @@ def test_bal_intra_tx_round_trip_after_prior_tx_write(
     blockchain_test: BlockchainTestFiller,
 ) -> None:
     """
-    A per-tx no-op SSTORE sequence is demoted to a read even when an
-    earlier tx in the same block already wrote to the slot.
+    Verify a per-tx no-op SSTORE round-trip is not recorded as a storage
+    change when an earlier tx in the same block wrote the slot.
 
-    Per EIP-7928 §Storage, "Implementations MUST check the
-    pre-transaction value to correctly distinguish between actual writes
-    and no-op writes." Pre-transaction is per-tx, not per-block, so a
-    prior tx's write to the slot does not change tx 2's classification.
+    Per EIP-7928 §Storage, a write is compared against "the storage value
+    as of immediately before the current `block_access_index` (i.e., the
+    cumulative state from all prior indices, falling back to the pre-block
+    state)", and "a no-op write MUST NOT remove `storage_changes` entries
+    from earlier indices for the same slot".
 
     Both txs call the same contract whose runtime SSTOREs 0xff then 0x42
-    to slot 1. Tx 1 changes slot 1 from 0 to 0x42 (real change). Tx 2
-    round-trips it 0x42 -> 0xff -> 0x42 (net-zero, per-tx no-op). Only
-    tx 1 must appear in `storage_changes`.
+    to slot 1. Tx 1 changes slot 1 from 0 to 0x42 (real change). Tx 1's
+    write becomes tx 2's baseline, so tx 2's 0x42 -> 0xff -> 0x42 nets to
+    a no-op and only tx 1 appears in `storage_changes` (with tx 1's entry
+    left intact).
     """
     # Runtime: write 0xff to slot 1, then write 0x42 to slot 1, STOP.
     # The two SSTOREs hit the journal at every call, but the net effect
@@ -315,6 +318,22 @@ def test_bal_intra_tx_round_trip_after_prior_tx_write(
                         ],
                     ),
                 ],
+                # `storage_changes` is only verified as a sub-sequence
+                # at fill time, so this additional check guards against a
+                # reference regression that emits tx 2's no-op as a
+                # spurious index-2 change.
+                absent_values=BalAccountAbsentValues(
+                    storage_changes=[
+                        BalStorageSlot(
+                            slot=1,
+                            slot_changes=[
+                                BalStorageChange(
+                                    block_access_index=2, post_value=0x42
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
             ),
             sender_a: BalAccountExpectation(
                 nonce_changes=[


### PR DESCRIPTION
## 🗒️ Description
Adds `test_bal_intra_tx_round_trip_after_prior_tx_write` to verify that a per-tx no-op SSTORE is classified as a read even when an earlier transaction in the same block already wrote to the slot.

Two txs call a contract that does
`SSTORE(slot=1, 0xff); SSTORE(slot=1, 0x42); STOP`. Tx 1 changes slot 1 from 0 to 0x42 (real change). Tx 2 round-trips 0x42 -> 0xff -> 0x42 (per-tx no-op). Per EIP-7928 §Storage, "MUST check the pre-transaction value" — and pre-transaction is per-tx, not per-block — so only tx 1 must appear in storage_changes.

Regression test for the bal-devnet-7 chain split (slot 96338 / EL block 94626). Reproduced live on a 2-node nethermind + erigon kurtosis devnet running the bal-devnet-7 images: erigon rejects with `block access list mismatch` and forks off.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

        /\_/\
      =( o.o )=
        > ^ <
