### PR TITLE
feat(consume): send slot_number in build-block payload attributes

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -560,6 +560,7 @@ class FixtureEngineNewPayload(CamelModel):
             suggested_fee_recipient=execution_payload.fee_recipient,
             withdrawals=execution_payload.withdrawals,
             parent_beacon_block_root=parent_beacon_block_root,
+            slot_number=execution_payload.slot_number,
         )
 
     @staticmethod


### PR DESCRIPTION
`get_payload_attributes()` never sets `slot_number`, so the build-block simulator always sends slot 0 to `testing_buildBlockV1`. Blocks whose expected slot is non-zero can't be built, and SLOTNUM (EIP-7843) only ever gets exercised returning 0.

The expected payload already has the slot, so just forward it. The field is already on `PayloadAttributes` (optional, serializes as `slotNumber`), so no other changes needed.

Noticed while running build-block against ethrex on the Amsterdam BAL fixtures.