### PR TITLE
feat(spec-specs, tests): refund EIP-8037 account creation for existing create targets

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1066,7 +1066,9 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    if tx_output.error is not None and isinstance(tx.to, Bytes0):
+    if isinstance(tx.to, Bytes0) and (
+        tx_output.error is not None or tx_output.created_target_alive
+    ):
         new_account_refund = StateGasCosts.NEW_ACCOUNT
         tx_output.state_gas_left += new_account_refund
         tx_output.state_refund += new_account_refund

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -130,6 +130,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    target_alive = is_account_alive(tx_state, contract_address)
+
     increment_nonce(tx_state, evm.message.current_target)
 
     child_message = Message(
@@ -162,6 +164,8 @@ def generic_create(
         push(evm.stack, U256(0))
     else:
         incorporate_child_on_success(evm, child_evm)
+        if target_alive:
+            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         evm.return_data = b""
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
 

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -39,6 +39,7 @@ from ..state_tracker import (
     get_account,
     get_code,
     increment_nonce,
+    is_account_alive,
     mark_account_created,
     move_ether,
     restore_tx_state,
@@ -91,6 +92,8 @@ class MessageCallOutput:
              authorities that already existed in state. Subtracted from
              `tx_state_gas` in block accounting so `block.gas_used`
              matches the receipt `cumulative_gas_used`.
+          10. `created_target_alive`: Whether a top-level creation
+              transaction targeted an already-existent account.
     """
 
     gas_left: Uint
@@ -103,6 +106,7 @@ class MessageCallOutput:
     regular_gas_used: Uint
     state_gas_used: int
     state_refund: Uint
+    created_target_alive: bool
 
 
 def process_message_call(message: Message) -> MessageCallOutput:
@@ -124,8 +128,10 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_state = message.tx_env.state
     refund_counter = U256(0)
     state_refund = Uint(0)
+    target_alive = False
     if message.target == Bytes0(b""):
         if account_deployable(tx_state, message.current_target):
+            target_alive = is_account_alive(tx_state, message.current_target)
             evm = process_create_message(message)
         else:
             return MessageCallOutput(
@@ -139,6 +145,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 regular_gas_used=message.gas,
                 state_gas_used=0,
                 state_refund=Uint(0),
+                created_target_alive=False,
             )
     else:
         if message.tx_env.authorizations != ():
@@ -180,6 +187,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         regular_gas_used=evm.regular_gas_used,
         state_gas_used=evm.state_gas_used,
         state_refund=state_refund,
+        created_target_alive=target_alive,
     )
 
 

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -3529,6 +3529,147 @@ def test_bal_create_early_failure(
 
 
 @pytest.mark.with_all_create_opcodes
+@pytest.mark.parametrize("creation_outcome", ["pre_frame_failure", "success"])
+def test_bal_create_existing_target(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    create_opcode: Op,
+    creation_outcome: str,
+) -> None:
+    """
+    Test BAL for CREATE/CREATE2 into a pre-existing balance-only target.
+
+    Under EIP-8037 the account-creation charge is unconditional, so the
+    target's existence is never read to decide it. On a pre-frame failure
+    (insufficient endowment) the pre-existing target is never accessed and
+    stays absent from the BAL; on success it appears with the deployed
+    nonce and code.
+    """
+    alice = pre.fund_eoa()
+
+    init_code = Initcode(deploy_code=Op.STOP)
+    init_code_bytes = bytes(init_code)
+
+    if creation_outcome == "pre_frame_failure":
+        factory_balance, endowment = 50, 100
+    else:
+        factory_balance, endowment = 0, 0
+
+    factory_code = (
+        Op.MSTORE(0, Op.PUSH32(init_code_bytes))
+        + Op.SSTORE(
+            0x00,
+            Op.GT(
+                create_opcode(
+                    value=endowment,
+                    offset=32 - len(init_code_bytes),
+                    size=len(init_code_bytes),
+                ),
+                0,
+            ),
+        )
+        + Op.STOP
+    )
+
+    factory = pre.deploy_contract(
+        code=factory_code,
+        balance=factory_balance,
+        storage={0x00: 0xDEAD},
+    )
+
+    target = compute_create_address(
+        address=factory,
+        nonce=1,
+        salt=0,
+        initcode=init_code_bytes,
+        opcode=create_opcode,
+    )
+    # Pre-existing balance-only leaf (balance, no code, zero nonce).
+    pre.fund_address(target, amount=1)
+
+    tx = Transaction(sender=alice, to=factory)
+
+    if creation_outcome == "pre_frame_failure":
+        expected_bal = BlockAccessListExpectation(
+            account_expectations={
+                alice: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=1)
+                    ],
+                ),
+                factory: BalAccountExpectation(
+                    nonce_changes=[],
+                    storage_changes=[
+                        BalStorageSlot(
+                            slot=0x00,
+                            slot_changes=[
+                                BalStorageChange(
+                                    block_access_index=1, post_value=0
+                                )
+                            ],
+                        )
+                    ],
+                ),
+                # Never accessed despite pre-existing: absent from the BAL.
+                target: None,
+            }
+        )
+        post = {
+            alice: Account(nonce=1),
+            factory: Account(
+                nonce=1, balance=factory_balance, storage={0x00: 0}
+            ),
+            target: Account(balance=1),
+        }
+    else:
+        expected_bal = BlockAccessListExpectation(
+            account_expectations={
+                alice: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=1)
+                    ],
+                ),
+                factory: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=2)
+                    ],
+                    storage_changes=[
+                        BalStorageSlot(
+                            slot=0x00,
+                            slot_changes=[
+                                BalStorageChange(
+                                    block_access_index=1, post_value=1
+                                )
+                            ],
+                        )
+                    ],
+                ),
+                target: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=1)
+                    ],
+                    code_changes=[
+                        BalCodeChange(
+                            block_access_index=1, new_code=bytes(Op.STOP)
+                        )
+                    ],
+                ),
+            }
+        )
+        post = {
+            alice: Account(nonce=1),
+            factory: Account(nonce=2, storage={0x00: 1}),
+            target: Account(nonce=1, balance=1, code=Op.STOP),
+        }
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx], expected_block_access_list=expected_bal)],
+        post=post,
+    )
+
+
+@pytest.mark.with_all_create_opcodes
 @pytest.mark.parametrize(
     "storage_op",
     ["read", "write"],

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1210,11 +1210,20 @@ def test_code_deposit_halt_discards_initcode_state_gas(
     )
 
 
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("new", id="new_account"),
+        pytest.param("existing", id="existing_account"),
+    ],
+)
+@pytest.mark.pre_alloc_mutable()
 @pytest.mark.valid_from("EIP8037")
 def test_create_tx_header_gas_used(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
+    target: str,
 ) -> None:
     """
     Verify block header gas_used for a successful CREATE transaction.
@@ -1223,22 +1232,45 @@ def test_create_tx_header_gas_used(
     exact gas_used from first principles and verify against the block
     header. Catches bugs where clients report gas_limit instead of
     actual consumed gas.
+
+    For a fresh target the NEW_ACCOUNT state gas is charged and
+    dominates the regular gas, so gas_used == NEW_ACCOUNT. For a
+    pre-existing balance-only leaf the NEW_ACCOUNT charge is refunded,
+    so net state gas is zero and the regular intrinsic gas dominates.
+    The expected value subtracts NEW_ACCOUNT and so fails if the
+    refund regresses.
     """
     gas_costs = fork.gas_costs()
     initcode = Op.STOP
     create_state_gas = fork.create_state_gas(code_size=1)
 
+    if target == "existing":
+        sender = pre.fund_eoa(nonce=0)
+        contract_address = compute_create_address(address=sender, nonce=0)
+        # Balance-only leaf: alive and deployable, so the creation
+        # succeeds and the intrinsic NEW_ACCOUNT charge is refunded.
+        pre.fund_address(contract_address, amount=1)
+    else:
+        sender = pre.fund_eoa()
+
     tx = Transaction(
         to=None,
         data=initcode,
         state_gas_reservoir=create_state_gas,
-        sender=pre.fund_eoa(),
+        sender=sender,
     )
 
     # block_gas_used = max(block_regular, block_state)
-    # For a minimal CREATE tx deploying Op.STOP (1 byte),
-    # state gas (new account) dominates regular gas.
-    expected_gas_used = gas_costs.NEW_ACCOUNT
+    if target == "existing":
+        intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+        intrinsic_total = intrinsic_cost(
+            calldata=bytes(initcode), contract_creation=True
+        )
+        expected_gas_used = intrinsic_total - gas_costs.NEW_ACCOUNT
+    else:
+        # For a minimal CREATE tx deploying Op.STOP (1 byte),
+        # state gas (new account) dominates regular gas.
+        expected_gas_used = gas_costs.NEW_ACCOUNT
 
     blockchain_test(
         pre=pre,
@@ -1831,6 +1863,117 @@ def test_create_code_deposit_oog_refunds_state_gas(
     tx = Transaction(
         to=caller,
         state_gas_reservoir=new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(pre=pre, post={factory: Account(storage=storage)}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "reservoir_covers",
+    [
+        pytest.param(True, id="charge_from_reservoir"),
+        pytest.param(False, id="charge_spills_from_gas_left"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_create_account_charge_reduces_child_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    reservoir_covers: bool,
+) -> None:
+    """
+    Verify the early NEW_ACCOUNT charge reduces forwarded child gas.
+
+    `generic_create` charges NEW_ACCOUNT before computing the child's
+    63/64 share. When the reservoir covers the charge `gas_left` is
+    untouched and the child receives the full share. When the reservoir
+    is empty the charge spills NEW_ACCOUNT from `gas_left` first, so the
+    child receives `NEW_ACCOUNT * 63 / 64` less. The init code burns a
+    fixed amount sized between the two shares, so it deploys when the
+    charge comes from the reservoir and runs out of gas when it spills.
+    The target is a pre-existing balance-only leaf, the EIP-8037
+    success-refund path that the old conditional charge skipped.
+    """
+    new_account = fork.gas_costs().NEW_ACCOUNT
+    memory_gas = fork.memory_expansion_gas_calculator()
+
+    # Factory `gas_left` at the NEW_ACCOUNT charge. Three times
+    # NEW_ACCOUNT gives a wide discrimination window and a large
+    # absolute child share.
+    gas_at_charge = 3 * new_account
+    full_share = gas_at_charge - gas_at_charge // 64
+    spilled = gas_at_charge - new_account
+    reduced_share = spilled - spilled // 64
+    # Burn the middle of `(reduced_share, full_share]` for robustness.
+    target_burn = (full_share + reduced_share) // 2
+
+    # Init code burns `target_burn` regular gas via one MSTORE memory
+    # expansion, then deploys empty code (zero code deposit). Invert
+    # `words * MEMORY_PER_WORD + words ** 2 // 512 = target_mem` to size
+    # the sink offset from gas rather than a magic number.
+    init_static = (Op.MSTORE(0, 0) + Op.RETURN(0, 0)).gas_cost(fork)
+    target_mem = target_burn - init_static
+    # Memory cost is monotonic in word count, so binary search the
+    # largest word count whose expansion stays within `target_mem`.
+    low, high = 1, target_mem
+    while low < high:
+        mid = (low + high + 1) // 2
+        if int(memory_gas(new_bytes=mid * 32)) <= target_mem:
+            low = mid
+        else:
+            high = mid - 1
+    words = low
+    sink_offset = (words - 1) * 32
+    child_burn = init_static + int(memory_gas(new_bytes=words * 32))
+    assert reduced_share < child_burn <= full_share
+
+    init_code = Op.MSTORE(sink_offset, 0) + Op.RETURN(0, 0)
+    mstore_value, size = init_code_at_high_bytes(init_code)
+    create_call = (
+        create_opcode(value=0, offset=0, size=size, salt=0)
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=0, size=size)
+    )
+
+    storage = Storage()
+    expected = 1 if reservoir_covers else 0
+    factory = pre.deploy_contract(
+        code=Op.MSTORE(0, mstore_value)
+        + Op.SSTORE(
+            storage.store_next(expected, "child_succeeds"),
+            Op.GT(create_call, 0),
+        ),
+    )
+
+    # Pre-existing balance-only target: the success-refund path. Under
+    # the old conditional approach this alive target skips NEW_ACCOUNT,
+    # so the child gets the full share and fits in both cases.
+    if create_opcode == Op.CREATE2:
+        create_address = compute_create2_address(
+            address=factory, salt=0, initcode=bytes(init_code)
+        )
+    else:
+        create_address = compute_create_address(address=factory, nonce=1)
+    pre.fund_address(create_address, amount=1)
+
+    # Regular gas the factory spends before the NEW_ACCOUNT charge: the
+    # initcode setup MSTORE plus the create opcode regular portion
+    # (`gas_cost` folds NEW_ACCOUNT into the create op, so strip it).
+    setup = Op.MSTORE(0, mstore_value)
+    pre_charge_regular = (
+        setup.gas_cost(fork) + create_call.gas_cost(fork) - new_account
+    )
+    forwarded_gas = gas_at_charge + pre_charge_regular
+    caller = pre.deploy_contract(
+        code=Op.CALL(gas=forwarded_gas, address=factory)
+    )
+    tx = Transaction(
+        to=caller,
+        state_gas_reservoir=new_account if reservoir_covers else 0,
         sender=pre.fund_eoa(),
     )
 
@@ -2567,4 +2710,75 @@ def test_create_collision_burned_gas_counted_in_block_regular(
             ),
         ],
         post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("new", id="new_account"),
+        pytest.param("existing", id="existing_account"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("EIP8037")
+def test_create_account_creation_charge(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    target: str,
+) -> None:
+    """
+    Verify NEW_ACCOUNT is charged for a new account and refunded for a
+    pre-existing balance-only leaf.
+
+    Empty init code means zero code deposit, so NEW_ACCOUNT is the only
+    create state cost. A fresh target is charged it; a pre-existing
+    balance-only target (balance, no code, zero nonce) refunds it on
+    success. The probe SSTORE both confirms the create succeeded and
+    makes state gas dominate, so gas_used drops by exactly NEW_ACCOUNT
+    when refunded.
+    """
+    new_account = fork.gas_costs().NEW_ACCOUNT
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    mstore_value, size = init_code_at_high_bytes(Op.STOP)
+    create_call = (
+        create_opcode(value=0, offset=0, size=size, salt=0)
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=0, size=size)
+    )
+
+    storage = Storage()
+    factory = pre.deploy_contract(
+        code=Op.MSTORE(0, mstore_value)
+        + Op.SSTORE(
+            storage.store_next(1, "create_succeeds"), Op.GT(create_call, 0)
+        )
+    )
+
+    # Factory deployed via deploy_contract starts at nonce 1.
+    if create_opcode == Op.CREATE2:
+        create_address = compute_create2_address(
+            address=factory, salt=0, initcode=bytes(Op.STOP)
+        )
+    else:
+        create_address = compute_create_address(address=factory, nonce=1)
+    if target == "existing":
+        pre.fund_address(create_address, amount=1)
+
+    tx = Transaction(
+        to=factory,
+        state_gas_reservoir=new_account + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    # State gas dominates regular: a new account adds NEW_ACCOUNT on top
+    # of the probe SSTORE, a pre-existing target refunds it.
+    expected = sstore_state_gas + (new_account if target == "new" else 0)
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={factory: Account(storage=storage)},
+        blockchain_test_header_verify=Header(gas_used=expected),
     )


### PR DESCRIPTION
## 🗒️ Description

Charge the `CREATE`/`CREATE2` state gas unconditionally before the create frame, and refund it on frame exit when the destination already existed. Aligns the EIP with the BAL conflict update in https://github.com/ethereum/EIPs/pull/11807.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Aligns with the first point in https://github.com/ethereum/EIPs/pull/11807.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia.tenor.com%2FY8HXAC2-Me0AAAAC%2Ffat-cat.gif&f=1&ipt=43269e06adb8d8bfe90e3a78c97b089b8d619cc496ed58059ca49a9cdbec0cc6)

