### PR TITLE
fix(tooling): include namespace packages in coverage reports

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -163,7 +163,7 @@ json-loader *args:
         --output="tests/json_loader/fixtures" \
         --cov-config=pyproject.toml \
         --cov=ethereum \
-        --cov-fail-under=85
+        --cov-fail-under=80
     uv run pytest \
         -m "not slow" \
         -n auto --maxprocesses 6 --dist=loadfile \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,12 @@ omit = [
     "*/ethereum/forks/bpo*/*",
 ]
 
+[tool.coverage.report]
+# `ethereum.forks` is a namespace package (no `__init__.py`); without this
+# option, coverage skips it when reporting never-imported files at 0%, so
+# forks absent from a run silently drop out of the coverage denominator.
+include_namespace_packages = true
+
 [tool.docc]
 context = [
     "docc.listing.context",


### PR DESCRIPTION
## 🗒️ Description

Enable coverage.py's `include_namespace_packages` option so that never-imported modules under the `ethereum.forks` namespace package count towards the coverage denominator (at 0%); this gives all coverage uploads the same denominator and explains the apparent coverage drop seen in #2975, where `fill`-only reports silently excluded the never-imported `spurious_dragon` and `tangerine_whistle` fork trees.

## 🔗 Related Issues or PRs

Related to #2975.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![A cute dog](https://upload.wikimedia.org/wikipedia/commons/4/43/Cute_dog.jpg)