### PR TITLE
feat(zkevm): tighten expectation of empty node not present in empty tries

### DIFF
--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_state_writes.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_state_writes.py
@@ -6,6 +6,7 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytes,
     ExecutionWitnessStateExpectation,
     Op,
     Transaction,
@@ -160,8 +161,8 @@ def test_witness_state_sstore_into_empty_storage_omits_post_state_nodes(
     """
     Empty pre-state storage should not require any storage proof nodes.
 
-    The nodes created solely by the insertion are post-state material and
-    must not appear in the witness.
+    The empty-trie RLP sentinel and nodes created solely by the insertion
+    are not pre-state material and must not appear in the witness.
     """
     insert_slot = 1
     insert_value = large_storage_value(insert_slot)
@@ -176,6 +177,7 @@ def test_witness_state_sstore_into_empty_storage_omits_post_state_nodes(
     )
     assert not proof_nodes
     assert post_state_only_nodes
+    empty_trie_sentinel = Bytes(b"\x80")
 
     contract = pre.deploy_contract(
         code=Op.SSTORE(insert_slot, insert_value) + Op.STOP,
@@ -191,7 +193,8 @@ def test_witness_state_sstore_into_empty_storage_omits_post_state_nodes(
                 txs=[tx],
                 expected_execution_witness_state=(
                     ExecutionWitnessStateExpectation(
-                        nodes_absent=post_state_only_nodes,
+                        nodes_absent=post_state_only_nodes
+                        + [empty_trie_sentinel],
                     )
                 ),
             )


### PR DESCRIPTION
## 🗒️ Description
This PR tightens an existing tests to explictly assert that the empty node `0x80` must not appear in casese where an account has an empty trie.

This is not a change in the spec, it is just making sure this is explicitly checked in implementations. To repeat the rationale: if an account has `EMPTY_TRIE_ROOT` as storage root (i.e. easily identifiable constant in EL codebases), that is already enough info to know the trie is empty, and thus how any get/set value should behave.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
