### PR TITLE
refactor(tests): encode z, y as big-endian in test_point_eval_gas

### DIFF
--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
@@ -22,7 +22,7 @@ from execution_testing import (
     ceiling_division,
 )
 
-from .common import INF_POINT, Z
+from .common import INF_POINT, Z_Y_VALID_ENDIANNESS, Z
 from .spec import Spec, ref_spec_4844
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_4844.git_path
@@ -41,8 +41,8 @@ def precompile_input(proof: Literal["correct", "incorrect"]) -> bytes:
     versioned_hash = Spec.kzg_to_versioned_hash(kzg_commitment)
     return (
         versioned_hash
-        + z.to_bytes(32, "little")
-        + y.to_bytes(32, "little")
+        + z.to_bytes(32, Z_Y_VALID_ENDIANNESS)
+        + y.to_bytes(32, Z_Y_VALID_ENDIANNESS)
         + kzg_commitment
         + kzg_proof
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This is just a nitpick fix to the tests.

The EIP-4844 point-evaluation precompile `z` and `y` inputs are supposed to be encoded big-endian, but `test_point_evaluation_precompile_gas` uses little-endian. For this gas test, this doesn't make a difference, but I found it confusing.

Changed it to use `Z_Y_VALID_ENDIANNESS` instead, consistent with `test_point_evaluation_precompile.py`.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [X] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [X] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [X] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [X] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [X] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

