### PR TITLE
feat(spec-specs, tests): add EIP-8038 state-access gas cost update

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -4,7 +4,13 @@ EIP-8037: State Creation Gas Cost Increase.
 Harmonization, increase and separate metering of state creation gas costs to
 mitigate state growth and unblock scaling.
 
+This mixin also folds in the EIP-8038 state-access gas repricing: the two EIPs
+ship together in Amsterdam and share one gas schedule, and the MRO places this
+(highest-numbered) mixin too low to be overridden by a separate EIP-8038 mixin.
+The EIP-8038 values are provisional (see the `gas_costs` override below).
+
 https://eips.ethereum.org/EIPS/eip-8037
+https://eips.ethereum.org/EIPS/eip-8038
 """
 
 from dataclasses import replace
@@ -22,9 +28,6 @@ from ....gas_costs import GasCosts
 STATE_BYTES_PER_NEW_ACCOUNT = 120
 STATE_BYTES_PER_STORAGE_SET = 64
 STATE_BYTES_PER_AUTH_BASE = 23
-
-PER_AUTH_BASE_COST = 7_500
-REGULAR_GAS_CREATE = 9_000
 
 SYSTEM_MAX_SSTORES_PER_CALL = 16
 
@@ -74,30 +77,99 @@ class EIP8037(BaseFork):
     @classmethod
     def gas_costs(cls) -> GasCosts:
         """
-        Return gas costs updated for two-dimensional gas metering,
-        with state gas folded into the relevant totals.
+        Return gas costs for Amsterdam's combined EIP-8037 (state
+        creation) and EIP-8038 (state access) repricing, with state gas
+        folded into the relevant totals. EIP-8038 values are provisional.
         """
         cpsb = cls.cost_per_state_byte()
         parent = super(EIP8037, cls).gas_costs()
         new_acct = STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+
+        # EIP-8038 state-access repricing (provisional values).
+        warm_access = 300
+        cold_account_access = 7_800
+        cold_storage_access = 6_300
+        storage_write = 8_400
+        # The framework models the SSTORE write via the compound
+        # COLD_STORAGE_WRITE (access + write), so preserve the invariant
+        # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS == STORAGE_WRITE.
+        cold_storage_write = cold_storage_access + storage_write
+        account_write = 20_100
+        create_access = 21_000
+        # ecRecover stays PRECOMPILE_ECRECOVER (3000) until EIP-7904 lands.
+        regular_per_auth_base_cost = (
+            1_616 + 3_000 + cold_account_access + 2 * warm_access
+        )
+
         return replace(
             parent,
+            WARM_ACCESS=warm_access,
+            WARM_SLOAD=warm_access,
+            COLD_ACCOUNT_ACCESS=cold_account_access,
+            COLD_STORAGE_ACCESS=cold_storage_access,
+            COLD_STORAGE_WRITE=cold_storage_write,
+            ACCOUNT_WRITE=account_write,
+            CALL_VALUE=account_write + 2_300,  # ACCOUNT_WRITE + CALL_STIPEND
+            REFUND_STORAGE_CLEAR=14_400,
+            TX_ACCESS_LIST_ADDRESS=7_200,
+            TX_ACCESS_LIST_STORAGE_KEY=5_700,
             BLOCK_ACCESS_LIST_ITEM=2000,
-            STORAGE_SET=(
-                parent.COLD_STORAGE_WRITE
-                - parent.COLD_STORAGE_ACCESS
-                + STATE_BYTES_PER_STORAGE_SET * cpsb
-            ),
+            STORAGE_SET=(storage_write + STATE_BYTES_PER_STORAGE_SET * cpsb),
             NEW_ACCOUNT=new_acct,
-            OPCODE_CREATE_BASE=REGULAR_GAS_CREATE,
-            TX_CREATE=(REGULAR_GAS_CREATE + new_acct),
+            OPCODE_CREATE_BASE=create_access,
+            TX_CREATE=(create_access + new_acct),
             AUTH_PER_EMPTY_ACCOUNT=(
-                PER_AUTH_BASE_COST
+                account_write
+                + regular_per_auth_base_cost
                 + (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE)
                 * cpsb
             ),
             REFUND_AUTH_PER_EXISTING_ACCOUNT=new_acct,
         )
+
+    @classmethod
+    def opcode_gas_map(
+        cls,
+    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
+        """
+        Return the opcode gas map with the EIP-8038 `EXT*` update:
+        `EXTCODESIZE` and `EXTCODECOPY` charge an extra `WARM_ACCESS`
+        for the second database read (the code).
+        """
+        gas_costs = cls.gas_costs()
+        opcode_gas_map = dict(super(EIP8037, cls).opcode_gas_map())
+
+        def with_extra_warm_access(
+            inner: int | Callable[[OpcodeBase], int],
+        ) -> Callable[[OpcodeBase], int]:
+            def fn(opcode: OpcodeBase) -> int:
+                inner_gas = inner(opcode) if callable(inner) else inner
+                return inner_gas + gas_costs.WARM_ACCESS
+
+            return fn
+
+        for opcode in (Opcodes.EXTCODESIZE, Opcodes.EXTCODECOPY):
+            opcode_gas_map[opcode] = with_extra_warm_access(
+                opcode_gas_map[opcode]
+            )
+        return opcode_gas_map
+
+    @classmethod
+    def _calculate_selfdestruct_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """
+        Calculate the regular SELFDESTRUCT gas cost. EIP-8038 adds
+        `ACCOUNT_WRITE` when a positive balance is sent to an empty
+        account, on top of the inherited cost (where `NEW_ACCOUNT`
+        holds the EIP-8037 state-gas portion).
+        """
+        gas_cost = super(EIP8037, cls)._calculate_selfdestruct_gas(
+            opcode, gas_costs
+        )
+        if opcode.metadata["account_new"]:
+            gas_cost += gas_costs.ACCOUNT_WRITE
+        return gas_cost
 
     @classmethod
     def opcode_gas_calculator(cls) -> OpcodeGasCalculator:
@@ -256,10 +328,11 @@ class EIP8037(BaseFork):
     ) -> int:
         """
         Calculate the regular SSTORE gas cost. The state portion is
-        returned separately by `_calculate_sstore_state_gas`. A cold
-        slot adds `COLD_STORAGE_ACCESS`, a write to an unchanged
-        original adds `COLD_STORAGE_WRITE` minus `COLD_STORAGE_ACCESS`,
-        and every other case adds `WARM_SLOAD`.
+        returned separately by `_calculate_sstore_state_gas`. Under
+        EIP-8038 the access cost (`COLD_STORAGE_ACCESS` when cold, else
+        `WARM_SLOAD`) is always charged, and a first-time change to the
+        slot additionally charges the write cost `STORAGE_WRITE`
+        (modeled as `COLD_STORAGE_WRITE` minus `COLD_STORAGE_ACCESS`).
         """
         metadata = opcode.metadata
 
@@ -269,14 +342,16 @@ class EIP8037(BaseFork):
             current_value = original_value
         new_value = metadata["new_value"]
 
-        gas_cost = 0 if metadata["key_warm"] else gas_costs.COLD_STORAGE_ACCESS
+        gas_cost = (
+            gas_costs.WARM_SLOAD
+            if metadata["key_warm"]
+            else gas_costs.COLD_STORAGE_ACCESS
+        )
 
         if original_value == current_value and current_value != new_value:
             gas_cost += (
                 gas_costs.COLD_STORAGE_WRITE - gas_costs.COLD_STORAGE_ACCESS
             )
-        else:
-            gas_cost += gas_costs.WARM_SLOAD
 
         return gas_cost
 
@@ -332,10 +407,11 @@ class EIP8037(BaseFork):
                 refund -= gas_costs.REFUND_STORAGE_CLEAR
 
             if original_value == new_value:
+                # Refund the STORAGE_WRITE charged on the first-time
+                # change earlier in the transaction.
                 refund += (
                     gas_costs.COLD_STORAGE_WRITE
                     - gas_costs.COLD_STORAGE_ACCESS
-                    - gas_costs.WARM_SLOAD
                 )
 
         return refund

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -4,12 +4,14 @@ EIP-8037: State Creation Gas Cost Increase.
 Harmonization, increase and separate metering of state creation gas costs to
 mitigate state growth and unblock scaling.
 
-This mixin also folds in the EIP-8038 state-access gas repricing: the two EIPs
-ship together in Amsterdam and share one gas schedule, and the MRO places this
-(highest-numbered) mixin too low to be overridden by a separate EIP-8038 mixin.
+The companion EIP-8038 state-access repricing lives in its own `EIP8038`
+mixin. Because the EIP mixins are ordered by number, `EIP8037` sits
+immediately above `EIP8038` in the MRO, so `super().gas_costs()` here
+returns the EIP-8038 schedule and this mixin folds its state-creation gas
+into the shared `STORAGE_SET`, `TX_CREATE`, and `AUTH_PER_EMPTY_ACCOUNT`
+totals on top of it.
 
 https://eips.ethereum.org/EIPS/eip-8037
-https://eips.ethereum.org/EIPS/eip-8038
 """
 
 from dataclasses import replace
@@ -76,99 +78,28 @@ class EIP8037(BaseFork):
     @classmethod
     def gas_costs(cls) -> GasCosts:
         """
-        Return gas costs for Amsterdam's combined EIP-8037 (state
-        creation) and EIP-8038 (state access) repricing, with state gas
-        folded into the relevant totals.
+        Return gas costs with the EIP-8037 state-creation gas folded
+        into the relevant totals, layered on top of the EIP-8038
+        state-access repricing returned by `super().gas_costs()`.
         """
         cpsb = cls.cost_per_state_byte()
         parent = super(EIP8037, cls).gas_costs()
         new_acct = STATE_BYTES_PER_NEW_ACCOUNT * cpsb
 
-        # EIP-8038 state-access repricing.
-        warm_access = 100
-        cold_account_access = 3_000
-        cold_storage_access = 3_000
-        storage_write = 10_000
-        # The framework models the SSTORE write via the compound
-        # COLD_STORAGE_WRITE (access + write), so preserve the invariant
-        # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS == STORAGE_WRITE.
-        cold_storage_write = cold_storage_access + storage_write
-        account_write = 8_000
-        create_access = 11_000
-        # ecRecover stays PRECOMPILE_ECRECOVER (3000) until EIP-7904 lands.
-        regular_per_auth_base_cost = (
-            1_616 + 3_000 + cold_account_access + 2 * warm_access
-        )
-
         return replace(
             parent,
-            WARM_ACCESS=warm_access,
-            WARM_SLOAD=warm_access,
-            COLD_ACCOUNT_ACCESS=cold_account_access,
-            COLD_STORAGE_ACCESS=cold_storage_access,
-            COLD_STORAGE_WRITE=cold_storage_write,
-            ACCOUNT_WRITE=account_write,
-            CALL_VALUE=account_write + 2_300,  # ACCOUNT_WRITE + CALL_STIPEND
-            REFUND_STORAGE_CLEAR=12_480,
-            TX_ACCESS_LIST_ADDRESS=3_000,
-            TX_ACCESS_LIST_STORAGE_KEY=3_000,
-            BLOCK_ACCESS_LIST_ITEM=2000,
-            STORAGE_SET=(storage_write + STATE_BYTES_PER_STORAGE_SET * cpsb),
+            STORAGE_SET=(
+                parent.STORAGE_SET + STATE_BYTES_PER_STORAGE_SET * cpsb
+            ),
             NEW_ACCOUNT=new_acct,
-            OPCODE_CREATE_BASE=create_access,
-            TX_CREATE=(create_access + new_acct),
+            TX_CREATE=parent.TX_CREATE + new_acct,
             AUTH_PER_EMPTY_ACCOUNT=(
-                account_write
-                + regular_per_auth_base_cost
+                parent.AUTH_PER_EMPTY_ACCOUNT
                 + (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE)
                 * cpsb
             ),
             REFUND_AUTH_PER_EXISTING_ACCOUNT=new_acct,
         )
-
-    @classmethod
-    def opcode_gas_map(
-        cls,
-    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
-        """
-        Return the opcode gas map with the EIP-8038 `EXT*` update:
-        `EXTCODESIZE` and `EXTCODECOPY` charge an extra `WARM_ACCESS`
-        for the second database read (the code).
-        """
-        gas_costs = cls.gas_costs()
-        opcode_gas_map = dict(super(EIP8037, cls).opcode_gas_map())
-
-        def with_extra_warm_access(
-            inner: int | Callable[[OpcodeBase], int],
-        ) -> Callable[[OpcodeBase], int]:
-            def fn(opcode: OpcodeBase) -> int:
-                inner_gas = inner(opcode) if callable(inner) else inner
-                return inner_gas + gas_costs.WARM_ACCESS
-
-            return fn
-
-        for opcode in (Opcodes.EXTCODESIZE, Opcodes.EXTCODECOPY):
-            opcode_gas_map[opcode] = with_extra_warm_access(
-                opcode_gas_map[opcode]
-            )
-        return opcode_gas_map
-
-    @classmethod
-    def _calculate_selfdestruct_gas(
-        cls, opcode: OpcodeBase, gas_costs: GasCosts
-    ) -> int:
-        """
-        Calculate the regular SELFDESTRUCT gas cost. EIP-8038 adds
-        `ACCOUNT_WRITE` when a positive balance is sent to an empty
-        account, on top of the inherited cost (where `NEW_ACCOUNT`
-        holds the EIP-8037 state-gas portion).
-        """
-        gas_cost = super(EIP8037, cls)._calculate_selfdestruct_gas(
-            opcode, gas_costs
-        )
-        if opcode.metadata["account_new"]:
-            gas_cost += gas_costs.ACCOUNT_WRITE
-        return gas_cost
 
     @classmethod
     def opcode_gas_calculator(cls) -> OpcodeGasCalculator:
@@ -322,39 +253,6 @@ class EIP8037(BaseFork):
         return state_gas
 
     @classmethod
-    def _calculate_sstore_gas(
-        cls, opcode: OpcodeBase, gas_costs: GasCosts
-    ) -> int:
-        """
-        Calculate the regular SSTORE gas cost. The state portion is
-        returned separately by `_calculate_sstore_state_gas`. Under
-        EIP-8038 the access cost (`COLD_STORAGE_ACCESS` when cold, else
-        `WARM_SLOAD`) is always charged, and a first-time change to the
-        slot additionally charges the write cost `STORAGE_WRITE`
-        (modeled as `COLD_STORAGE_WRITE` minus `COLD_STORAGE_ACCESS`).
-        """
-        metadata = opcode.metadata
-
-        original_value = metadata["original_value"]
-        current_value = metadata["current_value"]
-        if current_value is None:
-            current_value = original_value
-        new_value = metadata["new_value"]
-
-        gas_cost = (
-            gas_costs.WARM_SLOAD
-            if metadata["key_warm"]
-            else gas_costs.COLD_STORAGE_ACCESS
-        )
-
-        if original_value == current_value and current_value != new_value:
-            gas_cost += (
-                gas_costs.COLD_STORAGE_WRITE - gas_costs.COLD_STORAGE_ACCESS
-            )
-
-        return gas_cost
-
-    @classmethod
     def _calculate_sstore_state_gas(
         cls, opcode: OpcodeBase, gas_costs: GasCosts
     ) -> int:
@@ -380,40 +278,6 @@ class EIP8037(BaseFork):
         ):
             return STATE_BYTES_PER_STORAGE_SET * cpsb
         return 0
