### PR TITLE
feat(ci): deploy default branch docs at /docs/execution-specs/

### DIFF
--- a/.github/configs/docs-branches.yaml
+++ b/.github/configs/docs-branches.yaml
@@ -5,14 +5,19 @@
 # `docs-config.yml`; a branch that publishes here but isn't listed there
 # is dispatched but dropped by the aggregator.
 #
+# `default_branch` names the branch whose docs are deployed at the root
+# (steel.ethereum.foundation/docs/execution-specs/) instead of a
+# branch-nested path. It must also appear in `branches[]` below and must
+# match steel-website's `default_branch` setting in `docs-config.yml`.
+#
 # Each entry defines:
 #   - path: The branch name (must match the Git branch exactly)
 #   - label: Human-readable label for the version switcher UI
+
+default_branch: forks/amsterdam
 
 branches:
   - path: "mainnet"
     label: "Mainnet (BPO2)"
   - path: "forks/amsterdam"
     label: "Amsterdam"
-  - path: "devnets/bal/4"
-    label: "bal-devnet-4"

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -85,6 +85,7 @@ jobs:
       branch_artifact_name: ${{ steps.check.outputs.branch_artifact_name }}
       commit_sha: ${{ steps.check.outputs.commit_sha }}
       default_branch: ${{ steps.check.outputs.default_branch }}
