### PR TITLE
chore(packaging): ignore local memory files (CLAUDE.local.md, .mb/, mb/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 
 # AI
 .claude/settings.local.json
+CLAUDE.local.md
+.mb/
+mb/
 .devcontainer
 
 # Benchmark fixed opcode counts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,6 +441,10 @@ builtin = "clear,code,usage"
 # Version control & tooling, build artifacts, data files, test fixtures, temp files, lock files
 skip = [
     ".devcontainer",
+    # Local AI memory and notes files (gitignored, may exist as symlinks)
+    "CLAUDE.local.md",
+    ".mb",
+    "mb",
     ".git",
     ".just",
     ".venv",


### PR DESCRIPTION
## 🗒️ Description

Add the local-only AI memory and notes files to `.gitignore` so they do not show up as untracked in working trees:

- `CLAUDE.local.md`, the Claude Code local project memory file. The [memory docs](https://code.claude.com/docs/en/memory) describe it as the gitignored local instructions file.
- `.mb/` and `mb/`, local memory-bank directories for per-task documentation and scratch notes.

Also add the same files to the codespell `skip` list in `pyproject.toml`. They can exist as symlinks in a working tree, and codespell does not read `.gitignore`. Without the skip entries, codespell scans them and reports false typos coming from personal notes.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
