### PR TITLE
refactor(test-forks): Introduce `minimum_block_gas_limit`

### DIFF
--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -457,6 +457,12 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
+    def minimum_block_gas_limit(cls) -> int:
+        """Return the minimum block gas limit for it to be considered valid."""
+        pass
+
+    @classmethod
+    @abstractmethod
     def opcode_gas_map(
         cls,
     ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7928.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7928.py
@@ -40,19 +40,6 @@ class EIP7928(
         )
 
     @classmethod
-    def empty_block_bal_item_count(cls) -> int:
-        """
-        Return the BAL item count for an empty EIP-7928 block.
-
-        Four system contracts produce 15 items:
-          EIP-4788 beacon roots:           1 address + 1 write + 1 read = 3
-          EIP-2935 history storage:        1 address + 1 write          = 2
-          EIP-7002 withdrawal requests:    1 address + 4 reads          = 5
-          EIP-7251 consolidation requests: 1 address + 4 reads          = 5
-        """
-        return 15
-
-    @classmethod
     def engine_execution_payload_block_access_list(cls) -> bool:
         """
         From EIP-7928, engine execution payload includes `block_access_list`

--- a/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_4788.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_4788.py
@@ -19,6 +19,12 @@ class EIP4788(BaseFork):
     """EIP-4788 class."""
 
     @classmethod
+    def empty_block_bal_item_count(cls) -> int:
+        """Add block-level access list elements for an empty block."""
+        # Beacon roots contract: 1 address + 1 write + 1 read = 3
+        return super(EIP4788, cls).empty_block_bal_item_count() + 3
+
+    @classmethod
     def header_beacon_root_required(cls) -> bool:
         """Parent beacon block root is required."""
         return True

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_2935.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_2935.py
@@ -26,6 +26,12 @@ class EIP2935(BaseFork):
     """EIP-2935 class."""
 
     @classmethod
+    def empty_block_bal_item_count(cls) -> int:
+        """Add block-level access list elements for an empty block."""
+        # History contract: 1 address + 1 write = 2
+        return super(EIP2935, cls).empty_block_bal_item_count() + 2
+
+    @classmethod
     def system_contracts(cls) -> List[Address]:
         """Add the history storage contract."""
         return [

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7002.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7002.py
@@ -28,6 +28,12 @@ class EIP7002(BaseFork):
     """EIP-7002 class."""
 
     @classmethod
+    def empty_block_bal_item_count(cls) -> int:
+        """Add block-level access list elements for an empty block."""
+        # Withdrawals contract: 1 address + 4 reads = 5
+        return super(EIP7002, cls).empty_block_bal_item_count() + 5
+
+    @classmethod
     def system_contracts(cls) -> List[Address]:
         """Add the withdrawal request predeploy contract."""
         return [

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7251.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7251.py
@@ -27,6 +27,12 @@ class EIP7251(BaseFork):
     """EIP-7251 class."""
 
     @classmethod
+    def empty_block_bal_item_count(cls) -> int:
+        """Add block-level access list elements for an empty block."""
+        # Consolidations contract: 1 address + 4 reads = 5
+        return super(EIP7251, cls).empty_block_bal_item_count() + 5
+
+    @classmethod
     def system_contracts(cls) -> List[Address]:
         """Add the consolidation request predeploy contract."""
         return [

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -324,6 +324,22 @@ class Frontier(
         return wrapper
 
     @classmethod
+    def minimum_block_gas_limit(cls) -> int:
+        """
+        Return the minimum gas limit for the block to be considered valid.
+        """
+        minimum_block_gas_limit = 5_000
+        bal_minimum_block_gas_limit = 0
+        if cls.header_bal_hash_required():
+            # The block gas limit is influenced by the minimum amount of
+            # block level access elements the system contracts contain.
+            bal_minimum_block_gas_limit = (
+                cls.empty_block_bal_item_count()
+                * cls.gas_costs().BLOCK_ACCESS_LIST_ITEM
+            )
+        return max(minimum_block_gas_limit, bal_minimum_block_gas_limit)
+
+    @classmethod
     def opcode_gas_map(
         cls,
     ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_fork_transition.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_fork_transition.py
@@ -185,10 +185,7 @@ def test_fork_transition_bal_size_constraint(
       `BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED`.
     """
     amsterdam = fork.transitions_to()
-    min_gas_limit = (
-        amsterdam.empty_block_bal_item_count()
-        * amsterdam.gas_costs().BLOCK_ACCESS_LIST_ITEM
-    )
+    min_gas_limit = amsterdam.minimum_block_gas_limit()
     over_budget_gas_limit = min_gas_limit - 1
 
     pre_fork_block = Block(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -503,22 +503,26 @@ def test_tx_inclusion_at_regular_gas_block_limit_small(
     assert gas_limit_cap is not None
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
 
-    block_gas_limit = intrinsic_gas * 2
+    filler_tx_count = (fork.minimum_block_gas_limit() // intrinsic_gas) + 1
+    block_gas_limit = intrinsic_gas * (filler_tx_count + 1)
 
-    filler = pre.deploy_contract(code=Op.STOP)
-    filler_tx = Transaction(
-        to=filler,
-        gas_limit=intrinsic_gas,
-        sender=pre.fund_eoa(),
-    )
+    dest_contract = pre.deploy_contract(code=Op.STOP)
+    filler_sender = pre.fund_eoa()
+    filler_txs = [
+        Transaction(
+            to=dest_contract,
+            gas_limit=intrinsic_gas,
+            sender=filler_sender,
+        )
+        for _ in range(filler_tx_count)
+    ]
 
-    second_gas_limit = intrinsic_gas + delta
-    assert second_gas_limit < gas_limit_cap
+    excess_tx_gas_limit = intrinsic_gas + delta
+    assert excess_tx_gas_limit < gas_limit_cap
     error = TransactionException.GAS_ALLOWANCE_EXCEEDED if delta else None
-    second = pre.deploy_contract(code=Op.STOP)
-    second_tx = Transaction(
-        to=second,
-        gas_limit=second_gas_limit,
+    excess_tx = Transaction(
+        to=dest_contract,
+        gas_limit=excess_tx_gas_limit,
         sender=pre.fund_eoa(),
         error=error,
     )
@@ -528,7 +532,7 @@ def test_tx_inclusion_at_regular_gas_block_limit_small(
         pre=pre,
         blocks=[
             Block(
-                txs=[filler_tx, second_tx],
+                txs=filler_txs + [excess_tx],
                 gas_limit=block_gas_limit,
                 exception=error,
             )

--- a/tests/frontier/validation/test_header.py
+++ b/tests/frontier/validation/test_header.py
@@ -1,35 +1,50 @@
 """Test the block header validations applied from Frontier."""
 
+from typing import Generator
+
 import pytest
-from execution_testing import Fork
-from execution_testing.base_types.base_types import ZeroPaddedHexNumber
-from execution_testing.base_types.composite_types import Alloc
-from execution_testing.exceptions.exceptions import BlockException
-from execution_testing.specs.blockchain import (
+from execution_testing import (
+    Alloc,
     Block,
     BlockchainTestFiller,
+    BlockException,
+    Environment,
+    Fork,
     Header,
+    ParameterSet,
 )
-from execution_testing.test_types.block_types import Environment
+from execution_testing.base_types import ZeroPaddedHexNumber
+from execution_testing.forks import Frontier
+
+# Protocol minimum block gas limit, enforced since Frontier.
+PROTOCOL_GAS_LIMIT_FLOOR = Frontier.minimum_block_gas_limit()
 
 
-@pytest.mark.parametrize(
-    "gas_limit",
-    [
-        pytest.param(0, marks=pytest.mark.exception_test),
-        pytest.param(1, marks=pytest.mark.exception_test),
-        pytest.param(4999, marks=pytest.mark.exception_test),
-        pytest.param(5000, marks=pytest.mark.valid_before("EIP7928")),
-        pytest.param(
-            5000,
-            marks=[
-                pytest.mark.valid_from("EIP7928"),
-                pytest.mark.exception_test,
-            ],
-        ),
-    ],
-)
-def test_gas_limit_below_minimum(
+def gas_limit_cases_by_fork(
+    fork: Fork,
+) -> Generator[ParameterSet, None, None]:
+    """Yield gas limit cases around the fork's minimum block gas limit."""
+    minimum_block_gas_limit = fork.minimum_block_gas_limit()
+    yield pytest.param(
+        0,
+        id="zero",
+        marks=pytest.mark.exception_test,
+    )
+    yield pytest.param(
+        1,
+        id="one",
+        marks=pytest.mark.exception_test,
+    )
+    yield pytest.param(
+        minimum_block_gas_limit - 1,
+        id="minimum_minus_one",
+        marks=pytest.mark.exception_test,
+    )
+    yield pytest.param(minimum_block_gas_limit, id="minimum")
+
+
+@pytest.mark.parametrize_by_fork("gas_limit", gas_limit_cases_by_fork)
+def test_block_gas_limit_below_minimum(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     gas_limit: int,
@@ -40,14 +55,25 @@ def test_gas_limit_below_minimum(
     Tests that a block with a gas limit below the minimum throws an error.
     """
     modified_fields = {"gas_limit": gas_limit}
-    env.gas_limit = ZeroPaddedHexNumber(5000)
+    minimum_block_gas_limit = fork.minimum_block_gas_limit()
+    env.gas_limit = ZeroPaddedHexNumber(minimum_block_gas_limit)
 
     block = Block(txs=[])
 
-    if gas_limit < 5000:
+    if gas_limit < minimum_block_gas_limit:
         block.rlp_modifier = Header(**modified_fields)
-        block.exception = BlockException.INVALID_GASLIMIT
-    elif fork.is_eip_enabled(7928):
-        block.exception = BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED
+        if gas_limit < PROTOCOL_GAS_LIMIT_FLOOR:
+            block.exception = (
+                [
+                    BlockException.INVALID_GASLIMIT,
+                    BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED,
+                ]
+                if fork.is_eip_enabled(7928)
+                else BlockException.INVALID_GASLIMIT
+            )
+        else:
+            block.exception = (
+                BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED
+            )
 
     blockchain_test(pre=pre, post={}, blocks=[block], genesis_environment=env)

--- a/tests/ported_static/stStaticCall/test_static_internal_call_hitting_gas_limit2.py
+++ b/tests/ported_static/stStaticCall/test_static_internal_call_hitting_gas_limit2.py
@@ -3,6 +3,8 @@ Test_static_internal_call_hitting_gas_limit2.
 
 Ported from:
 state_tests/stStaticCall/static_InternalCallHittingGasLimit2Filler.json
+
+@manually-enhanced: Do not overwrite.
 """
 
 import pytest
@@ -43,7 +45,6 @@ def test_static_internal_call_hitting_gas_limit2(
         timestamp=1000,
         prev_randao=0x20000,
         base_fee_per_gas=10,
-        gas_limit=47766,
     )
 
     # Source: lll


### PR DESCRIPTION
## 🗒️ Description

Noticed during the implementation of EIP-8282 that it is clunky to update the minimum block gas limit when a new system contract is introduced due to the Block-level-access-list max element constrain.

This PR introduces a `Fork.minimum_block_gas_limit()` helper so tests no longer hardcode the minimum valid block gas limit, which now varies per fork because of EIP-7928 (Block-Level Access Lists).

Previously the minimum was a fixed `5000`, and EIP-7928's empty-block BAL cost was a single hardcoded `empty_block_bal_item_count() = 15` constant living in `EIP7928`. With EIP-8282 adding two more system contracts, that constant no longer holds, and the value was duplicated across several tests.

This refactor:

- **Adds `minimum_block_gas_limit()`** (abstract in `BaseFork`, implemented in `Frontier`). It returns `max(5000, empty_block_bal_item_count() * BLOCK_ACCESS_LIST_ITEM)`, only applying the BAL-derived floor when `header_bal_hash_required()` is set.
- **Composes `empty_block_bal_item_count()` per EIP** via `super()` chaining instead of a single hardcoded total. Each system-contract EIP contributes its own items: EIP-4788 `+3`, EIP-2935 `+2`, EIP-7002 `+5`, EIP-7251 `+5`, EIP-8282 `+10`. The base returns `0`. This reproduces the previous total (15) for Prague and correctly yields 15 for Amsterdam (25 after EIP-8282).
- **Updates tests** to call `fork.minimum_block_gas_limit()` instead of recomputing or hardcoding the value:
  - `tests/frontier/validation/test_header.py`: `test_gas_limit_below_minimum` → `test_block_gas_limit_below_minimum`, reparametrized via `parametrize_by_fork` so the boundary cases (`minimum_minus_one`, `minimum`) track the active fork. Gas limits below the protocol floor (`5000`) expect `INVALID_GASLIMIT`; on EIP-7928 forks they accept either `INVALID_GASLIMIT` or `BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED`, since a client may reject on the header gas-limit floor before reaching the BAL check.
  - `tests/amsterdam/eip7928_block_level_access_lists/test_fork_transition.py`: use the helper for the size-constraint boundary.
  - `tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py`: scale the number of filler txs so the block gas limit meets the fork minimum while preserving the off-by-one boundary check.
  - `tests/ported_static/stStaticCall/test_static_internal_call_hitting_gas_limit2.py`: drop the `Environment` `gas_limit=47766`, which would fall below the Amsterdam minimum and invalidate the block; tagged `@manually-enhanced` so the porter won't re-add it.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/e/e0/Youngtoyxolo.jpg)