+      site_url: ${{ steps.check.outputs.site_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -134,6 +135,20 @@ jobs:
           fi
           echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
 
+          # Resolve SITE_URL once so downstream consumers don't re-derive it.
+          # Default branch publishes at the root of /docs/execution-specs/ so
+          # canonical/OG/sitemap URLs omit the <branch>/ segment.
+          if [ "$SHOULD_PUBLISH" = "true" ]; then
+            if [ "$BRANCH_INPUT" = "$DEFAULT_BRANCH" ]; then
+              SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/"
+            else
+              SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/${BRANCH_INPUT}/"
+            fi
+          else
+            SITE_URL="https://example.com/docs/${BRANCH_INPUT}/"
+          fi
+          echo "site_url=$SITE_URL" >> "$GITHUB_OUTPUT"
+
           # Resolve the concrete SHA we will build, so metadata.json and the
           # aggregator dispatch payload match what the build jobs check out.
           #
@@ -177,11 +192,9 @@ jobs:
             if [ "$EVENT_NAME" = "pull_request" ]; then
               echo "-> **Build only** -- pull request; artifacts are not published."
             elif [ "$SHOULD_PUBLISH" = "true" ]; then
-              if [ "$BRANCH_INPUT" = "$DEFAULT_BRANCH" ]; then
-                echo "-> **Will publish** at <https://steel.ethereum.foundation/docs/execution-specs/> (default branch; deployed at root)"
-              else
-                echo "-> **Will publish** at <https://steel.ethereum.foundation/docs/execution-specs/${BRANCH_INPUT}/>"
-              fi
+              SUFFIX=""
+              [ "$BRANCH_INPUT" = "$DEFAULT_BRANCH" ] && SUFFIX=" (default branch; deployed at root)"
+              echo "-> **Will publish** at <$SITE_URL>$SUFFIX"
               echo ""
               echo "_Note: the URL only resolves if \`${BRANCH_INPUT}\` is also configured in steel-website's \`BRANCH_CONFIG\` (\`deploy.yml\`). If not, the aggregator will receive the dispatch but drop the artifact._"
             else
@@ -212,22 +225,8 @@ jobs:
 
       - name: Build MkDocs documentation
         env:
-          BRANCH: ${{ needs.check-should-publish.outputs.branch }}
-          DEFAULT_BRANCH: ${{ needs.check-should-publish.outputs.default_branch }}
-          SHOULD_PUBLISH: ${{ needs.check-should-publish.outputs.should_publish }}
+          SITE_URL: ${{ needs.check-should-publish.outputs.site_url }}
         run: |
-          if [ "$SHOULD_PUBLISH" = "true" ]; then
-            if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
-              # Default branch is deployed at /docs/execution-specs/ (no branch
-              # segment), so canonical/OG/sitemap URLs must omit it too.
-              export SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/"
-            else
-              export SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/${BRANCH}/"
-            fi
-          else
-            export SITE_URL="https://example.com/docs/${BRANCH}/"
-          fi
-
           echo "Building MkDocs with SITE_URL=$SITE_URL"
           just docs
 

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -6,10 +6,14 @@
 #     the aggregator workflow in steel-website for deployment
 #
 # Site structure at steel.ethereum.foundation/docs/execution-specs/:
-#   /docs/execution-specs/                         - Default branch docs (mirrored)
-#   /docs/execution-specs/specs/reference/         - Default branch spec reference (mirrored)
-#   /docs/execution-specs/<branch>/                - Branch-specific docs
-#   /docs/execution-specs/<branch>/specs/reference - Branch-specific spec reference (docc output)
+#   /docs/execution-specs/                         - Default branch docs (deployed at root)
+#   /docs/execution-specs/specs/reference/         - Default branch spec reference
+#   /docs/execution-specs/<branch>/                - Non-default branch docs
+#   /docs/execution-specs/<branch>/specs/reference - Non-default branch spec reference (docc output)
+#
+# The "default branch" is named in .github/configs/docs-branches.yaml. Its
+# SITE_URL is built without a `<branch>/` segment so canonical/OG/sitemap
+# URLs match where steel-website actually publishes the artifact.
 
 name: Build Docs
 
@@ -80,6 +84,7 @@ jobs:
       branch: ${{ steps.check.outputs.branch }}
       branch_artifact_name: ${{ steps.check.outputs.branch_artifact_name }}
       commit_sha: ${{ steps.check.outputs.commit_sha }}
+      default_branch: ${{ steps.check.outputs.default_branch }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -107,6 +112,19 @@ jobs:
             echo "ERROR: Could not read allowlist from .github/configs/docs-branches.yaml"
             exit 1
           fi
+
+          # The default branch is deployed at /docs/execution-specs/ (no branch
+          # segment) so its SITE_URL and the publish summary differ.
+          DEFAULT_BRANCH=$(yq '.default_branch' .github/configs/docs-branches.yaml 2>/dev/null || echo "")
+          if [ -z "$DEFAULT_BRANCH" ] || [ "$DEFAULT_BRANCH" = "null" ]; then
+            echo "ERROR: default_branch is missing from .github/configs/docs-branches.yaml"
+            exit 1
+          fi
+          if ! echo "$ALLOWLISTED_BRANCHES" | grep -qxF "$DEFAULT_BRANCH"; then
+            echo "ERROR: default_branch '$DEFAULT_BRANCH' is not present in branches[]"
+            exit 1
+          fi
+          echo "default_branch=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
 
           # Check if branch is in allowlist
           if echo "$ALLOWLISTED_BRANCHES" | grep -qxF "$BRANCH_INPUT"; then
@@ -159,7 +177,11 @@ jobs:
             if [ "$EVENT_NAME" = "pull_request" ]; then
               echo "-> **Build only** -- pull request; artifacts are not published."
             elif [ "$SHOULD_PUBLISH" = "true" ]; then
-              echo "-> **Will publish** at <https://steel.ethereum.foundation/docs/execution-specs/${BRANCH_INPUT}/>"
+              if [ "$BRANCH_INPUT" = "$DEFAULT_BRANCH" ]; then
+                echo "-> **Will publish** at <https://steel.ethereum.foundation/docs/execution-specs/> (default branch; deployed at root)"
+              else
+                echo "-> **Will publish** at <https://steel.ethereum.foundation/docs/execution-specs/${BRANCH_INPUT}/>"
+              fi
               echo ""
               echo "_Note: the URL only resolves if \`${BRANCH_INPUT}\` is also configured in steel-website's \`BRANCH_CONFIG\` (\`deploy.yml\`). If not, the aggregator will receive the dispatch but drop the artifact._"
             else
@@ -191,10 +213,17 @@ jobs:
       - name: Build MkDocs documentation
         env:
           BRANCH: ${{ needs.check-should-publish.outputs.branch }}
+          DEFAULT_BRANCH: ${{ needs.check-should-publish.outputs.default_branch }}
           SHOULD_PUBLISH: ${{ needs.check-should-publish.outputs.should_publish }}
         run: |
           if [ "$SHOULD_PUBLISH" = "true" ]; then
-            export SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/${BRANCH}/"
+            if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+              # Default branch is deployed at /docs/execution-specs/ (no branch
+              # segment), so canonical/OG/sitemap URLs must omit it too.
+              export SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/"
+            else
+              export SITE_URL="https://steel.ethereum.foundation/docs/execution-specs/${BRANCH}/"
+            fi
           else
             export SITE_URL="https://example.com/docs/${BRANCH}/"
           fi


### PR DESCRIPTION
TLDR:

We currently deploy the default branch's docs (forks/amsterdam) at:
- https://steel.ethereum.foundation/docs/execution-specs/forks/amsterdam/

This PR and https://github.com/ethereum/steel-website/pull/59 changes this to deploy at:
- https://steel.ethereum.foundation/docs/execution-specs/

This is so that when we bump the default branch, the URL doesn't change: The most up-to-date version of the docs will always be available at https://steel.ethereum.foundation/docs/execution-specs/

## Summary

- Adds a `default_branch` field to `.github/configs/docs-branches.yaml` to name the branch whose docs are deployed at the root of the product namespace on steel.ethereum.foundation (rather than under a `<branch>/` segment).
- Updates `docs-build.yaml` to set `SITE_URL` without a `<branch>/` segment when building the default branch, so canonical, OG, Twitter, and sitemap URLs match where the artifact is actually published.
- Removes `devnets/bal/4` from the allowlist (no longer required).

## Commits

1. `feat(ci): deploy default branch docs at /docs/execution-specs/` — the substantive change.
2. `refactor(ci): resolve SITE_URL once in check-should-publish` — cleanup pass: `SITE_URL` is now derived once and emitted as a job output; the publish-summary line and the html-docs Build step both consume it. Replaces two separate default-vs-non-default conditionals. Same behavior, html-docs Build drops from 14 lines to 4.

## Why

Today the default development branch (currently `forks/amsterdam`) ships at `steel.ethereum.foundation/docs/execution-specs/forks/amsterdam/`. The URL becomes ephemeral at each fork rollover and the docs landing page has to recommend `mainnet` for stable incoming links, which lags reality.

Pairing this PR with the steel-website change moves the default branch's docs to `steel.ethereum.foundation/docs/execution-specs/`, which is stable across rollovers and is the right URL to share. This PR is the upstream half: it ensures `SITE_URL` (and therefore canonical/OG/sitemap URLs baked into the built HTML) matches the new publish path.

## Pairing

- Requires https://github.com/ethereum/steel-website/pull/59, which stages the default branch artifact at `site/docs/execution-specs/` instead of `site/docs/execution-specs/<branch>/`.
- Order is flexible: until both land, the default branch URL is cosmetically inconsistent (canonicals point at one URL, deploy is at another) but functionally fine because in-page links are relative.

## Behavior

- `forks/amsterdam` (default): `SITE_URL=https://steel.ethereum.foundation/docs/execution-specs/`.
- `mainnet`, other allowlisted branches: `SITE_URL=https://steel.ethereum.foundation/docs/execution-specs/<branch>/` (unchanged).
- Pull requests: `SITE_URL=https://example.com/docs/<branch>/` (unchanged).
- The `check-should-publish` job validates that `default_branch` is present in `branches[]` and fails fast on misconfiguration.
