### PR TITLE
chore(ci): rename bal release feature to glamsterdam-devnet

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -13,7 +13,7 @@ benchmark_fast:
   fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
   feature_only: true
 
-bal:
+glamsterdam-devnet:
   evm-type: eels
   fill-params: --fork=Amsterdam
   feature_only: true

--- a/.github/scripts/tests/test_release_scripts.py
+++ b/.github/scripts/tests/test_release_scripts.py
@@ -70,12 +70,12 @@ class TestGenerateBuildMatrix:
 
     def test_feature_only_can_be_requested_explicitly(self):
         """Verify feature_only entries work when named directly."""
-        result = run_script(BUILD_MATRIX_SCRIPT, "bal")
+        result = run_script(BUILD_MATRIX_SCRIPT, "glamsterdam-devnet")
         assert result.returncode == 0
         out = parse_matrix_output(result.stdout)
         matrix = json.loads(out["build_matrix"])
         assert len(matrix) == 1
-        assert matrix[0]["feature"] == "bal"
+        assert matrix[0]["feature"] == "glamsterdam-devnet"
         assert out["combine_labels"] == ""
 
     def test_unknown_feature_fails(self):


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Lets release with: `git tag tests-glamsterdam-devnet@v6.0.0 && git push upstream tests-glamsterdam-devnet@v6.0.0`.

Aligns with https://github.com/ethpandaops/hive-tests/pull/60.

This will be deprecated/changed when we merge #2888 and is only required for release tags before it is merged.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#2888 & https://github.com/ethpandaops/hive-tests/pull/60

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="254" height="252" alt="Screenshot 2026-06-17 at 13 14 28" src="https://github.com/user-attachments/assets/1992562b-6318-4d33-a411-844bdf6c52eb" />