-
-    @classmethod
-    def _calculate_sstore_refund(
-        cls, opcode: OpcodeBase, gas_costs: GasCosts
-    ) -> int:
-        """
-        Calculate the regular SSTORE gas refund. The state portion is
-        returned separately by `_calculate_sstore_state_refund`.
-        """
-        metadata = opcode.metadata
-
-        original_value = metadata["original_value"]
-        current_value = metadata["current_value"]
-        if current_value is None:
-            current_value = original_value
-        new_value = metadata["new_value"]
-
-        refund = 0
-        if current_value != new_value:
-            if original_value != 0 and current_value != 0 and new_value == 0:
-                refund += gas_costs.REFUND_STORAGE_CLEAR
-
-            if original_value != 0 and current_value == 0:
-                refund -= gas_costs.REFUND_STORAGE_CLEAR
-
-            if original_value == new_value:
-                # Refund the STORAGE_WRITE charged on the first-time
-                # change earlier in the transaction.
-                refund += (
-                    gas_costs.COLD_STORAGE_WRITE
-                    - gas_costs.COLD_STORAGE_ACCESS
-                )
-
-        return refund
 
     @classmethod
     def _calculate_sstore_state_refund(

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -7,7 +7,6 @@ mitigate state growth and unblock scaling.
 This mixin also folds in the EIP-8038 state-access gas repricing: the two EIPs
 ship together in Amsterdam and share one gas schedule, and the MRO places this
 (highest-numbered) mixin too low to be overridden by a separate EIP-8038 mixin.
-The EIP-8038 values are provisional (see the `gas_costs` override below).
 
 https://eips.ethereum.org/EIPS/eip-8037
 https://eips.ethereum.org/EIPS/eip-8038
@@ -79,23 +78,23 @@ class EIP8037(BaseFork):
         """
         Return gas costs for Amsterdam's combined EIP-8037 (state
         creation) and EIP-8038 (state access) repricing, with state gas
-        folded into the relevant totals. EIP-8038 values are provisional.
+        folded into the relevant totals.
         """
         cpsb = cls.cost_per_state_byte()
         parent = super(EIP8037, cls).gas_costs()
         new_acct = STATE_BYTES_PER_NEW_ACCOUNT * cpsb
 
-        # EIP-8038 state-access repricing (provisional values).
-        warm_access = 300
-        cold_account_access = 7_800
-        cold_storage_access = 6_300
-        storage_write = 8_400
+        # EIP-8038 state-access repricing.
+        warm_access = 100
+        cold_account_access = 3_000
+        cold_storage_access = 3_000
+        storage_write = 10_000
         # The framework models the SSTORE write via the compound
         # COLD_STORAGE_WRITE (access + write), so preserve the invariant
         # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS == STORAGE_WRITE.
         cold_storage_write = cold_storage_access + storage_write
-        account_write = 20_100
-        create_access = 21_000
+        account_write = 8_000
+        create_access = 11_000
         # ecRecover stays PRECOMPILE_ECRECOVER (3000) until EIP-7904 lands.
         regular_per_auth_base_cost = (
             1_616 + 3_000 + cold_account_access + 2 * warm_access
@@ -110,9 +109,9 @@ class EIP8037(BaseFork):
             COLD_STORAGE_WRITE=cold_storage_write,
             ACCOUNT_WRITE=account_write,
             CALL_VALUE=account_write + 2_300,  # ACCOUNT_WRITE + CALL_STIPEND
-            REFUND_STORAGE_CLEAR=14_400,
-            TX_ACCESS_LIST_ADDRESS=7_200,
-            TX_ACCESS_LIST_STORAGE_KEY=5_700,
+            REFUND_STORAGE_CLEAR=12_480,
+            TX_ACCESS_LIST_ADDRESS=3_000,
+            TX_ACCESS_LIST_STORAGE_KEY=3_000,
             BLOCK_ACCESS_LIST_ITEM=2000,
             STORAGE_SET=(storage_write + STATE_BYTES_PER_STORAGE_SET * cpsb),
             NEW_ACCOUNT=new_acct,

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
@@ -48,6 +48,8 @@ class EIP8038(BaseFork):
         # COLD_STORAGE_WRITE (access + write), so preserve the invariant
         # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS == STORAGE_WRITE.
         cold_storage_write = cold_storage_access + storage_write
+        # Surcharge for the first write to an account leaf, introduced as a
+        # standalone parameter by this repricing.
         account_write = 8_000
         create_access = 11_000
         # ecRecover stays PRECOMPILE_ECRECOVER (3000) until EIP-7904 lands.

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
@@ -1,0 +1,186 @@
+"""
+EIP-8038: State Access Gas Cost Increase.
+
+Harmonization and increase of state-access gas costs, repricing warm and
+cold account and storage access, account writes, and the related access
+list and authorization costs.
+
+This mixin ships alongside EIP-8037 in Amsterdam. It carries the
+state-access repricing only; the EIP-8037 state-creation gas is folded in
+on top by the (lower-numbered, therefore shallower) `EIP8037` mixin, which
+reads these values via `super().gas_costs()` and adds its state-byte
+portions to the shared `STORAGE_SET`, `TX_CREATE`, and
+`AUTH_PER_EMPTY_ACCOUNT` totals.
+
+https://eips.ethereum.org/EIPS/eip-8038
+"""
+
+from dataclasses import replace
+from typing import Callable, Dict
+
+from execution_testing.vm import (
+    OpcodeBase,
+    Opcodes,
+)
+
+from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
+
+
+class EIP8038(BaseFork):
+    """EIP-8038 class."""
+
+    @classmethod
+    def gas_costs(cls) -> GasCosts:
+        """
+        Return the EIP-8038 state-access gas repricing, layered on top
+        of the parent fork's schedule. EIP-8037 then folds its
+        state-creation gas into the relevant totals via
+        `super().gas_costs()`.
+        """
+        parent = super(EIP8038, cls).gas_costs()
+
+        warm_access = 100
+        cold_account_access = 3_000
+        cold_storage_access = 3_000
+        storage_write = 10_000
+        # The framework models the SSTORE write via the compound
+        # COLD_STORAGE_WRITE (access + write), so preserve the invariant
+        # COLD_STORAGE_WRITE - COLD_STORAGE_ACCESS == STORAGE_WRITE.
+        cold_storage_write = cold_storage_access + storage_write
+        account_write = 8_000
+        create_access = 11_000
+        # ecRecover stays PRECOMPILE_ECRECOVER (3000) until EIP-7904 lands.
+        regular_per_auth_base_cost = (
+            1_616 + 3_000 + cold_account_access + 2 * warm_access
+        )
+
+        return replace(
+            parent,
+            WARM_ACCESS=warm_access,
+            WARM_SLOAD=warm_access,
+            COLD_ACCOUNT_ACCESS=cold_account_access,
+            COLD_STORAGE_ACCESS=cold_storage_access,
+            COLD_STORAGE_WRITE=cold_storage_write,
+            ACCOUNT_WRITE=account_write,
+            CALL_VALUE=account_write + 2_300,  # ACCOUNT_WRITE + CALL_STIPEND
+            REFUND_STORAGE_CLEAR=12_480,
+            TX_ACCESS_LIST_ADDRESS=3_000,
+            TX_ACCESS_LIST_STORAGE_KEY=3_000,
+            BLOCK_ACCESS_LIST_ITEM=2000,
+            STORAGE_SET=storage_write,
+            OPCODE_CREATE_BASE=create_access,
+            TX_CREATE=create_access,
+            AUTH_PER_EMPTY_ACCOUNT=account_write + regular_per_auth_base_cost,
+        )
+
+    @classmethod
+    def opcode_gas_map(
+        cls,
+    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
+        """
+        Return the opcode gas map with the EIP-8038 `EXT*` update:
+        `EXTCODESIZE` and `EXTCODECOPY` charge an extra `WARM_ACCESS`
+        for the second database read (the code).
+        """
+        gas_costs = cls.gas_costs()
+        opcode_gas_map = dict(super(EIP8038, cls).opcode_gas_map())
+
+        def with_extra_warm_access(
+            inner: int | Callable[[OpcodeBase], int],
+        ) -> Callable[[OpcodeBase], int]:
+            def fn(opcode: OpcodeBase) -> int:
+                inner_gas = inner(opcode) if callable(inner) else inner
+                return inner_gas + gas_costs.WARM_ACCESS
+
+            return fn
+
+        for opcode in (Opcodes.EXTCODESIZE, Opcodes.EXTCODECOPY):
+            opcode_gas_map[opcode] = with_extra_warm_access(
+                opcode_gas_map[opcode]
+            )
+        return opcode_gas_map
+
+    @classmethod
+    def _calculate_selfdestruct_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """
+        Calculate the regular SELFDESTRUCT gas cost. EIP-8038 adds
+        `ACCOUNT_WRITE` when a positive balance is sent to an empty
+        account, on top of the inherited cost (where `NEW_ACCOUNT`
+        holds the EIP-8037 state-gas portion).
+        """
+        gas_cost = super(EIP8038, cls)._calculate_selfdestruct_gas(
+            opcode, gas_costs
+        )
+        if opcode.metadata["account_new"]:
+            gas_cost += gas_costs.ACCOUNT_WRITE
+        return gas_cost
+
+    @classmethod
+    def _calculate_sstore_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """
+        Calculate the regular SSTORE gas cost. The state portion is
+        returned separately by `_calculate_sstore_state_gas`. Under
+        EIP-8038 the access cost (`COLD_STORAGE_ACCESS` when cold, else
+        `WARM_SLOAD`) is always charged, and a first-time change to the
+        slot additionally charges the write cost `STORAGE_WRITE`
+        (modeled as `COLD_STORAGE_WRITE` minus `COLD_STORAGE_ACCESS`).
+        """
+        metadata = opcode.metadata
+
+        original_value = metadata["original_value"]
+        current_value = metadata["current_value"]
+        if current_value is None:
+            current_value = original_value
+        new_value = metadata["new_value"]
+
+        gas_cost = (
+            gas_costs.WARM_SLOAD
+            if metadata["key_warm"]
+            else gas_costs.COLD_STORAGE_ACCESS
+        )
+
+        if original_value == current_value and current_value != new_value:
+            gas_cost += (
+                gas_costs.COLD_STORAGE_WRITE - gas_costs.COLD_STORAGE_ACCESS
+            )
+
+        return gas_cost
+
+    @classmethod
+    def _calculate_sstore_refund(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """
+        Calculate the regular SSTORE gas refund. The state portion is
+        returned separately by `_calculate_sstore_state_refund`.
+        """
+        metadata = opcode.metadata
+
+        original_value = metadata["original_value"]
+        current_value = metadata["current_value"]
+        if current_value is None:
+            current_value = original_value
+        new_value = metadata["new_value"]
+
+        refund = 0
+        if current_value != new_value:
+            if original_value != 0 and current_value != 0 and new_value == 0:
+                refund += gas_costs.REFUND_STORAGE_CLEAR
+
+            if original_value != 0 and current_value == 0:
+                refund -= gas_costs.REFUND_STORAGE_CLEAR
+
+            if original_value == new_value:
+                # Refund the STORAGE_WRITE charged on the first-time
+                # change earlier in the transaction.
+                refund += (
+                    gas_costs.COLD_STORAGE_WRITE
+                    - gas_costs.COLD_STORAGE_ACCESS
+                )
+
+        return refund

--- a/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_1153.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_1153.py
@@ -7,15 +7,30 @@ but is discarded after every transaction.
 https://eips.ethereum.org/EIPS/eip-1153
 """
 
+from dataclasses import replace
 from typing import Callable, Dict, List
 
 from execution_testing.vm import OpcodeBase, Opcodes
 
 from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
 
 
 class EIP1153(BaseFork):
     """EIP-1153 class."""
+
+    @classmethod
+    def gas_costs(cls) -> GasCosts:
+        """
+        Set dedicated TLOAD and TSTORE gas costs. Transient storage is
+        in-memory only; its cost matches a warm storage access at
+        introduction but is independent of state-access pricing.
+        """
+        return replace(
+            super(EIP1153, cls).gas_costs(),
+            OPCODE_TLOAD=100,
+            OPCODE_TSTORE=100,
+        )
 
     @classmethod
     def opcode_gas_map(
@@ -26,8 +41,8 @@ class EIP1153(BaseFork):
         base_map = super(EIP1153, cls).opcode_gas_map()
         return {
             **base_map,
-            Opcodes.TLOAD: gas_costs.WARM_SLOAD,
-            Opcodes.TSTORE: gas_costs.WARM_SLOAD,
+            Opcodes.TLOAD: gas_costs.OPCODE_TLOAD,
+            Opcodes.TSTORE: gas_costs.OPCODE_TSTORE,
         }
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -146,3 +146,5 @@ class GasCosts:
     OPCODE_BLOBHASH: int = 0
     OPCODE_MCOPY_BASE: int = 0
     OPCODE_CLZ: int = 0
+    OPCODE_TLOAD: int = 0
+    OPCODE_TSTORE: int = 0

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -36,6 +36,9 @@ class GasCosts:
     CALL_VALUE: int
     CALL_STIPEND: int
     NEW_ACCOUNT: int
+    # Surcharge for the first write to an account leaf; 0 before the
+    # state-access repricing introduces it as a standalone parameter.
+    ACCOUNT_WRITE: int = 0
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: int

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -36,8 +36,6 @@ class GasCosts:
     CALL_VALUE: int
     CALL_STIPEND: int
     NEW_ACCOUNT: int
-    # Surcharge for the first write to an account leaf; 0 before the
-    # state-access repricing introduces it as a standalone parameter.
     ACCOUNT_WRITE: int = 0
 
     # Contract Creation

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -665,7 +665,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     create_state_gas = Uint(0)
     if tx.to == Bytes0(b""):
         create_state_gas = StateGasCosts.NEW_ACCOUNT
-        create_regular_gas = GasCosts.REGULAR_GAS_CREATE + init_code_cost(
+        create_regular_gas = GasCosts.CREATE_ACCESS + init_code_cost(
             ulen(tx.data)
         )
 
@@ -688,9 +688,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     auth_regular_gas = Uint(0)
     auth_state_gas = Uint(0)
     if isinstance(tx, SetCodeTransaction):
-        auth_regular_gas = GasCosts.PER_AUTH_BASE_COST * ulen(
-            tx.authorizations
-        )
+        auth_regular_gas = (
+            GasCosts.ACCOUNT_WRITE + GasCosts.REGULAR_PER_AUTH_BASE_COST
+        ) * ulen(tx.authorizations)
         auth_state_gas = (
             StateGasCosts.NEW_ACCOUNT + StateGasCosts.AUTH_BASE
         ) * ulen(tx.authorizations)

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -192,14 +192,17 @@ def validate_authorization(
     return (authority, authority_account)
 
 
-def set_delegation(message: Message) -> Uint:
+def set_delegation(message: Message) -> Tuple[Uint, Uint]:
     """
     Set the delegation code for the authorities in the message.
 
     Refills `StateGasCosts.NEW_ACCOUNT` when the authority's account
     leaf already exists, and `StateGasCosts.AUTH_BASE` when its code
-    slot already holds a delegation indicator. The total is returned
-    so block accounting can subtract it from `tx_state_gas`.
+    slot already holds a delegation indicator. When the authority leaf
+    already exists, the worst-case `GasCosts.ACCOUNT_WRITE` charged in
+    the intrinsic cost is also refunded to the regular-gas refund
+    counter. The totals are returned so block accounting can subtract
+    the state refill from `tx_state_gas` and apply the regular refund.
 
     Parameters
     ----------
@@ -210,10 +213,14 @@ def set_delegation(message: Message) -> Uint:
     -------
     state_refund : `Uint`
         Total state gas refunded across all processed authorizations.
+    regular_refund : `Uint`
+        Total regular gas (`ACCOUNT_WRITE`) refunded for authorities
+        whose account leaf already existed.
 
     """
     tx_state = message.tx_env.state
     state_refund = Uint(0)
+    regular_refund = Uint(0)
     for auth in message.tx_env.authorizations:
         match validate_authorization(message, auth):
             case None:
@@ -225,6 +232,9 @@ def set_delegation(message: Message) -> Uint:
             refund = StateGasCosts.NEW_ACCOUNT
             message.state_gas_reservoir += refund
             state_refund += refund
+            # The new-account ACCOUNT_WRITE charged at intrinsic time is
+            # not needed: refund it to the regular refund counter.
+            regular_refund += GasCosts.ACCOUNT_WRITE
 
         # No new delegation indicator bytes are written: either the
         # authority already has one (overwrite in place / clear) or
@@ -253,4 +263,4 @@ def set_delegation(message: Message) -> Uint:
         get_account(tx_state, message.code_address).code_hash,
     )
 
-    return state_refund
+    return state_refund, regular_refund

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -196,6 +196,10 @@ class GasCosts:
     OPCODE_DUPN: Final[Uint] = VERY_LOW
     OPCODE_SWAPN: Final[Uint] = VERY_LOW
     OPCODE_EXCHANGE: Final[Uint] = VERY_LOW
+    # Transient storage is in-memory only; its cost is independent of
+    # state-access pricing (EIP-7971 proposes dedicated values).
+    OPCODE_TLOAD: Final[Uint] = Uint(100)
+    OPCODE_TSTORE: Final[Uint] = Uint(100)
 
     # Dynamic Opcode Components
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -63,24 +63,25 @@ class GasCosts:
     HIGH: Final[Uint] = Uint(10)
 
     # Access
-    WARM_ACCESS: Final[Uint] = Uint(100)
-    COLD_ACCOUNT_ACCESS: Final[Uint] = Uint(2600)
-    COLD_STORAGE_ACCESS: Final[Uint] = Uint(2100)
+    WARM_ACCESS: Final[Uint] = Uint(300)
+    COLD_ACCOUNT_ACCESS: Final[Uint] = Uint(7800)
+    COLD_STORAGE_ACCESS: Final[Uint] = Uint(6300)
 
     # Storage
-    COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
+    STORAGE_WRITE: Final[Uint] = Uint(8400)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
+    CALL_VALUE: Final[Uint] = Uint(22400)  # ACCOUNT_WRITE + CALL_STIPEND
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    ACCOUNT_WRITE: Final[Uint] = Uint(20100)
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: Final[Uint] = Uint(200)
     CODE_INIT_PER_WORD: Final[Uint] = Uint(2)
-    REGULAR_GAS_CREATE: Final[Uint] = Uint(9000)
-
-    # Authorization
-    PER_AUTH_BASE_COST: Final[Uint] = Uint(7500)
+    # Provisional value (flat 3x of legacy 7000). The EIP derives
+    # CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS (= 26400); the
+    # provisional table keeps the legacy decomposition instead.
+    CREATE_ACCESS: Final[Uint] = Uint(21000)
 
     # Utility
     ZERO: Final[Uint] = Uint(0)
@@ -88,7 +89,9 @@ class GasCosts:
     FAST_STEP: Final[Uint] = Uint(5)
 
     # Refunds
-    REFUND_STORAGE_CLEAR: Final[int] = 4800
+    # Provisional value (flat 3x of legacy 4800). EIP derivation:
+    # (STORAGE_WRITE + COLD_STORAGE_ACCESS) x 4800/5000 = 14112.
+    REFUND_STORAGE_CLEAR: Final[int] = 14400
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -112,6 +115,19 @@ class GasCosts:
     PRECOMPILE_ECPAIRING_BASE: Final[Uint] = Uint(45000)
     PRECOMPILE_ECPAIRING_PER_POINT: Final[Uint] = Uint(34000)
 
+    # Authorization
+    # Regular-gas charged per EIP-7702 authorization, in addition to
+    # ACCOUNT_WRITE. Sum of: 1616 calldata (101 bytes x TX_DATA_TOKEN_FLOOR),
+    # ecRecover (PRECOMPILE_ECRECOVER, updated by EIP-7904), one cold
+    # authority read (COLD_ACCOUNT_ACCESS), and two warm writes
+    # (2 x WARM_ACCESS).
+    REGULAR_PER_AUTH_BASE_COST: Final[Uint] = (
+        Uint(1616)
+        + PRECOMPILE_ECRECOVER
+        + COLD_ACCOUNT_ACCESS
+        + Uint(2) * WARM_ACCESS
+    )
+
     # Blobs
     PER_BLOB: Final[U64] = U64(2**17)
     BLOB_SCHEDULE_TARGET: Final[U64] = U64(14)
@@ -129,8 +145,11 @@ class GasCosts:
     TX_CREATE: Final[Uint] = Uint(32000)
     TX_DATA_TOKEN_STANDARD: Final[Uint] = Uint(4)
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(16)
-    TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
-    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    # Provisional values (flat 3x). EIP derivation sets these equal to the
+    # access costs: ADDRESS = COLD_ACCOUNT_ACCESS (7800), STORAGE_KEY =
+    # COLD_STORAGE_ACCESS (6300).
+    TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(7200)
+    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(5700)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -209,10 +209,25 @@ class GasCosts:
     OPCODE_DUPN: Final[Uint] = VERY_LOW
     OPCODE_SWAPN: Final[Uint] = VERY_LOW
     OPCODE_EXCHANGE: Final[Uint] = VERY_LOW
-    # Transient storage is in-memory only; its cost is independent of
-    # state-access pricing (EIP-7971 proposes dedicated values).
     OPCODE_TLOAD: Final[Uint] = Uint(100)
+    """
+    Cost of the opcode that reads from transient storage.
+
+    Transient storage is in-memory only; its cost is independent of
+    state-access pricing ([EIP-7971] proposes dedicated values).
+
+    [EIP-7971]: https://eips.ethereum.org/EIPS/eip-7971
+    """
+
     OPCODE_TSTORE: Final[Uint] = Uint(100)
+    """
+    Cost of the opcode that writes to transient storage.
+
+    Transient storage is in-memory only; its cost is independent of
+    state-access pricing ([EIP-7971] proposes dedicated values).
+
+    [EIP-7971]: https://eips.ethereum.org/EIPS/eip-7971
+    """
 
     # Dynamic Opcode Components
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -63,25 +63,23 @@ class GasCosts:
     HIGH: Final[Uint] = Uint(10)
 
     # Access
-    WARM_ACCESS: Final[Uint] = Uint(300)
-    COLD_ACCOUNT_ACCESS: Final[Uint] = Uint(7800)
-    COLD_STORAGE_ACCESS: Final[Uint] = Uint(6300)
+    WARM_ACCESS: Final[Uint] = Uint(100)
+    COLD_ACCOUNT_ACCESS: Final[Uint] = Uint(3000)
+    COLD_STORAGE_ACCESS: Final[Uint] = Uint(3000)
 
     # Storage
-    STORAGE_WRITE: Final[Uint] = Uint(8400)
+    STORAGE_WRITE: Final[Uint] = Uint(10000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(22400)  # ACCOUNT_WRITE + CALL_STIPEND
+    CALL_VALUE: Final[Uint] = Uint(10300)  # ACCOUNT_WRITE + CALL_STIPEND
     CALL_STIPEND: Final[Uint] = Uint(2300)
-    ACCOUNT_WRITE: Final[Uint] = Uint(20100)
+    ACCOUNT_WRITE: Final[Uint] = Uint(8000)
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: Final[Uint] = Uint(200)
     CODE_INIT_PER_WORD: Final[Uint] = Uint(2)
-    # Provisional value (flat 3x of legacy 7000). The EIP derives
-    # CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS (= 26400); the
-    # provisional table keeps the legacy decomposition instead.
-    CREATE_ACCESS: Final[Uint] = Uint(21000)
+    # ACCOUNT_WRITE + COLD_STORAGE_ACCESS, per the EIP-8038 derivation.
+    CREATE_ACCESS: Final[Uint] = Uint(11000)
 
     # Utility
     ZERO: Final[Uint] = Uint(0)
@@ -89,9 +87,9 @@ class GasCosts:
     FAST_STEP: Final[Uint] = Uint(5)
 
     # Refunds
-    # Provisional value (flat 3x of legacy 4800). EIP derivation:
-    # (STORAGE_WRITE + COLD_STORAGE_ACCESS) x 4800/5000 = 14112.
-    REFUND_STORAGE_CLEAR: Final[int] = 14400
+    # (STORAGE_WRITE + COLD_STORAGE_ACCESS) x 4800/5000, per the
+    # EIP-8038 derivation.
+    REFUND_STORAGE_CLEAR: Final[int] = 12480
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -145,11 +143,10 @@ class GasCosts:
     TX_CREATE: Final[Uint] = Uint(32000)
     TX_DATA_TOKEN_STANDARD: Final[Uint] = Uint(4)
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(16)
-    # Provisional values (flat 3x). EIP derivation sets these equal to the
-    # access costs: ADDRESS = COLD_ACCOUNT_ACCESS (7800), STORAGE_KEY =
-    # COLD_STORAGE_ACCESS (6300).
-    TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(7200)
-    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(5700)
+    # Per the EIP-8038 derivation these equal the access costs:
+    # ADDRESS = COLD_ACCOUNT_ACCESS, STORAGE_KEY = COLD_STORAGE_ACCESS.
+    TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(3000)
+    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(3000)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -112,19 +112,6 @@ class GasCosts:
     PRECOMPILE_ECPAIRING_BASE: Final[Uint] = Uint(45000)
     PRECOMPILE_ECPAIRING_PER_POINT: Final[Uint] = Uint(34000)
 
-    # Authorization
-    # Regular-gas charged per EIP-7702 authorization, in addition to
-    # ACCOUNT_WRITE. Sum of: 1616 calldata (101 bytes x TX_DATA_TOKEN_FLOOR),
-    # ecRecover (PRECOMPILE_ECRECOVER, updated by EIP-7904), one cold
-    # authority read (COLD_ACCOUNT_ACCESS), and two warm writes
-    # (2 x WARM_ACCESS).
-    REGULAR_PER_AUTH_BASE_COST: Final[Uint] = (
-        Uint(1616)
-        + PRECOMPILE_ECRECOVER
-        + COLD_ACCOUNT_ACCESS
-        + Uint(2) * WARM_ACCESS
-    )
-
     # Blobs
     PER_BLOB: Final[U64] = U64(2**17)
     BLOB_SCHEDULE_TARGET: Final[U64] = U64(14)
@@ -144,6 +131,29 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(16)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = COLD_ACCOUNT_ACCESS
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = COLD_STORAGE_ACCESS
+
+    # Authorization
+    AUTH_TUPLE_BYTES: Final[Uint] = Uint(101)
+    """
+    Calldata bytes charged for one [EIP-7702] authorization tuple.
+
+    Counts the tuple's fields: the chain id, authority address, nonce,
+    signature parity, and the two signature scalars. Charged at the
+    calldata floor rate (`TX_DATA_TOKEN_FLOOR`).
+
+    [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+    """
+
+    REGULAR_PER_AUTH_BASE_COST: Final[Uint] = (
+        AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
+        + PRECOMPILE_ECRECOVER
+        + COLD_ACCOUNT_ACCESS
+        + Uint(2) * WARM_ACCESS
+    )
+    """
+    Regular gas charged per EIP-7702 authorization, in addition to
+    `ACCOUNT_WRITE`.
+    """
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -78,8 +78,7 @@ class GasCosts:
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: Final[Uint] = Uint(200)
     CODE_INIT_PER_WORD: Final[Uint] = Uint(2)
-    # ACCOUNT_WRITE + COLD_STORAGE_ACCESS, per the EIP-8038 derivation.
-    CREATE_ACCESS: Final[Uint] = Uint(11000)
+    CREATE_ACCESS: Final[Uint] = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
 
     # Utility
     ZERO: Final[Uint] = Uint(0)
@@ -87,9 +86,9 @@ class GasCosts:
     FAST_STEP: Final[Uint] = Uint(5)
 
     # Refunds
-    # (STORAGE_WRITE + COLD_STORAGE_ACCESS) x 4800/5000, per the
-    # EIP-8038 derivation.
-    REFUND_STORAGE_CLEAR: Final[int] = 12480
+    REFUND_STORAGE_CLEAR: Final[int] = int(
+        (STORAGE_WRITE + COLD_STORAGE_ACCESS) * Uint(4800) // Uint(5000)
+    )
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -143,10 +142,8 @@ class GasCosts:
     TX_CREATE: Final[Uint] = Uint(32000)
     TX_DATA_TOKEN_STANDARD: Final[Uint] = Uint(4)
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(16)
-    # Per the EIP-8038 derivation these equal the access costs:
-    # ADDRESS = COLD_ACCOUNT_ACCESS, STORAGE_KEY = COLD_STORAGE_ACCESS.
-    TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(3000)
-    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(3000)
+    TX_ACCESS_LIST_ADDRESS: Final[Uint] = COLD_ACCOUNT_ACCESS
+    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = COLD_STORAGE_ACCESS
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -345,8 +345,8 @@ def extcodesize(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
-    # EIP-8038: extra WARM_ACCESS for the second read (the code).
-    charge_gas(evm, access_gas_cost + GasCosts.WARM_ACCESS)
+    access_gas_cost += GasCosts.WARM_ACCESS  # Code reading cost (EIP-8038)
+    charge_gas(evm, access_gas_cost)
 
     # OPERATION
     tx_state = evm.message.tx_env.state
@@ -388,8 +388,7 @@ def extcodecopy(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
-    # EIP-8038: extra WARM_ACCESS for the second read (the code).
-    access_gas_cost += GasCosts.WARM_ACCESS
+    access_gas_cost += GasCosts.WARM_ACCESS  # Code reading cost (EIP-8038)
 
     total_gas_cost = access_gas_cost + copy_gas_cost + extend_memory.cost
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -341,10 +341,12 @@ def extcodesize(evm: Evm) -> None:
 
     # GAS
     if address in evm.accessed_addresses:
-        charge_gas(evm, GasCosts.WARM_ACCESS)
+        access_gas_cost = GasCosts.WARM_ACCESS
     else:
         evm.accessed_addresses.add(address)
-        charge_gas(evm, GasCosts.COLD_ACCOUNT_ACCESS)
+        access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
+    # EIP-8038: extra WARM_ACCESS for the second read (the code).
+    charge_gas(evm, access_gas_cost + GasCosts.WARM_ACCESS)
 
     # OPERATION
     tx_state = evm.message.tx_env.state
@@ -386,6 +388,8 @@ def extcodecopy(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
+    # EIP-8038: extra WARM_ACCESS for the second read (the code).
+    access_gas_cost += GasCosts.WARM_ACCESS
 
     total_gas_cost = access_gas_cost + copy_gas_cost + extend_memory.cost
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -92,16 +92,16 @@ def sstore(evm: Evm) -> None:
     gas_cost = Uint(0)
     state_gas = Uint(0)
 
+    # Access cost: cold or warm, always charged.
     if (evm.message.current_target, key) not in evm.accessed_storage_keys:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GasCosts.COLD_STORAGE_ACCESS
-
-    if original_value == current_value and current_value != new_value:
-        # charge regular cost for the operation, even when we
-        # already charge state gas for state creation
-        gas_cost += GasCosts.COLD_STORAGE_WRITE - GasCosts.COLD_STORAGE_ACCESS
     else:
         gas_cost += GasCosts.WARM_ACCESS
+
+    # Write cost: charged on the first change to the slot this transaction.
+    if original_value == current_value and current_value != new_value:
+        gas_cost += GasCosts.STORAGE_WRITE
 
     # Refund Counter Calculation
     if current_value != new_value:
@@ -114,12 +114,9 @@ def sstore(evm: Evm) -> None:
             evm.refund_counter -= GasCosts.REFUND_STORAGE_CLEAR
 
         if original_value == new_value:
-            # Storage slot being restored to its original value
-            evm.refund_counter += int(
-                GasCosts.COLD_STORAGE_WRITE
-                - GasCosts.COLD_STORAGE_ACCESS
-                - GasCosts.WARM_ACCESS
-            )
+            # Slot restored to its original value: refund the STORAGE_WRITE
+            # charged on the first-time change earlier this transaction.
+            evm.refund_counter += int(GasCosts.STORAGE_WRITE)
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -156,7 +156,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -186,7 +186,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     set_transient_storage(
         evm.message.tx_env.state,
         evm.message.current_target,

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -195,7 +195,7 @@ def create(evm: Evm) -> None:
     init_code_gas = init_code_cost(Uint(memory_size))
     charge_gas(
         evm,
-        GasCosts.REGULAR_GAS_CREATE + extend_memory.cost + init_code_gas,
+        GasCosts.CREATE_ACCESS + extend_memory.cost + init_code_gas,
     )
 
     # OPERATION
@@ -249,7 +249,7 @@ def create2(evm: Evm) -> None:
     init_code_gas = init_code_cost(Uint(memory_size))
     charge_gas(
         evm,
-        GasCosts.REGULAR_GAS_CREATE
+        GasCosts.CREATE_ACCESS
         + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
         + extend_memory.cost
         + init_code_gas,
@@ -659,16 +659,19 @@ def selfdestruct(evm: Evm) -> None:
         evm.accessed_addresses.add(beneficiary)
 
     state_gas = Uint(0)
+    account_write_gas = Uint(0)
     if (
         not is_account_alive(tx_state, beneficiary)
         and get_account(tx_state, evm.message.current_target).balance != 0
     ):
         state_gas = StateGasCosts.NEW_ACCOUNT
+        # EIP-8038: positive balance sent to an empty account.
+        account_write_gas = GasCosts.ACCOUNT_WRITE
 
     # Charge regular gas before state gas so that a regular-gas OOG
     # does not consume state gas that would inflate the parent's
     # reservoir on frame failure.
-    charge_gas(evm, gas_cost)
+    charge_gas(evm, gas_cost + account_write_gas)
     charge_state_gas(evm, state_gas)
 
     originator = evm.message.current_target

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -151,7 +151,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         if message.tx_env.authorizations != ():
             auth_state_refund, auth_regular_refund = set_delegation(message)
             state_refund += auth_state_refund
-            refund_counter += U256(int(auth_regular_refund))
+            refund_counter += U256(auth_regular_refund)
 
         delegated_address = get_delegated_code_address(message.code)
         if delegated_address is not None:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -149,7 +149,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
             )
     else:
         if message.tx_env.authorizations != ():
-            state_refund += set_delegation(message)
+            auth_state_refund, auth_regular_refund = set_delegation(message)
+            state_refund += auth_state_refund
+            refund_counter += U256(int(auth_regular_refund))
 
         delegated_address = get_delegated_code_address(message.code)
         if delegated_address is not None:

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -105,6 +105,10 @@ def build_refund_tx(
                 auth_state_refund = (
                     gsc.REFUND_AUTH_PER_EXISTING_ACCOUNT * refunds_count
                 )
+                # The worst-case `ACCOUNT_WRITE` charged at intrinsic
+                # time is refunded via the refund counter for existing
+                # authorities, even if the transaction reverts.
+                refund_counter += gsc.ACCOUNT_WRITE * refunds_count
             case _:
                 raise ValueError(
                     f"Unknown refund type: {refund_type} (Test needs update)"

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_refunds.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_refunds.py
@@ -164,10 +164,11 @@ def intrinsic_gas_data_floor_minimum_delta() -> int:
     would always be the below the execution gas cost even after the refund is
     applied.
 
-    This value has been set as of Amsterdam and should be adjusted if the gas
-    costs change.
+    This value has been set as of Amsterdam (with the provisional
+    state-access repricing) and should be adjusted if the gas costs
+    change.
     """
-    return 250
+    return 11_000
 
 
 @pytest.fixture

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_refunds.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_refunds.py
@@ -97,11 +97,15 @@ def max_refund(fork: Fork, refund_type: RefundTypes) -> int:
         if refund_type == RefundTypes.STORAGE_CLEAR
         else 0
     )
-    if (
-        not fork.is_eip_enabled(8037)
-        and refund_type == RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY
-    ):
-        max_refund += gas_costs.REFUND_AUTH_PER_EXISTING_ACCOUNT
+    if refund_type == RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
+        if fork.is_eip_enabled(8037):
+            # The worst-case `ACCOUNT_WRITE` charged at intrinsic time
+            # is refunded via the refund counter when the authority's
+            # account leaf already exists; the state-gas portion is
+            # refilled separately and is not subject to the cap.
+            max_refund += gas_costs.ACCOUNT_WRITE
+        else:
+            max_refund += gas_costs.REFUND_AUTH_PER_EXISTING_ACCOUNT
     return max_refund
 
 

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
@@ -31,7 +31,11 @@ pytestmark = pytest.mark.valid_at("EIP7981")
 @pytest.mark.parametrize(
     "nonzero_bytes",
     [
-        pytest.param(1000, id="1000_nonzero_bytes"),
+        # Must be large enough that the floor midpoint chosen below
+        # stays above the access-list intrinsic cost (asserted in the
+        # test body): each nonzero byte adds 64 gas to the floor but
+        # only 16 to the intrinsic cost.
+        pytest.param(1700, id="1700_nonzero_bytes"),
         pytest.param(2000, id="2000_nonzero_bytes"),
     ],
 )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -49,9 +49,9 @@ class Spec:
     STATE_BYTES_PER_AUTH_BASE = 23
 
     # Regular gas constants. EIP-8037 separated state from regular gas;
-    # EIP-8038 then repriced them (provisional values).
-    REGULAR_GAS_CREATE = 21000
+    # EIP-8038 then repriced them.
+    REGULAR_GAS_CREATE = 11000
     # Total regular intrinsic per EIP-7702 authorization:
-    # ACCOUNT_WRITE (20100) + REGULAR_PER_AUTH_BASE_COST (13016).
-    PER_AUTH_BASE_COST = 33116
-    GAS_COLD_STORAGE_WRITE = 14700
+    # ACCOUNT_WRITE (8000) + REGULAR_PER_AUTH_BASE_COST (7816).
+    PER_AUTH_BASE_COST = 15816
+    GAS_COLD_STORAGE_WRITE = 13000

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -48,7 +48,10 @@ class Spec:
     STATE_BYTES_PER_STORAGE_SET = 64
     STATE_BYTES_PER_AUTH_BASE = 23
 
-    # Regular gas constants (EIP-8037 replaces old combined costs)
-    REGULAR_GAS_CREATE = 9000
-    PER_AUTH_BASE_COST = 7500
-    GAS_COLD_STORAGE_WRITE = 5000
+    # Regular gas constants. EIP-8037 separated state from regular gas;
+    # EIP-8038 then repriced them (provisional values).
+    REGULAR_GAS_CREATE = 21000
+    # Total regular intrinsic per EIP-7702 authorization:
+    # ACCOUNT_WRITE (20100) + REGULAR_PER_AUTH_BASE_COST (13016).
+    PER_AUTH_BASE_COST = 33116
+    GAS_COLD_STORAGE_WRITE = 14700

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -90,8 +90,9 @@ def test_delegatecall_child_spill_not_double_charged(
     """
     Test DELEGATECALL child state gas paid from `gas_left` is not recharged.
 
-    With gas below the Amsterdam tx gas cap, the top-level frame starts with
-    no state gas reservoir and the child pays for SSTOREs by spilling from
+    With the gas limit pinned to the Amsterdam tx gas cap and no requested
+    reservoir (`state_gas_reservoir=0`), the top-level frame starts with no
+    state gas reservoir and the child pays for SSTOREs by spilling from
     `gas_left`. The parent frame must not charge the same state growth again
     at frame end.
     """
@@ -113,7 +114,7 @@ def test_delegatecall_child_spill_not_double_charged(
 
     tx = Transaction(
         to=caller,
-        gas_limit=700_000,
+        state_gas_reservoir=0,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2287,7 +2287,9 @@ def test_selfdestruct_in_create_tx_initcode(
     create_state_gas = fork.create_state_gas(code_size=0)
 
     beneficiary = 0xDEAD
-    initcode = Op.SELFDESTRUCT(beneficiary)
+    # `account_new` folds the beneficiary's `ACCOUNT_WRITE` regular
+    # cost and account-creation state gas into `gas_cost`.
+    initcode = Op.SELFDESTRUCT(beneficiary, account_new=True)
 
     sender = pre.fund_eoa()
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
@@ -2298,7 +2300,7 @@ def test_selfdestruct_in_create_tx_initcode(
     expected_state = create_state_gas + gas_costs.NEW_ACCOUNT
 
     initcode_gas = initcode.gas_cost(fork)
-    gas_limit = intrinsic_total + initcode_gas + gas_costs.NEW_ACCOUNT + 1000
+    gas_limit = intrinsic_total + initcode_gas + 1000
 
     tx = Transaction(
         sender=sender,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -573,8 +573,8 @@ def test_code_deposit_oog_preserves_parent_reservoir(
     init_code = Op.RETURN(0, deploy_size)
 
     # Limited regular gas forwarded to the factory.  After CREATE
-    # takes 63/64, the factory retains ~15 K for its SSTOREs.
-    child_gas = 1_000_000
+    # takes 63/64, the factory retains ~23 K for its SSTOREs.
+    child_gas = 1_500_000
 
     factory_storage = Storage()
     factory = pre.deploy_contract(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -706,8 +706,9 @@ def test_parent_state_gas_after_child_failure(
     # Factory bytecode shape costs, derived from fork.gas_costs():
     #   pre-CREATE: PUSH32 + PUSH1 + MSTORE (with 1-word expansion)
     #               + 3 PUSHes for CREATE inputs
-    #   post-CREATE: PUSH key + SSTORE (no-op) + 2 PUSHes + SSTORE
-    #                (zero-to-nonzero regular)
+    #   post-CREATE: PUSH key + SSTORE (cold no-op: access cost only)
+    #                + 2 PUSHes + SSTORE (cold zero-to-nonzero:
+    #                access + write, the compound COLD_STORAGE_WRITE)
     factory_pre_create_regular = (
         gas_costs.VERY_LOW * 2
         + gas_costs.OPCODE_MSTORE_BASE
@@ -717,7 +718,6 @@ def test_parent_state_gas_after_child_failure(
     factory_post_create_regular = (
         gas_costs.VERY_LOW
         + gas_costs.COLD_STORAGE_ACCESS
-        + gas_costs.WARM_ACCESS
         + gas_costs.VERY_LOW * 2
         + gas_costs.COLD_STORAGE_WRITE
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -701,34 +701,30 @@ def test_selfdestruct_via_delegatecall_chain_no_refund(
 
 
 @pytest.mark.valid_from("EIP8037")
-def test_selfdestruct_new_beneficiary_no_regular_account_creation_cost(
+def test_selfdestruct_new_beneficiary_account_write_cost(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Verify SELFDESTRUCT to a new beneficiary does not charge a
-    regular account-creation cost on top of state gas.
+    Verify SELFDESTRUCT to a new beneficiary charges `ACCOUNT_WRITE`
+    regular gas plus the account-creation state gas, and not the
+    legacy combined regular account-creation cost.
     """
-    gas_costs = fork.gas_costs()
-    new_account_state_gas = gas_costs.NEW_ACCOUNT
-
     beneficiary = pre.fund_eoa(amount=0)
 
-    victim_code = Op.SELFDESTRUCT(beneficiary)
+    victim_code = Op.SELFDESTRUCT(beneficiary, account_new=True)
     victim = pre.deploy_contract(code=victim_code, balance=1)
 
-    # Tight budget: slack is less than the old pre-Amsterdam regular
-    # account-creation cost, so any extra regular draw would OOG.
+    # Tight budget: slack is less than the legacy 25,000 regular
+    # account-creation cost minus `ACCOUNT_WRITE`, so any regular draw
+    # beyond `ACCOUNT_WRITE` would OOG. The opcode metadata folds the
+    # `ACCOUNT_WRITE` regular cost and the account-creation state gas
+    # into `gas_cost`.
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
     tx = Transaction(
         to=victim,
-        gas_limit=(
-            intrinsic
-            + victim_code.gas_cost(fork)
-            + new_account_state_gas
-            + 20_000
-        ),
+        gas_limit=(intrinsic + victim_code.gas_cost(fork) + 4_000),
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -386,6 +386,10 @@ def test_auth_refund_block_gas_accounting(
       `RESET_DELEGATION_ADDRESS`; same full refill, since the refill
       keys off the *pre-state* code slot, not what we're writing.
 
+    When the authority's account leaf already exists, the worst-case
+    `ACCOUNT_WRITE` charged at intrinsic time is additionally refunded
+    via the regular refund counter, subject to the refund cap.
+
     Verified via header `gas_used`, receipt `cumulative_gas_used`, and
     the authority post-state (catches a silently-skipped auth).
     """
@@ -397,6 +401,7 @@ def test_auth_refund_block_gas_accounting(
     )
     intrinsic_regular = total_intrinsic - intrinsic_state_gas
     new_account_refund = fork.gas_costs().REFUND_AUTH_PER_EXISTING_ACCOUNT
+    account_write = fork.gas_costs().ACCOUNT_WRITE
     # Per-auth intrinsic state gas covers NEW_ACCOUNT + AUTH_BASE; the
     # AUTH_BASE portion is what's left after stripping NEW_ACCOUNT.
     auth_base_refund = intrinsic_state_gas - new_account_refund
@@ -411,17 +416,20 @@ def test_auth_refund_block_gas_accounting(
         signer = pre.fund_eoa(amount=0)
         pre_nonce = 0
         auth_refund = auth_base_refund if authorize_to_null else 0
+        refund_counter = 0
     elif signer_pre_state == "existing_leaf":
         signer = pre.fund_eoa()
         pre_nonce = 0
         auth_refund = new_account_refund + (
             auth_base_refund if authorize_to_null else 0
         )
+        refund_counter = account_write
     elif signer_pre_state == "existing_delegation":
         # `fund_eoa(delegation=...)` sets the authority's nonce to 1.
         signer = pre.fund_eoa(delegation=contract_old)
         pre_nonce = 1
         auth_refund = new_account_refund + auth_base_refund
+        refund_counter = account_write
     else:
         raise ValueError(f"unknown signer_pre_state: {signer_pre_state!r}")
 
@@ -450,7 +458,14 @@ def test_auth_refund_block_gas_accounting(
         intrinsic_regular,
         intrinsic_state_gas - auth_refund,
     )
-    receipt_cumulative_gas_used = total_intrinsic - auth_refund
+    # The state refill is not subject to the refund cap; the regular
+    # `ACCOUNT_WRITE` refund is.
+    gas_used_before_refund = total_intrinsic - auth_refund
+    regular_refund = min(
+        gas_used_before_refund // fork.max_refund_quotient(),
+        refund_counter,
+    )
+    receipt_cumulative_gas_used = gas_used_before_refund - regular_refund
 
     tx = Transaction(
         to=contract_new,
@@ -1409,9 +1424,12 @@ def test_auth_sender_billing_after_failure(
     on top-level failure.
 
     For existing accounts, set_delegation refunds new-account state
-    gas to the reservoir. On REVERT, the restored reservoir reduces
-    the sender's bill via the billing formula. The sender pays less
-    than in the new-account case by exactly the refund amount.
+    gas to the reservoir and the worst-case `ACCOUNT_WRITE` to the
+    regular refund counter; both survive the top-level REVERT since
+    delegations are applied before execution. On REVERT, the restored
+    reservoir and the capped regular refund reduce the sender's bill
+    via the billing formula. The sender pays less than in the
+    new-account case.
     """
     auth_intrinsic_state = fork.transaction_intrinsic_state_gas(
         authorization_count=1,
@@ -1431,7 +1449,13 @@ def test_auth_sender_billing_after_failure(
 
     revert_gas = (Op.REVERT(0, 0)).gas_cost(fork)
     auth_refund = new_account_refund if authority_exists else 0
-    expected_cumulative = intrinsic_total + revert_gas - auth_refund
+    refund_counter = fork.gas_costs().ACCOUNT_WRITE if authority_exists else 0
+    gas_used_before_refund = intrinsic_total + revert_gas - auth_refund
+    regular_refund = min(
+        gas_used_before_refund // fork.max_refund_quotient(),
+        refund_counter,
+    )
+    expected_cumulative = gas_used_before_refund - regular_refund
     expected_gas_used = max(
         intrinsic_regular + revert_gas,
         auth_intrinsic_state - auth_refund,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -968,29 +968,36 @@ def test_sstore_restoration_ancestor_revert(
     probe = pre.deploy_contract(code=probe_code)
 
     caller_storage = Storage()
-    caller_code = Op.POP(call_opcode(gas=Op.GAS, address=middle)) + Op.SSTORE(
+    # The probe OOGs and returns 0, so the caller's outer SSTORE is a
+    # cold no-op (0 to 0) on a fresh slot, charging only
+    # COLD_STORAGE_ACCESS rather than the cold set `regular_cost`
+    # assumes by default.
+    caller_code = Op.POP(
+        call_opcode(gas=Op.GAS, address=middle)
+    ) + Op.SSTORE.with_metadata(
+        key_warm=False,
+        original_value=0,
+        current_value=0,
+        new_value=0,
+    )(
         caller_storage.store_next(0, "probe_must_fail"),
         Op.CALL(gas=probe_gas, address=probe),
     )
     caller = pre.deploy_contract(code=caller_code)
 
-    # Block state gas commits only the caller's outer SSTORE-set. The
-    # probe OOGs and inner's set+clear cancel before middle reverts.
-    # The probe's CALL burns its forwarded budget on the OOG, less the
-    # cold-call surcharge already in the caller's static regular cost.
-    # Header gas_used is max(regular, state).
-    probe_burned = (
-        probe_gas - gas_costs.COLD_ACCOUNT_ACCESS - 2 * gas_costs.WARM_ACCESS
-    )
-    expected_regular = (
+    # No SSTORE-set persists (inner's set+clear cancel, middle reverts,
+    # the probe OOGs and reverts, and the caller's outer SSTORE is a
+    # no-op), so block state gas is zero and header gas_used (the max of
+    # regular and state) is just the regular total. The probe burns its
+    # full forwarded budget on the OOG; its CALL's cold-access surcharge
+    # is already counted in the caller's regular cost.
+    expected_gas_used = (
         intrinsic_cost
         + caller_code.regular_cost(fork)
         + middle_code.regular_cost(fork)
         + inner_code.regular_cost(fork)
-        + probe_burned
+        + probe_gas
     )
-    expected_state = Op.SSTORE(new_value=1).state_cost(fork)
-    expected_gas_used = max(expected_regular, expected_state)
 
     # gas_limit at the cap means the caller's reservoir starts at 0.
     tx = Transaction(

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -6,7 +6,6 @@ from enum import unique
 
 import pytest
 from execution_testing import (
-    AccessList,
     Account,
     Address,
     Alloc,
@@ -280,24 +279,33 @@ def test_tstore_rollback_on_failed_create(
     https://github.com/ethereum/execution-specs/issues/917
 
     Initcode does TLOAD(1) to compute a return size, then does
-    TSTORE(1, 0x6000), then returns data of the computed size.
-    When TLOAD(1) is 0, the return size is 0x600a (exceeds max code
-    size 0x6000), so creation fails.
+    TSTORE(1, max_code_size), then returns data of the computed size.
+    When TLOAD(1) is 0, the return size exceeds the max code size, so
+    creation fails.
 
     The caller invokes CREATE/CREATE2 twice with the same initcode.
     If TSTORE from the first (failed) creation is properly rolled
-    back, the second creation also sees TLOAD(1)==0 and fails the
-    same way. If not rolled back, TLOAD(1)==0x6000 and the second
-    creation succeeds.
+    back, the second CREATE2 also sees TLOAD(1)==0 and fails the same
+    way, so nothing is deployed. If it were not rolled back, the
+    second CREATE2 would see TLOAD(1)==max_code_size, return a small
+    valid contract and succeed; the post-state therefore asserts the
+    target address is non-existent.
+
+    The create results are not recorded with SSTORE: a failed create
+    burns its full 63/64 gas forward, and under the EIP-8037
+    transaction gas-limit cap two of them in sequence leave too little
+    regular gas to write the result. Asserting account non-existence
+    checks the same rollback property without that write.
     """
     # Initcode:
-    #   return_size = 0x600a - TLOAD(1)
-    #   TSTORE(1, 0x6000)
+    #   return_size = (max_code_size + 0x0A) - TLOAD(1)
+    #   TSTORE(1, max_code_size)
     #   RETURN(offset=0, size=return_size)
     #
-    # TLOAD(1)==0:     return_size = 0x600a > max code size -> fail
-    # TLOAD(1)==0x6000: return_size = 0x0a <= max code size -> succeed
+    # TLOAD(1)==0:             return_size > max code size -> fail
+    # TLOAD(1)==max_code_size: return_size = 0x0A <= max   -> succeed
     max_code_size = fork.max_code_size()
+    salt = 0
 
     initcode = (
         Op.TLOAD(1)
@@ -310,36 +318,47 @@ def test_tstore_rollback_on_failed_create(
     initcode_bytes = bytes(initcode)
     initcode_len = len(initcode_bytes)
 
+    create_call = (
+        create_opcode(0, 0, initcode_len, salt)
+        if create_opcode == Op.CREATE2
+        else create_opcode(0, 0, initcode_len)
+    )
     caller_code = (
         Om.MSTORE(initcode_bytes, 0)
-        + Op.SSTORE(
-            0,
-            create_opcode(0, 0, initcode_len, 0)
-            if create_opcode == Op.CREATE2
-            else create_opcode(0, 0, initcode_len),
-        )
-        + Op.SSTORE(
-            1,
-            create_opcode(0, 0, initcode_len, 0)
-            if create_opcode == Op.CREATE2
-            else create_opcode(0, 0, initcode_len),
-        )
+        + create_call
+        + Op.POP
+        + create_call
+        + Op.POP
     )
-    caller_address = pre.deploy_contract(caller_code, storage={0: 1, 1: 1})
+    caller_address = pre.deploy_contract(caller_code)
+
+    # CREATE2 targets one deterministic address (salt + initcode) for
+    # both attempts; CREATE targets nonce-derived addresses (the
+    # deployed caller starts at nonce 1).
+    if create_opcode == Op.CREATE2:
+        created_addresses = [
+            compute_create_address(
+                address=caller_address,
+                salt=salt,
+                initcode=initcode,
+                opcode=Op.CREATE2,
+            )
+        ]
+    else:
+        created_addresses = [
+            compute_create_address(
+                address=caller_address, nonce=nonce, opcode=Op.CREATE
+            )
+            for nonce in (1, 2)
+        ]
 
     sender = pre.fund_eoa()
-    tx = Transaction(
-        sender=sender,
-        to=caller_address,
-        access_list=[
-            AccessList(address=caller_address, storage_keys=[0, 1]),
-        ],
-    )
+    tx = Transaction(sender=sender, to=caller_address)
 
-    post = {
-        # Both creations fail because TSTORE is rolled back;
-        # initial storage {0: 1, 1: 1} is overwritten to zeros
-        caller_address: Account(storage={0: 0, 1: 0}),
-    }
+    # Both creations fail because TSTORE is rolled back, so nothing is
+    # deployed; the caller nonce still advances once per attempt.
+    post = {caller_address: Account(nonce=3)}
+    for created_address in created_addresses:
+        post[created_address] = Account.NONEXISTENT  # type: ignore
 
     state_test(pre=pre, post=post, tx=tx)

--- a/tests/paris/eip7610_create_collision/test_collision_selfdestruct.py
+++ b/tests/paris/eip7610_create_collision/test_collision_selfdestruct.py
@@ -74,14 +74,12 @@ def test_selfdestruct_after_create2_collision(
         + Op.SSTORE(
             storage.store_next(1, "create2_call_success"),
             Op.CALL(
-                # Forwarded budget covers deployer's CREATE2 (charged
-                # then refunded on collision under EIP-8037) plus its
-                # SSTORE; both 0 pre-EIP-8037 and scale with cpsb.
-                gas=(
-                    500_000
-                    + fork.gas_costs().NEW_ACCOUNT
-                    + Op.SSTORE(new_value=1).state_cost(fork)
-                ),
+                # The colliding CREATE2 consumes 63/64 of the deployer's
+                # gas (the account-creation state gas is charged then
+                # refunded on collision under EIP-8037); size the budget
+                # so the surviving 1/64 still covers the deployer's cold
+                # SSTORE of the CREATE2 result.
+                gas=500_000 + 64 * fork.gas_costs().COLD_STORAGE_WRITE,
                 address=deployer,
                 args_size=Op.CALLDATASIZE,
             ),

--- a/tests/ported_static/stBadOpcode/test_measure_gas.py
+++ b/tests/ported_static/stBadOpcode/test_measure_gas.py
@@ -3,6 +3,15 @@ Ori Pomerantz   qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stBadOpcode/measureGasFiller.yml
+
+@manually-enhanced: Do not overwrite. A binary search measures the gas
+an opcode needs to succeed. Only the EXTCODE case shifts: it runs a
+warm `EXTCODESIZE` plus a warm `EXTCODECOPY` (the target is warmed by
+earlier search iterations), and EIP-8038 adds a flat +100 to each warm
+extcode access. The stored threshold therefore grows by the sum of the
+two opcodes' warm `(Amsterdam - Cancun)` cost deltas, derived from the
+fork's own gas model so it is exactly 0 before EIP-8038; do not
+hardcode the Amsterdam number.
 """
 
 import pytest
@@ -363,6 +372,26 @@ def test_measure_gas(
         address=Address(0x0000000000000000000000000000000000C0DEF2),  # noqa: E501
     )
 
+    # The EXTCODE search measures a warm `EXTCODESIZE` plus a warm
+    # `EXTCODECOPY` (the target is warmed by earlier search iterations).
+    # EIP-8038 adds a flat surcharge to each warm extcode access, so the
+    # threshold grows by the two opcodes' combined warm cost delta versus
+    # Cancun. Derived from the fork gas model so it is 0 before EIP-8038.
+    # The EXTCODECOPY metadata mirrors the measured access: a 0x20-byte
+    # copy into already-expanded memory, so only the account-access
+    # component varies across forks.
+    warm_extcode_delta = (
+        Op.EXTCODESIZE.with_metadata(address_warm=True).gas_cost(fork) - 100
+    ) + (
+        Op.EXTCODECOPY.with_metadata(
+            address_warm=True,
+            data_size=0x20,
+            new_memory_size=0x120,
+            old_memory_size=0x120,
+        ).gas_cost(fork)
+        - 103
+    )
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [0], "gas": -1, "value": -1},
@@ -397,7 +426,9 @@ def test_measure_gas(
         {
             "indexes": {"data": [10], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_12: Account(storage={0: 221})},
+            "result": {
+                contract_12: Account(storage={0: 221 + warm_extcode_delta})
+            },
         },
         {
             "indexes": {"data": [9], "gas": -1, "value": -1},

--- a/tests/ported_static/stBadOpcode/test_operation_diff_gas.py
+++ b/tests/ported_static/stBadOpcode/test_operation_diff_gas.py
@@ -3,6 +3,16 @@ Ori Pomerantz   qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stBadOpcode/operationDiffGasFiller.yml
+
+@manually-enhanced: Do not overwrite. A search measures the gas an
+opcode needs to succeed. Two access classes shift under EIP-8038: the
+CALL-family probes (`CALL`/`CALLCODE`/`DELEGATECALL`/`STATICCALL`) make
+one cold account access to the callee, repricing by
+`COLD_ACCOUNT_ACCESS - 2600`; the EXTCODE probe runs a cold
+`EXTCODESIZE` plus a warm `EXTCODECOPY`, each carrying the extra
+extcode surcharge. Every delta is derived from the fork's own gas
+model, so it is exactly 0 before EIP-8038 and tracks future parameter
+changes; do not hardcode the Amsterdam numbers.
 """
 
 import pytest
@@ -358,6 +368,27 @@ def test_operation_diff_gas(
         address=Address(0x0000000000000000000000000000000000C0DEF2),  # noqa: E501
     )
 
+    # The CALL-family probes make one cold account access to the callee;
+    # EIP-8038 reprices it by `COLD_ACCOUNT_ACCESS - 2600`. The EXTCODE
+    # probe runs a cold `EXTCODESIZE` plus a warm `EXTCODECOPY`, each
+    # carrying the extcode surcharge. Both deltas come from the fork gas
+    # model, so they are 0 before EIP-8038. The EXTCODECOPY metadata
+    # mirrors the measured access (a 0x20-byte copy into already-expanded
+    # memory) so only the account-access component varies across forks.
+    gas_costs = fork.gas_costs()
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    extcode_probe_delta = (
+        Op.EXTCODESIZE.with_metadata(address_warm=False).gas_cost(fork) - 2600
+    ) + (
+        Op.EXTCODECOPY.with_metadata(
+            address_warm=True,
+            data_size=0x20,
+            new_memory_size=0x120,
+            old_memory_size=0x120,
+        ).gas_cost(fork)
+        - 103
+    )
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [0], "gas": -1, "value": -1},
@@ -372,7 +403,9 @@ def test_operation_diff_gas(
         {
             "indexes": {"data": [2, 3, 4, 5], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_12: Account(storage={0: 2700})},
+            "result": {
+                contract_12: Account(storage={0: 2700 + cold_account_delta})
+            },
         },
         {
             "indexes": {"data": [8, 6, 7], "gas": -1, "value": -1},
@@ -382,7 +415,9 @@ def test_operation_diff_gas(
         {
             "indexes": {"data": [10], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_12: Account(storage={0: 2800})},
+            "result": {
+                contract_12: Account(storage={0: 2800 + extcode_probe_delta})
+            },
         },
         {
             "indexes": {"data": [9], "gas": -1, "value": -1},

--- a/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code.py
+++ b/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code.py
@@ -3,9 +3,15 @@ Test_create2_oo_gafter_init_code.
 
 Ported from:
 state_tests/stCreate2/Create2OOGafterInitCodeFiller.json
-@manually-enhanced: Do not overwrite. tx_gas[1] is tuned to barely
-succeed CREATE2 on Cancun; on Amsterdam EIP-8037 the NEW_ACCOUNT
-state-gas spills, so lift the budget by Fork.oog_budget_lift.
+@manually-enhanced: Do not overwrite. The init code RETURNs a 5-byte
+deployed contract; g0 must run out before the deposit (account stays
+NONEXISTENT) and g1 must just clear it (account created). On Cancun
+the deploy gap is the 1000-gas regular code deposit and the test's
+two budgets straddle it. EIP-8037/8038 move account creation into a
+spilling state-gas charge AND drop OPCODE_CREATE_BASE, so the budget
+that reaches the same RETURN point changes by a fork-derived amount.
+The lift restores the straddle: it is exactly 0 pre-EIP-8037 and
+tracks the parameters. See `_oog_lift` below for the derivation.
 """
 
 import pytest
@@ -113,19 +119,39 @@ def test_create2_oo_gafter_init_code(
     tx_data = [
         Bytes(""),
     ]
-    # Lift both entries on Amsterdam so the test still exercises its
-    # named scenario. With only tx_gas[1] lifted, g=0 OoG'd at CREATE2
-    # dispatch (NEW_ACCOUNT state-gas spill) before init code ever ran —
-    # the assertion still passes (`NONEXISTENT` either way) but the
-    # failure mode is "dispatch-time OoG" instead of "OoG after init
-    # code". A simple `fork.oog_budget_lift(creates_before_oog=1)` (183600)
-    # is *too* generous and pushes g=0 past the deploy threshold; the
-    # Cancun 1000-gas gap between g=0 and g=1 collapses on Amsterdam
-    # because once dispatch is cleared, the 5-byte init code is cheap
-    # enough to always complete. The value below is the middle of the
-    # empirically-safe range (166499, 167000) where g=0 still OoGs at
-    # dispatch *and* g=1 just clears the deploy threshold (~221.5k).
-    _oog_lift = 166_750 if fork.is_eip_enabled(8037) else 0
+    # The init code RETURNs a 5-byte deployed contract, so the CREATE2
+    # frame is charged a code deposit after the init RETURN. On Cancun
+    # that deposit is 1000 (200 * 5 regular) and the two budgets below
+    # straddle it: g0 reaches RETURN just under 1000 gas (deploy fails,
+    # account NONEXISTENT) and g1 just over (deploy succeeds). The
+    # 1000-gas gap between the budgets is exactly this Cancun deploy
+    # threshold.
+    #
+    # EIP-8037/8038 change the CREATE2 dispatch in two ways that the
+    # budget must absorb before the init code RETURNs: the new
+    # `create_state_gas()` spills into regular gas (empty reservoir),
+    # and `OPCODE_CREATE_BASE` drops from its Cancun value of 32000.
+    # Their sum is the net extra the dispatch consumes from the budget.
+    # The deposit step then changes too: its regular `CODE_DEPOSIT_PER_BYTE
+    # * 5` portion is now covered by the state-gas reservoir credited at
+    # dispatch, while `code_deposit_state_gas(code_size=5)` spills and
+    # must come from the forwarded gas instead. The lift restores the
+    # Cancun straddle by funding the net dispatch consumption plus the
+    # deposit's state spill, minus the regular deposit the budgets
+    # already carried in their 1000-gas gap. Every term is 0
+    # pre-EIP-8037, so the original Cancun behavior is preserved.
+    gas_costs = fork.gas_costs()
+    _cancun_create_base = 32000
+    _deploy_size = 5
+    _oog_lift = 0
+    if fork.is_eip_enabled(8037):
+        _oog_lift = (
+            fork.oog_budget_lift(
+                creates_before_oog=1, deploy_code_size=_deploy_size
+            )
+            + (gas_costs.OPCODE_CREATE_BASE - _cancun_create_base)
+            - gas_costs.CODE_DEPOSIT_PER_BYTE * _deploy_size
+        )
     tx_gas = [54000 + _oog_lift, 55000 + _oog_lift]
 
     tx = Transaction(

--- a/tests/ported_static/stCreate2/test_create2_smart_init_code.py
+++ b/tests/ported_static/stCreate2/test_create2_smart_init_code.py
@@ -4,9 +4,16 @@ Create2SmartInitCode. create2 works different each time you call it.
 Ported from:
 state_tests/stCreate2/create2SmartInitCodeFiller.json
 
-@manually-enhanced: Do not overwrite. tx_gas was raised from 400 000 to
-1 000 000 so the CREATE2 path can afford its EIP-8037 NEW_ACCOUNT state
-gas on Amsterdam (post-state expectations are unchanged on all forks).
+@manually-enhanced: Do not overwrite. The d0 call chain performs two
+value-bearing CREATE2s plus a SELFDESTRUCT to a non-alive beneficiary
+and two fresh SSTORE-sets before it finishes; with an empty state-gas
+reservoir every one of those state-gas charges spills into regular gas
+on EIP-8037, overrunning the original 400 000 budget. Lift the budget
+by exactly that spilled state gas via `fork.oog_budget_lift` (three
+`create_state_gas()` charges -- two CREATE2 dispatches and the
+SELFDESTRUCT account creation -- plus two fresh SSTORE-set state
+costs), which is 0 pre-EIP-8037. Post-state expectations are unchanged
+on all forks.
 """
 
 import pytest
@@ -173,11 +180,14 @@ def test_create2_smart_init_code(
         Hash(contract_0, left_padding=True),
         Hash(contract_1, left_padding=True),
     ]
-    # EIP-8037 NEW_ACCOUNT + per-byte state-gas spill into the regular
-    # budget on Amsterdam; pre-EIP-8037 forks keep the original 400 000.
-    outer_tx_gas = 400_000
-    if fork.is_eip_enabled(8037):
-        outer_tx_gas = 1_000_000
+    # The d0 chain spills three `create_state_gas()` charges (two
+    # CREATE2 dispatches and the SELFDESTRUCT to a non-alive
+    # beneficiary) and two fresh SSTORE-set state costs into regular
+    # gas when the reservoir is empty. Lift the original budget by
+    # exactly that spilled state gas; 0 pre-EIP-8037.
+    outer_tx_gas = 400_000 + fork.oog_budget_lift(
+        creates_before_oog=3, sstores_before_oog=2
+    )
     tx_gas = [outer_tx_gas]
 
     tx = Transaction(

--- a/tests/ported_static/stCreateTest/test_create_address_warm_after_fail.py
+++ b/tests/ported_static/stCreateTest/test_create_address_warm_after_fail.py
@@ -9,6 +9,14 @@ Written primarily by Paweł Bylica (@chfast). Somewhat modified by Ori (@qbzzt)
 
 Ported from:
 state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml
+
+@manually-enhanced: Do not overwrite. The post-state records the
+measured cost of accessing the create address after a failed CREATE,
+which is a cold account access. EIP-8038 reprices a cold account
+access from 2 600 to 3 000, so each such measurement gains 400 at
+Amsterdam. Derive that delta from the fork's gas model so it is
+exactly 0 pre-EIP-8037 and tracks parameter changes; do not hardcode
+the Amsterdam value.
 """
 
 import pytest
@@ -381,6 +389,11 @@ def test_create_address_warm_after_fail(
         address=Address(0x00000000000000000000000000000000000C0DEC),  # noqa: E501
     )
 
+    # The create address access after a failed CREATE is cold here;
+    # EIP-8038 reprices a cold account access from 2 600 to 3 000.
+    # Derive the delta from the fork so it is 0 pre-EIP-8037.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [0, 2, 11, 4], "gas": -1, "value": [0]},
@@ -396,7 +409,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,
@@ -447,7 +460,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,
@@ -498,7 +511,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,
@@ -549,7 +562,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,
@@ -600,7 +613,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,
@@ -649,9 +662,9 @@ def test_create_address_warm_after_fail(
                         3: 1,
                         4: 1,
                         5: 1,
-                        12: 2828,
+                        12: 2828 + cold_account_delta,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=0,
@@ -703,9 +716,9 @@ def test_create_address_warm_after_fail(
                         3: 1,
                         4: 1,
                         5: 1,
-                        12: 2828,
+                        12: 2828 + cold_account_delta,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=0,
@@ -753,7 +766,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,
@@ -804,7 +817,7 @@ def test_create_address_warm_after_fail(
                         5: 1,
                         12: 328,
                         13: 316,
-                        14: 2828,
+                        14: 2828 + cold_account_delta,
                         15: 316,
                     },
                     nonce=1,

--- a/tests/ported_static/stCreateTest/test_create_oo_gafter_init_code.py
+++ b/tests/ported_static/stCreateTest/test_create_oo_gafter_init_code.py
@@ -3,9 +3,15 @@ Test_create_oo_gafter_init_code.
 
 Ported from:
 state_tests/stCreateTest/CreateOOGafterInitCodeFiller.json
-@manually-enhanced: Do not overwrite. tx_gas[1] is tuned to barely
-succeed CREATE on Cancun; on Amsterdam EIP-8037 the NEW_ACCOUNT
-state-gas spills, so lift the budget by Fork.oog_budget_lift.
+@manually-enhanced: Do not overwrite. The init code RETURNs a 5-byte
+deployed contract; g0 must run out before the deposit (account stays
+NONEXISTENT) and g1 must just clear it (account created). On Cancun
+the deploy gap is the 1000-gas regular code deposit and the test's
+two budgets straddle it. EIP-8037/8038 move account creation into a
+spilling state-gas charge AND drop OPCODE_CREATE_BASE, so the budget
+that reaches the same RETURN point changes by a fork-derived amount.
+The lift restores the straddle: it is exactly 0 pre-EIP-8037 and
+tracks the parameters. See `_oog_lift` below for the derivation.
 """
 
 import pytest
@@ -109,19 +115,39 @@ def test_create_oo_gafter_init_code(
     tx_data = [
         Bytes(""),
     ]
-    # Lift both entries on Amsterdam so the test still exercises its
-    # named scenario. With only tx_gas[1] lifted, g=0 OoG'd at CREATE
-    # dispatch (NEW_ACCOUNT state-gas spill) before init code ever ran —
-    # the assertion still passes (`NONEXISTENT` either way) but the
-    # failure mode is "dispatch-time OoG" instead of "OoG after init
-    # code". A simple `fork.oog_budget_lift(creates_before_oog=1)` (183600)
-    # is *too* generous and pushes g=0 past the deploy threshold; the
-    # Cancun 1000-gas gap between g=0 and g=1 collapses on Amsterdam
-    # because once dispatch is cleared, the 5-byte init code is cheap
-    # enough to always complete. The value below is the middle of the
-    # empirically-safe range (166499, 167000) where g=0 still OoGs at
-    # dispatch *and* g=1 just clears the deploy threshold (~221.5k).
-    _oog_lift = 166_750 if fork.is_eip_enabled(8037) else 0
+    # The init code RETURNs a 5-byte deployed contract, so the CREATE
+    # frame is charged a code deposit after the init RETURN. On Cancun
+    # that deposit is 1000 (CODE_DEPOSIT_PER_BYTE * 5 regular) and the
+    # two budgets below straddle it: g0 reaches RETURN just under the
+    # threshold (deploy fails, account NONEXISTENT) and g1 just over
+    # (deploy succeeds). The 1000-gas gap between the budgets is exactly
+    # this Cancun deploy threshold.
+    #
+    # EIP-8037/8038 change the CREATE dispatch in two ways that the
+    # budget must absorb before the init code RETURNs: the new
+    # `create_state_gas()` spills into regular gas (empty reservoir),
+    # and `OPCODE_CREATE_BASE` drops from its Cancun value of 32000.
+    # Their sum is the net extra the dispatch consumes from the budget.
+    # The deposit step then changes too: its regular `CODE_DEPOSIT_PER_BYTE
+    # * 5` portion is now covered by the state-gas reservoir credited at
+    # dispatch, while `code_deposit_state_gas(code_size=5)` spills and
+    # must come from the forwarded gas instead. The lift restores the
+    # Cancun straddle by funding the net dispatch consumption plus the
+    # deposit's state spill, minus the regular deposit the budgets
+    # already carried in their 1000-gas gap. Every term is 0
+    # pre-EIP-8037, so the original Cancun behavior is preserved.
+    gas_costs = fork.gas_costs()
+    _cancun_create_base = 32000
+    _deploy_size = 5
+    _oog_lift = 0
+    if fork.is_eip_enabled(8037):
+        _oog_lift = (
+            fork.oog_budget_lift(
+                creates_before_oog=1, deploy_code_size=_deploy_size
+            )
+            + (gas_costs.OPCODE_CREATE_BASE - _cancun_create_base)
+            - gas_costs.CODE_DEPOSIT_PER_BYTE * _deploy_size
+        )
     tx_gas = [54000 + _oog_lift, 55000 + _oog_lift]
 
     tx = Transaction(

--- a/tests/ported_static/stEIP1153_transientStorage/test_14_revert_after_nested_staticcall.py
+++ b/tests/ported_static/stEIP1153_transientStorage/test_14_revert_after_nested_staticcall.py
@@ -3,6 +3,16 @@ Transient storage can't be manipulated from nested staticcall.
 
 Ported from:
 state_tests/Cancun/stEIP1153_transientStorage/14_revertAfterNestedStaticcallFiller.yml
+
+@manually-enhanced: Do not overwrite. The caller writes four fresh
+storage slots and asserts the resulting values (slot 1's pre-marker
+must be overwritten). EIP-8037/8038 spill each fresh SSTORE's
+state-gas charge back into regular gas (the reservoir is empty),
+pushing total consumption past the original 400 000 transaction
+budget; the final SSTORE then OOGs and reverts the whole call,
+leaving slot 1 at its marker. Bump the gas limit by the summed
+fork-derived SSTORE increases so the success path stays funded; the
+bump is exactly 0 before EIP-8037.
 """
 
 import pytest
@@ -15,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,8 +42,30 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_14_revert_after_nested_staticcall(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Transient storage can't be manipulated from nested staticcall."""
+
+    # EIP-8037/8038 spill each fresh SSTORE's state-gas charge back into
+    # regular gas. The caller writes three fresh slots (0, 2, 3: each a
+    # cold zero -> nonzero set) and clears slot 1's cold marker; sum the
+    # per-slot increases so the original budget stays sufficient. Each
+    # term is exactly 0 before EIP-8037.
+    def _sstore_delta(cancun_cost: int, **metadata: int) -> int:
+        op = Op.SSTORE.with_metadata(**metadata)
+        return op.gas_cost(fork) - cancun_cost
+
+    cold_set_delta = _sstore_delta(
+        22100, key_warm=False, original_value=0, current_value=0, new_value=10
+    )
+    cold_clear_delta = _sstore_delta(
+        5000,
+        key_warm=False,
+        original_value=65535,
+        current_value=65535,
+        new_value=0,
+    )
+    gas_limit_bump = 3 * cold_set_delta + cold_clear_delta
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0x3635C9ADC5DEA00000)
 
@@ -136,7 +169,7 @@ def test_14_revert_after_nested_staticcall(
         sender=sender,
         to=target,
         data=Bytes("f5f40590"),
-        gas_limit=400000,
+        gas_limit=400000 + gas_limit_bump,
         max_fee_per_gas=2000,
         max_priority_fee_per_gas=0,
         access_list=[],

--- a/tests/ported_static/stEIP150Specific/test_suicide_to_existing_contract.py
+++ b/tests/ported_static/stEIP150Specific/test_suicide_to_existing_contract.py
@@ -3,6 +3,13 @@ Test_suicide_to_existing_contract.
 
 Ported from:
 state_tests/stEIP150Specific/SuicideToExistingContractFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a value-0 CALL to a cold contract that then
+SELFDESTRUCTs back to its (warm, alive) caller. EIP-8038 reprices the
+cold account access of that CALL; the beneficiary is warm so the
+SELFDESTRUCT is unchanged. The delta is therefore the fork's
+`COLD_ACCOUNT_ACCESS - 2600`, exactly 0 before EIP-8038.
 """
 
 import pytest
@@ -15,6 +22,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +37,11 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_suicide_to_existing_contract(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_suicide_to_existing_contract."""
+    # EIP-8038 cold account access reprice; 0 before EIP-8038.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -90,7 +101,7 @@ def test_suicide_to_existing_contract(
             balance=0,
             nonce=0,
         ),
-        target: Account(storage={1: 7637}),
+        target: Account(storage={1: 7637 + cold_account_delta}),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP150Specific/test_suicide_to_not_existing_contract.py
+++ b/tests/ported_static/stEIP150Specific/test_suicide_to_not_existing_contract.py
@@ -3,6 +3,14 @@ Test_suicide_to_not_existing_contract.
 
 Ported from:
 state_tests/stEIP150Specific/SuicideToNotExistingContractFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a value-0 CALL to a cold contract that then
+SELFDESTRUCTs (with a zero balance) to a cold, non-alive beneficiary.
+EIP-8038 reprices both the CALL's cold account access and the
+SELFDESTRUCT beneficiary's cold access; no value is sent so there is
+no new-account write. The delta is therefore twice the fork's
+`COLD_ACCOUNT_ACCESS - 2600`, exactly 0 before EIP-8038.
 """
 
 import pytest
@@ -15,6 +23,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +38,13 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_suicide_to_not_existing_contract(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_suicide_to_not_existing_contract."""
+    # EIP-8038 cold account access reprice; 0 before EIP-8038. Charged
+    # twice: once for the CALL target, once for the cold SELFDESTRUCT
+    # beneficiary.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -88,7 +102,7 @@ def test_suicide_to_not_existing_contract(
             balance=0,
             nonce=0,
         ),
-        target: Account(storage={1: 10237}),
+        target: Account(storage={1: 10237 + 2 * cold_account_delta}),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_eip2929.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_eip2929.py
@@ -3,6 +3,25 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/eip2929Filler.yml
+
+@manually-enhanced: Do not overwrite. Each parametrization runs three
+operations (`oper1, oper2, oper3` from the calldata) on the same
+measurement contract and stores each one's `Op.GAS` cost in slots 0,
+1, 2. EIP-8038 reprices state access, so the cost of every measured
+operation shifts by the (Amsterdam - Cancun) repricing of whatever
+cold/warm account or storage access it performs. The access pattern,
+and hence the delta, depends on what the two preceding operations
+already warmed, so the deltas are computed by a small simulator
+(`_slot_deltas`) that walks the operation triple while tracking the
+warm state of the contract-0 account and storage slot 0x100. Each
+component is built only from the fork's own gas model
+(`COLD_ACCOUNT_ACCESS`, `COLD_STORAGE_ACCESS`, the EIP-8038 extra
+`WARM_ACCESS` for code reads, and `Op.SSTORE` metadata costs), so
+every delta is exactly 0 pre-EIP-8037 and tracks future parameter
+changes. The `far*` operations call contract-1 (which does
+`BALANCE(contract-0)`) or contract-2 (which does `SLOAD(0x100)`), so
+they contribute the inner access's delta. Do not hardcode the
+Amsterdam numbers.
 """
 
 import pytest
@@ -836,113 +855,201 @@ def test_eip2929(
         nonce=0,
     )
 
+    # EIP-8038 access-repricing component deltas (each 0 pre-EIP-8037).
+    gas_costs = fork.gas_costs()
+    eip_active = fork.is_eip_enabled(8037)
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    cold_storage_delta = gas_costs.COLD_STORAGE_ACCESS - 2100
+    # EIP-8038 charges an extra warm access for an EXTCODE* code read,
+    # on every access (cold adds it on top of the cold account cost,
+    # warm pays it as a second warm access).
+    extra_code_read = gas_costs.WARM_ACCESS if eip_active else 0
+    cold_code_read_delta = cold_account_delta + extra_code_read
+    warm_code_read_delta = extra_code_read
+
+    def _sstore_delta(cancun_cost: int, **metadata: int) -> int:
+        return Op.SSTORE.with_metadata(**metadata).gas_cost(fork) - cancun_cost
+
+    # SSTORE 24743 -> 5 (existing nonzero slot changed to a new nonzero
+    # value): cold first write vs warm subsequent write.
+    cold_sstore_write_delta = _sstore_delta(
+        5000, key_warm=False, original_value=1, current_value=1, new_value=2
+    )
+    warm_sstore_write_delta = _sstore_delta(
+        2900, key_warm=True, original_value=1, current_value=1, new_value=2
+    )
+
+    # Operation opcodes (from the calldata oper words).
+    op_nop, op_sload, op_sstore = 0x0, 0x1, 0x2
+    op_balance, op_extsize, op_extcopy, op_exthash = 0xB, 0xC, 0xD, 0xE
+    op_call0, op_callcode0, op_deleg0, op_static0 = 0x15, 0x16, 0x17, 0x18
+    op_call1, op_callcode2, op_deleg2 = 0x1F, 0x20, 0x21
+    account_c0_ops = {
+        op_balance,
+        op_exthash,
+        op_call0,
+        op_callcode0,
+        op_deleg0,
+        op_static0,
+    }
+    code_read_ops = {op_extsize, op_extcopy}
+    inner_sload_ops = {op_sload, op_callcode2, op_deleg2}
+    # oper triples per data index, matching tx_data below.
+    oper_triples = {
+        0: (op_nop, op_nop, op_nop),
+        1: (op_sload, op_sload, op_sload),
+        2: (op_sstore, op_sstore, op_sstore),
+        3: (op_balance, op_balance, op_balance),
+        4: (op_extsize, op_extsize, op_extsize),
+        5: (op_extcopy, op_extcopy, op_extcopy),
+        6: (op_exthash, op_exthash, op_exthash),
+        7: (op_call0, op_call0, op_call0),
+        8: (op_callcode0, op_callcode0, op_callcode0),
+        9: (op_deleg0, op_deleg0, op_deleg0),
+        10: (op_static0, op_static0, op_static0),
+        11: (op_call1, op_call1, op_call1),
+        12: (op_callcode2, op_callcode2, op_callcode2),
+        13: (op_deleg2, op_deleg2, op_deleg2),
+        14: (op_sload, op_sstore, op_sload),
+        15: (op_sload, op_callcode2, op_deleg2),
+        16: (op_sload, op_sstore, op_deleg2),
+        17: (op_callcode2, op_sload, op_deleg2),
+        18: (op_deleg2, op_sload, op_sstore),
+        19: (op_balance, op_extsize, op_exthash),
+        20: (op_balance, op_exthash, op_extsize),
+        21: (op_extsize, op_balance, op_exthash),
+        22: (op_extsize, op_exthash, op_balance),
+        23: (op_exthash, op_extsize, op_balance),
+        24: (op_exthash, op_balance, op_extsize),
+        25: (op_call0, op_callcode0, op_call0),
+        26: (op_callcode0, op_callcode0, op_call0),
+        27: (op_deleg0, op_static0, op_deleg0),
+        28: (op_deleg0, op_static0, op_static0),
+        29: (op_balance, op_call0, op_callcode0),
+        30: (op_extsize, op_call0, op_callcode0),
+        31: (op_exthash, op_call0, op_callcode0),
+        32: (op_balance, op_callcode0, op_call0),
+        33: (op_extsize, op_callcode0, op_call0),
+        34: (op_exthash, op_callcode0, op_call0),
+        35: (op_balance, op_extsize, op_call1),
+        36: (op_balance, op_call1, op_exthash),
+        37: (op_call1, op_exthash, op_balance),
+    }
+
+    def _slot_deltas(index: int) -> tuple[int, int, int]:
+        """
+        Return the (slot0, slot1, slot2) EIP-8038 deltas for an index.
+
+        Walk the operation triple, tracking the warm state of the
+        contract-0 account and storage slot 0x100 (pre-value 24743),
+        and accumulate the (Amsterdam - Cancun) repricing each measured
+        operation incurs. The `far*` calls reach a pre-warmed contract
+        whose body performs the inner access, so they contribute that
+        inner access's delta.
+        """
+        c0_warm = False
+        slot_warm = False
+        slot_value = 24743
+        out = []
+        for op in oper_triples[index]:
+            delta = 0
+            if op in inner_sload_ops:
+                # Direct SLOAD(0x100) or a far call whose body SLOADs it.
+                if not slot_warm:
+                    delta = cold_storage_delta
+                    slot_warm = True
+            elif op == op_sstore:
+                if slot_value != 5:
+                    delta = (
+                        cold_sstore_write_delta
+                        if not slot_warm
+                        else warm_sstore_write_delta
+                    )
+                    slot_value = 5
+                slot_warm = True
+            elif op in code_read_ops:
+                delta = (
+                    cold_code_read_delta
+                    if not c0_warm
+                    else warm_code_read_delta
+                )
+                c0_warm = True
+            elif op in account_c0_ops or op == op_call1:
+                # Account access to contract-0 (CALL1's body BALANCEs it).
+                if not c0_warm:
+                    delta = cold_account_delta
+                    c0_warm = True
+            out.append(delta)
+        return out[0], out[1], out[2]
+
+    def _expect(index: int, base: tuple[int, int, int]) -> dict:
+        """Storage dict with each slot bumped by its EIP-8038 delta."""
+        deltas = _slot_deltas(index)
+        return {i: base[i] + deltas[i] for i in range(3)}
+
+    # Cancun-era base value of each measured slot, per data index. The
+    # per-index EIP-8038 delta is added by `_expect`, so each entry is a
+    # single data index (grouped entries with identical Cancun bases can
+    # still need different deltas once the access pattern differs).
+    base_values: dict[int, tuple[int, int, int]] = {
+        1: (2090, 90, 90),
+        2: (4991, 91, 91),
+        3: (2590, 90, 90),
+        4: (2590, 90, 90),
+        5: (2597, 97, 97),
+        6: (2590, 90, 90),
+        7: (2608, 108, 108),
+        8: (2608, 108, 108),
+        9: (2605, 105, 105),
+        10: (2605, 105, 105),
+        11: (2711, 211, 211),
+        12: (2211, 211, 211),
+        13: (2208, 208, 208),
+        14: (2090, 2891, 90),
+        15: (2090, 211, 208),
+        16: (2090, 2891, 208),
+        17: (2211, 90, 208),
+        18: (2208, 90, 2891),
+        19: (2590, 90, 90),
+        20: (2590, 90, 90),
+        21: (2590, 90, 90),
+        22: (2590, 90, 90),
+        23: (2590, 90, 90),
+        24: (2590, 90, 90),
+        25: (2608, 108, 108),
+        26: (2608, 108, 108),
+        27: (2605, 105, 105),
+        28: (2605, 105, 105),
+        29: (2590, 108, 108),
+        30: (2590, 108, 108),
+        31: (2590, 108, 108),
+        32: (2590, 108, 108),
+        33: (2590, 108, 108),
+        34: (2590, 108, 108),
+        35: (2590, 90, 211),
+        36: (2590, 211, 90),
+        37: (2711, 90, 90),
+    }
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [0], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_3: Account(storage={0: 0})},
         },
-        {
-            "indexes": {"data": [1], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2090, 1: 90, 2: 90})},
-        },
-        {
-            "indexes": {"data": [2], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 4991, 1: 91, 2: 91})},
-        },
-        {
-            "indexes": {"data": [14], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2090, 1: 2891, 2: 90})},
-        },
-        {
-            "indexes": {
-                "data": [3, 4, 6, 19, 20, 21, 22, 23, 24],
-                "gas": -1,
-                "value": -1,
-            },
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2590, 1: 90, 2: 90})},
-        },
-        {
-            "indexes": {"data": [5], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2597, 1: 97, 2: 97})},
-        },
-        {
-            "indexes": {"data": [8, 25, 26, 7], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2608, 1: 108, 2: 108})},
-        },
-        {
-            "indexes": {"data": [9, 10, 27, 28], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2605, 1: 105, 2: 105})},
-        },
-        {
-            "indexes": {
-                "data": [32, 33, 34, 29, 30, 31],
-                "gas": -1,
-                "value": -1,
-            },
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2590, 1: 108, 2: 108})},
-        },
-        {
-            "indexes": {"data": [11], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2711, 1: 211, 2: 211})},
-        },
-        {
-            "indexes": {"data": [35], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2590, 1: 90, 2: 211})},
-        },
-        {
-            "indexes": {"data": [36], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2590, 1: 211, 2: 90})},
-        },
-        {
-            "indexes": {"data": [37], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2711, 1: 90, 2: 90})},
-        },
-        {
-            "indexes": {"data": [12], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2211, 1: 211, 2: 211})},
-        },
-        {
-            "indexes": {"data": [13], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2208, 1: 208, 2: 208})},
-        },
-        {
-            "indexes": {"data": [15], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2090, 1: 211, 2: 208})},
-        },
-        {
-            "indexes": {"data": [16], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {
-                contract_3: Account(storage={0: 2090, 1: 2891, 2: 208})
-            },
-        },
-        {
-            "indexes": {"data": [17], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2211, 1: 90, 2: 208})},
-        },
-        {
-            "indexes": {"data": [18], "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 2208, 1: 90, 2: 2891})},
-        },
     ]
+    for index in sorted(base_values):
+        expect_entries_.append(
+            {
+                "indexes": {"data": [index], "gas": -1, "value": -1},
+                "network": [">=Cancun"],
+                "result": {
+                    contract_3: Account(
+                        storage=_expect(index, base_values[index])
+                    )
+                },
+            }
+        )
 
     post, _exc = resolve_expect_post(expect_entries_, d, g, v, fork)
 

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_eip2929_minus_ff.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_eip2929_minus_ff.py
@@ -3,6 +3,15 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/eip2929-ffFiller.yml
+
+@manually-enhanced: Do not overwrite. The first expect-entry (the
+`simple`/NOP case) measures a `CALL` into a contract that
+`SELFDESTRUCT`s with an as-yet-untouched (cold) beneficiary. EIP-8038
+reprices the cold account access (`COLD_ACCOUNT_ACCESS`, 2600 -> 3000),
+so that cost shifts by `COLD_ACCOUNT_ACCESS - 2600`, derived from the
+fork's own constant so it is exactly 0 pre-EIP-8038. The other entry
+pre-warms the beneficiary, so its cost is unchanged. Do not hardcode
+the Amsterdam number.
 """
 
 import pytest
@@ -99,6 +108,8 @@ def test_eip2929_minus_ff(
     v: int,
 ) -> None:
     """Ori Pomerantz qbzzt1@gmail."""
+    # EIP-8038 cold account repricing (2600 -> 3000); 0 on earlier forks.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x000000000000000000000000000000000000DE57)
     contract_1 = Address(0x000000000000000000000000000000000000CA11)
@@ -315,7 +326,11 @@ def test_eip2929_minus_ff(
         {
             "indexes": {"data": [0], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_2: Account(storage={0: 7726, 1: 105})},
+            "result": {
+                contract_2: Account(
+                    storage={0: 7726 + cold_account_delta, 1: 105}
+                )
+            },
         },
         {
             "indexes": {

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_gas_cost.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_gas_cost.py
@@ -3,6 +3,17 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/gasCostFiller.yml
+
+@manually-enhanced: Do not overwrite. This crafts a one-opcode
+contract, CALLs it, and stores the opcode's measured gas via `Op.GAS`.
+EIP-8038 reprices state access, so four opcodes shift: `BALANCE` and
+`SELFDESTRUCT` (cold account, `COLD_ACCOUNT_ACCESS` 2600 -> 3000, +400),
+`EXTCODESIZE` (cold account plus the extra `WARM_ACCESS` charged for
+the opcode's second read of the code, +500), and `SSTORE` to a cold
+fresh slot (`COLD_STORAGE_ACCESS` 2100 -> 3000, +900). `BALANCE` and
+`EXTCODESIZE` share a Cancun baseline but need different deltas, so
+their expect-entries are split. Every delta is derived from the fork's
+own constants and is exactly 0 pre-EIP-8038; do not hardcode it.
 """
 
 import pytest
@@ -714,6 +725,14 @@ def test_gas_cost(
     v: int,
 ) -> None:
     """Ori Pomerantz qbzzt1@gmail."""
+    gas_costs = fork.gas_costs()
+    # EIP-8038 access repricing; each term is 0 on earlier forks.
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    cold_storage_delta = gas_costs.COLD_STORAGE_ACCESS - 2100
+    # EXTCODESIZE also gains an extra warm access for its code read.
+    code_read_delta = cold_account_delta + (
+        gas_costs.WARM_ACCESS if fork.is_eip_enabled(8037) else 0
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = EOA(
         key=0x40AC0FC28C27E961EE46EC43355A094DE205856EDBD4654CF2577C2608D4EC1E
@@ -1070,10 +1089,15 @@ def test_gas_cost(
             },
         },
         {
+            # SSTORE to a cold fresh slot: cold storage repricing.
             "indexes": {"data": [39], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                addr: Account(storage=_storage_with_any({0: 700}, [1]))
+                addr: Account(
+                    storage=_storage_with_any(
+                        {0: 700 + cold_storage_delta}, [1]
+                    )
+                )
             },
         },
         {
@@ -1084,17 +1108,38 @@ def test_gas_cost(
             },
         },
         {
+            # SELFDESTRUCT to a cold (zero) beneficiary: cold account.
             "indexes": {"data": [45], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                addr: Account(storage=_storage_with_any({0: 2000}, [1]))
+                addr: Account(
+                    storage=_storage_with_any(
+                        {0: 2000 + cold_account_delta}, [1]
+                    )
+                )
             },
         },
         {
-            "indexes": {"data": [31, 23], "gas": -1, "value": -1},
+            # BALANCE on a cold (zero) address: cold account.
+            "indexes": {"data": [23], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                addr: Account(storage=_storage_with_any({0: 1300}, [1]))
+                addr: Account(
+                    storage=_storage_with_any(
+                        {0: 1300 + cold_account_delta}, [1]
+                    )
+                )
+            },
+        },
+        {
+            # EXTCODESIZE on a cold (zero) address: cold account plus the
+            # extra warm access for the opcode's code read.
+            "indexes": {"data": [31], "gas": -1, "value": -1},
+            "network": [">=Cancun"],
+            "result": {
+                addr: Account(
+                    storage=_storage_with_any({0: 1300 + code_read_delta}, [1])
+                )
             },
         },
     ]

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_gas_cost_berlin.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_gas_cost_berlin.py
@@ -3,6 +3,18 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/gasCostBerlinFiller.yml
+
+@manually-enhanced: Do not overwrite. This crafts a one-opcode
+contract, CALLs it, and stores the opcode's measured gas minus the
+data's hardcoded Cancun-era expected cost (so the net is normally 0).
+EIP-8038 reprices state access, so four opcodes now exceed their old
+expected cost by a fork-derived delta: `BALANCE` and `SELFDESTRUCT`
+(cold account, `COLD_ACCOUNT_ACCESS` 2600 -> 3000, +400), `EXTCODESIZE`
+(cold account plus the extra `WARM_ACCESS` for the opcode's code read,
++500), and `SLOAD` (cold storage, `COLD_STORAGE_ACCESS` 2100 -> 3000,
++900). The stored net for those four data indices becomes that delta;
+every other index stays 0. Each delta is derived from the fork's own
+constants and is exactly 0 pre-EIP-8038; do not hardcode it.
 """
 
 import pytest
@@ -710,6 +722,23 @@ def test_gas_cost_berlin(
     v: int,
 ) -> None:
     """Ori Pomerantz qbzzt1@gmail."""
+    gas_costs = fork.gas_costs()
+    # EIP-8038 access repricing; each term is 0 on earlier forks.
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    cold_storage_delta = gas_costs.COLD_STORAGE_ACCESS - 2100
+    # EXTCODESIZE also gains an extra warm access for its code read.
+    code_read_delta = cold_account_delta + (
+        gas_costs.WARM_ACCESS if fork.is_eip_enabled(8037) else 0
+    )
+    # Each measured opcode subtracts its Cancun-era expected cost, so the
+    # net is the (Amsterdam - Cancun) repricing of the one state access
+    # it performs (cold address 0 / cold fresh slot), keyed by data index.
+    measured_delta = {
+        23: cold_account_delta,  # BALANCE
+        31: code_read_delta,  # EXTCODESIZE
+        39: cold_storage_delta,  # SLOAD
+        45: cold_account_delta,  # SELFDESTRUCT
+    }.get(d, 0)
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xBA1A9CE0BA1A9CE)
 
@@ -969,6 +998,6 @@ def test_gas_cost_berlin(
         value=tx_value[v],
     )
 
-    post = {addr: Account(storage=_storage_with_any({0: 0}, [1]))}
+    post = {addr: Account(storage=_storage_with_any({0: measured_delta}, [1]))}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_gas_cost_memory.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_gas_cost_memory.py
@@ -3,6 +3,15 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/gasCostMemoryFiller.yml
+
+@manually-enhanced: Do not overwrite. The second expect-entry (data
+36-48) stores the regular gas of a measured window that includes one
+extra cold `CALL` to a previously untouched contract relative to its
+baseline. EIP-8038 reprices `COLD_ACCOUNT_ACCESS` (2600 -> 3000), so
+that net cost shifts by `COLD_ACCOUNT_ACCESS - 2600`, derived from the
+fork's own constant so it is exactly 0 pre-EIP-8038. The first entry
+measures a difference of two equal-cost operations and is unchanged.
+Do not hardcode the Amsterdam number.
 """
 
 import pytest
@@ -495,6 +504,8 @@ def test_gas_cost_memory(
     v: int,
 ) -> None:
     """Ori Pomerantz qbzzt1@gmail."""
+    # EIP-8038 cold account repricing (2600 -> 3000); 0 on earlier forks.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x000000000000000000000000000000000000BA5E)
     contract_1 = Address(0x000000000000000000000000000000000010BA5E)
@@ -846,7 +857,9 @@ def test_gas_cost_memory(
                 "value": -1,
             },
             "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 1900})},
+            "result": {
+                contract_3: Account(storage={0: 1900 + cold_account_delta})
+            },
         },
     ]
 

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_raw_ext_code_copy_gas.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_raw_ext_code_copy_gas.py
@@ -3,6 +3,17 @@ Test_raw_ext_code_copy_gas.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/RawExtCodeCopyGasFiller.json
+
+@manually-enhanced: Do not overwrite. This measures the regular gas
+that a single cold `EXTCODECOPY` consumes via `Op.GAS`. EIP-8038
+reprices the cold account access (`COLD_ACCOUNT_ACCESS`, 2600 -> 3000)
+and charges an extra `WARM_ACCESS` for the opcode's second read (the
+code). The stored cost therefore shifts by
+`(COLD_ACCOUNT_ACCESS - 2600) + WARM_ACCESS`. The cold term comes from
+the fork's own constant; the extra warm term is gated on the
+`is_eip_enabled(8037)` flag (the registered flag that activates the
+repricing at Amsterdam), so the delta is exactly 0 on earlier forks.
+Do not hardcode it.
 """
 
 import pytest
@@ -15,6 +26,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +41,17 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_raw_ext_code_copy_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_raw_ext_code_copy_gas."""
+    gas_costs = fork.gas_costs()
+    # EIP-8038: cold account repricing plus the extra warm access charged
+    # for the opcode's second read (the code). Both terms are 0 before
+    # EIP-8038, so the stored cost is unchanged on earlier forks.
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    code_read_delta = cold_account_delta + (
+        gas_costs.WARM_ACCESS if fork.is_eip_enabled(8037) else 0
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -68,6 +89,6 @@ def test_raw_ext_code_copy_gas(
         gas_limit=600000,
     )
 
-    post = {target: Account(storage={1: 2629})}
+    post = {target: Account(storage={1: 2629 + code_read_delta})}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_raw_ext_code_copy_memory_gas.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_raw_ext_code_copy_memory_gas.py
@@ -3,6 +3,17 @@ Test_raw_ext_code_copy_memory_gas.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/RawExtCodeCopyMemoryGasFiller.json
+
+@manually-enhanced: Do not overwrite. This measures the regular gas
+that a single cold `EXTCODECOPY` (with memory expansion) consumes via
+`Op.GAS`. EIP-8038 reprices the cold account access
+(`COLD_ACCOUNT_ACCESS`, 2600 -> 3000) and charges an extra
+`WARM_ACCESS` for the opcode's second read (the code). The stored cost
+therefore shifts by `(COLD_ACCOUNT_ACCESS - 2600) + WARM_ACCESS`. The
+cold term comes from the fork's own constant; the extra warm term is
+gated on the `is_eip_enabled(8037)` flag (the registered flag that
+activates the repricing at Amsterdam), so the delta is exactly 0 on
+earlier forks. Do not hardcode it.
 """
 
 import pytest
@@ -15,6 +26,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,8 +43,17 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_raw_ext_code_copy_memory_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_raw_ext_code_copy_memory_gas."""
+    gas_costs = fork.gas_costs()
+    # EIP-8038: cold account repricing plus the extra warm access charged
+    # for the opcode's second read (the code). Both terms are 0 before
+    # EIP-8038, so the stored cost is unchanged on earlier forks.
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    code_read_delta = cold_account_delta + (
+        gas_costs.WARM_ACCESS if fork.is_eip_enabled(8037) else 0
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -72,6 +93,6 @@ def test_raw_ext_code_copy_memory_gas(
         gas_limit=600000,
     )
 
-    post = {target: Account(storage={1: 4948})}
+    post = {target: Account(storage={1: 4948 + code_read_delta})}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP150singleCodeGasPrices/test_raw_ext_code_size_gas.py
+++ b/tests/ported_static/stEIP150singleCodeGasPrices/test_raw_ext_code_size_gas.py
@@ -3,6 +3,17 @@ Test_raw_ext_code_size_gas.
 
 Ported from:
 state_tests/stEIP150singleCodeGasPrices/RawExtCodeSizeGasFiller.json
+
+@manually-enhanced: Do not overwrite. This measures the regular gas
+that a single cold `EXTCODESIZE` consumes via `Op.GAS`. EIP-8038
+reprices the cold account access (`COLD_ACCOUNT_ACCESS`, 2600 -> 3000)
+and charges an extra `WARM_ACCESS` for the opcode's second read (the
+code). The stored cost therefore shifts by
+`(COLD_ACCOUNT_ACCESS - 2600) + WARM_ACCESS`. The cold term comes from
+the fork's own constant; the extra warm term is gated on the
+`is_eip_enabled(8037)` flag (the registered flag that activates the
+repricing at Amsterdam), so the delta is exactly 0 on earlier forks.
+Do not hardcode it.
 """
 
 import pytest
@@ -15,6 +26,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +41,17 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_raw_ext_code_size_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_raw_ext_code_size_gas."""
+    gas_costs = fork.gas_costs()
+    # EIP-8038: cold account repricing plus the extra warm access charged
+    # for the opcode's second read (the code). Both terms are 0 before
+    # EIP-8038, so the stored cost is unchanged on earlier forks.
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    code_read_delta = cold_account_delta + (
+        gas_costs.WARM_ACCESS if fork.is_eip_enabled(8037) else 0
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -68,6 +89,6 @@ def test_raw_ext_code_size_gas(
         gas_limit=600000,
     )
 
-    post = {target: Account(storage={1: 2616})}
+    post = {target: Account(storage={1: 2616 + code_read_delta})}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP158Specific/test_call_one_v_call_suicide.py
+++ b/tests/ported_static/stEIP158Specific/test_call_one_v_call_suicide.py
@@ -3,6 +3,15 @@ Test_call_one_v_call_suicide.
 
 Ported from:
 state_tests/stEIP158Specific/CALL_OneVCallSuicideFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a CALL with value to a not-yet-accessed contract that
+SELFDESTRUCTs to the (alive) caller. EIP-8038 reprices the cold account
+access (2600 -> 3000) and the CALL value transfer (9000 -> 10300); the
+beneficiary stays alive so there is no new-account write. The delta is
+`(COLD_ACCOUNT_ACCESS - 2600) + (CALL_VALUE - 9000)`, exactly 0 before
+EIP-8037 and tracks parameter changes; do not hardcode the Amsterdam
+value.
 """
 
 import pytest
@@ -15,6 +24,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +39,14 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_call_one_v_call_suicide(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_one_v_call_suicide."""
+    # EIP-8038 deltas, each 0 before EIP-8037. The CALL pays a cold
+    # account access plus a value transfer; the beneficiary stays alive.
+    gas_costs = fork.gas_costs()
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    call_value_delta = gas_costs.CALL_VALUE - 9000
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -84,7 +100,10 @@ def test_call_one_v_call_suicide(
 
     post = {
         addr: Account(storage={}, balance=0),
-        target: Account(storage={100: 14337}, balance=100),
+        target: Account(
+            storage={100: 14337 + cold_account_delta + call_value_delta},
+            balance=100,
+        ),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP158Specific/test_call_one_v_call_suicide2.py
+++ b/tests/ported_static/stEIP158Specific/test_call_one_v_call_suicide2.py
@@ -3,6 +3,15 @@ Test_call_one_v_call_suicide2.
 
 Ported from:
 state_tests/stEIP158Specific/CALL_OneVCallSuicide2Filler.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a value-1 CALL to a cold contract that then
+SELFDESTRUCTs (with a zero balance) to a cold, alive beneficiary.
+EIP-8038 reprices the CALL's cold account access and value transfer,
+plus the SELFDESTRUCT beneficiary's cold access; the beneficiary is
+alive so there is no new-account write. The delta is therefore
+`2 * (COLD_ACCOUNT_ACCESS - 2600) + (CALL_VALUE - 9000)`, exactly 0
+before EIP-8038.
 """
 
 import pytest
@@ -16,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -30,8 +40,15 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_call_one_v_call_suicide2(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_one_v_call_suicide2."""
+    # EIP-8038 deltas, each 0 before EIP-8038. The CALL pays the cold
+    # account reprice and the value-transfer reprice; the cold
+    # SELFDESTRUCT beneficiary pays a second cold account reprice.
+    gas_costs = fork.gas_costs()
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    call_value_delta = gas_costs.CALL_VALUE - 9000
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     addr_2 = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
     sender = EOA(
@@ -90,7 +107,10 @@ def test_call_one_v_call_suicide2(
 
     post = {
         addr: Account(storage={}, balance=0),
-        target: Account(storage={100: 16937}, balance=99),
+        target: Account(
+            storage={100: 16937 + 2 * cold_account_delta + call_value_delta},
+            balance=99,
+        ),
         addr_2: Account(balance=1),
     }
 

--- a/tests/ported_static/stEIP158Specific/test_call_zero_v_call_suicide.py
+++ b/tests/ported_static/stEIP158Specific/test_call_zero_v_call_suicide.py
@@ -3,6 +3,13 @@ Test_call_zero_v_call_suicide.
 
 Ported from:
 state_tests/stEIP158Specific/CALL_ZeroVCallSuicideFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a value-0 CALL to a cold contract that then
+SELFDESTRUCTs back to its (warm, alive) caller. EIP-8038 reprices the
+cold account access of that CALL; the beneficiary is warm so the
+SELFDESTRUCT is unchanged. The delta is therefore the fork's
+`COLD_ACCOUNT_ACCESS - 2600`, exactly 0 before EIP-8038.
 """
 
 import pytest
@@ -15,6 +22,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +37,11 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_call_zero_v_call_suicide(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_zero_v_call_suicide."""
+    # EIP-8038 cold account access reprice; 0 before EIP-8038.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -83,7 +94,7 @@ def test_call_zero_v_call_suicide(
 
     post = {
         addr: Account(balance=0),
-        target: Account(storage={100: 7637}),
+        target: Account(storage={100: 7637 + cold_account_delta}),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP158Specific/test_extcodesize_to_epmty_paris.py
+++ b/tests/ported_static/stEIP158Specific/test_extcodesize_to_epmty_paris.py
@@ -3,6 +3,15 @@ Test_extcodesize_to_epmty_paris.
 
 Ported from:
 state_tests/stEIP158Specific/EXTCODESIZE_toEpmtyParisFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of an EXTCODESIZE on a cold (empty, code-less) EOA plus
+the SSTORE that clears a populated slot to its (zero) result.
+EIP-8038 reprices the cold account access and adds a second
+WARM_ACCESS for the code read (EXTCODESIZE delta), and spills the
+cold SSTORE-clear's state-gas into regular gas (the reservoir is
+empty). Both deltas are derived from the fork's own opcode gas model,
+so each is exactly 0 before EIP-8038.
 """
 
 import pytest
@@ -15,6 +24,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,8 +39,22 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_extcodesize_to_epmty_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_extcodesize_to_epmty_paris."""
+    # EIP-8038 deltas, each 0 before EIP-8038. EXTCODESIZE gains the
+    # cold account reprice plus a second WARM_ACCESS for the code read;
+    # the cold SSTORE-clear (nonzero -> 0) spills its state-gas back
+    # into regular gas.
+    extcodesize_delta = (
+        Op.EXTCODESIZE.with_metadata(address_warm=False).gas_cost(fork) - 2600
+    )
+    cold_clear_sstore_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=1, current_value=1, new_value=0
+        ).gas_cost(fork)
+        - 5000
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -64,7 +88,9 @@ def test_extcodesize_to_epmty_paris(
 
     post = {
         addr: Account(storage={}, code=b"", balance=10, nonce=0),
-        target: Account(storage={100: 7617}),
+        target: Account(
+            storage={100: 7617 + extcodesize_delta + cold_clear_sstore_delta}
+        ),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP158Specific/test_extcodesize_to_non_existent.py
+++ b/tests/ported_static/stEIP158Specific/test_extcodesize_to_non_existent.py
@@ -3,6 +3,14 @@ Test_extcodesize_to_non_existent.
 
 Ported from:
 state_tests/stEIP158Specific/EXTCODESIZE_toNonExistentFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of an EXTCODESIZE on a cold, non-existent address plus the
+SSTORE that stores its (zero) result. EIP-8038 reprices the cold
+account access and adds a second WARM_ACCESS for the code read
+(EXTCODESIZE delta), and reprices the cold value-unchanged SSTORE.
+Both deltas are derived from the fork's own opcode gas model, so each
+is exactly 0 before EIP-8038.
 """
 
 import pytest
@@ -16,6 +24,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -30,8 +39,21 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_extcodesize_to_non_existent(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_extcodesize_to_non_existent."""
+    # EIP-8038 deltas, each 0 before EIP-8038. EXTCODESIZE gains the
+    # cold account reprice plus a second WARM_ACCESS for the code read;
+    # the cold value-unchanged SSTORE gains its own reprice.
+    extcodesize_delta = (
+        Op.EXTCODESIZE.with_metadata(address_warm=False).gas_cost(fork) - 2600
+    )
+    cold_noop_sstore_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=0, current_value=0, new_value=0
+        ).gas_cost(fork)
+        - 2200
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B)
     sender = EOA(
@@ -75,7 +97,9 @@ def test_extcodesize_to_non_existent(
         Address(
             0xC94F5374FCE5EDBC8E2A8697C15331677E6EBF0B
         ): Account.NONEXISTENT,
-        contract_0: Account(storage={100: 4817}),
+        contract_0: Account(
+            storage={100: 4817 + extcodesize_delta + cold_noop_sstore_delta}
+        ),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stEIP2930/test_address_opcodes.py
+++ b/tests/ported_static/stEIP2930/test_address_opcodes.py
@@ -3,6 +3,18 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP2930/addressOpcodesFiller.yml
+
+@manually-enhanced: Do not overwrite. The contract measures, via
+`Op.GAS`, the regular gas of each account-touching opcode (`BALANCE`,
+`EXTCODESIZE`, `EXTCODEHASH`, `EXTCODECOPY`) on both a first (cold or
+pre-warmed) and a second (warm) access. EIP-8038 reprices these: cold
+`BALANCE`/`EXTCODEHASH` by +`COLD_ACCOUNT_ACCESS - 2600`, while
+`EXTCODESIZE`/`EXTCODECOPY` carry an extra flat surcharge on both their
+warm and cold forms. The single Cancun-era literals are therefore split
+per opcode and per access, each adjusted by that opcode's own warm or
+cold `(Amsterdam - Cancun)` cost delta taken from the fork gas model, so
+every value is exactly 0 before EIP-8038 and tracks future parameter
+changes; do not hardcode the Amsterdam numbers.
 """
 
 import pytest
@@ -21,7 +33,7 @@ from execution_testing.forks import Fork
 from execution_testing.specs.static_state.expect_section import (
     resolve_expect_post,
 )
-from execution_testing.vm import Op
+from execution_testing.vm import Op, Opcode
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -545,65 +557,154 @@ def test_address_opcodes(
         address=Address(0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC),  # noqa: E501
     )
 
+    # Per-opcode warm and cold cost deltas versus Cancun, derived from
+    # the fork gas model so each is exactly 0 before EIP-8038. The
+    # EXTCODECOPY metadata mirrors the measured access (a 0x20-byte copy
+    # into already-expanded memory) so only the account-access component
+    # varies across forks. `BALANCE`/`EXTCODEHASH` warm forms are
+    # unchanged; `EXTCODESIZE`/`EXTCODECOPY` gain a flat warm surcharge.
+    extcodecopy_meta = dict(
+        data_size=0x20, new_memory_size=0x120, old_memory_size=0x120
+    )
+
+    def _account_delta(op: Opcode, warm: bool, base: int, **meta: int) -> int:
+        cost = op.with_metadata(address_warm=warm, **meta).gas_cost(fork)
+        return cost - base
+
+    balance_warm_d = _account_delta(Op.BALANCE, True, 100)
+    balance_cold_d = _account_delta(Op.BALANCE, False, 2600)
+    extcodesize_warm_d = _account_delta(Op.EXTCODESIZE, True, 100)
+    extcodesize_cold_d = _account_delta(Op.EXTCODESIZE, False, 2600)
+    extcodehash_warm_d = _account_delta(Op.EXTCODEHASH, True, 100)
+    extcodehash_cold_d = _account_delta(Op.EXTCODEHASH, False, 2600)
+    extcodecopy_warm_d = _account_delta(
+        Op.EXTCODECOPY, True, 103, **extcodecopy_meta
+    )
+    extcodecopy_cold_d = _account_delta(
+        Op.EXTCODECOPY, False, 2603, **extcodecopy_meta
+    )
+
+    # Slot 0 holds the first access (pre-warmed in the valid cases, cold
+    # in the invalid cases); slot 1 holds the always-warm second access.
     expect_entries_: list[dict] = [
+        # valid (pre-warmed first access): both slots measure a warm
+        # access; only EXTCODESIZE/EXTCODECOPY shift.
         {
             "indexes": {
-                "data": [
-                    0,
-                    1,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9,
-                    10,
-                    11,
-                    12,
-                    13,
-                    16,
-                    17,
-                    18,
-                    19,
-                    20,
-                    21,
-                    22,
-                    23,
-                    24,
-                    25,
-                    28,
-                    29,
-                    30,
-                    31,
-                    32,
-                    33,
-                    34,
-                    35,
-                    36,
-                    37,
-                    40,
-                    41,
-                    42,
-                    43,
-                    44,
-                    45,
-                    46,
-                    47,
-                ],
+                "data": [0, 1, 4, 5, 6, 7, 8, 9, 10, 11],
                 "gas": -1,
                 "value": -1,
             },
             "network": [">=Cancun"],
-            "result": {contract_0: Account(storage={0: 97, 1: 97})},
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 97 + balance_warm_d,
+                        1: 97 + balance_warm_d,
+                    }
+                )
+            },
         },
         {
             "indexes": {
-                "data": [2, 3, 14, 15, 26, 27, 38, 39],
+                "data": [12, 13, 16, 17, 18, 19, 20, 21, 22, 23],
                 "gas": -1,
                 "value": -1,
             },
             "network": [">=Cancun"],
-            "result": {contract_0: Account(storage={0: 2597, 1: 97, 2: 0})},
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 97 + extcodesize_warm_d,
+                        1: 97 + extcodesize_warm_d,
+                    }
+                )
+            },
+        },
+        {
+            "indexes": {
+                "data": [24, 25, 28, 29, 30, 31, 32, 33, 34, 35],
+                "gas": -1,
+                "value": -1,
+            },
+            "network": [">=Cancun"],
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 97 + extcodehash_warm_d,
+                        1: 97 + extcodehash_warm_d,
+                    }
+                )
+            },
+        },
+        {
+            "indexes": {
+                "data": [36, 37, 40, 41, 42, 43, 44, 45, 46, 47],
+                "gas": -1,
+                "value": -1,
+            },
+            "network": [">=Cancun"],
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 97 + extcodecopy_warm_d,
+                        1: 97 + extcodecopy_warm_d,
+                    }
+                )
+            },
+        },
+        # invalid (cold first access): slot 0 cold, slot 1 warm.
+        {
+            "indexes": {"data": [2, 3], "gas": -1, "value": -1},
+            "network": [">=Cancun"],
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 2597 + balance_cold_d,
+                        1: 97 + balance_warm_d,
+                        2: 0,
+                    }
+                )
+            },
+        },
+        {
+            "indexes": {"data": [14, 15], "gas": -1, "value": -1},
+            "network": [">=Cancun"],
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 2597 + extcodesize_cold_d,
+                        1: 97 + extcodesize_warm_d,
+                        2: 0,
+                    }
+                )
+            },
+        },
+        {
+            "indexes": {"data": [26, 27], "gas": -1, "value": -1},
+            "network": [">=Cancun"],
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 2597 + extcodehash_cold_d,
+                        1: 97 + extcodehash_warm_d,
+                        2: 0,
+                    }
+                )
+            },
+        },
+        {
+            "indexes": {"data": [38, 39], "gas": -1, "value": -1},
+            "network": [">=Cancun"],
+            "result": {
+                contract_0: Account(
+                    storage={
+                        0: 2597 + extcodecopy_cold_d,
+                        1: 97 + extcodecopy_warm_d,
+                        2: 0,
+                    }
+                )
+            },
         },
     ]
 

--- a/tests/ported_static/stEIP2930/test_coinbase_t01.py
+++ b/tests/ported_static/stEIP2930/test_coinbase_t01.py
@@ -3,6 +3,14 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP2930/coinbaseT01Filler.yml
+
+@manually-enhanced: Do not overwrite. The target contract measures, via
+`Op.GAS`, the regular gas of a `CALL` that transfers value to the warm,
+already-existing coinbase. EIP-8038 reprices the value-transfer
+component (`CALL_VALUE` 9 000 -> 10 300), so the measurement grows by
+`gas_costs.CALL_VALUE - 9000`. That delta is derived from the fork's
+own gas model, so it is exactly 0 before EIP-8038 and tracks future
+parameter changes; do not hardcode the Amsterdam number.
 """
 
 import pytest
@@ -111,16 +119,22 @@ def test_coinbase_t01(
         nonce=1,
     )
 
+    # EIP-8038 reprices the value-transfer component of `CALL`; with the
+    # coinbase warm and already in state, the measured gas grows by the
+    # `CALL_VALUE` reprice alone. Derived from the fork gas model so it
+    # is 0 before EIP-8038.
+    call_value_delta = fork.gas_costs().CALL_VALUE - 9000
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [1], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {target: Account(storage={0: 6800})},
+            "result": {target: Account(storage={0: 6800 + call_value_delta})},
         },
         {
             "indexes": {"data": [0, 2], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {target: Account(storage={0: 6800})},
+            "result": {target: Account(storage={0: 6800 + call_value_delta})},
         },
     ]
 

--- a/tests/ported_static/stEIP2930/test_coinbase_t2.py
+++ b/tests/ported_static/stEIP2930/test_coinbase_t2.py
@@ -3,6 +3,14 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP2930/coinbaseT2Filler.yml
+
+@manually-enhanced: Do not overwrite. The target contract measures, via
+`Op.GAS`, the regular gas of a `CALL` that transfers value to the warm,
+already-existing coinbase. EIP-8038 reprices the value-transfer
+component (`CALL_VALUE` 9 000 -> 10 300), so the measurement grows by
+`gas_costs.CALL_VALUE - 9000`. That delta is derived from the fork's
+own gas model, so it is exactly 0 before EIP-8038 and tracks future
+parameter changes; do not hardcode the Amsterdam number.
 """
 
 import pytest
@@ -105,16 +113,22 @@ def test_coinbase_t2(
         nonce=1,
     )
 
+    # EIP-8038 reprices the value-transfer component of `CALL`; with the
+    # coinbase warm and already in state, the measured gas grows by the
+    # `CALL_VALUE` reprice alone. Derived from the fork gas model so it
+    # is 0 before EIP-8038.
+    call_value_delta = fork.gas_costs().CALL_VALUE - 9000
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [0], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {target: Account(storage={0: 6800})},
+            "result": {target: Account(storage={0: 6800 + call_value_delta})},
         },
         {
             "indexes": {"data": [1], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {target: Account(storage={0: 6800})},
+            "result": {target: Account(storage={0: 6800 + call_value_delta})},
         },
     ]
 

--- a/tests/ported_static/stEIP2930/test_manual_create.py
+++ b/tests/ported_static/stEIP2930/test_manual_create.py
@@ -6,12 +6,13 @@ state_tests/stEIP2930/manualCreateFiller.yml
 
 @manually-enhanced: Do not overwrite. The three parametrizations of
 this test measure regular gas around a fresh SSTORE-set inside a
-CREATE-deployed contract. EIP-8037 splits the Cancun-era SSTORE-set
-base into a smaller regular portion plus 37 568 state-gas; with an
-empty reservoir the full state-gas spills into regular gas and
-`Op.GAS` reads +20 468 = 37 568 - 17 100 compared to Cancun. Bake
-that delta into both `[">=Cancun"]` expect entries fork-conditionally
-via `Op.SSTORE(new_value=1).state_cost(fork) - 17100`.
+CREATE-deployed contract. EIP-8037 moves the bulk of the SSTORE-set
+cost into a per-storage state-gas charge; with an empty reservoir it
+spills back into regular gas, which `Op.GAS` observes. Derive the
+warm and cold fresh-set deltas from the fork's own gas model so each
+is exactly 0 pre-EIP-8037 and tracks parameter changes; bake the
+warm delta into the declared-key entry and the cold delta into the
+undeclared-key entries.
 """
 
 import pytest
@@ -90,12 +91,18 @@ def test_manual_create(
 
     pre[sender] = Account(balance=0x1000000000000000000, nonce=1)
 
-    # EIP-8037 SSTORE-set spillover: +20 468 regular gas per fresh set
-    # when the reservoir is empty.
-    sstore_set_delta = (
-        (Op.SSTORE(new_value=1).state_cost(fork) - 17100)
-        if fork.is_eip_enabled(8037)
-        else 0
+    # EIP-8037 SSTORE-set spill into regular gas (empty reservoir).
+    # Derive the warm and cold fresh-set deltas from the fork's own
+    # gas model so each is exactly 0 pre-EIP-8037.
+    def _sstore_delta(cancun_cost: int, **metadata: int) -> int:
+        op = Op.SSTORE.with_metadata(**metadata)
+        return op.gas_cost(fork) - cancun_cost
+
+    warm_set_delta = _sstore_delta(
+        20000, key_warm=True, current_value=0, new_value=2
+    )
+    cold_set_delta = _sstore_delta(
+        22100, key_warm=False, current_value=0, new_value=2
     )
 
     expect_entries_: list[dict] = [
@@ -104,7 +111,7 @@ def test_manual_create(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=sender, nonce=1): Account(
-                    storage={0: 20008 + sstore_set_delta, 1: 106}
+                    storage={0: 20008 + warm_set_delta, 1: 106}
                 ),
             },
         },
@@ -113,7 +120,7 @@ def test_manual_create(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=sender, nonce=1): Account(
-                    storage={0: 22108 + sstore_set_delta, 1: 106}
+                    storage={0: 22108 + cold_set_delta, 1: 106}
                 ),
             },
         },

--- a/tests/ported_static/stEIP2930/test_storage_costs.py
+++ b/tests/ported_static/stEIP2930/test_storage_costs.py
@@ -4,19 +4,19 @@ Ori Pomerantz qbzzt1@gmail.com.
 Ported from:
 state_tests/stEIP2930/storageCostsFiller.yml
 
-@manually-enhanced: Do not overwrite. The SSTORE gas measurements in
-this test were authored against the Cancun-era SSTORE-set base cost
-of 20 000 (per EIP-2200). EIP-8037 splits that cost into a smaller
-regular portion (~2 900) plus a per-storage state-gas charge of
-`STATE_BYTES_PER_STORAGE_SET (32) * COST_PER_STATE_BYTE (1174) =
-37 568`. When the state-gas reservoir is empty — as it is here, since
-the tests don't pre-allocate state-gas budget — the full state-gas
-spills back into regular gas, so `Op.GAS` observes
-`+37 568 - 17 100 = +20 468` regular gas per fresh SSTORE-set
-compared to Cancun. Bake that fork-conditional delta into the
-expected post-state values for the 10 parametrizations whose measured
-SSTORE writes triggered the spill; the remaining entries (SLOAD-only,
-no-op SSTOREs) are unaffected.
+@manually-enhanced: Do not overwrite. This test measures the regular
+gas consumed by storage accesses via `Op.GAS`. EIP-8037 moves the
+bulk of storage-write cost into a per-storage state-gas charge; with
+an empty state-gas reservoir (these tests pre-allocate none) the full
+state gas spills back into regular gas, so each measurement shifts by
+its `(Amsterdam - Cancun)` cost delta. Six access classes shift: warm
+and cold fresh SSTORE-sets (state-gas spill dominates), warm and cold
+SSTORE writes to existing slots (clear/reset: the storage-write
+component), cold value-unchanged SSTOREs, and cold SLOADs (the
+`COLD_STORAGE_ACCESS` repricing). Warm reads and no-op SSTOREs are
+unchanged. Each delta below is derived from the fork's own opcode gas
+model, so it is exactly 0 pre-EIP-8037 and tracks future parameter
+changes; do not hardcode the Amsterdam numbers.
 """
 
 import pytest
@@ -661,113 +661,150 @@ def test_storage_costs(
         address=Address(0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC),  # noqa: E501
     )
 
-    # EIP-8037 splits the SSTORE-set base cost (Cancun: 20 000 regular)
-    # into a smaller regular portion plus per-storage state-gas. When
-    # the state-gas reservoir is empty for these tests, the full state
-    # gas spills into regular gas, so Op.GAS sees +20 468 per fresh
-    # SSTORE-set compared to Cancun (=37 568 state-gas - 17 100 base
-    # regular drop). Apply that delta to the 10 measurements that
-    # trigger a fresh-set spill; the SLOAD-only and no-op SSTORE
-    # entries below are unchanged.
-    sstore_set_delta = (
-        (Op.SSTORE(new_value=1).state_cost(fork) - 17100)
-        if fork.is_eip_enabled(8037)
-        else 0
+    # EIP-8037 moves the bulk of storage-write cost into a per-storage
+    # state-gas charge. These tests pre-allocate no state-gas reservoir,
+    # so the full state gas spills back into regular gas and `Op.GAS`
+    # observes each measured SSTORE/SLOAD at its combined regular + state
+    # cost. Every measured access therefore shifts by its
+    # (Amsterdam - Cancun) delta; derive each delta from the fork's own
+    # opcode gas model so it is exactly 0 pre-EIP-8037 and tracks future
+    # parameter changes. The subtracted Cancun-era pure costs are frozen
+    # historical values.
+    def _sstore_delta(cancun_cost: int, **metadata: int) -> int:
+        op = Op.SSTORE.with_metadata(**metadata)
+        return op.gas_cost(fork) - cancun_cost
+
+    d_warm_set = _sstore_delta(
+        20000, key_warm=True, original_value=0, current_value=0, new_value=2
     )
+    d_cold_set = _sstore_delta(
+        22100, key_warm=False, original_value=0, current_value=0, new_value=2
+    )
+    d_warm_write = _sstore_delta(
+        2900, key_warm=True, original_value=1, current_value=1, new_value=2
+    )
+    d_cold_write = _sstore_delta(
+        5000, key_warm=False, original_value=1, current_value=1, new_value=2
+    )
+    d_cold_noop = _sstore_delta(
+        2200, key_warm=False, original_value=1, current_value=1, new_value=1
+    )
+    d_cold_read = fork.gas_costs().COLD_STORAGE_ACCESS - 2100
 
     expect_entries_: list[dict] = [
+        # declaredKeyWrite: warm fresh SSTORE-set.
         {
             "indexes": {"data": [0, 35], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                contract_0: Account(
-                    storage={0: 2, 1: 20003 + sstore_set_delta}
-                )
+                contract_0: Account(storage={0: 2, 1: 20003 + d_warm_set})
             },
         },
+        # undeclaredKeyWrite: cold fresh SSTORE-set.
         {
             "indexes": {"data": [6, 12, 18], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                contract_0: Account(
-                    storage={0: 2, 1: 22103 + sstore_set_delta}
-                )
+                contract_0: Account(storage={0: 2, 1: 22103 + d_cold_set})
             },
         },
+        # declaredKeyUpdate: warm SSTORE-reset (nonzero -> nonzero).
         {
             "indexes": {"data": [3], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 48879, 1: 2903})},
+            "result": {
+                contract_3: Account(storage={0: 48879, 1: 2903 + d_warm_write})
+            },
         },
+        # undeclaredKeyUpdate: cold SSTORE-reset (nonzero -> nonzero).
         {
             "indexes": {"data": [9, 15, 21], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={0: 48879, 1: 5003})},
+            "result": {
+                contract_3: Account(storage={0: 48879, 1: 5003 + d_cold_write})
+            },
         },
+        # declaredKeyNOP: warm value-unchanged SSTORE (no write).
         {
             "indexes": {"data": [4], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_4: Account(storage={0: 24743, 1: 103})},
         },
+        # undeclaredKeyNOP: cold value-unchanged SSTORE.
         {
             "indexes": {"data": [10, 16, 22], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_4: Account(storage={0: 24743, 1: 2203})},
+            "result": {
+                contract_4: Account(storage={0: 24743, 1: 2203 + d_cold_noop})
+            },
         },
+        # declaredKeyNOP0: warm value-unchanged SSTORE (no write).
         {
             "indexes": {"data": [5], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_5: Account(storage={1: 103})},
         },
+        # undeclaredKeyNOP0: cold value-unchanged SSTORE.
         {
             "indexes": {"data": [11, 17, 23], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_5: Account(storage={1: 2203})},
+            "result": {contract_5: Account(storage={1: 2203 + d_cold_noop})},
         },
+        # declaredKeyDel: warm SSTORE-clear (nonzero -> 0).
         {
             "indexes": {"data": [2], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_2: Account(storage={0: 0, 1: 2903})},
+            "result": {
+                contract_2: Account(storage={0: 0, 1: 2903 + d_warm_write})
+            },
         },
+        # undeclaredKeyDel: cold SSTORE-clear (nonzero -> 0).
         {
             "indexes": {"data": [8, 14, 20], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_2: Account(storage={0: 0, 1: 5003})},
+            "result": {
+                contract_2: Account(storage={0: 0, 1: 5003 + d_cold_write})
+            },
         },
+        # declaredKeyRead: warm SLOAD.
         {
             "indexes": {"data": [1], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_1: Account(storage={1: 100})},
         },
+        # undeclaredKeyRead: cold SLOAD.
         {
             "indexes": {"data": [7, 13, 19], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_1: Account(storage={1: 2100})},
+            "result": {contract_1: Account(storage={1: 2100 + d_cold_read})},
         },
+        # postSSTORE write: key already warm/dirty, no fresh-set spill.
         {
             "indexes": {"data": [24, 25], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_6: Account(storage={0: 2, 1: 103})},
         },
+        # postSSTORE read: key already warm.
         {
             "indexes": {"data": [26, 27], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_7: Account(storage={0: 24743, 1: 100})},
         },
+        # postSLOAD write: SLOAD warms the key, then warm fresh SSTORE-set.
         {
             "indexes": {"data": [28, 29], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                contract_8: Account(
-                    storage={0: 2, 1: 20000 + sstore_set_delta}
-                )
+                contract_8: Account(storage={0: 2, 1: 20000 + d_warm_set})
             },
         },
+        # postSLOAD read: key already warm.
         {
             "indexes": {"data": [30, 31], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {contract_9: Account(storage={1: 97})},
         },
+        # declaredTo: warm SLOAD (slot 1) + warm fresh SSTORE-set (slot 2).
         {
             "indexes": {"data": [32], "gas": -1, "value": -1},
             "network": [">=Cancun"],
@@ -776,12 +813,13 @@ def test_storage_costs(
                     storage={
                         0: 2,
                         1: 100,
-                        2: 20000 + sstore_set_delta,
+                        2: 20000 + d_warm_set,
                         24743: 57005,
                     }
                 )
             },
         },
+        # undeclaredTo: cold SLOAD (slot 1) + cold fresh SSTORE-set (slot 2).
         {
             "indexes": {"data": [33, 34], "gas": -1, "value": -1},
             "network": [">=Cancun"],
@@ -789,8 +827,8 @@ def test_storage_costs(
                 contract_10: Account(
                     storage={
                         0: 2,
-                        1: 2100,
-                        2: 22100 + sstore_set_delta,
+                        1: 2100 + d_cold_read,
+                        2: 22100 + d_cold_set,
                         24743: 57005,
                     }
                 ),

--- a/tests/ported_static/stEIP2930/test_varied_context.py
+++ b/tests/ported_static/stEIP2930/test_varied_context.py
@@ -4,21 +4,21 @@ Ori Pomerantz qbzzt1@gmail.com.
 Ported from:
 state_tests/stEIP2930/variedContextFiller.yml
 
-@manually-enhanced: Do not overwrite. 28 parametrizations of this
-test measure gas consumption around SSTORE/CALL/SELFDESTRUCT in
-various access-list contexts. EIP-8037 splits the Cancun-era base
-costs (SSTORE-set 20 000, CALL-new-account 25 000, SELFDESTRUCT-new-
-beneficiary 25 000) into smaller regular portions plus per-storage
-or per-new-account state-gas charges. When the reservoir is empty —
-the case here, since no state-gas budget is pre-allocated — the
-full state-gas spills back into regular gas and Op.GAS reads three
-distinct deltas:
-  +20 468  per fresh SSTORE-set
-  +106 488 per NEW_ACCOUNT (CALL with value or SELFDESTRUCT)
-  +126 956 = both, for SELFDESTRUCT-with-write paths
-Each affected post-state literal is bumped by the appropriate
-delta fork-conditionally; pre-EIP-8037 forks use the original
-values.
+@manually-enhanced: Do not overwrite. This test measures gas
+consumption around SSTORE/CALL/SELFDESTRUCT in various access-list
+contexts via `Op.GAS`. EIP-8037/8038 reprice several components;
+with an empty reservoir (the case here) the state-gas portion
+spills back into regular gas, so each measurement shifts by its
+`(Amsterdam - Cancun)` delta. Every delta below is derived from the
+fork's own opcode gas model, so it is exactly 0 pre-EIP-8037 and
+tracks parameter changes: warm/cold fresh SSTORE-sets, the
+NEW_ACCOUNT spill for CALL-with-value and SELFDESTRUCT-to-non-alive
+(the latter also gaining `ACCOUNT_WRITE` and the cold reprice), and
+the cold account/storage access reprices. The `*ValidGas`
+parametrizations instead forward a fixed in-bytecode gas budget that
+EIP-8038 made insufficient; those budgets are bumped by the inner
+SSTORE-write increase so the success path stays funded while the
+under-funded cold path still runs out of gas.
 """
 
 import pytest
@@ -1152,9 +1152,24 @@ def test_varied_context(
     # {  ; WRITE_INVALID_OOG    WRITE_VALID_NO_OOG
     #    (call 0x0B65 0xF114 0 0 0 0 0x20)
     # }
+    # EIP-8038 raises the inner SSTORE-write cost. Bump the "valid" gas
+    # these callers forward by exactly that increase so their success
+    # path stays funded at Amsterdam (preserving the original Cancun
+    # margin) while the under-funded cold "invalid" path still OOGs.
+    # The contract_13 inner SSTORE is a warm reset; contract_15's is a
+    # cold reset. Both bumps are 0 pre-EIP-8037.
+    _warm_reset = Op.SSTORE.with_metadata(
+        key_warm=True, original_value=1, current_value=1, new_value=2
+    )
+    _cold_reset = Op.SSTORE.with_metadata(
+        key_warm=False, original_value=1, current_value=1, new_value=2
+    )
+    valid_write_gas = 0xB65 + (_warm_reset.gas_cost(fork) - 2900)
+    valid_read_gas = 0x1800 + (_cold_reset.gas_cost(fork) - 5000)
+
     contract_13 = pre.deploy_contract(  # noqa: F841
         code=Op.CALL(
-            gas=0xB65,
+            gas=valid_write_gas,
             address=0xF114,
             value=0x0,
             args_offset=0x0,
@@ -1173,7 +1188,7 @@ def test_varied_context(
     # }
     contract_15 = pre.deploy_contract(  # noqa: F841
         code=Op.CALL(
-            gas=0x1800,
+            gas=valid_read_gas,
             address=0xF115,
             value=0x0,
             args_offset=0x0,
@@ -1337,24 +1352,41 @@ def test_varied_context(
         address=Address(0x0000000000000000000000000000000000001016),  # noqa: E501
     )
 
-    # EIP-8037 splits SSTORE-set, NEW_ACCOUNT call value transfer, and
-    # SELFDESTRUCT new-beneficiary base costs into state-gas portions.
-    # With an empty reservoir (the case here), the full state-gas
-    # spills into regular gas, which Op.GAS observes.
-    #   sstore-set spill:    +37 568 - 17 100 = +20 468 per fresh set
-    #   new-account spill:   +131 488 - 25 000 = +106 488 per CALL
-    #                        with value to a non-alive account, and
-    #                        per SELFDESTRUCT to non-alive beneficiary
-    #   suicide-write spill: +126 956 = both deltas combined
-    sstore_set_delta = (
-        (Op.SSTORE(new_value=1).state_cost(fork) - 17100)
-        if fork.is_eip_enabled(8037)
-        else 0
+    # EIP-8037/8038 reprice several access components. With an empty
+    # reservoir (the case here) the state-gas portion spills back into
+    # regular gas, which `Op.GAS` observes. Derive each delta from the
+    # fork's own gas model so it is exactly 0 pre-EIP-8037 and tracks
+    # parameter changes.
+    gas_costs = fork.gas_costs()
+
+    def _sstore_delta(cancun_cost: int, **metadata: int) -> int:
+        op = Op.SSTORE.with_metadata(**metadata)
+        return op.gas_cost(fork) - cancun_cost
+
+    # Fresh SSTORE-set (state-gas spill dominates), warm vs cold key.
+    warm_set_delta = _sstore_delta(
+        20000, key_warm=True, current_value=0, new_value=2
     )
+    cold_set_delta = _sstore_delta(
+        22100, key_warm=False, current_value=0, new_value=2
+    )
+    # CALL value transfer to a non-alive account: the 25 000 NEW_ACCOUNT
+    # base becomes a spilling state-gas charge.
     new_account_delta = (
         (fork.create_state_gas() - 25000) if fork.is_eip_enabled(8037) else 0
     )
-    suicide_write_delta = sstore_set_delta + new_account_delta
+    # Cold account access reprice (0 pre-Amsterdam).
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    # Cold storage access (SLOAD) reprice (0 pre-Amsterdam).
+    cold_storage_delta = gas_costs.COLD_STORAGE_ACCESS - 2100
+    # SELFDESTRUCT to a non-alive cold beneficiary: new-account spill,
+    # the new ACCOUNT_WRITE charge (0 pre-Amsterdam), and the cold
+    # reprice.
+    suicide_new_delta = (
+        new_account_delta + gas_costs.ACCOUNT_WRITE + cold_account_delta
+    )
+    # callWriteSuicide measures a warm SSTORE-set then that SELFDESTRUCT.
+    suicide_write_delta = warm_set_delta + suicide_new_delta
 
     expect_entries_: list[dict] = [
         {
@@ -1362,7 +1394,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_0: Account(
-                    storage={0: 2, 1: (20003 + sstore_set_delta), 2: 107}
+                    storage={0: 2, 1: (20003 + warm_set_delta), 2: 107}
                 )
             },
         },
@@ -1371,7 +1403,11 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_0: Account(
-                    storage={0: 2, 1: (22103 + sstore_set_delta), 2: 2107}
+                    storage={
+                        0: 2,
+                        1: (22103 + cold_set_delta),
+                        2: 2107 + cold_storage_delta,
+                    }
                 )
             },
         },
@@ -1380,7 +1416,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_2: Account(
-                    storage={0: 2, 1: (20003 + sstore_set_delta), 2: 107}
+                    storage={0: 2, 1: (20003 + warm_set_delta), 2: 107}
                 )
             },
         },
@@ -1389,7 +1425,11 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_2: Account(
-                    storage={0: 2, 1: (22103 + sstore_set_delta), 2: 2107}
+                    storage={
+                        0: 2,
+                        1: (22103 + cold_set_delta),
+                        2: 2107 + cold_storage_delta,
+                    }
                 )
             },
         },
@@ -1400,8 +1440,8 @@ def test_varied_context(
                 contract_3: Account(
                     storage={
                         0: 2,
-                        1: (22103 + sstore_set_delta),
-                        2: 2107,
+                        1: (22103 + cold_set_delta),
+                        2: 2107 + cold_storage_delta,
                         24743: 57005,
                     }
                 )
@@ -1414,7 +1454,7 @@ def test_varied_context(
                 contract_3: Account(
                     storage={
                         0: 2,
-                        1: (20003 + sstore_set_delta),
+                        1: (20003 + warm_set_delta),
                         2: 107,
                         24743: 57005,
                     }
@@ -1424,7 +1464,9 @@ def test_varied_context(
         {
             "indexes": {"data": [6], "gas": -1, "value": -1},
             "network": [">=Cancun"],
-            "result": {contract_4: Account(storage={0: 2107})},
+            "result": {
+                contract_4: Account(storage={0: 2107 + cold_storage_delta})
+            },
         },
         {
             "indexes": {"data": [7], "gas": -1, "value": -1},
@@ -1436,7 +1478,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_26: Account(
-                    storage={0: (20003 + sstore_set_delta), 1: 100}
+                    storage={0: (20003 + warm_set_delta), 1: 100}
                 )
             },
         },
@@ -1445,7 +1487,10 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_26: Account(
-                    storage={0: (22103 + sstore_set_delta), 1: 2100}
+                    storage={
+                        0: (22103 + cold_set_delta),
+                        1: 2100 + cold_storage_delta,
+                    }
                 )
             },
         },
@@ -1460,21 +1505,37 @@ def test_varied_context(
             "indexes": {"data": [11], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                contract_7: Account(storage={0: (24601 + suicide_write_delta)})
+                contract_7: Account(
+                    storage={
+                        0: (
+                            24601
+                            + cold_set_delta
+                            + suicide_new_delta
+                            + cold_account_delta
+                        )
+                    }
+                )
             },
         },
         {
             "indexes": {"data": [12], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                contract_9: Account(storage={0: 100 + new_account_delta})
+                contract_9: Account(storage={0: 100 + suicide_new_delta})
             },
         },
         {
             "indexes": {"data": [13], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                contract_9: Account(storage={0: 4600 + new_account_delta})
+                contract_9: Account(
+                    storage={
+                        0: 4600
+                        + suicide_new_delta
+                        + cold_account_delta
+                        + cold_storage_delta
+                    }
+                )
             },
         },
         {
@@ -1524,7 +1585,7 @@ def test_varied_context(
                         268: 103,
                         269: 103,
                         270: 103,
-                        271: (20003 + sstore_set_delta),
+                        271: (20003 + warm_set_delta),
                         512: 100,
                         513: 100,
                         514: 100,
@@ -1541,22 +1602,22 @@ def test_varied_context(
                         525: 100,
                         526: 100,
                         527: 100,
-                        768: (20003 + sstore_set_delta),
-                        769: (20003 + sstore_set_delta),
-                        770: (20003 + sstore_set_delta),
-                        771: (20003 + sstore_set_delta),
-                        772: (20003 + sstore_set_delta),
-                        773: (20003 + sstore_set_delta),
-                        774: (20003 + sstore_set_delta),
-                        775: (20003 + sstore_set_delta),
-                        776: (20003 + sstore_set_delta),
-                        777: (20003 + sstore_set_delta),
-                        778: (20003 + sstore_set_delta),
-                        779: (20003 + sstore_set_delta),
-                        780: (20003 + sstore_set_delta),
-                        781: (20003 + sstore_set_delta),
-                        782: (20003 + sstore_set_delta),
-                        783: (20003 + sstore_set_delta),
+                        768: (20003 + warm_set_delta),
+                        769: (20003 + warm_set_delta),
+                        770: (20003 + warm_set_delta),
+                        771: (20003 + warm_set_delta),
+                        772: (20003 + warm_set_delta),
+                        773: (20003 + warm_set_delta),
+                        774: (20003 + warm_set_delta),
+                        775: (20003 + warm_set_delta),
+                        776: (20003 + warm_set_delta),
+                        777: (20003 + warm_set_delta),
+                        778: (20003 + warm_set_delta),
+                        779: (20003 + warm_set_delta),
+                        780: (20003 + warm_set_delta),
+                        781: (20003 + warm_set_delta),
+                        782: (20003 + warm_set_delta),
+                        783: (20003 + warm_set_delta),
                         1024: 100,
                         1025: 100,
                         1026: 100,
@@ -1617,7 +1678,7 @@ def test_varied_context(
                         268: 103,
                         269: 103,
                         270: 103,
-                        271: (22103 + sstore_set_delta),
+                        271: (22103 + cold_set_delta),
                         512: 100,
                         513: 100,
                         514: 100,
@@ -1633,39 +1694,39 @@ def test_varied_context(
                         524: 100,
                         525: 100,
                         526: 100,
-                        527: 2100,
-                        768: (22103 + sstore_set_delta),
-                        769: (22103 + sstore_set_delta),
-                        770: (22103 + sstore_set_delta),
-                        771: (22103 + sstore_set_delta),
-                        772: (22103 + sstore_set_delta),
-                        773: (22103 + sstore_set_delta),
-                        774: (22103 + sstore_set_delta),
-                        775: (22103 + sstore_set_delta),
-                        776: (22103 + sstore_set_delta),
-                        777: (22103 + sstore_set_delta),
-                        778: (22103 + sstore_set_delta),
-                        779: (22103 + sstore_set_delta),
-                        780: (22103 + sstore_set_delta),
-                        781: (22103 + sstore_set_delta),
-                        782: (22103 + sstore_set_delta),
-                        783: (22103 + sstore_set_delta),
-                        1024: 2100,
-                        1025: 2100,
-                        1026: 2100,
-                        1027: 2100,
-                        1028: 2100,
-                        1029: 2100,
-                        1030: 2100,
-                        1031: 2100,
-                        1032: 2100,
-                        1033: 2100,
-                        1034: 2100,
-                        1035: 2100,
-                        1036: 2100,
-                        1037: 2100,
-                        1038: 2100,
-                        1039: 2100,
+                        527: 2100 + cold_storage_delta,
+                        768: (22103 + cold_set_delta),
+                        769: (22103 + cold_set_delta),
+                        770: (22103 + cold_set_delta),
+                        771: (22103 + cold_set_delta),
+                        772: (22103 + cold_set_delta),
+                        773: (22103 + cold_set_delta),
+                        774: (22103 + cold_set_delta),
+                        775: (22103 + cold_set_delta),
+                        776: (22103 + cold_set_delta),
+                        777: (22103 + cold_set_delta),
+                        778: (22103 + cold_set_delta),
+                        779: (22103 + cold_set_delta),
+                        780: (22103 + cold_set_delta),
+                        781: (22103 + cold_set_delta),
+                        782: (22103 + cold_set_delta),
+                        783: (22103 + cold_set_delta),
+                        1024: 2100 + cold_storage_delta,
+                        1025: 2100 + cold_storage_delta,
+                        1026: 2100 + cold_storage_delta,
+                        1027: 2100 + cold_storage_delta,
+                        1028: 2100 + cold_storage_delta,
+                        1029: 2100 + cold_storage_delta,
+                        1030: 2100 + cold_storage_delta,
+                        1031: 2100 + cold_storage_delta,
+                        1032: 2100 + cold_storage_delta,
+                        1033: 2100 + cold_storage_delta,
+                        1034: 2100 + cold_storage_delta,
+                        1035: 2100 + cold_storage_delta,
+                        1036: 2100 + cold_storage_delta,
+                        1037: 2100 + cold_storage_delta,
+                        1038: 2100 + cold_storage_delta,
+                        1039: 2100 + cold_storage_delta,
                         24743: 57005,
                         48879: 2,
                         61440: 48879,
@@ -1693,7 +1754,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=contract_18, nonce=0): Account(
-                    storage={0: 65535, 1: (20017 + sstore_set_delta)}
+                    storage={0: 65535, 1: (20017 + warm_set_delta)}
                 ),
             },
         },
@@ -1702,7 +1763,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=contract_18, nonce=0): Account(
-                    storage={0: 65535, 1: (22117 + sstore_set_delta)}
+                    storage={0: 65535, 1: (22117 + cold_set_delta)}
                 ),
             },
         },
@@ -1711,7 +1772,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 Address(0xD82F21135ED7D7D833A9F2A0F1CF6C3DA214B8E3): Account(
-                    storage={0: 65535, 1: (20017 + sstore_set_delta)}
+                    storage={0: 65535, 1: (20017 + warm_set_delta)}
                 ),
             },
         },
@@ -1720,7 +1781,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 Address(0xD82F21135ED7D7D833A9F2A0F1CF6C3DA214B8E3): Account(
-                    storage={0: 65535, 1: (22117 + sstore_set_delta)}
+                    storage={0: 65535, 1: (22117 + cold_set_delta)}
                 ),
             },
         },
@@ -1729,7 +1790,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=contract_20, nonce=0): Account(
-                    storage={0: 65535, 1: (20017 + sstore_set_delta)}
+                    storage={0: 65535, 1: (20017 + warm_set_delta)}
                 ),
             },
         },
@@ -1738,7 +1799,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=contract_20, nonce=0): Account(
-                    storage={0: 65535, 1: (22117 + sstore_set_delta)}
+                    storage={0: 65535, 1: (22117 + cold_set_delta)}
                 ),
             },
         },
@@ -1747,7 +1808,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 Address(0x530508498D2AA75D8E591612809FEC3D37A45615): Account(
-                    storage={0: 65535, 1: (20017 + sstore_set_delta)}
+                    storage={0: 65535, 1: (20017 + warm_set_delta)}
                 ),
             },
         },
@@ -1756,7 +1817,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 Address(0x530508498D2AA75D8E591612809FEC3D37A45615): Account(
-                    storage={0: 65535, 1: (22117 + sstore_set_delta)}
+                    storage={0: 65535, 1: (22117 + cold_set_delta)}
                 ),
             },
         },
@@ -1765,7 +1826,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=contract_22, nonce=0): Account(
-                    storage={0: 65535, 1: (20017 + sstore_set_delta), 2: 117}
+                    storage={0: 65535, 1: (20017 + warm_set_delta), 2: 117}
                 ),
             },
         },
@@ -1774,7 +1835,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 compute_create_address(address=contract_22, nonce=0): Account(
-                    storage={0: 65535, 1: (22117 + sstore_set_delta), 2: 117}
+                    storage={0: 65535, 1: (22117 + cold_set_delta), 2: 117}
                 ),
             },
         },
@@ -1783,7 +1844,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 Address(0x83FBDAE70258AC0FA837B701CC63CEDF48D4B6BF): Account(
-                    storage={0: 65535, 1: (20017 + sstore_set_delta), 2: 117}
+                    storage={0: 65535, 1: (20017 + warm_set_delta), 2: 117}
                 ),
             },
         },
@@ -1792,7 +1853,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 Address(0x83FBDAE70258AC0FA837B701CC63CEDF48D4B6BF): Account(
-                    storage={0: 65535, 1: (22117 + sstore_set_delta), 2: 117}
+                    storage={0: 65535, 1: (22117 + cold_set_delta), 2: 117}
                 ),
             },
         },
@@ -1801,7 +1862,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_25: Account(
-                    storage={0: 24743, 1: (20017 + sstore_set_delta), 2: 117}
+                    storage={0: 24743, 1: (20017 + warm_set_delta), 2: 117}
                 )
             },
         },
@@ -1810,7 +1871,7 @@ def test_varied_context(
             "network": [">=Cancun"],
             "result": {
                 contract_25: Account(
-                    storage={0: 24743, 1: (22117 + sstore_set_delta), 2: 117}
+                    storage={0: 24743, 1: (22117 + cold_set_delta), 2: 117}
                 )
             },
         },

--- a/tests/ported_static/stMemoryTest/test_oog.py
+++ b/tests/ported_static/stMemoryTest/test_oog.py
@@ -3,6 +3,15 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stMemoryTest/oogFiller.yml
+
+@manually-enhanced: Do not overwrite. Each parametrization forwards a
+fixed in-bytecode gas budget to an inner operation and asserts whether
+it succeeds. The `0x3E` (RETURNDATACOPY) success case routes through a
+nested value-0 CALL to a cold contract; EIP-8038's cold account access
+reprice consumes the budget's slack and OOGs the copy. Bump only that
+budget by the fork-derived `COLD_ACCOUNT_ACCESS - 2600` so the success
+path stays funded; the value is exactly 0 before EIP-8038 and all
+other budgets are untouched.
 """
 
 import pytest
@@ -297,6 +306,11 @@ def test_oog(
     v: int,
 ) -> None:
     """Ori Pomerantz qbzzt1@gmail."""
+    # EIP-8038 cold account access reprice; 0 before EIP-8038. The
+    # `0x3E` RETURNDATACOPY success case forwards just enough gas for a
+    # nested CALL to a cold contract plus the copy; the reprice eats the
+    # slack, so add it back to that one budget.
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x0000000000000000000000000000000000010020)
     contract_1 = Address(0x0000000000000000000000000000000000010037)
@@ -753,7 +767,7 @@ def test_oog(
         Bytes("1a8451e6") + Hash(0x3C) + Hash(0xFFFF),
         Bytes("1a8451e6") + Hash(0x3C) + Hash(0x2BC),
         Bytes("1a8451e6") + Hash(0x3E) + Hash(0xFFFF),
-        Bytes("1a8451e6") + Hash(0x3E) + Hash(0xC02),
+        Bytes("1a8451e6") + Hash(0x3E) + Hash(0xC02 + cold_account_delta),
         Bytes("1a8451e6") + Hash(0x3E) + Hash(0x7D0),
         Bytes("1a8451e6") + Hash(0x3E) + Hash(0xC01),
         Bytes("1a8451e6") + Hash(0x51) + Hash(0xFFFF),

--- a/tests/ported_static/stNonZeroCallsTest/test_non_zero_value_call_to_non_non_zero_balance.py
+++ b/tests/ported_static/stNonZeroCallsTest/test_non_zero_value_call_to_non_non_zero_balance.py
@@ -3,6 +3,15 @@ Test_non_zero_value_call_to_non_non_zero_balance.
 
 Ported from:
 state_tests/stNonZeroCallsTest/NonZeroValue_CALL_ToNonNonZeroBalanceFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a value-1 CALL to a cold, alive EOA plus the SSTORE
+storing the (success) result. EIP-8038 reprices the CALL's cold
+account access and value transfer, and reprices the cold
+value-unchanged SSTORE. The delta is therefore
+`(COLD_ACCOUNT_ACCESS - 2600) + (CALL_VALUE - 9000)` plus the cold
+SSTORE reprice, each derived from the fork and exactly 0 before
+EIP-8038.
 """
 
 import pytest
@@ -15,6 +24,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,8 +41,24 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_non_zero_value_call_to_non_non_zero_balance(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_non_zero_value_call_to_non_non_zero_balance."""
+    # EIP-8038 deltas, each 0 before EIP-8038. The CALL pays the cold
+    # account reprice and the value-transfer reprice; the cold
+    # value-unchanged SSTORE gains its own reprice.
+    gas_costs = fork.gas_costs()
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    call_value_delta = gas_costs.CALL_VALUE - 9000
+    cold_noop_sstore_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=0, current_value=0, new_value=0
+        ).gas_cost(fork)
+        - 2200
+    )
+    call_measure_delta = (
+        cold_account_delta + call_value_delta + cold_noop_sstore_delta
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -76,7 +102,7 @@ def test_non_zero_value_call_to_non_non_zero_balance(
 
     post = {
         addr: Account(balance=100),
-        target: Account(storage={100: 11535}),
+        target: Account(storage={100: 11535 + call_measure_delta}),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stNonZeroCallsTest/test_non_zero_value_callcode_to_non_non_zero_balance.py
+++ b/tests/ported_static/stNonZeroCallsTest/test_non_zero_value_callcode_to_non_non_zero_balance.py
@@ -3,6 +3,15 @@ Test_non_zero_value_callcode_to_non_non_zero_balance.
 
 Ported from:
 state_tests/stNonZeroCallsTest/NonZeroValue_CALLCODE_ToNonNonZeroBalanceFiller.json
+
+@manually-enhanced: Do not overwrite. The measured slot captures the
+regular gas of a value-1 CALLCODE to a cold, alive EOA plus the SSTORE
+storing the (success) result. EIP-8038 reprices the CALLCODE's cold
+account access and value transfer, and reprices the cold
+value-unchanged SSTORE. The delta is therefore
+`(COLD_ACCOUNT_ACCESS - 2600) + (CALL_VALUE - 9000)` plus the cold
+SSTORE reprice, each derived from the fork and exactly 0 before
+EIP-8038.
 """
 
 import pytest
@@ -15,6 +24,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,8 +41,24 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_non_zero_value_callcode_to_non_non_zero_balance(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_non_zero_value_callcode_to_non_non_zero_balance."""
+    # EIP-8038 deltas, each 0 before EIP-8038. The CALLCODE pays the
+    # cold account reprice and the value-transfer reprice; the cold
+    # value-unchanged SSTORE gains its own reprice.
+    gas_costs = fork.gas_costs()
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    call_value_delta = gas_costs.CALL_VALUE - 9000
+    cold_noop_sstore_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=0, current_value=0, new_value=0
+        ).gas_cost(fork)
+        - 2200
+    )
+    call_measure_delta = (
+        cold_account_delta + call_value_delta + cold_noop_sstore_delta
+    )
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(amount=0xE8D4A51000)
 
@@ -76,7 +102,7 @@ def test_non_zero_value_callcode_to_non_non_zero_balance(
 
     post = {
         addr: Account(balance=100),
-        target: Account(storage={100: 11535}),
+        target: Account(storage={100: 11535 + call_measure_delta}),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stPreCompiledContracts/test_precomps_eip2929_cancun.py
+++ b/tests/ported_static/stPreCompiledContracts/test_precomps_eip2929_cancun.py
@@ -8,12 +8,14 @@ state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml
 test measure the regular gas consumed by a CALL with value to an
 inactive precompile address. EIP-8037 replaces the Cancun-era
 CALL_NEW_ACCOUNT cost of 25 000 with a per-new-account state-gas
-charge of `STATE_BYTES_PER_NEW_ACCOUNT (112) * COST_PER_STATE_BYTE
-(1174) = 131 488`. With an empty reservoir (the case here), the
-full state-gas spills back into regular gas, so `Op.GAS` reads
-+106 488 (= 131 488 - 25 000) compared to Cancun. Bake that delta
-into the two affected `[">=Cancun"]` expect-entries fork-condition-
-ally; the third entry is gated to `["Cancun"]` only and unchanged.
+charge that, with an empty reservoir (the case here), spills back
+into regular gas; EIP-8038 also reprices the cold account access
+from 2 600 to 3 000. `Op.GAS` therefore reads
+`fork.create_state_gas() - 25 000 + COLD_ACCOUNT_ACCESS - 2 600`
+extra regular gas compared to Cancun. Derive that delta from the
+fork so it is 0 pre-EIP-8037 and tracks parameter changes; bake it
+into the two affected `[">=Cancun"]` expect-entries. The third
+entry is gated to `["Cancun"]` only and unchanged.
 """
 
 import pytest
@@ -3591,12 +3593,18 @@ def test_precomps_eip2929_cancun(
         nonce=1,
     )
 
-    # EIP-8037 replaces the 25 000 CALL_NEW_ACCOUNT base cost with a
-    # 131 488 state-gas charge. With an empty reservoir the full
-    # state-gas spills into regular gas, so Op.GAS reads +106 488.
+    # These measurements isolate repriced components applied per
+    # expect-entry below: EIP-8037 replaces the 25 000 CALL_NEW_ACCOUNT
+    # base cost with a state-gas charge that, with an empty reservoir,
+    # spills back into regular gas; EIP-8038 separately reprices a cold
+    # account access from 2 600 to 3 000. Derive both from the fork so
+    # they are 0 pre-EIP-8037 and track parameter changes. `new`
+    # entries shift by the account delta, `no` entries by the cold
+    # delta, and `all` entries by both.
     new_account_delta = (
         (fork.create_state_gas() - 25000) if fork.is_eip_enabled(8037) else 0
     )
+    cold_account_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
 
     expect_entries_: list[dict] = [
         {
@@ -4060,7 +4068,9 @@ def test_precomps_eip2929_cancun(
                 "value": -1,
             },
             "network": [">=Cancun"],
-            "result": {target: Account(storage={0: 0, 1: 2500})},
+            "result": {
+                target: Account(storage={0: 0, 1: 2500 + cold_account_delta})
+            },
         },
         {
             "indexes": {
@@ -4248,7 +4258,12 @@ def test_precomps_eip2929_cancun(
             },
             "network": [">=Cancun"],
             "result": {
-                target: Account(storage={0: 0, 1: 27500 + new_account_delta})
+                target: Account(
+                    storage={
+                        0: 0,
+                        1: 27500 + new_account_delta + cold_account_delta,
+                    }
+                )
             },
         },
         {

--- a/tests/ported_static/stRefundTest/test_refund50_1.py
+++ b/tests/ported_static/stRefundTest/test_refund50_1.py
@@ -3,6 +3,16 @@ Test_refund50_1.
 
 Ported from:
 state_tests/stRefundTest/refund50_1Filler.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The
+contract clears five cold storage slots; EIP-8038 raises each cold
+SSTORE-clear charge from 5000 to 13000. The EIP-3529 refund cap
+(`gas_used // 5`) binds at both forks (the clear refunds far exceed a
+fifth of gas used), so the extra charge raises `gas_used` by exactly
+four fifths of itself. Derive the per-clear charge delta from the fork
+gas model (0 pre-EIP-8037) and subtract `gas_price * 5 * delta * 4 // 5`
+from the Cancun balance; do not hardcode the Amsterdam value.
 """
 
 import pytest
@@ -15,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +40,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund50_1(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund50_1."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -65,10 +77,20 @@ def test_refund50_1(
         gas_limit=100000,
     )
 
+    # EIP-8038 raises each cold SSTORE-clear charge; with the EIP-3529
+    # refund cap binding, gas_used rises by 4/5 of the extra charge.
+    cold_clear_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=1, current_value=1, new_value=0
+        ).gas_cost(fork)
+        - 5000
+    )
+    extra_gas_used = 5 * cold_clear_delta * 4 // 5
+
     post = {
         target: Account(storage={}),
         coinbase: Account(balance=0),
-        sender: Account(balance=0x92F810, nonce=1),
+        sender: Account(balance=0x92F810 - 10 * extra_gas_used, nonce=1),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_call_a_not_enough_gas_in_call.py
+++ b/tests/ported_static/stRefundTest/test_refund_call_a_not_enough_gas_in_call.py
@@ -3,6 +3,16 @@ Test_refund_call_a_not_enough_gas_in_call.
 
 Ported from:
 state_tests/stRefundTest/refund_CallA_notEnoughGasInCallFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The inner
+CALL is starved of gas so its SSTORE clear always reverts (no refund
+survives); the only surviving repricing is in the outer frame, where
+EIP-8038 raises the cold account-access charged by the CALL (2600 ->
+3000) and the cold no-op SSTORE of slot 0 (2200 -> 3000). Derive both
+deltas from the fork gas model (0 pre-EIP-8037) and subtract
+`gas_price * (call_access_delta + outer_sstore_delta)` from the Cancun
+balance; do not hardcode the Amsterdam value.
 """
 
 import pytest
@@ -15,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +40,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_call_a_not_enough_gas_in_call(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund_call_a_not_enough_gas_in_call."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -81,10 +93,24 @@ def test_refund_call_a_not_enough_gas_in_call(
         value=10,
     )
 
+    # The inner SSTORE clear always reverts (gas-starved), so its refund
+    # never survives. Only the outer frame reprices under EIP-8038: the
+    # cold account access charged by the CALL and the cold no-op SSTORE
+    # of slot 0 (original == current == new == 0).
+    gas_costs = fork.gas_costs()
+    call_access_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
+    outer_sstore_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=0, current_value=0, new_value=0
+        ).gas_cost(fork)
+        - 2200
+    )
+    gas_used_delta = call_access_delta + outer_sstore_delta
+
     post = {
         target: Account(storage={1: 1}, balance=0xDE0B6B3A764000A),
         coinbase: Account(balance=0),
-        sender: Account(balance=0xA8DF4, nonce=1),
+        sender: Account(balance=0xA8DF4 - 10 * gas_used_delta, nonce=1),
         addr: Account(storage={1: 1}),
     }
 

--- a/tests/ported_static/stRefundTest/test_refund_change_non_zero_storage.py
+++ b/tests/ported_static/stRefundTest/test_refund_change_non_zero_storage.py
@@ -3,6 +3,16 @@ Test_refund_change_non_zero_storage.
 
 Ported from:
 state_tests/stRefundTest/refund_changeNonZeroStorageFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The
+contract resets one warm-after-cold storage slot from a non-zero value
+to another non-zero value (1 -> 23); EIP-8038 raises this cold
+SSTORE-reset charge from 5000 to 13000. There is no storage-clear
+refund, so `gas_used` rises by exactly the charge delta. Derive that
+delta from the fork gas model (0 pre-EIP-8037) and subtract
+`gas_price * delta` from the Cancun balance; do not hardcode the
+Amsterdam value.
 """
 
 import pytest
@@ -15,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +40,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_change_non_zero_storage(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund_change_non_zero_storage."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -61,10 +73,19 @@ def test_refund_change_non_zero_storage(
         value=10,
     )
 
+    # EIP-8038 raises the cold SSTORE-reset charge (non-zero to non-zero);
+    # with no storage-clear refund, gas_used rises by the full delta.
+    cold_reset_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=1, current_value=1, new_value=23
+        ).gas_cost(fork)
+        - 5000
+    )
+
     post = {
         target: Account(storage={1: 23}, balance=0xDE0B6B3A764000A),
         coinbase: Account(balance=0),
-        sender: Account(balance=0x3C2F689A, nonce=1),
+        sender: Account(balance=0x3C2F689A - 10 * cold_reset_delta, nonce=1),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_ff.py
+++ b/tests/ported_static/stRefundTest/test_refund_ff.py
@@ -3,6 +3,16 @@ Ori Pomerantz   qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stRefundTest/refundFFFiller.yml
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The
+contract self-destructs and sends its (zero) balance to a cold, already
+existing beneficiary; EIP-8038 raises the cold account-access surcharge
+from 2600 to 3000. No positive balance is moved, so no `ACCOUNT_WRITE`
+applies and there is no refund, so `gas_used` rises by exactly the
+SELFDESTRUCT charge delta. Derive that delta from the fork gas model
+(0 pre-EIP-8037) and subtract `gas_price * delta` from the Cancun
+balance; do not hardcode the Amsterdam value.
 """
 
 import pytest
@@ -15,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +40,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_ff(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Ori Pomerantz   qbzzt1@gmail."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -64,6 +76,16 @@ def test_refund_ff(
         access_list=[],
     )
 
-    post = {sender: Account(balance=0xE8D4A51000)}
+    # EIP-8038 raises the cold account-access surcharge applied by
+    # SELFDESTRUCT; with no balance transfer and no refund, gas_used
+    # rises by exactly this charge delta.
+    selfdestruct_delta = (
+        Op.SELFDESTRUCT.with_metadata(
+            address_warm=False, account_new=False
+        ).gas_cost(fork)
+        - 7600
+    )
+
+    post = {sender: Account(balance=0xE8D4A51000 - 1000 * selfdestruct_delta)}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_get_ether_back.py
+++ b/tests/ported_static/stRefundTest/test_refund_get_ether_back.py
@@ -3,6 +3,18 @@ Test_refund_get_ether_back.
 
 Ported from:
 state_tests/stRefundTest/refund_getEtherBackFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The
+contract clears one cold storage slot (1 -> 0); EIP-8038 raises the cold
+SSTORE-clear charge from 5000 to 13000 and the storage-clear refund from
+4800 to 12480. The EIP-3529 refund cap (`gas_used // 5`) does not bind at
+Cancun but does at Amsterdam, so the shift is modeled from the fork gas
+model: reconstruct the cap-bounded `gas_used` from the fork-invariant
+non-SSTORE gross gas plus the fork SSTORE charge minus the capped refund,
+and subtract the same expression evaluated with the pre-repricing Cancun
+charges (so the adjustment is exactly 0 pre-EIP-8037). Do not hardcode
+the Amsterdam value.
 """
 
 import pytest
@@ -15,6 +27,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +42,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_get_ether_back(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund_get_ether_back."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -61,10 +75,30 @@ def test_refund_get_ether_back(
         value=10,
     )
 
+    # Gas used = gross gas minus the capped storage-clear refund. The
+    # non-SSTORE gross gas is fork-invariant: the intrinsic transaction
+    # cost plus the two PUSH1s that feed the single SSTORE (STOP is free).
+    gas_costs = fork.gas_costs()
+    base_gross = gas_costs.TX_BASE + 2 * gas_costs.VERY_LOW
+
+    def clear_gas_used(sstore_charge: int, clear_refund: int) -> int:
+        gross = base_gross + sstore_charge
+        return gross - min(clear_refund, gross // 5)
+
+    sstore_charge = Op.SSTORE.with_metadata(
+        key_warm=False, original_value=1, current_value=1, new_value=0
+    ).gas_cost(fork)
+    # Cancun charges 5000 for the clear and refunds 4800; subtracting the
+    # same model evaluated at those constants makes this exactly 0 before
+    # the EIP-8037/8038 repricing.
+    gas_used_delta = clear_gas_used(
+        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR
+    ) - clear_gas_used(5000, 4800)
+
     post = {
         target: Account(storage={}, balance=0xDE0B6B3A764000A),
         coinbase: Account(balance=0),
-        sender: Account(balance=0x3CF4376A, nonce=1),
+        sender: Account(balance=0x3CF4376A - 10 * gas_used_delta, nonce=1),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_max.py
+++ b/tests/ported_static/stRefundTest/test_refund_max.py
@@ -3,6 +3,16 @@ Ori Pomerantz   qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stRefundTest/refundMaxFiller.yml
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The
+contract clears eight cold storage slots; EIP-8038 raises each cold
+SSTORE-clear charge from 5000 to 13000. The EIP-3529 refund cap
+(`gas_used // 5`) binds at both forks (the clear refunds far exceed a
+fifth of gas used), so the extra charge raises `gas_used` by exactly
+four fifths of itself. Derive the per-clear charge delta from the fork
+gas model (0 pre-EIP-8037) and subtract `gas_price * 8 * delta * 4 // 5`
+from the Cancun balance; do not hardcode the Amsterdam value.
 """
 
 import pytest
@@ -15,6 +25,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +40,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_max(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Ori Pomerantz   qbzzt1@gmail."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -95,6 +107,16 @@ def test_refund_max(
         access_list=[],
     )
 
-    post = {sender: Account(balance=0xE8D55F7E90)}
+    # EIP-8038 raises each cold SSTORE-clear charge; with the EIP-3529
+    # refund cap binding, gas_used rises by 4/5 of the extra charge.
+    cold_clear_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=1, current_value=1, new_value=0
+        ).gas_cost(fork)
+        - 5000
+    )
+    extra_gas_used = 8 * cold_clear_delta * 4 // 5
+
+    post = {sender: Account(balance=0xE8D55F7E90 - 1000 * extra_gas_used)}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_no_oog_1.py
+++ b/tests/ported_static/stRefundTest/test_refund_no_oog_1.py
@@ -3,6 +3,17 @@ Test_refund_no_oog_1.
 
 Ported from:
 state_tests/stRefundTest/refund_NoOOG_1Filler.json
+
+@manually-enhanced: Do not overwrite. The transaction supplies exactly
+enough gas to clear one cold storage slot (1 -> 0) and no more (the "no
+out-of-gas" boundary). EIP-8038 raises the cold SSTORE-clear charge from
+5000 to 13000, so the gas limit must rise by that charge delta to keep
+the slot clearing instead of running out of gas. The asserted sender
+balance equals its start minus `gas_used * gas_price`, and `gas_used`
+is the gross gas minus the storage-clear refund (capped by EIP-3529 only
+at Amsterdam). Both the gas limit bump and the balance shift are derived
+from the fork gas model and are exactly 0 pre-EIP-8037; do not hardcode
+the Amsterdam values.
 """
 
 import pytest
@@ -15,6 +26,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +41,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_no_oog_1(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund_no_oog_1."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -53,17 +66,42 @@ def test_refund_no_oog_1(
         nonce=0,
     )
 
+    # EIP-8038 raises the cold SSTORE-clear charge; bump the gas limit by
+    # the charge delta so the clear still lands exactly at the limit
+    # (the "no out-of-gas" boundary) instead of running out of gas.
+    sstore_charge = Op.SSTORE.with_metadata(
+        key_warm=False, original_value=1, current_value=1, new_value=0
+    ).gas_cost(fork)
+    cold_clear_delta = sstore_charge - 5000
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=26006,
+        gas_limit=26006 + cold_clear_delta,
     )
+
+    # Gas used = gross gas minus the capped storage-clear refund. The
+    # non-SSTORE gross gas is fork-invariant: the intrinsic transaction
+    # cost plus the two PUSH1s that feed the single SSTORE (STOP is free).
+    gas_costs = fork.gas_costs()
+    base_gross = gas_costs.TX_BASE + 2 * gas_costs.VERY_LOW
+
+    def clear_gas_used(charge: int, clear_refund: int) -> int:
+        gross = base_gross + charge
+        return gross - min(clear_refund, gross // 5)
+
+    # Cancun charges 5000 for the clear and refunds 4800; subtracting the
+    # same model evaluated at those constants makes this exactly 0 before
+    # the EIP-8037/8038 repricing.
+    gas_used_delta = clear_gas_used(
+        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR
+    ) - clear_gas_used(5000, 4800)
 
     post = {
         target: Account(storage={}),
         coinbase: Account(balance=0),
-        sender: Account(balance=0x9D0314, nonce=1),
+        sender: Account(balance=0x9D0314 - 10 * gas_used_delta, nonce=1),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_sstore.py
+++ b/tests/ported_static/stRefundTest/test_refund_sstore.py
@@ -3,6 +3,18 @@ Ori Pomerantz   qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stRefundTest/refundSSTOREFiller.yml
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which equals its start minus `gas_used * gas_price`. The
+contract clears one cold storage slot (non-zero -> 0); EIP-8038 raises
+the cold SSTORE-clear charge from 5000 to 13000 and the storage-clear
+refund from 4800 to 12480. The EIP-3529 refund cap (`gas_used // 5`) does
+not bind at Cancun but does at Amsterdam, so the shift is modeled from
+the fork gas model: reconstruct the cap-bounded `gas_used` from the
+fork-invariant non-SSTORE gross gas plus the fork SSTORE charge minus the
+capped refund, and subtract the same expression evaluated with the
+pre-repricing Cancun charges (so the adjustment is exactly 0
+pre-EIP-8037). Do not hardcode the Amsterdam value.
 """
 
 import pytest
@@ -15,6 +27,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +42,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_sstore(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Ori Pomerantz   qbzzt1@gmail."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -65,6 +79,29 @@ def test_refund_sstore(
         access_list=[],
     )
 
-    post = {sender: Account(balance=0xE8D4EE4E00)}
+    # Gas used = gross gas minus the capped storage-clear refund. The
+    # non-SSTORE gross gas is fork-invariant: the intrinsic transaction
+    # cost (including the single zero data byte) plus the PUSH1 and DUP1
+    # that feed the SSTORE (STOP is free).
+    gas_costs = fork.gas_costs()
+    base_gross = (
+        gas_costs.TX_BASE + 2 * gas_costs.VERY_LOW + gas_costs.TX_DATA_PER_ZERO
+    )
+
+    def clear_gas_used(sstore_charge: int, clear_refund: int) -> int:
+        gross = base_gross + sstore_charge
+        return gross - min(clear_refund, gross // 5)
+
+    sstore_charge = Op.SSTORE.with_metadata(
+        key_warm=False, original_value=24743, current_value=24743, new_value=0
+    ).gas_cost(fork)
+    # Cancun charges 5000 for the clear and refunds 4800; subtracting the
+    # same model evaluated at those constants makes this exactly 0 before
+    # the EIP-8037/8038 repricing.
+    gas_used_delta = clear_gas_used(
+        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR
+    ) - clear_gas_used(5000, 4800)
+
+    post = {sender: Account(balance=0xE8D4EE4E00 - 1000 * gas_used_delta)}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRevertTest/test_revert_opcode_calls.py
+++ b/tests/ported_static/stRevertTest/test_revert_opcode_calls.py
@@ -5,7 +5,13 @@ Ported from:
 state_tests/stRevertTest/RevertOpcodeCallsFiller.json
 @manually-enhanced: Do not overwrite. Gas bumped fork-conditionally
 to cover EIP-8037 state-gas spill into regular gas; pre-EIP-8037
-behavior unchanged.
+behavior unchanged. The d3 call chain ends in a fresh SSTORE-set in
+the outermost (transaction) frame; with an empty state-gas reservoir
+that set's state gas spills into regular gas, so the success path
+(g=0) runs out at the final `SSTORE` unless the outer budget absorbs
+the spill. Lift `tx_gas[0]` by one fresh-set SSTORE state cost via
+`fork.oog_budget_lift`, which is exactly 0 pre-EIP-8037 and tracks
+the parameter. g=1 (the OoG case) keeps the original budget.
 
 """
 
@@ -334,7 +340,12 @@ def test_revert_opcode_calls(
         Hash(addr_3, left_padding=True),
         Hash(addr_4, left_padding=True),
     ]
-    tx_gas = [460000, 83622]
+    # The g=0 success path bottoms out on a fresh SSTORE-set in the
+    # transaction frame whose EIP-8037 state gas spills (empty
+    # reservoir). Lift the outer budget by that spilled state cost so
+    # the chain still completes on Amsterdam; 0 pre-EIP-8037.
+    g0_lift = fork.oog_budget_lift(sstores_before_oog=1)
+    tx_gas = [460000 + g0_lift, 83622]
 
     tx = Transaction(
         sender=sender,

--- a/tests/ported_static/stSpecialTest/test_eoa_empty_paris.py
+++ b/tests/ported_static/stSpecialTest/test_eoa_empty_paris.py
@@ -3,6 +3,14 @@ Test_eoa_empty_paris.
 
 Ported from:
 state_tests/stSpecialTest/eoaEmptyParisFiller.yml
+
+@manually-enhanced: Do not overwrite. Two measured slots shift under
+EIP-8038. Slot 0xF1 times a CALL that forwards `value` to the (warm)
+origin EOA: when `value` is nonzero it gains the value-transfer
+reprice `CALL_VALUE - 9000`; the value-0 cases are unchanged. Slot
+0xFF times a value-0 CALL to a cold contract and gains the cold
+account reprice `COLD_ACCOUNT_ACCESS - 2600`. Both deltas come from
+the fork's own gas model, so each is exactly 0 before EIP-8038.
 """
 
 import pytest
@@ -97,6 +105,13 @@ def test_eoa_empty_paris(
     v: int,
 ) -> None:
     """Test_eoa_empty_paris."""
+    # EIP-8038 deltas, each 0 before EIP-8038. Slot 0xF1's value-bearing
+    # CALL to the warm origin gains the value-transfer reprice; slot
+    # 0xFF's value-0 CALL to a cold contract gains the cold account
+    # reprice.
+    gas_costs = fork.gas_costs()
+    call_value_delta = gas_costs.CALL_VALUE - 9000
+    cold_account_delta = gas_costs.COLD_ACCOUNT_ACCESS - 2600
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x000000000000000000000000000000000000BAD1)
     contract_1 = Address(0x000000000000000000000000000000000000BAD2)
@@ -244,7 +259,7 @@ def test_eoa_empty_paris(
                         59: 0,
                         63: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         241: 118,
-                        255: 7626,
+                        255: 7626 + cold_account_delta,
                         319: 0,
                         47825: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         47826: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
@@ -265,8 +280,8 @@ def test_eoa_empty_paris(
                         49: 0,
                         59: 0,
                         63: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
-                        241: 6818,
-                        255: 7626,
+                        241: 6818 + call_value_delta,
+                        255: 7626 + cold_account_delta,
                         319: 0,
                         47825: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         47826: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
@@ -296,7 +311,7 @@ def test_eoa_empty_paris(
                         59: 0,
                         63: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         241: 118,
-                        255: 7626,
+                        255: 7626 + cold_account_delta,
                         319: 0,
                         47825: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         47826: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
@@ -317,8 +332,8 @@ def test_eoa_empty_paris(
                         49: 100,
                         59: 0,
                         63: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
-                        241: 6818,
-                        255: 7626,
+                        241: 6818 + call_value_delta,
+                        255: 7626 + cold_account_delta,
                         319: 0,
                         47825: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         47826: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
@@ -340,7 +355,7 @@ def test_eoa_empty_paris(
                         59: 0,
                         63: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         241: 118,
-                        255: 7626,
+                        255: 7626 + cold_account_delta,
                         319: 0,
                         47825: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         47826: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
@@ -361,8 +376,8 @@ def test_eoa_empty_paris(
                         49: 0,
                         59: 0,
                         63: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
-                        241: 6818,
-                        255: 7626,
+                        241: 6818 + call_value_delta,
+                        255: 7626 + cold_account_delta,
                         319: 0,
                         47825: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501
                         47826: 0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,  # noqa: E501

--- a/tests/ported_static/stTransactionTest/test_contract_store_clears_success.py
+++ b/tests/ported_static/stTransactionTest/test_contract_store_clears_success.py
@@ -3,6 +3,18 @@ Test_contract_store_clears_success.
 
 Ported from:
 state_tests/stTransactionTest/ContractStoreClearsSuccessFiller.json
+
+@manually-enhanced: Do not overwrite. The contract clears 10 cold
+storage slots (each 12 -> 0) and the transaction sends value alongside,
+so the asserted post is the cleared storage plus the received value.
+EIP-8038 raises the cold SSTORE-clear charge from 5000 to 13000, so the
+10 clears no longer fit in the original gas limit and the contract runs
+out of gas before clearing the storage or keeping the transfer. Bump the
+gas limit by the per-clear charge delta times the 10 clears so every
+clear still lands at Amsterdam. The delta is derived from the fork gas
+model and is exactly 0 pre-EIP-8037; do not hardcode the Amsterdam
+value. The post asserts only the target account (cleared storage and the
+received value), which holds at every fork once the gas fits.
 """
 
 import pytest
@@ -15,6 +27,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +42,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_contract_store_clears_success(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_contract_store_clears_success."""
     coinbase = Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B)
@@ -72,11 +86,21 @@ def test_contract_store_clears_success(
         nonce=0,
     )
 
+    # EIP-8038 raises the cold SSTORE-clear charge; bump the gas limit by
+    # the per-clear charge delta times the 10 clears so all of them still
+    # land instead of running out of gas before clearing the storage.
+    cold_clear_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=1, current_value=1, new_value=0
+        ).gas_cost(fork)
+        - 5000
+    )
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=130000,
+        gas_limit=130000 + 10 * cold_clear_delta,
         value=10,
     )
 

--- a/tests/ported_static/stTransactionTest/test_internal_call_store_clears_success.py
+++ b/tests/ported_static/stTransactionTest/test_internal_call_store_clears_success.py
@@ -3,6 +3,20 @@ Test_internal_call_store_clears_success.
 
 Ported from:
 state_tests/stTransactionTest/InternalCallStoreClearsSuccessFiller.json
+
+@manually-enhanced: Do not overwrite. The `target` contract forwards a
+fixed `CALL` gas budget (0x186A0) to `addr`, which clears 10 cold
+storage slots (12 -> 0). EIP-8038 raises the cold SSTORE-clear charge
+from 5000 to 13000, so the 10 clears jump from 50000 to 130000 gas and
+no longer fit in the forwarded budget or the transaction gas limit:
+`addr` runs out of gas, its slots stay set, and the inner value
+transfer rolls back, defeating the "store clears success" intent. Both
+the inner `CALL` gas argument and the transaction gas limit are raised
+by `10 * cold_clear_delta` so all 10 clears still succeed. The per-clear
+delta is derived from the fork gas model and is exactly 0 pre-EIP-8037;
+do not hardcode the Amsterdam values. The asserted balances are
+fork-invariant once the clears land, and the post does not assert the
+sender balance, so no balance adjustment is needed.
 """
 
 import pytest
@@ -15,6 +29,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,6 +46,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_internal_call_store_clears_success(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_internal_call_store_clears_success."""
     coinbase = Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B)
@@ -44,6 +60,18 @@ def test_internal_call_store_clears_success(
         base_fee_per_gas=10,
         gas_limit=1000000,
     )
+
+    # EIP-8038 raises the cold SSTORE-clear charge; bump the forwarded
+    # CALL gas and the transaction gas limit by the per-clear delta times
+    # the 10 clears so every clear still lands instead of running out of
+    # gas. The delta is 0 before the EIP-8037/8038 repricing.
+    cold_clear_delta = (
+        Op.SSTORE.with_metadata(
+            key_warm=False, original_value=1, current_value=1, new_value=0
+        ).gas_cost(fork)
+        - 5000
+    )
+    clears_gas_bump = 10 * cold_clear_delta
 
     # Source: lll
     # {(SSTORE 0 0)(SSTORE 1 0)(SSTORE 2 0)(SSTORE 3 0)(SSTORE 4 0)(SSTORE 5 0)(SSTORE 6 0)(SSTORE 7 0)(SSTORE 8 0)(SSTORE 9 0)}  # noqa: E501
@@ -77,7 +105,7 @@ def test_internal_call_store_clears_success(
     # { (CALL 100000 <contract:0x0000000000000000000000000000000000000000> 1 0 0 0 0) }  # noqa: E501
     target = pre.deploy_contract(  # noqa: F841
         code=Op.CALL(
-            gas=0x186A0,
+            gas=0x186A0 + clears_gas_bump,
             address=addr,
             value=0x1,
             args_offset=0x0,
@@ -94,7 +122,7 @@ def test_internal_call_store_clears_success(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=160000,
+        gas_limit=160000 + clears_gas_bump,
         value=10,
     )
 

--- a/tests/ported_static/stTransactionTest/test_store_clears_and_internal_call_store_clears_success.py
+++ b/tests/ported_static/stTransactionTest/test_store_clears_and_internal_call_store_clears_success.py
@@ -3,6 +3,19 @@ Test_store_clears_and_internal_call_store_clears_success.
 
 Ported from:
 state_tests/stTransactionTest/StoreClearsAndInternalCallStoreClearsSuccessFiller.json
+
+@manually-enhanced: Do not overwrite. The outer contract `target` clears 4
+cold storage slots then `CALL`s the inner contract `addr`, which clears 10
+cold storage slots; the value transfer and clears must all succeed.
+EIP-8037/8038 raise the cold SSTORE-clear charge from 5000 to 13000 at
+Amsterdam, so both gas budgets must rise by that charge delta or the inner
+frame runs out of gas (clearing only 4 of its 10 slots) and the value
+transfer rolls back. The inner `CALL` only forwards a fixed gas amount, so
+its budget is bumped by the 10 inner clears; the transaction gas limit is
+bumped by all 14 clears (10 inner plus 4 outer) so the outer frame can both
+pay its own clears and forward the larger amount. Both bumps are derived
+from the fork gas model and are exactly 0 pre-EIP-8037; do not hardcode the
+Amsterdam values.
 """
 
 import pytest
@@ -15,6 +28,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,10 +45,18 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_store_clears_and_internal_call_store_clears_success(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_store_clears_and_internal_call_store_clears_success."""
     coinbase = Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B)
     sender = pre.fund_eoa(amount=0x1DCD6500)
+
+    # EIP-8037/8038 raise the cold SSTORE-clear charge; derive the per-clear
+    # delta (0 pre-EIP-8037) so both gas budgets keep every clear landing.
+    sstore_charge = Op.SSTORE.with_metadata(
+        key_warm=False, original_value=1, current_value=1, new_value=0
+    ).gas_cost(fork)
+    cold_clear_delta = sstore_charge - 5000
 
     env = Environment(
         fee_recipient=coinbase,
@@ -81,7 +103,10 @@ def test_store_clears_and_internal_call_store_clears_success(
         + Op.SSTORE(key=0x2, value=0x0)
         + Op.SSTORE(key=0x3, value=0x0)
         + Op.CALL(
-            gas=0xC350,
+            # The inner frame clears 10 cold slots; forward its extra
+            # charge so all 10 clears land at Amsterdam (delta is 0
+            # pre-EIP-8037).
+            gas=0xC350 + 10 * cold_clear_delta,
             address=addr,
             value=0x1,
             args_offset=0x0,
@@ -99,7 +124,10 @@ def test_store_clears_and_internal_call_store_clears_success(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=200000,
+        # The whole transaction clears 14 cold slots (4 in the outer frame,
+        # 10 in the inner frame); bump the limit by all of them so the outer
+        # frame can pay its own clears and forward the larger inner budget.
+        gas_limit=200000 + 14 * cold_clear_delta,
         value=10,
     )
 

--- a/tests/ported_static/vmTests/test_suicide.py
+++ b/tests/ported_static/vmTests/test_suicide.py
@@ -3,6 +3,18 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/VMTests/vmTests/suicideFiller.yml
+
+@manually-enhanced: Do not overwrite. For the `caller` case the post-state
+asserts the sender balance, which equals its start minus
+`gas_used * gas_price`. The transaction calls a contract that CALLs a
+cold, existing account (slot 0x1000) before it self-destructs; EIP-8038
+raises the cold account-access surcharge on that CALL from 2600 to 3000.
+The SELFDESTRUCT itself is to a warm, non-empty beneficiary (the caller),
+so its charge is unchanged, and there is no refund. Derive the
+account-access delta from the fork gas model (0 pre-EIP-8037) and
+subtract `gas_price * delta` from the Cancun balance; do not hardcode the
+Amsterdam value. The `random` and `myself` cases assert only
+non-gas-dependent balances and need no adjustment.
 """
 
 import pytest
@@ -133,12 +145,21 @@ def test_suicide(
         address=Address(0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC),  # noqa: E501
     )
 
+    # The CALL into the self-destructing contract touches a cold, already
+    # existing account; EIP-8038 raises that cold account-access surcharge
+    # from 2600 to 3000. The SELFDESTRUCT beneficiary is warm and
+    # non-empty, so its charge is unchanged. The sender pays this extra
+    # gas at the base fee (no priority fee), so its balance drops by the
+    # account-access delta times the gas price.
+    cold_account_access_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
+    caller_balance = 0x5AF31075D9DE - 10 * cold_account_access_delta
+
     expect_entries_: list[dict] = [
         {
             "indexes": {"data": [0], "gas": -1, "value": -1},
             "network": [">=Cancun"],
             "result": {
-                sender: Account(balance=0x5AF31075D9DE),
+                sender: Account(balance=caller_balance),
                 contract_3: Account(balance=0xFF100000000000),
             },
         },

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -972,6 +972,7 @@ def test_gas_cost(
 def test_account_warming(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
     authorization_list_with_properties: List[AuthorizationWithProperties],
     authorization_list: List[AuthorizationTuple],
     access_list: List[AccessList],
@@ -987,8 +988,9 @@ def test_account_warming(
     # check.
     overhead_cost = 3 * len(Op.CALL.kwargs)
 
-    cold_account_cost = 2600
-    warm_account_cost = 100
+    gas_costs = fork.gas_costs()
+    cold_account_cost = gas_costs.COLD_ACCOUNT_ACCESS
+    warm_account_cost = gas_costs.WARM_ACCESS
 
     access_list_addresses = {
         access_list.address for access_list in access_list
@@ -1190,6 +1192,7 @@ def test_intrinsic_gas_cost(
 def test_self_set_code_cost(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
     pre_authorized: bool,
 ) -> None:
     """Test set to code account access cost when it delegates to itself."""
@@ -1199,6 +1202,10 @@ def test_self_set_code_cost(
         auth_signer = pre.fund_eoa(0)
 
     slot_call_cost = 1
+
+    gas_costs = fork.gas_costs()
+    cold_account_cost = gas_costs.COLD_ACCOUNT_ACCESS
+    warm_account_cost = gas_costs.WARM_ACCESS
 
     overhead_cost = 3 * len(Op.CALL.kwargs)
 
@@ -1211,7 +1218,11 @@ def test_self_set_code_cost(
 
     callee_address = pre.deploy_contract(callee_code)
     callee_storage = Storage()
-    callee_storage[slot_call_cost] = 200 if not pre_authorized else 2700
+    callee_storage[slot_call_cost] = (
+        2 * warm_account_cost
+        if not pre_authorized
+        else cold_account_cost + warm_account_cost
+    )
 
     tx = Transaction(
         to=callee_address,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -1472,6 +1472,7 @@ def test_ext_code_on_self_set_code(
 def test_set_code_address_and_authority_warm_state(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
     set_code_address_first: bool,
 ) -> None:
     """
@@ -1516,13 +1517,18 @@ def test_set_code_address_and_authority_warm_state(
     callee_code += Op.SSTORE(slot_call_success, 1) + Op.STOP
 
     callee_address = pre.deploy_contract(callee_code)
+    gas_costs = fork.gas_costs()
+    cold_account_cost = gas_costs.COLD_ACCOUNT_ACCESS
+    warm_account_cost = gas_costs.WARM_ACCESS
     callee_storage = Storage()
     callee_storage[slot_call_success] = 1
     callee_storage[slot_set_code_to_warm_state] = (
-        2_600 if set_code_address_first else 100
+        cold_account_cost if set_code_address_first else warm_account_cost
     )
     callee_storage[slot_authority_warm_state] = (
-        200 if set_code_address_first else 2_700
+        2 * warm_account_cost
+        if set_code_address_first
+        else warm_account_cost + cold_account_cost
     )
 
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description

### Summary

Implements [EIP-8038: State-access gas cost update](https://eips.ethereum.org/EIPS/eip-8038) in `forks/amsterdam`. This PR uses the gas parameter values from [Maria's EIP-8038 update (`ethereum/EIPs#11802`)](https://github.com/ethereum/EIPs/pull/11802):

| Parameter | Legacy | New |
| --- | ---: | ---: |
| `COLD_ACCOUNT_ACCESS` | 2,600 | 3,000 |
| `ACCOUNT_WRITE` | 6,700 | 8,000 |
| `COLD_STORAGE_ACCESS` | 2,100 | 3,000 |
| `STORAGE_WRITE` | 2,800 | 10,000 |
| `WARM_ACCESS` | 100 | 100 |
| `STORAGE_CLEAR_REFUND` | 4,800 | 12,480 |
| `CREATE_ACCESS` | 7,000 | 11,000 |
| `ACCESS_LIST_STORAGE_KEY_COST` | 1,900 | 3,000 |
| `ACCESS_LIST_ADDRESS_COST` | 2,400 | 3,000 |

The commits relevant to specs and testing framework are organized to be reviewed in order:

1. `refactor(specs)`: give `TLOAD`/`TSTORE` dedicated gas constants (unchanged at 100) so transient storage, which is in-memory only and not covered by EIP-8038, is priced independently of `WARM_ACCESS`. Forward-compatible with EIP-7971.
2. `feat(specs)`: the repricing itself, including the new `SSTORE` formula (access cost always charged; `STORAGE_WRITE` on first change, refunded on restore), the `EXT*` second-read surcharge, the `SELFDESTRUCT` `ACCOUNT_WRITE` charge, `CALL_VALUE` = `ACCOUNT_WRITE` + `CALL_STIPEND`, and the EIP-7702 per-authorization intrinsic cost restructuring with the `ACCOUNT_WRITE` refund for existing authorities.
3. `refactor(test-forks)`: the same transient-storage decoupling in the EEST fork gas model.
4. `feat(test-forks)`: the repricing in the EEST fork gas model (folded into the `EIP8037` mixin, which shares the gas schedule), including the `EXT*`/`SELFDESTRUCT` formula updates and a new `GasCosts.ACCOUNT_WRITE` field.
## 🔗 Related Issues or PRs

- Uses the gas parameter values from [`ethereum/EIPs#11802`](https://github.com/ethereum/EIPs/pull/11802) (Maria's EIP-8038 update).

### Review Strategy

| Area | Reviewer | Approve? |
| --- | ---: | ---: |
| `packages/testing` | @spencer-tb / @marioevz | |
| `ethereum/src` | @SamWilsn  | |
| `tests/amsterdam` | | |
| `tests/cancun` | | |
| `tests/ported_static` | @spencer-tb | |
| `tests/paris` | | |
| `tests/prague` | | |

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="1249" height="617" alt="image" src="https://github.com/user-attachments/assets/54d4f553-bd06-4063-9685-875558a5ba0c" />
