### PR TITLE
refactor(tests): sort refund types for deterministic fixture output

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -66,7 +66,10 @@ def build_refund_tx(
     auth_state_gas = 0
     auth_state_refund = 0
 
-    for refund_type in refund_types:
+    # Sort by name so iteration order is deterministic across Python
+    # invocations (set iteration over enum members depends on Python's
+    # per-process hash randomization).
+    for refund_type in sorted(refund_types, key=lambda r: r.name):
         match refund_type:
             case RefundTypes.STORAGE_CLEAR:
                 for slot in storage_slots:


### PR DESCRIPTION
## 🗒️ Description
`build_refund_tx` iterated `set(fork.refund_types())`, whose order depends on Python's per-process string-hash randomization.

This creates a lot of noise when one is trying to compare two different fill fixtures using `hasher compare`


## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.

