### PR TITLE
feat(test-forks): enable filling for TangerineWhistle and SpuriousDragon

### DIFF
--- a/.github/configs/fork-ranges.yaml
+++ b/.github/configs/fork-ranges.yaml
@@ -1,11 +1,11 @@
 # Shared fork ranges for splitting multi-fork releases across parallel runners.
 # Features using --until are automatically split using applicable ranges.
 # Features using --fork (single fork) are never split.
-- label: pre-cancun
+- label: pre-shanghai
   from: Frontier
-  until: Shanghai
-- label: cancun
-  from: Cancun
+  until: Paris
+- label: shanghai-cancun
+  from: Shanghai
   until: Cancun
 - label: prague
   from: Prague

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,11 +81,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: pre-cancun
+          - label: pre-shanghai
             from_fork: Frontier
-            until_fork: Shanghai
-          - label: cancun
-            from_fork: Cancun
+            until_fork: Paris
+          - label: shanghai-cancun
+            from_fork: Shanghai
             until_fork: Cancun
           - label: prague
             from_fork: Prague

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -26,7 +26,12 @@ def test_case(state_test):
                 valid_until='"Cancun"',
             ),
             [],
-            {"passed": 10, "failed": 0, "skipped": 0, "errors": 0},
+            # All deployed forks from Frontier through Cancun, except
+            # Constantinople (filled as ConstantinopleFix): Frontier,
+            # Homestead, TangerineWhistle, SpuriousDragon, Byzantium,
+            # ConstantinopleFix, Istanbul, Berlin, London, Paris, Shanghai,
+            # Cancun = 12 forks.
+            {"passed": 12, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_until",
         ),
         pytest.param(

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1340,7 +1340,6 @@ class DAOFork(
 
 class TangerineWhistle(
     DAOFork,
-    ignore=True,
     ruleset_name="TANGERINE",
 ):
     """TangerineWhistle fork (EIP-150)."""
@@ -1353,7 +1352,6 @@ class SpuriousDragon(
     eips.EIP161,
     eips.EIP155,
     TangerineWhistle,
-    ignore=True,
     ruleset_name="SPURIOUS",
 ):
     """SpuriousDragon fork."""


### PR DESCRIPTION
## 🗒️ Description

- Enable `fill` for `TangerineWhistle` and `SpuriousDragon` by removing `ignore=True`, so they are included in `get_deployed_forks()`. Both have distinct EVM rulesets (`TANGERINE`/`SPURIOUS`) and full EELS `t8n` support, but were never filled. This restores dormant coverage: e.g. `valid_from("TangerineWhistle")` EIP-150 gas-cost tests previously started filling at Byzantium.
- `DAOFork` and the Glacier forks stay ignored, as they introduce no EVM-level rule changes to cover (DAO is a one-off state move, Glaciers only delay the difficulty bomb).
- Rebalance the `fill` matrix and the release `fork-ranges.yaml` split to absorb the two extra forks with no added runners: `pre-cancun` + `cancun` (`Frontier`->`Shanghai`, `Cancun`) become `pre-shanghai` + `shanghai-cancun` (`Frontier`->`Paris`, `Shanghai`->`Cancun`). Coverage is identical and the critical path stays bound by the single-fork `prague`/`amsterdam` jobs.

## 🔗 Related Issues or PRs

Motivation: https://github.com/ethereum/execution-specs/pull/2975#discussion_r3415139587 (`fill` is EELS' entire test coverage, so forks that get refactored often, like Tangerine Whistle and Spurious Dragon, must not be disabled).

Partially fixes https://github.com/ethereum/execution-specs/issues/2173
- https://github.com/ethereum/execution-specs/issues/2173

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="665" height="674" alt="image" src="https://github.com/user-attachments/assets/6f147eab-b65c-47a0-a896-8923ce4751f6" />
