### PR TITLE
feat(tests): implement eip-8070 sparse blob pool tests

### DIFF
--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -14,11 +14,16 @@ from execution_testing.logging import (
 from execution_testing.rpc import (
     BlobAndProofV1,
     BlobAndProofV2,
+    BlobCellsAndProofsV1,
     EngineRPC,
     EthRPC,
 )
-from execution_testing.rpc.rpc_types import GetBlobsResponse
+from execution_testing.rpc.rpc_types import (
+    GetBlobsResponse,
+    GetBlobsV4Response,
+)
 from execution_testing.test_types import (
+    Blob,
     Environment,
     NetworkWrappedTransaction,
     Transaction,
@@ -107,6 +112,78 @@ def _validate_blob_and_proof(
         )
 
 
+def _validate_cells_and_proofs(
+    expected_blob: Blob | None,
+    received: BlobCellsAndProofsV1 | None,
+    cell_mask: int,
+    index: int,
+) -> None:
+    """
+    Validate a received `engine_getBlobsV4` cell matrix against a local blob.
+
+    Bit `i` of `cell_mask` says whether cell `i` was requested: requested
+    cells and proofs must match the local values, non-requested ones must be
+    `null`. When `expected_blob` is `None` (a non-existing hash), the whole
+    entry must be `null`.
+    """
+    if expected_blob is None:
+        if received is None:
+            logger.info(
+                f"Blob at index {index} correctly returned null "
+                "(non-existing blob hash)"
+            )
+            return
+        raise ValueError(
+            f"Blob at index {index} should be null (non-existing hash), "
+            f"but client returned a cell matrix."
+        )
+    if received is None:
+        raise ValueError(f"Received cell matrix at index {index} is empty.")
+
+    assert expected_blob.cells is not None, (
+        "Local blob has no cells; getBlobsV4 requires a fork with cell proofs."
+    )
+    assert isinstance(expected_blob.proof, list), (
+        "Local blob proof is not a cell-proof list."
+    )
+    cells_per_ext_blob = len(expected_blob.cells)
+    if len(received.blob_cells) != cells_per_ext_blob:
+        raise ValueError(
+            f"Cell matrix at index {index} has {len(received.blob_cells)} "
+            f"cells, expected {cells_per_ext_blob}."
+        )
+    if len(received.proofs) != cells_per_ext_blob:
+        raise ValueError(
+            f"Proof matrix at index {index} has {len(received.proofs)} "
+            f"proofs, expected {cells_per_ext_blob}."
+        )
+
+    for i in range(cells_per_ext_blob):
+        requested = (cell_mask >> i) & 1
+        recv_cell = received.blob_cells[i]
+        recv_proof = received.proofs[i]
+        if requested:
+            if recv_cell != expected_blob.cells[i]:
+                raise ValueError(
+                    f"Cell mismatch at blob index {index}, cell {i}."
+                )
+            if recv_proof != expected_blob.proof[i]:
+                raise ValueError(
+                    f"Cell proof mismatch at blob index {index}, cell {i}."
+                )
+        else:
+            if recv_cell is not None:
+                raise ValueError(
+                    f"Cell at blob index {index}, cell {i} was not requested "
+                    "but client returned a non-null cell."
+                )
+            if recv_proof is not None:
+                raise ValueError(
+                    f"Proof at blob index {index}, cell {i} was not requested "
+                    "but client returned a non-null proof."
+                )
+
+
 def versioned_hashes_with_blobs_and_proofs(
     tx: NetworkWrappedTransaction,
 ) -> Dict[Hash, BlobAndProofV1 | BlobAndProofV2]:
@@ -149,6 +226,7 @@ class BlobTransaction(BaseExecute):
     txs: List[NetworkWrappedTransaction | Transaction]
     nonexisting_blob_hashes: List[Hash] | None = None
     get_blobs_version: int | None = None
+    cell_mask: int | None = None
 
     def prepare_transactions(
         self,
@@ -208,6 +286,7 @@ class BlobTransaction(BaseExecute):
     ) -> ExecuteResult:
         """Execute the format."""
         versioned_hashes: Dict[Hash, BlobAndProofV1 | BlobAndProofV2] = {}
+        blobs_by_hash: Dict[Hash, Blob] = {}
         sent_txs: List[Transaction] = []
         for tx_index, tx in enumerate(self.txs):
             tx = tx.with_signature_and_sender()
@@ -218,6 +297,8 @@ class BlobTransaction(BaseExecute):
                 versioned_hashes.update(
                     versioned_hashes_with_blobs_and_proofs(tx)
                 )
+                for blob in tx.blob_objects:
+                    blobs_by_hash[blob.versioned_hash] = blob
             else:
                 sent_txs.append(tx)
             label = (
@@ -259,8 +340,13 @@ class BlobTransaction(BaseExecute):
         if self.nonexisting_blob_hashes is not None:
             list_versioned_hashes.extend(self.nonexisting_blob_hashes)
 
-        blob_response: GetBlobsResponse | None = engine_rpc.get_blobs(
-            list_versioned_hashes, version=version
+        indices_bitarray = self.cell_mask if version >= 4 else None
+        blob_response: GetBlobsResponse | GetBlobsV4Response | None = (
+            engine_rpc.get_blobs(
+                list_versioned_hashes,
+                version=version,
+                indices_bitarray=indices_bitarray,
+            )
         )
 
         if version <= 2:
@@ -284,6 +370,7 @@ class BlobTransaction(BaseExecute):
                     f"getBlobsV{version} returned 'null' but all "
                     "requested blobs should exist."
                 )
+                assert isinstance(blob_response, GetBlobsResponse)
                 local_blobs_and_proofs = list(versioned_hashes.values())
                 assert len(blob_response) == len(local_blobs_and_proofs), (
                     f"Expected {len(local_blobs_and_proofs)} blobs and "
@@ -305,6 +392,7 @@ class BlobTransaction(BaseExecute):
                     "response, but V3 should always return an array "
                     "(with null entries for missing blobs)."
                 )
+            assert isinstance(blob_response, GetBlobsResponse)
             expected_blobs_and_proofs: List[
                 BlobAndProofV1 | BlobAndProofV2 | None
             ] = list(versioned_hashes.values())
@@ -334,10 +422,38 @@ class BlobTransaction(BaseExecute):
                     f"blobs and {nonexisting_count} null entries for "
                     "missing blobs"
                 )
+        elif version == 4:
+            # V4 (EIP-8070): partial cell matrix, selected by cell_mask
+            assert self.cell_mask is not None, (
+                f"getBlobsV{version} requires a cell_mask."
+            )
+            if blob_response is None:
+                raise ValueError(
+                    f"getBlobsV{version} returned 'null' for the entire "
+                    "response, but V4 should always return an array "
+                    "(with null entries for missing blobs)."
+                )
+            assert isinstance(blob_response, GetBlobsV4Response)
+            expected_blobs: List[Blob | None] = [
+                blobs_by_hash[vh] for vh in versioned_hashes
+            ]
+            if self.nonexisting_blob_hashes is not None:
+                expected_blobs += [None] * len(self.nonexisting_blob_hashes)
+            if len(blob_response) != len(expected_blobs):
+                raise ValueError(
+                    f"Expected {len(expected_blobs)} blob responses, "
+                    f"got {len(blob_response)}."
+                )
+            for i, (expected_cells, received_cells) in enumerate(
+                zip(expected_blobs, blob_response.root, strict=True)
+            ):
+                _validate_cells_and_proofs(
+                    expected_cells, received_cells, self.cell_mask, i
+                )
         else:
             raise NotImplementedError(
                 f"getBlobsV{version} is not supported. "
-                "Supported versions: V1, V2, V3."
+                "Supported versions: V1, V2, V3, V4."
             )
 
         eth_rpc.wait_for_transactions(sent_txs)

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -19,8 +19,11 @@ from execution_testing.rpc import (
     EthRPC,
 )
 from execution_testing.rpc.rpc_types import (
+    ForkchoiceState,
     GetBlobsResponse,
     GetBlobsV4Response,
+    JSONRPCError,
+    PayloadStatusEnum,
 )
 from execution_testing.test_types import (
     Blob,
@@ -35,6 +38,20 @@ from execution_testing.test_types.transaction_types import (
 from .base import BaseExecute, ExecuteResult
 
 logger = get_logger(__name__)
+
+CUSTODY_COLUMNS_BYTE_LENGTH = 16
+"""Byte length of a well-formed `custodyColumns` bitmap (EIP-8070)."""
+
+
+def _interleave_hashes(a: List[Hash], b: List[Hash]) -> List[Hash]:
+    """Interleave two hash lists, starting with `a`, appending leftovers."""
+    interleaved: List[Hash] = []
+    for x, y in zip(a, b, strict=False):
+        interleaved.extend((x, y))
+    shorter_length = min(len(a), len(b))
+    interleaved.extend(a[shorter_length:])
+    interleaved.extend(b[shorter_length:])
+    return interleaved
 
 
 def _validate_blob_and_proof(
@@ -228,8 +245,10 @@ class BlobTransaction(BaseExecute):
 
     txs: List[NetworkWrappedTransaction | Transaction]
     nonexisting_blob_hashes: List[Hash] | None = None
+    interleave_nonexisting_blob_hashes: bool = False
     get_blobs_version: int | None = None
     cell_mask: int | None = None
+    custody_columns: bytes | None = None
 
     def prepare_transactions(
         self,
@@ -279,6 +298,64 @@ class BlobTransaction(BaseExecute):
                 balances[sender] = 0
             balances[sender] += tx.signer_minimum_balance(fork=fork)
         return balances
+
+    def _update_custody_columns(
+        self,
+        fork: Fork,
+        eth_rpc: EthRPC,
+        engine_rpc: EngineRPC,
+    ) -> None:
+        """
+        Send a forkchoice update carrying the `custodyColumns` bitmap.
+
+        A 16-byte bitmap must be accepted with a VALID payload status
+        (custody set update errors must not affect the forkchoice flow,
+        per `engine_forkchoiceUpdatedV4`); any other length must be
+        rejected with `-32602: Invalid params`.
+        """
+        assert self.custody_columns is not None
+        fcu_version = fork.engine_forkchoice_updated_version()
+        assert fcu_version is not None and fcu_version >= 4, (
+            "custodyColumns requires engine_forkchoiceUpdatedV4."
+        )
+        latest_block = eth_rpc.get_block_by_number("latest")
+        assert latest_block is not None, "Failed to fetch the latest block."
+        forkchoice_state = ForkchoiceState(
+            head_block_hash=Hash(latest_block["hash"]),
+        )
+        valid_length = len(self.custody_columns) == CUSTODY_COLUMNS_BYTE_LENGTH
+        try:
+            response = engine_rpc.forkchoice_updated(
+                forkchoice_state,
+                None,
+                version=fcu_version,
+                custody_columns=self.custody_columns,
+            )
+        except JSONRPCError as e:
+            if valid_length:
+                raise
+            if e.code != -32602:
+                raise ValueError(
+                    f"Expected error -32602 (Invalid params) for a "
+                    f"{len(self.custody_columns)}-byte custodyColumns, "
+                    f"got {e.code}: {e.message}"
+                ) from e
+            logger.info(
+                f"Client correctly rejected a "
+                f"{len(self.custody_columns)}-byte custodyColumns bitmap."
+            )
+            return
+        if not valid_length:
+            raise ValueError(
+                f"Client accepted a {len(self.custody_columns)}-byte "
+                "custodyColumns bitmap; expected -32602 (Invalid params)."
+            )
+        status = response.payload_status.status
+        if status != PayloadStatusEnum.VALID:
+            raise ValueError(
+                f"forkchoiceUpdatedV{fcu_version} with custodyColumns "
+                f"returned payload status {status}, expected VALID."
+            )
 
     def execute(
         self,
@@ -341,7 +418,19 @@ class BlobTransaction(BaseExecute):
 
         list_versioned_hashes = list(versioned_hashes.keys())
         if self.nonexisting_blob_hashes is not None:
-            list_versioned_hashes.extend(self.nonexisting_blob_hashes)
+            if self.interleave_nonexisting_blob_hashes:
+                assert version >= 4, (
+                    "interleave_nonexisting_blob_hashes is only supported "
+                    "with getBlobsV4."
+                )
+                list_versioned_hashes = _interleave_hashes(
+                    self.nonexisting_blob_hashes, list_versioned_hashes
+                )
+            else:
+                list_versioned_hashes.extend(self.nonexisting_blob_hashes)
+
+        if self.custody_columns is not None:
+            self._update_custody_columns(fork, eth_rpc, engine_rpc)
 
         indices_bitarray = self.cell_mask if version >= 4 else None
         blob_response: GetBlobsResponse | GetBlobsV4Response | None = (
@@ -437,11 +526,11 @@ class BlobTransaction(BaseExecute):
                     "(with null entries for missing blobs)."
                 )
             assert isinstance(blob_response, GetBlobsV4Response)
+            # `blobs_by_hash` only holds existing blobs, so non-existing
+            # hashes map to `None` at their exact request positions.
             expected_blobs: List[Blob | None] = [
-                blobs_by_hash[vh] for vh in versioned_hashes
+                blobs_by_hash.get(vh) for vh in list_versioned_hashes
             ]
-            if self.nonexisting_blob_hashes is not None:
-                expected_blobs += [None] * len(self.nonexisting_blob_hashes)
             if len(blob_response) != len(expected_blobs):
                 raise ValueError(
                     f"Expected {len(expected_blobs)} blob responses, "

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -121,10 +121,16 @@ def _validate_cells_and_proofs(
     """
     Validate a received `engine_getBlobsV4` cell matrix against a local blob.
 
-    Bit `i` of `cell_mask` says whether cell `i` was requested: requested
-    cells and proofs must match the local values, non-requested ones must be
-    `null`. When `expected_blob` is `None` (a non-existing hash), the whole
-    entry must be `null`.
+    The response is a compact matrix: for each existing blob the client
+    returns only the cells selected by `cell_mask`, ordered by ascending
+    cell index, so `blob_cells[k]` is the k-th requested cell. When
+    `expected_blob` is `None` (a non-existing hash), the whole entry must be
+    `null`.
+
+    Per execution-apis `engine_getBlobsV4`, `cell_mask` is a little-endian
+    16-byte bitmap where bit `i` selects cell `i` (see `EngineRPC.get_blobs`).
+    Network-wrapped txs deliver the full blob, so the client holds every
+    requested cell; a returned `null` means an unavailable cell and fails.
     """
     if expected_blob is None:
         if received is None:
@@ -146,42 +152,39 @@ def _validate_cells_and_proofs(
     assert isinstance(expected_blob.proof, list), (
         "Local blob proof is not a cell-proof list."
     )
-    cells_per_ext_blob = len(expected_blob.cells)
-    if len(received.blob_cells) != cells_per_ext_blob:
+    # Compact matrix: the client returns only the requested cells, in
+    # ascending cell-index order (bit `i` of the mask selects cell `i`).
+    requested_indices = [
+        i for i in range(len(expected_blob.cells)) if (cell_mask >> i) & 1
+    ]
+    if len(received.blob_cells) != len(requested_indices):
         raise ValueError(
             f"Cell matrix at index {index} has {len(received.blob_cells)} "
-            f"cells, expected {cells_per_ext_blob}."
+            f"cells, expected {len(requested_indices)}."
         )
-    if len(received.proofs) != cells_per_ext_blob:
+    if len(received.proofs) != len(requested_indices):
         raise ValueError(
             f"Proof matrix at index {index} has {len(received.proofs)} "
-            f"proofs, expected {cells_per_ext_blob}."
+            f"proofs, expected {len(requested_indices)}."
         )
 
-    for i in range(cells_per_ext_blob):
-        requested = (cell_mask >> i) & 1
-        recv_cell = received.blob_cells[i]
-        recv_proof = received.proofs[i]
-        if requested:
-            if recv_cell != expected_blob.cells[i]:
-                raise ValueError(
-                    f"Cell mismatch at blob index {index}, cell {i}."
-                )
-            if recv_proof != expected_blob.proof[i]:
-                raise ValueError(
-                    f"Cell proof mismatch at blob index {index}, cell {i}."
-                )
-        else:
-            if recv_cell is not None:
-                raise ValueError(
-                    f"Cell at blob index {index}, cell {i} was not requested "
-                    "but client returned a non-null cell."
-                )
-            if recv_proof is not None:
-                raise ValueError(
-                    f"Proof at blob index {index}, cell {i} was not requested "
-                    "but client returned a non-null proof."
-                )
+    for pos, cell_index in enumerate(requested_indices):
+        recv_cell = received.blob_cells[pos]
+        recv_proof = received.proofs[pos]
+        if recv_cell is None or recv_proof is None:
+            raise ValueError(
+                f"Requested cell {cell_index} at blob index {index} was "
+                "returned as null."
+            )
+        if recv_cell != expected_blob.cells[cell_index]:
+            raise ValueError(
+                f"Cell mismatch at blob index {index}, cell {cell_index}."
+            )
+        if recv_proof != expected_blob.proof[cell_index]:
+            raise ValueError(
+                f"Cell proof mismatch at blob index {index}, "
+                f"cell {cell_index}."
+            )
 
 
 def versioned_hashes_with_blobs_and_proofs(

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8070.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8070.py
@@ -1,0 +1,16 @@
+"""
+EIP-8070: eth/72 - Sparse Blobpool.
+
+Custody-aligned sampling of the blobpool, adding the `engine_getBlobsV4`
+endpoint to retrieve a partial cell matrix of a blob.
+
+https://eips.ethereum.org/EIPS/eip-8070
+"""
+
+from ....base_fork import BaseFork
+
+
+class EIP8070(BaseFork):
+    """EIP-8070 class."""
+
+    pass

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -22,6 +22,7 @@ from .rpc import (
 from .rpc_types import (
     BlobAndProofV1,
     BlobAndProofV2,
+    BlobCellsAndProofsV1,
     EthConfigResponse,
     ForkConfig,
     ForkConfigBlobSchedule,
@@ -35,6 +36,7 @@ __all__ = [
     "AdminRPC",
     "BlobAndProofV1",
     "BlobAndProofV2",
+    "BlobCellsAndProofsV1",
     "BlockNotAvailableError",
     "BlockNumberType",
     "DebugRPC",

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -1500,7 +1500,11 @@ class EngineRPC(BaseJwtRPC):
             assert indices_bitarray is not None, (
                 f"getBlobsV{version} requires an indices_bitarray cell mask."
             )
-            params.append(f"0x{indices_bitarray.to_bytes(16, 'big').hex()}")
+            # `indices_bitarray` is a little-endian 16-byte bitmap where bit
+            # `i` selects cell `i` (execution-apis `engine_getBlobsV4`).
+            params.append(
+                f"0x{indices_bitarray.to_bytes(16, 'little').hex()}"
+            )
 
         response = self.post_request(
             request=RPCCall(method=method, params=params),

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -1445,6 +1445,7 @@ class EngineRPC(BaseJwtRPC):
         payload_attributes: PayloadAttributes | None = None,
         *,
         version: int,
+        custody_columns: bytes | None = None,
     ) -> ForkchoiceUpdateResponse:
         """
         `engine_forkchoiceUpdatedVX`: Updates the forkchoice state of the
@@ -1452,10 +1453,16 @@ class EngineRPC(BaseJwtRPC):
         """
         method = f"forkchoiceUpdatedV{version}"
 
+        params: List[Any]
         if payload_attributes is None:
             params = [to_json(forkchoice_state), None]
         else:
             params = [to_json(forkchoice_state), to_json(payload_attributes)]
+        if custody_columns is not None:
+            # Third parameter of `engine_forkchoiceUpdatedV4` (EIP-8070):
+            # a bitmap of the blob columns custodied by the node.
+            assert version >= 4, "custodyColumns requires forkchoiceUpdatedV4."
+            params.append(f"0x{custody_columns.hex()}")
 
         return ForkchoiceUpdateResponse.model_validate(
             self.post_request(

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -1502,9 +1502,7 @@ class EngineRPC(BaseJwtRPC):
             )
             # `indices_bitarray` is a little-endian 16-byte bitmap where bit
             # `i` selects cell `i` (execution-apis `engine_getBlobsV4`).
-            params.append(
-                f"0x{indices_bitarray.to_bytes(16, 'little').hex()}"
-            )
+            params.append(f"0x{indices_bitarray.to_bytes(16, 'little').hex()}")
 
         response = self.post_request(
             request=RPCCall(method=method, params=params),

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -51,6 +51,7 @@ from .rpc_types import (
     ForkchoiceState,
     ForkchoiceUpdateResponse,
     GetBlobsResponse,
+    GetBlobsV4Response,
     GetPayloadResponse,
     JSONRPCError,
     JSONRPCRequest,
@@ -1487,21 +1488,31 @@ class EngineRPC(BaseJwtRPC):
         versioned_hashes: List[Hash],
         *,
         version: int,
-    ) -> GetBlobsResponse | None:
+        indices_bitarray: int | None = None,
+    ) -> GetBlobsResponse | GetBlobsV4Response | None:
         """
         `engine_getBlobsVX`: Retrieves blobs from an execution layers tx pool.
         """
         method = f"getBlobsV{version}"
-        params = [f"{h}" for h in versioned_hashes]
+        params: List[Any] = [[f"{h}" for h in versioned_hashes]]
+
+        if version >= 4:
+            assert indices_bitarray is not None, (
+                f"getBlobsV{version} requires an indices_bitarray cell mask."
+            )
+            params.append(f"0x{indices_bitarray.to_bytes(16, 'big').hex()}")
 
         response = self.post_request(
-            request=RPCCall(method=method, params=[params]),
+            request=RPCCall(method=method, params=params),
         ).result_or_raise()
         if response is None:  # for tests that request non-existing blobs
             logger.debug("get_blobs response received but it has value: None")
             return None
 
-        return GetBlobsResponse.model_validate(
+        response_model = (
+            GetBlobsV4Response if version >= 4 else GetBlobsResponse
+        )
+        return response_model.model_validate(
             response,
             context=self.response_validation_context,
         )

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -313,6 +313,13 @@ class BlobAndProofV2(CamelModel):
     proofs: List[Bytes]
 
 
+class BlobCellsAndProofsV1(CamelModel):
+    """Represents a partial cell and cell-proof structure (>= Amsterdam)."""
+
+    blob_cells: List[Bytes | None]
+    proofs: List[Bytes | None]
+
+
 class GetPayloadResponse(CamelModel):
     """Represents the response of a get payload request."""
 
@@ -338,6 +345,22 @@ class GetBlobsResponse(
         self, index: int
     ) -> BlobAndProofV1 | BlobAndProofV2 | None:
         """Return the blob at the given index."""
+        return self.root[index]
+
+
+class GetBlobsV4Response(
+    EthereumTestRootModel[List[BlobCellsAndProofsV1 | None]]
+):
+    """Represents the response of an `engine_getBlobsV4` request."""
+
+    root: List[BlobCellsAndProofsV1 | None]
+
+    def __len__(self) -> int:
+        """Return the number of blob entries in the response."""
+        return len(self.root)
+
+    def __getitem__(self, index: int) -> BlobCellsAndProofsV1 | None:
+        """Return the blob cell matrix at the given index."""
         return self.root[index]
 
 

--- a/packages/testing/src/execution_testing/specs/blobs.py
+++ b/packages/testing/src/execution_testing/specs/blobs.py
@@ -24,6 +24,7 @@ class BlobsTest(BaseTest):
     txs: List[NetworkWrappedTransaction | Transaction]
     nonexisting_blob_hashes: List[Hash] | None = None
     get_blobs_version: int | None = None
+    cell_mask: int | None = None
 
     supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
         LabeledExecuteFormat(
@@ -54,6 +55,7 @@ class BlobsTest(BaseTest):
                 txs=self.txs,
                 nonexisting_blob_hashes=self.nonexisting_blob_hashes,
                 get_blobs_version=self.get_blobs_version,
+                cell_mask=self.cell_mask,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/packages/testing/src/execution_testing/specs/blobs.py
+++ b/packages/testing/src/execution_testing/specs/blobs.py
@@ -23,8 +23,10 @@ class BlobsTest(BaseTest):
     pre: Alloc
     txs: List[NetworkWrappedTransaction | Transaction]
     nonexisting_blob_hashes: List[Hash] | None = None
+    interleave_nonexisting_blob_hashes: bool = False
     get_blobs_version: int | None = None
     cell_mask: int | None = None
+    custody_columns: bytes | None = None
 
     supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
         LabeledExecuteFormat(
@@ -54,8 +56,12 @@ class BlobsTest(BaseTest):
             return BlobTransaction(
                 txs=self.txs,
                 nonexisting_blob_hashes=self.nonexisting_blob_hashes,
+                interleave_nonexisting_blob_hashes=(
+                    self.interleave_nonexisting_blob_hashes
+                ),
                 get_blobs_version=self.get_blobs_version,
                 cell_mask=self.cell_mask,
+                custody_columns=self.custody_columns,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/tests/amsterdam/eip8070_sparse_blobpool/__init__.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test suite for [EIP-8070: eth/72 - Sparse Blobpool](https://eips.ethereum.org/EIPS/eip-8070).
+"""

--- a/tests/amsterdam/eip8070_sparse_blobpool/conftest.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/conftest.py
@@ -1,0 +1,148 @@
+"""Shared fixtures for building blob transactions in EIP-8070 tests."""
+
+from typing import List, Optional
+
+import pytest
+from execution_testing import (
+    Address,
+    Alloc,
+    Blob,
+    Fork,
+    NetworkWrappedTransaction,
+    Transaction,
+    TransactionException,
+)
+
+
+@pytest.fixture
+def destination_account(pre: Alloc) -> Address:
+    """Destination account for the blob transactions."""
+    return pre.fund_eoa(amount=0)
+
+
+@pytest.fixture
+def tx_value() -> int:
+    """Value contained by the transactions sent during test."""
+    return 1
+
+
+@pytest.fixture
+def tx_gas(fork: Fork) -> int:
+    """Gas allocated to transactions sent during test."""
+    return fork.transaction_intrinsic_cost_calculator()()
+
+
+@pytest.fixture
+def block_base_fee_per_gas() -> int:
+    """Return default max fee per gas for transactions sent during test."""
+    return 7
+
+
+@pytest.fixture
+def tx_calldata() -> bytes:
+    """Calldata in transactions sent during test."""
+    return b""
+
+
+@pytest.fixture(autouse=True)
+def parent_excess_blobs() -> int:
+    """Excess blobs of the parent block (defaults to a blob gas price of 1)."""
+    return 10
+
+
+@pytest.fixture(autouse=True)
+def parent_blobs() -> int:
+    """Blobs of the parent block."""
+    return 0
+
+
+@pytest.fixture
+def excess_blob_gas(
+    fork: Fork,
+    parent_excess_blobs: int | None,
+    parent_blobs: int | None,
+    block_base_fee_per_gas: int,
+) -> int | None:
+    """Calculate the excess blob gas of the block under test."""
+    if parent_excess_blobs is None or parent_blobs is None:
+        return None
+    excess_blob_gas = fork.excess_blob_gas_calculator()
+    return excess_blob_gas(
+        parent_excess_blobs=parent_excess_blobs,
+        parent_blob_count=parent_blobs,
+        parent_base_fee_per_gas=block_base_fee_per_gas,
+    )
+
+
+@pytest.fixture
+def blob_gas_price(
+    fork: Fork,
+    excess_blob_gas: int | None,
+) -> int | None:
+    """Return blob gas price for the block of the test."""
+    if excess_blob_gas is None:
+        return None
+    get_blob_gas_price = fork.blob_gas_price_calculator()
+    return get_blob_gas_price(excess_blob_gas=excess_blob_gas)
+
+
+@pytest.fixture
+def txs_versioned_hashes(txs_blobs: List[List[Blob]]) -> List[List[bytes]]:
+    """List of blob versioned hashes derived from the blobs."""
+    return [[blob.versioned_hash for blob in blob_tx] for blob_tx in txs_blobs]
+
+
+@pytest.fixture
+def tx_max_fee_per_blob_gas(fork: Fork, blob_gas_price: Optional[int]) -> int:
+    """Max fee per blob gas for transactions sent during test."""
+    if blob_gas_price is None:
+        return fork.min_base_fee_per_blob_gas()
+    return blob_gas_price
+
+
+@pytest.fixture
+def tx_error() -> Optional[TransactionException]:
+    """No transaction is expected to be rejected by the transition tool."""
+    return None
+
+
+@pytest.fixture(autouse=True)
+def txs(
+    pre: Alloc,
+    destination_account: Optional[Address],
+    tx_gas: int,
+    tx_value: int,
+    tx_calldata: bytes,
+    tx_max_fee_per_blob_gas: int,
+    txs_versioned_hashes: List[List[bytes]],
+    tx_error: Optional[TransactionException],
+    txs_blobs: List[List[Blob]],
+    fork: Fork,
+) -> List[NetworkWrappedTransaction | Transaction]:
+    """Prepare the list of transactions that are sent during the test."""
+    if len(txs_blobs) != len(txs_versioned_hashes):
+        raise ValueError(
+            "txs_blobs and txs_versioned_hashes should have the same length"
+        )
+    txs: List[NetworkWrappedTransaction | Transaction] = []
+    for tx_blobs, tx_versioned_hashes in zip(
+        txs_blobs, txs_versioned_hashes, strict=False
+    ):
+        tx = Transaction(
+            sender=pre.fund_eoa(),
+            to=destination_account,
+            value=tx_value,
+            gas_limit=tx_gas,
+            data=tx_calldata,
+            max_fee_per_blob_gas=tx_max_fee_per_blob_gas,
+            access_list=[],
+            blob_versioned_hashes=tx_versioned_hashes,
+            error=tx_error,
+        )
+        network_wrapped_tx = NetworkWrappedTransaction(
+            tx=tx,
+            blob_objects=tx_blobs,
+            wrapper_version=fork.full_blob_tx_wrapper_version(),
+        )
+        txs.append(network_wrapped_tx)
+    return txs

--- a/tests/amsterdam/eip8070_sparse_blobpool/spec.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/spec.py
@@ -28,3 +28,15 @@ class Spec:
 
     RECONSTRUCTION_THRESHOLD = 64
     """Number of cells required for Reed-Solomon reconstruction of a blob."""
+
+    SAMPLES_PER_SLOT = 8
+    """Minimum number of blob columns a node must custody."""
+
+    CUSTODY_BITMAP_BYTES = 16
+    """Byte length of the `custodyColumns` and cell mask bitmaps."""
+
+    MIN_SUPPORTED_REQUEST_SIZE = 128
+    """
+    Minimum `getBlobsV4` request size (in versioned hashes) that clients
+    must support, per the execution-apis `engine_getBlobsV4` definition.
+    """

--- a/tests/amsterdam/eip8070_sparse_blobpool/spec.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/spec.py
@@ -1,0 +1,30 @@
+"""Defines EIP-8070 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_8070 = ReferenceSpec(
+    "EIPS/eip-8070.md", "64d1b463e1c75884c995f81d8ffab40401acbcaa"
+)
+
+
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-8070 specification as defined at
+    https://eips.ethereum.org/EIPS/eip-8070.
+    """
+
+    CELLS_PER_EXT_BLOB = 128
+    """Number of cells an extended blob is split into for `getBlobsV4`."""
+
+    RECONSTRUCTION_THRESHOLD = 64
+    """Number of cells required for Reed-Solomon reconstruction of a blob."""

--- a/tests/amsterdam/eip8070_sparse_blobpool/test_custody_columns.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/test_custody_columns.py
@@ -1,0 +1,108 @@
+"""
+Custody columns forkchoice tests.
+
+Tests for the `custodyColumns` parameter of `engine_forkchoiceUpdatedV4`
+in [EIP-8070: eth/72 - Sparse Blobpool](
+https://eips.ethereum.org/EIPS/eip-8070).
+
+`custodyColumns` is an optional 16-byte bitmap informing the execution
+client of the blob columns it must custody. A well-formed bitmap must be
+accepted (custody set update errors must not affect the forkchoice flow);
+a bitmap of any other length must be rejected with `-32602: Invalid
+params`. Blob serving via `engine_getBlobsV4` must be unaffected either
+way, since the client holds the full blobs.
+"""
+
+from typing import List
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Blob,
+    BlobsTestFiller,
+    Fork,
+    NetworkWrappedTransaction,
+    Transaction,
+)
+
+from .spec import Spec, ref_spec_8070
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8070.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8070.version
+
+pytestmark = pytest.mark.valid_from("EIP8070")
+
+CELLS = Spec.CELLS_PER_EXT_BLOB
+ALL_CELLS_MASK = (1 << CELLS) - 1
+BITMAP_BYTES = Spec.CUSTODY_BITMAP_BYTES
+
+
+def generate_single_blob_layout(fork: Fork) -> List:
+    """Return a single-blob transaction layout."""
+    return [
+        pytest.param([[Blob.from_fork(fork)]], id="single_blob_transaction")
+    ]
+
+
+@pytest.mark.parametrize(
+    "custody_columns",
+    [
+        pytest.param(b"\xff" * BITMAP_BYTES, id="all_columns"),
+        pytest.param(
+            ((1 << Spec.SAMPLES_PER_SLOT) - 1).to_bytes(
+                BITMAP_BYTES, "little"
+            ),
+            id="custody_aligned_8",
+        ),
+        pytest.param(b"\x00" * BITMAP_BYTES, id="no_columns"),
+    ],
+)
+@pytest.mark.parametrize_by_fork("txs_blobs", generate_single_blob_layout)
+@pytest.mark.exception_test
+def test_fcu_custody_columns(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+    custody_columns: bytes,
+) -> None:
+    """
+    Test that `engine_forkchoiceUpdatedV4` accepts a 16-byte
+    `custodyColumns` bitmap with a VALID payload status and that blob
+    serving via `getBlobsV4` is unaffected by the custody update.
+    """
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        get_blobs_version=4,
+        cell_mask=ALL_CELLS_MASK,
+        custody_columns=custody_columns,
+    )
+
+
+@pytest.mark.parametrize(
+    "custody_columns",
+    [
+        pytest.param(b"\xff" * (BITMAP_BYTES - 1), id="fifteen_bytes"),
+        pytest.param(b"\xff" * (BITMAP_BYTES + 1), id="seventeen_bytes"),
+        pytest.param(b"", id="empty"),
+    ],
+)
+@pytest.mark.parametrize_by_fork("txs_blobs", generate_single_blob_layout)
+@pytest.mark.exception_test
+def test_fcu_custody_columns_invalid_length(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+    custody_columns: bytes,
+) -> None:
+    """
+    Test that a malformed-length `custodyColumns` bitmap is rejected with
+    `-32602: Invalid params` and does not affect subsequent blob serving.
+    """
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        get_blobs_version=4,
+        cell_mask=ALL_CELLS_MASK,
+        custody_columns=custody_columns,
+    )

--- a/tests/amsterdam/eip8070_sparse_blobpool/test_get_cells.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/test_get_cells.py
@@ -37,7 +37,26 @@ ALL_CELLS_MASK = (1 << CELLS) - 1
 
 def generate_blob_layouts(fork: Fork) -> List:
     """Return blob transaction layouts to exercise `getBlobsV4`."""
+    max_blobs_per_block = fork.max_blobs_per_block()
     max_blobs_per_tx = fork.max_blobs_per_tx()
+    target_blobs_per_block = fork.target_blobs_per_block()
+
+    # Ascending pattern (1, 2, 3... blobs per tx) capped at the target
+    ascending_txs = []
+    total_blobs = 0
+    blob_offset = 0
+    for tx_size in range(1, max_blobs_per_tx + 1):
+        if total_blobs + tx_size > target_blobs_per_block:
+            break
+        ascending_txs.append(
+            [Blob.from_fork(fork, blob_offset + j) for j in range(tx_size)]
+        )
+        total_blobs += tx_size
+        blob_offset += tx_size
+
+    two_tx_blobs = min(target_blobs_per_block // 2, max_blobs_per_tx)
+    three_tx_blobs = min(target_blobs_per_block // 3, max_blobs_per_tx)
+
     return [
         pytest.param(
             [[Blob.from_fork(fork)]],
@@ -47,6 +66,63 @@ def generate_blob_layouts(fork: Fork) -> List:
             [[Blob.from_fork(fork, s) for s in range(max_blobs_per_tx)]],
             id="max_blobs_per_tx",
         ),
+        pytest.param(
+            [[Blob.from_fork(fork, s)] for s in range(max_blobs_per_block)],
+            id="max_blobs_per_block",
+        ),
+        pytest.param(
+            [[Blob.from_fork(fork, s)] for s in range(target_blobs_per_block)],
+            id="target_blobs_per_block",
+        ),
+        pytest.param(
+            [
+                [Blob.from_fork(fork, s) for s in range(two_tx_blobs)],
+                [
+                    Blob.from_fork(fork, s + two_tx_blobs)
+                    for s in range(two_tx_blobs)
+                ],
+            ],
+            id="two_tx_equal_blobs",
+        ),
+        pytest.param(
+            [
+                [
+                    Blob.from_fork(fork, s + i * three_tx_blobs)
+                    for s in range(three_tx_blobs)
+                ]
+                for i in range(3)
+            ],
+            id="three_tx_equal_blobs",
+        ),
+        pytest.param(
+            [[Blob.from_fork(fork, s) for s in range(max_blobs_per_tx)]]
+            + [
+                [Blob.from_fork(fork, max_blobs_per_tx + s)]
+                for s in range(max_blobs_per_block - max_blobs_per_tx)
+            ],
+            id="mixed_max_tx_plus_singles",
+        ),
+        pytest.param(
+            ascending_txs,
+            id="ascending_blob_pattern",
+        ),
+    ]
+
+
+def generate_single_blob_layout(fork: Fork) -> List:
+    """Return a single-blob transaction layout."""
+    return [
+        pytest.param([[Blob.from_fork(fork)]], id="single_blob_transaction")
+    ]
+
+
+def generate_single_blob_txs_layout(fork: Fork) -> List:
+    """Return a layout of three single-blob transactions."""
+    return [
+        pytest.param(
+            [[Blob.from_fork(fork, s)] for s in range(3)],
+            id="three_single_blob_txs",
+        )
     ]
 
 
@@ -55,11 +131,17 @@ def generate_cell_masks() -> List:
     return [
         pytest.param(ALL_CELLS_MASK, id="all_cells"),
         pytest.param((1 << Spec.RECONSTRUCTION_THRESHOLD) - 1, id="first_64"),
+        pytest.param(
+            ALL_CELLS_MASK ^ ((1 << Spec.RECONSTRUCTION_THRESHOLD) - 1),
+            id="top_64",
+        ),
         pytest.param(0xFF, id="custody_aligned_8"),
         pytest.param(1, id="single_cell"),
+        pytest.param(1 << (CELLS - 1), id="last_cell"),
         pytest.param(
             sum(1 << i for i in range(0, CELLS, 2)), id="alternating_cells"
         ),
+        pytest.param(0, id="no_cells"),
     ]
 
 
@@ -141,4 +223,69 @@ def test_get_cells_only_nonexisting(
         get_blobs_version=4,
         cell_mask=cell_mask,
         nonexisting_blob_hashes=nonexisting_blob_hashes,
+    )
+
+
+@pytest.mark.parametrize(
+    "cell_mask",
+    [pytest.param(0xFF, id="custody_aligned_8")],
+)
+@pytest.mark.parametrize_by_fork("txs_blobs", generate_single_blob_layout)
+@pytest.mark.exception_test
+def test_get_cells_min_request_size(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+    cell_mask: int,
+) -> None:
+    """
+    Test a request of 128 versioned hashes, the minimum request size a
+    client must support for `getBlobsV4`.
+
+    The response must hold one entry per requested hash: a cell matrix for
+    the existing blob and `null` for each non-existing hash.
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest())
+        for i in range(Spec.MIN_SUPPORTED_REQUEST_SIZE - 1)
+    ]
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        get_blobs_version=4,
+        cell_mask=cell_mask,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+    )
+
+
+@pytest.mark.parametrize(
+    "cell_mask",
+    [
+        pytest.param(ALL_CELLS_MASK, id="all_cells"),
+        pytest.param(0xFF, id="custody_aligned_8"),
+    ],
+)
+@pytest.mark.parametrize_by_fork("txs_blobs", generate_single_blob_txs_layout)
+@pytest.mark.exception_test
+def test_get_cells_interleaved_missing(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+    cell_mask: int,
+) -> None:
+    """
+    Test that `null` entries appear at the exact request positions when
+    non-existing hashes are interleaved with existing ones (leading,
+    middle, and trailing positions of the request).
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest()) for i in range(5)
+    ]
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        get_blobs_version=4,
+        cell_mask=cell_mask,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+        interleave_nonexisting_blob_hashes=True,
     )

--- a/tests/amsterdam/eip8070_sparse_blobpool/test_get_cells.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/test_get_cells.py
@@ -1,0 +1,144 @@
+"""
+Get cells engine endpoint tests.
+
+Tests for the `engine_getBlobsV4` endpoint in [EIP-8070: eth/72 - Sparse
+Blobpool](https://eips.ethereum.org/EIPS/eip-8070).
+
+`engine_getBlobsV4` retrieves a custody-aligned subset of a blob's cells,
+selected by a `uint128` `indices_bitarray` cell mask, and returns a partial
+cell matrix with `null` entries for cells that were not requested or are not
+held by the client.
+"""
+
+from hashlib import sha256
+from typing import List
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Blob,
+    BlobsTestFiller,
+    Fork,
+    Hash,
+    NetworkWrappedTransaction,
+    Transaction,
+)
+
+from .spec import Spec, ref_spec_8070
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8070.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8070.version
+
+pytestmark = pytest.mark.valid_from("EIP8070")
+
+CELLS = Spec.CELLS_PER_EXT_BLOB
+ALL_CELLS_MASK = (1 << CELLS) - 1
+
+
+def generate_blob_layouts(fork: Fork) -> List:
+    """Return blob transaction layouts to exercise `getBlobsV4`."""
+    max_blobs_per_tx = fork.max_blobs_per_tx()
+    return [
+        pytest.param(
+            [[Blob.from_fork(fork)]],
+            id="single_blob_transaction",
+        ),
+        pytest.param(
+            [[Blob.from_fork(fork, s) for s in range(max_blobs_per_tx)]],
+            id="max_blobs_per_tx",
+        ),
+    ]
+
+
+def generate_cell_masks() -> List:
+    """Return cell masks to exercise `getBlobsV4`."""
+    return [
+        pytest.param(ALL_CELLS_MASK, id="all_cells"),
+        pytest.param((1 << Spec.RECONSTRUCTION_THRESHOLD) - 1, id="first_64"),
+        pytest.param(0xFF, id="custody_aligned_8"),
+        pytest.param(1, id="single_cell"),
+        pytest.param(
+            sum(1 << i for i in range(0, CELLS, 2)), id="alternating_cells"
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "cell_mask",
+    generate_cell_masks(),
+)
+@pytest.mark.parametrize_by_fork("txs_blobs", generate_blob_layouts)
+@pytest.mark.exception_test
+def test_get_cells(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+    cell_mask: int,
+) -> None:
+    """
+    Test that `getBlobsV4` returns exactly the cells selected by the mask.
+
+    Requested cells (and their proofs) must match the locally computed values;
+    non-requested cell indices must be `null` in the partial matrix.
+    """
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        get_blobs_version=4,
+        cell_mask=cell_mask,
+    )
+
+
+@pytest.mark.parametrize(
+    "cell_mask",
+    generate_cell_masks(),
+)
+@pytest.mark.parametrize_by_fork("txs_blobs", generate_blob_layouts)
+@pytest.mark.exception_test
+def test_get_cells_partial_and_missing(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+    cell_mask: int,
+) -> None:
+    """
+    Test that `getBlobsV4` returns a partial response: existing blobs yield a
+    cell matrix while non-existing versioned hashes yield `null` entries.
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest()) for i in range(5)
+    ]
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        get_blobs_version=4,
+        cell_mask=cell_mask,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+    )
+
+
+@pytest.mark.parametrize(
+    "cell_mask",
+    generate_cell_masks(),
+)
+@pytest.mark.parametrize("txs_blobs", [[]], ids=["no_blobs"])
+@pytest.mark.exception_test
+def test_get_cells_only_nonexisting(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    cell_mask: int,
+) -> None:
+    """
+    Test that `getBlobsV4` returns an array of `null` entries (one per
+    requested hash) when all requested blobs are non-existing.
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest()) for i in range(5)
+    ]
+    blobs_test(
+        pre=pre,
+        txs=[],
+        get_blobs_version=4,
+        cell_mask=cell_mask,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add test coverage for [EIP-8070: eth/72 - Sparse Blobpool](https://eips.ethereum.org/EIPS/eip-8070), specifically the new `engine_getBlobsV4` engine API endpoint.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

