### PR TITLE
feat(tests): EIP-7928 cover many storage changes for one account

### DIFF
--- a/docs/writing_tests/post_mortems.md
+++ b/docs/writing_tests/post_mortems.md
@@ -44,6 +44,34 @@ None required - the existing framework supported writing these tests.
 
 ---
 
+## 2026-06 - Block Access List Storage Change Cardinality - Amsterdam
+
+### Description
+
+A stateless zkEVM client implementation was found to mishandle a single account that accumulates a large number of distinct storage changes in the block access list (EIP-7928). When preloading the transaction recipient's BAL storage keys, the client copied them into a fixed-size buffer sized for 16 slots with no bounds check. A transaction that wrote more than 16 distinct storage slots to one contract overflowed the buffer into adjacent state, corrupting the transaction's computed gas usage and therefore the block validity verdict.
+
+The bug was latent against the existing test suite: no fixture exercised more than eight distinct storage changes for a single account, and those eight were spread one-per-transaction (`test_bal_cross_tx_storage_chain`), so the per-account, per-transaction storage-change cardinality never approached the buffer boundary.
+
+### Root Cause Analysis
+
+- Existing BAL storage tests focused on the correctness of recording, ordering, and the uniqueness rules for small numbers of slots; the high-cardinality case (many distinct slots for one account in one transaction) was implicitly assumed covered or low-risk.
+- No fixture pushed a single account past a handful of storage changes, so fixed-size per-account buffers in client implementations were never stressed.
+- The block access list is a new structure in EIP-7928, so client-side handling of large per-account storage-change lists had little prior fuzzing or property-based coverage.
+
+### Steps Taken To Avoid Recurrence
+
+- Added a parametrized regression test that writes many distinct, previously-zero storage slots (17, 32, and 128) to one contract in a single transaction and asserts the BAL records every slot, in ascending order, at a single block access index.
+
+### Implemented Test Case
+
+- `tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py::test_bal_many_storage_writes_single_account`
+
+### Framework/Documentation Changes
+
+None required - the existing framework supported writing these tests.
+
+---
+
 ## TEMPLATE
 
 ## Date - Title - Fork

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -2638,6 +2638,85 @@ def test_bal_cross_tx_storage_chain(
     )
 
 
+@pytest.mark.parametrize(
+    "num_slots",
+    [
+        pytest.param(17, id="17_slots"),
+        pytest.param(32, id="32_slots"),
+        pytest.param(128, id="128_slots"),
+    ],
+)
+def test_bal_many_storage_writes_single_account(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+    num_slots: int,
+) -> None:
+    """
+    Verify the BAL records many distinct storage changes for a single
+    account written by a single transaction.
+
+    One transaction calls a contract that writes `num_slots` distinct,
+    previously-zero slots (`slot[i] = i + 1` for `i` in `0..num_slots`).
+    The account's `storage_changes` in the BAL must list every slot, in
+    ascending slot order, each at `block_access_index=1`.
+
+    Existing BAL storage tests touch at most a handful of slots per
+    account (e.g. `test_bal_cross_tx_storage_chain` writes 8 slots, one
+    per transaction). This exercises a much higher per-account,
+    per-transaction storage-change cardinality, which stresses any client
+    that records or preloads an account's BAL storage keys into a
+    fixed-size buffer.
+    """
+    contract_code = Op.SSTORE(0, 1)
+    for i in range(1, num_slots):
+        contract_code += Op.SSTORE(i, i + 1)
+    contract_code += Op.STOP
+    contract = pre.deploy_contract(code=contract_code)
+
+    alice = pre.fund_eoa()
+    tx = Transaction(
+        sender=alice,
+        to=contract,
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    account_expectations = {
+        alice: BalAccountExpectation(
+            nonce_changes=[BalNonceChange(block_access_index=1, post_nonce=1)],
+        ),
+        contract: BalAccountExpectation(
+            storage_changes=[
+                BalStorageSlot(
+                    slot=i,
+                    slot_changes=[
+                        BalStorageChange(
+                            block_access_index=1, post_value=i + 1
+                        )
+                    ],
+                )
+                for i in range(num_slots)
+            ],
+            storage_reads=[],
+        ),
+    }
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_block_access_list=BlockAccessListExpectation(
+                    account_expectations=account_expectations
+                ),
+            )
+        ],
+        post={
+            contract: Account(storage={i: i + 1 for i in range(num_slots)}),
+        },
+    )
+
+
 @pytest.mark.with_all_create_opcodes
 def test_bal_cross_tx_deploy_then_call(
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description

Add `test_bal_many_storage_writes_single_account` to the EIP-7928 block-access-list suite, parametrized over **17, 32, and 128** distinct storage slots written by a single transaction to one contract.

Existing BAL storage tests touch at most a handful of slots per account — `test_bal_cross_tx_storage_chain` writes eight, one slot per transaction. This adds coverage for a much higher per-account, per-transaction storage-change cardinality: the block access list must record every slot, in ascending order, at a single block access index. It stresses any client that records or preloads an account's BAL storage keys into a fixed-size buffer.

This scenario was not covered by the existing suite and surfaced a fixed-size-buffer overflow in a stateless client implementation, so a post-mortem entry is also added in `docs/writing_tests/post_mortems.md`.

Filled clean for Amsterdam (blockchain + engine fixture formats); the produced BAL contains 17 / 32 / 128 storage changes for the recipient as expected.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/3873/14436384874_bda3f6e756_b.jpg)

"Brown Bear Sitting" by Accretion Disc is licensed under CC BY 2.0. To view a copy of this license, visit https://creativecommons.org/licenses/by/2.0/?ref=openverse.