### PR TITLE
refactor(spec-specs): remove unused regular gas constants in amsterdam

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -68,13 +68,11 @@ class GasCosts:
     COLD_STORAGE_ACCESS: Final[Uint] = Uint(2100)
 
     # Storage
-    STORAGE_SET: Final[Uint] = Uint(20000)
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
     CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
-    NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: Final[Uint] = Uint(200)
@@ -82,7 +80,6 @@ class GasCosts:
     REGULAR_GAS_CREATE: Final[Uint] = Uint(9000)
 
     # Authorization
-    AUTH_PER_EMPTY_ACCOUNT: Final[int] = 25000
     PER_AUTH_BASE_COST: Final[Uint] = Uint(7500)
 
     # Utility
@@ -218,7 +215,6 @@ class GasCosts:
     OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
     OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)
     OPCODE_SELFDESTRUCT_BASE: Final[Uint] = Uint(5000)
-    OPCODE_SELFDESTRUCT_NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
 
 @final


### PR DESCRIPTION
## 🗒️ Description

Removes four regular gas constants from `forks/amsterdam` that became unreferenced when EIP-8037 (#2901) moved the corresponding charges to state gas (`StateGasCosts`):

- `GasCosts.STORAGE_SET` (20000): SSTORE set-from-zero now charges `StateGasCosts.STORAGE_SET`.
- `GasCosts.NEW_ACCOUNT` (25000): `CALL*`/`SELFDESTRUCT`/creation account charges now use `StateGasCosts.NEW_ACCOUNT`.
- `GasCosts.AUTH_PER_EMPTY_ACCOUNT` (25000): Per-authorization costs are now split into `PER_AUTH_BASE_COST` (regular) and `StateGasCosts.NEW_ACCOUNT + StateGasCosts.AUTH_BASE` (state).
- `GasCosts.OPCODE_SELFDESTRUCT_NEW_ACCOUNT` (25000): Folded into the state-gas charge above.

Pure dead-code removal with no behavior change. Verified each constant has no remaining references within `forks/amsterdam`; earlier forks keep their own copies per the WET principle.

## 🔗 Related Issues or PRs

Follow-up to #2901.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="474" height="282" alt="image" src="https://github.com/user-attachments/assets/0ba2a6ce-79ab-4415-a0de-8848cd3da515" />

