### PR TITLE
feat(spec-specs): EIP-8037 - check static context upfront in CREATE opcodes

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -99,9 +99,6 @@ def generic_create(
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
 
-    if evm.message.is_static:
-        raise WriteInStaticContext
-
     # Move full reservoir to child (no 63/64 rule for state gas). Parent's
     # `state_gas_left` is zeroed and restored when the child returns.
     create_message_state_gas_reservoir = evm.state_gas_left
@@ -182,6 +179,9 @@ def create(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    if evm.message.is_static:
+        raise WriteInStaticContext
+
     # STACK
     endowment = pop(evm.stack)
     memory_start_position = pop(evm.stack)
@@ -231,6 +231,9 @@ def create2(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    if evm.message.is_static:
+        raise WriteInStaticContext
+
     # STACK
     endowment = pop(evm.stack)
     memory_start_position = pop(evm.stack)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Restores the upfront static context check in `CREATE`/`CREATE2`, reverted during #2901 review ([thread](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3313873108)).

Already pushed to `devnets/bal/7` as `cd19a9addc`.

### Details

Before EIP-8037 the check position didn't matter: the static violation burns all the frame's gas either way. With EIP-8037 it does:
- `CREATE`/`CREATE2` charge `NEW_ACCOUNT` state gas before the static check.
- If the frame's reservoir can't cover it, the rest is taken from `gas_left`.
- The static check then halts the frame, and the caller gets all charged state gas back as reservoir
- The caller now has more reservoir than it sent, so it can pay for state it otherwise couldn't, so get different state root.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Reverts part of https://github.com/ethereum/execution-specs/pull/2901/commits/ac3961810cbd624938f246cfa9a9366fb1fd347f.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fusagif.com%2Fwp-content%2Fuploads%2Fgifs%2Ffunny-animals-27.gif&f=1&nofb=1&ipt=31a7b41c213ffff3bbd0334d2d2cd6b94f13e062eb776e0cba4d1aceaa8011e2)

