### PR TITLE
chore(test-forks): include sibling BPO forks in `--until` ranges

### DIFF
--- a/packages/testing/src/execution_testing/forks/helpers.py
+++ b/packages/testing/src/execution_testing/forks/helpers.py
@@ -195,6 +195,38 @@ def get_last_descendants(
     return resulting_forks
 
 
+def get_bpo_sibling_forks(
+    forks: Set[Type[BaseFork]] | FrozenSet[Type[BaseFork]],
+    forks_from: Set[Type[BaseFork]],
+    forks_until: Set[Type[BaseFork]],
+) -> Set[Type[BaseFork]]:
+    """
+    Return BPO forks that branch off an ancestor of an `--until` fork.
+
+    BPO (Blob Parameter Only) forks form a chain hanging off the fork
+    they extend (e.g. the `BPO3`/`BPO4`/`BPO5` chain branches off `BPO2`).
+    A later fork such as `Amsterdam` descends from that same `BPO2` on a
+    parallel branch, so an ancestry-based `--until=Amsterdam` range never
+    reaches the BPO chain. Return those siblings, bounded below by
+    `forks_from`, so filling until such a fork still exercises the
+    blob-parameter paths the BPO forks cover.
+    """
+    siblings: Set[Type[BaseFork]] = set()
+    for fork_until in forks_until:
+        if issubclass(fork_until, TransitionBaseClass):
+            continue
+        for fork in forks:
+            if not fork.bpo_fork():
+                continue
+            if fork <= fork_until or fork >= fork_until:
+                continue
+            if fork.non_bpo_ancestor() <= fork_until and any(
+                fork >= fork_from for fork_from in forks_from
+            ):
+                siblings.add(fork)
+    return siblings
+
+
 def get_selected_fork_set(
     *,
     single_fork: Set[Type[BaseFork]],
@@ -225,6 +257,9 @@ def get_selected_fork_set(
         for fork_until in forks_until:
             if issubclass(fork_until, TransitionBaseClass):
                 selected_fork_set.discard(fork_until.transitions_to())
+        selected_fork_set |= get_bpo_sibling_forks(
+            ALL_FORKS, forks_from, forks_until
+        )
     selected_fork_set_with_transitions: Set[
         Type[BaseFork | TransitionBaseClass]
     ] = set() | selected_fork_set

--- a/packages/testing/src/execution_testing/forks/helpers.py
+++ b/packages/testing/src/execution_testing/forks/helpers.py
@@ -233,6 +233,7 @@ def get_selected_fork_set(
     forks_from: Set[Type[BaseFork]],
     forks_until: Set[Type[BaseFork]],
     transition_forks: bool = True,
+    bpo_siblings: bool = True,
 ) -> Set[Type[BaseFork | TransitionBaseClass]]:
     """
     Process sets derived from `--fork`, `--until` and `--from` to return an
@@ -257,9 +258,10 @@ def get_selected_fork_set(
         for fork_until in forks_until:
             if issubclass(fork_until, TransitionBaseClass):
                 selected_fork_set.discard(fork_until.transitions_to())
-        selected_fork_set |= get_bpo_sibling_forks(
-            ALL_FORKS, forks_from, forks_until
-        )
+        if bpo_siblings:
+            selected_fork_set |= get_bpo_sibling_forks(
+                ALL_FORKS, forks_from, forks_until
+            )
     selected_fork_set_with_transitions: Set[
         Type[BaseFork | TransitionBaseClass]
     ] = set() | selected_fork_set

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -712,6 +712,18 @@ class TestSelectedForkSetWithTransitionBoundaries:
             Amsterdam,
         }
 
+    def test_until_amsterdam_bpo_siblings_disabled(self) -> None:
+        """`bpo_siblings=False` keeps the parallel BPO branch out."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from=set(),
+            forks_until={Amsterdam},
+            bpo_siblings=False,
+        )
+        normal = self._normal_forks(result)
+        assert {BPO1, BPO2, Amsterdam} <= normal
+        assert not ({BPO3, BPO4, BPO5} & normal)
+
     def test_until_bpo2_excludes_later_bpo_siblings(self) -> None:
         """`--until=BPO2` must not pull in the later BPO branch."""
         result = get_selected_fork_set(

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -13,6 +13,7 @@ from ..forks.forks import (
     BPO2,
     BPO3,
     BPO4,
+    BPO5,
     Amsterdam,
     Berlin,
     Cancun,
@@ -681,6 +682,55 @@ class TestSelectedForkSetWithTransitionBoundaries:
         assert OsakaToBPO1AtTime15k in result
         assert BPO1ToBPO2AtTime15k in result
         assert BPO2ToAmsterdamAtTime15k not in result
+
+    def test_until_amsterdam_includes_bpo_siblings(self) -> None:
+        """`--until=Amsterdam` pulls in the parallel BPO branch."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from=set(),
+            forks_until={Amsterdam},
+        )
+        normal = self._normal_forks(result)
+        assert {BPO1, BPO2, BPO3, BPO4, BPO5, Amsterdam} <= normal
+        assert BPO2ToBPO3AtTime15k in result
+        assert BPO3ToBPO4AtTime15k in result
+
+    def test_from_osaka_until_amsterdam_spans_bpo_branch(self) -> None:
+        """`--from=Osaka --until=Amsterdam` spans the full BPO branch."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={Osaka},
+            forks_until={Amsterdam},
+        )
+        assert self._normal_forks(result) == {
+            Osaka,
+            BPO1,
+            BPO2,
+            BPO3,
+            BPO4,
+            BPO5,
+            Amsterdam,
+        }
+
+    def test_until_bpo2_excludes_later_bpo_siblings(self) -> None:
+        """`--until=BPO2` must not pull in the later BPO branch."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from=set(),
+            forks_until={BPO2},
+        )
+        normal = self._normal_forks(result)
+        assert {BPO1, BPO2} <= normal
+        assert not ({BPO3, BPO4, BPO5} & normal)
+
+    def test_from_amsterdam_until_amsterdam_excludes_bpos(self) -> None:
+        """`--from=Amsterdam --until=Amsterdam` stays Amsterdam-only."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={Amsterdam},
+            forks_until={Amsterdam},
+        )
+        assert self._normal_forks(result) == {Amsterdam}
 
 
 def test_blob_constants() -> None:  # noqa: D103


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Currently when filling with `--until Amsterdam`, we are missing tests that use the BPO3/4/5 test constants.

This PR updates `--until` to include them so we don't miss mainnet coverage in releases.

The missing tests are denoted below (96 cases):
- `tests/cancun/eip4844_blobs/`
  - `test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis`
- `tests/osaka/eip7918_blob_reserve_price/`
  - `test_blob_reserve_price_with_bpo_transitions.py::test_reserve_price_at_transition`
  
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fusagif.com%2Fwp-content%2Fuploads%2Fgifs%2Ffunny-animals-27.gif&f=1&nofb=1&ipt=31a7b41c213ffff3bbd0334d2d2cd6b94f13e062eb776e0cba4d1aceaa8011e2)
