### PR TITLE
feat(tests): sign state test transactions with their secret key to prevent bogus sender recovery

### DIFF
--- a/tests/frontier/touch/test_touch.py
+++ b/tests/frontier/touch/test_touch.py
@@ -69,7 +69,6 @@ def test_zero_gas_price_nonexistent_sender(
     )
 
     tx = Transaction(
-        gas_limit=500_000,
         to=contract,
         gas_price=0,  # Part of the test, do not change.
         value=0,  # Part of the test, do not change.

--- a/tests/frontier/touch/test_touch.py
+++ b/tests/frontier/touch/test_touch.py
@@ -47,7 +47,6 @@ def test_zero_gas_price_and_touching(
 
 @pytest.mark.valid_from("Frontier")
 @pytest.mark.valid_before("EIP1559")
-@pytest.mark.eels_base_coverage
 def test_zero_gas_price_nonexistent_sender(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/touch/test_touch.py
+++ b/tests/frontier/touch/test_touch.py
@@ -61,12 +61,6 @@ def test_zero_gas_price_nonexistent_sender(
     materialized when its nonce is incremented. Clients must create the sender
     account in this case rather than failing on a missing account.
 
-    Triggers a Nethermind state-test-runner crash: the runner identifies the
-    sender by secret key but signs the tx with a placeholder signature. When
-    the sender is absent from the pre-state, RecoverSenderIfNeeded re-recovers
-    a bogus sender from that placeholder, never creates it, and the nonce
-    increment then dereferences a null account. Not reachable in production,
-    where the real signature recovers the correct (and created) sender.
     """
     # amount=0 means the sender is NOT added to the pre-alloc.
     sender = pre.fund_eoa(amount=0)

--- a/tests/frontier/touch/test_touch.py
+++ b/tests/frontier/touch/test_touch.py
@@ -43,3 +43,53 @@ def test_zero_gas_price_and_touching(
         tx=tx,
         post={contract: Account(storage={0: value})},
     )
+
+
+@pytest.mark.valid_from("Frontier")
+@pytest.mark.valid_before("EIP1559")
+@pytest.mark.eels_base_coverage
+def test_zero_gas_price_nonexistent_sender(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test a zero gasprice, zero value transaction from a sender that does not
+    exist in the pre-state.
+
+    Because the transaction is free (gas_price=0) and transfers no value, no
+    balance is ever deducted from the sender, so the sender account is only
+    materialized when its nonce is incremented. Clients must create the sender
+    account in this case rather than failing on a missing account.
+
+    Triggers a Nethermind state-test-runner crash: the runner identifies the
+    sender by secret key but signs the tx with a placeholder signature. When
+    the sender is absent from the pre-state, RecoverSenderIfNeeded re-recovers
+    a bogus sender from that placeholder, never creates it, and the nonce
+    increment then dereferences a null account. Not reachable in production,
+    where the real signature recovers the correct (and created) sender.
+    """
+    # amount=0 means the sender is NOT added to the pre-alloc.
+    sender = pre.fund_eoa(amount=0)
+
+    contract = pre.deploy_contract(
+        code=(Op.SSTORE(0, 0x01) + Op.STOP),
+    )
+
+    tx = Transaction(
+        gas_limit=500_000,
+        to=contract,
+        gas_price=0,  # Part of the test, do not change.
+        value=0,  # Part of the test, do not change.
+        sender=sender,
+        protected=False,
+    )
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={
+            contract: Account(storage={0: 0x01}),
+            sender: Account(nonce=1, balance=0),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
this test is useful for reproduction of a nethtest issue (not relevant for mainnet): currently their state-test runner identifies the sender via `secretKey` but attaches a placeholder signature, so when the sender account is absent from the pre-state `RecoverSenderIfNeeded` re-recovers a bogus sender from that placeholder and a zero-gas-price transaction then crashes with `Account … is null` when incrementing nonce. This signs the transaction with its `secretKey` so recovery yields the correct sender

fill with 
`uv run fill tests/frontier/touch/test_touch.py::test_zero_gas_price_nonexistent_sender --fork=berlin -v -s --clean`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1337018504141864963/1514660075099127840/IMG_0226.png?ex=6a2c2c9e&is=6a2adb1e&hm=9007547e7ea191c6d8a88389b2977bd86a2c5a3b553db0c6a6aeeef64026e995"
  alt="Cute Animal Picture"
  width="320">
