### PR TITLE
fix(ci,tooling): include json-loader in coverage reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -145,6 +145,12 @@ jobs:
         run: just json-loader
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          files: .just/json-loader/coverage.xml
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-tests:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/Justfile
+++ b/Justfile
@@ -163,10 +163,17 @@ json-loader *args:
         --output="tests/json_loader/fixtures" \
         --cov-config=pyproject.toml \
         --cov=ethereum \
-        --cov-fail-under=80
+        --cov-branch \
+        --cov-report=term \
+        --cov-fail-under=85
     uv run pytest \
         -m "not slow" \
         -n auto --maxprocesses 6 --dist=loadfile \
+        --cov-config=pyproject.toml \
+        --cov=ethereum \
+        --cov-branch \
+        --cov-report=term \
+        --cov-report "xml:{{ output_dir }}/json-loader/coverage.xml" \
         --basetemp="{{ output_dir }}/json-loader/tmp" \
         "$@" \
         tests/json_loader


### PR DESCRIPTION
## 🗒️ Description

Coverage wasn't being collected for json_loader, so files like `genesis.py` were showing as 0%.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.ml/pictrs/image/c765e32b-51fa-4b05-8218-e53186b87eee.jpeg?format=webp)
