### PR TITLE
chore(tooling): update write-test skill for automatic tx gas-limit

### DIFF
--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -47,8 +47,9 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 
 ## Transactions
 
-- Omit `gas_limit` unless the test asserts on an exact gas amount: it auto-fills so the transaction executes in full without running out of gas. Set it explicitly only for gas-sensitive cases (intrinsic-gas boundaries, OOG, code-deposit or metering).
-- Anti-pattern: boilerplate `gas_limit=fork.transaction_gas_limit_cap()`, now redundant.
+- Rule: omit `gas_limit`. It auto-fills so the transaction executes in full without running out of gas.
+- Exception: set `gas_limit` explicitly for gas-sensitive tests (intrinsic-gas boundaries, OOG, code-deposit limits, or gas metering).
+- Anti-pattern: the `gas_limit=fork.transaction_gas_limit_cap()` boilerplate is now redundant.
 
 ## Exception Testing
 

--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -45,6 +45,11 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 - `fork.gas_costs()` returns `GasCosts` dataclass with constants like `G_WARM_SLOAD`, `G_COLD_ACCOUNT_ACCESS`, `G_BASE`, etc.
 - `fork.transaction_intrinsic_cost_calculator()` for computing tx intrinsic gas
 
+## Transactions
+
+- Omit `gas_limit` unless the test asserts on an exact gas amount: it auto-fills so the transaction executes in full without running out of gas. Set it explicitly only for gas-sensitive cases (intrinsic-gas boundaries, OOG, code-deposit or metering).
+- Anti-pattern: boilerplate `gas_limit=fork.transaction_gas_limit_cap()`, now redundant.
+
 ## Exception Testing
 
 - Pass `error=TransactionException.INTRINSIC_GAS_TOO_LOW` to `Transaction`


### PR DESCRIPTION
## 🗒️ Description

Since #2969 the transaction `gas_limit` is optional and auto-fills when omitted, but the `write-test` skill never mentioned it, so agents kept adding the redundant `gas_limit=fork.transaction_gas_limit_cap()` boilerplate. This adds a minimal `Transactions` section: omit `gas_limit` by default, set it explicitly only for gas-sensitive tests.

## 🔗 Related Issues or PRs

Follows up on #2969 (automatic transaction gas-limit).

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just lint-md
    just spellcheck
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cute animal](https://cataas.com/cat)
