### PR TITLE
fix(tests): accept tx-level exception for over-budget block (EIP-7778)

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -327,7 +327,10 @@ def test_multi_transaction_gas_accounting(
         blocks=[
             Block(
                 txs=txs,
-                exception=BlockException.GAS_USED_OVERFLOW
+                exception=[
+                    BlockException.GAS_USED_OVERFLOW,
+                    TransactionException.GAS_ALLOWANCE_EXCEEDED,
+                ]
                 if exceed_block_gas_limit
                 else None,
                 expected_gas_used=total_block_gas_used


### PR DESCRIPTION
## 🗒️ Description

In test_multi_transaction_gas_accounting, a block whose included transaction exceeds the remaining block gas was expected to fail only with the block-level BlockException.GAS_USED_OVERFLOW. A client may legitimately report the same condition at the transaction level as TransactionException.GAS_ALLOWANCE_EXCEEDED (the best I found).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
