### PR TITLE
feat(spec, spec-tests): 8037 Calldata floor accounting alignment

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1118,15 +1118,13 @@ def process_transaction(
 
     all_logs = tx_output.logs + tuple(finalization_logs)
 
-    tx_regular_gas = tx_env.intrinsic_regular_gas + tx_output.regular_gas_used
     tx_state_gas = (
         int(tx_env.intrinsic_state_gas)
         + tx_output.state_gas_used
         - int(tx_output.state_refund)
     )
-    block_output.block_gas_used += max(
-        tx_regular_gas, intrinsic.calldata_floor
-    )
+    tx_regular_gas = tx_gas_used_before_refund - Uint(max(0, tx_state_gas))
+    block_output.block_gas_used += tx_regular_gas
     block_output.block_state_gas_used += Uint(max(0, tx_state_gas))
     block_output.blob_gas_used += tx_blob_gas_used
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -329,6 +329,7 @@ class GenericCall:
     memory_output_size: U256
     code: Bytes
     disable_precompiles: bool
+    new_account_charged: bool = False
 
 
 def generic_call(evm: Evm, params: GenericCall) -> None:
@@ -342,6 +343,8 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
         evm.gas_left += params.gas
         evm.state_gas_left += params.state_gas_reservoir
+        if params.new_account_charged:
+            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         push(evm.stack, U256(0))
         return
 
@@ -376,6 +379,8 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
 
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
+        if params.new_account_charged:
+            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
@@ -461,7 +466,9 @@ def call(evm: Evm) -> None:
     code = get_code(tx_state, code_hash)
 
     charge_gas(evm, extra_gas + extend_memory.cost)
-    if value != 0 and not is_account_alive(tx_state, to):
+    has_value = value != 0
+    new_account_charged = has_value and not is_account_alive(tx_state, to)
+    if new_account_charged:
         charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
 
     message_call_gas = calculate_message_call_gas(
@@ -487,6 +494,8 @@ def call(evm: Evm) -> None:
         evm.return_data = b""
         evm.gas_left += message_call_gas.sub_call
         evm.state_gas_left += call_state_gas_reservoir
+        if new_account_charged:
+            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
     else:
         generic_call(
             evm,
@@ -505,6 +514,7 @@ def call(evm: Evm) -> None:
                 memory_output_size=memory_output_size,
                 code=code,
                 disable_precompiles=is_delegated,
+                new_account_charged=new_account_charged,
             ),
         )
 

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -219,7 +219,7 @@ def build_refund_tx(
 )
 @pytest.mark.with_all_refund_types()
 @pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
-@pytest.mark.valid_from("EIP7778")
+@pytest.mark.valid_from("EIP8037")
 def test_simple_gas_accounting(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -248,7 +248,7 @@ def test_simple_gas_accounting(
     )
 
     # EIP-8037: block gas_used = max(block_regular_gas, block_state_gas)
-    block_regular = max(gas_used_pre_refund, call_data_floor_cost)
+    block_regular = gas_used_pre_refund
     refund_tx_block_gas_used = max(block_regular, tx_state_gas)
 
     blockchain_test(
@@ -293,7 +293,7 @@ def test_simple_gas_accounting(
 )
 @pytest.mark.with_all_refund_types()
 @pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
-@pytest.mark.valid_from("EIP7778")
+@pytest.mark.valid_from("EIP8037")
 def test_multi_transaction_gas_accounting(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -352,12 +352,16 @@ def test_multi_transaction_gas_accounting(
         exceed_block_gas_limit=exceed_block_gas_limit,
     )
     refund_tx_gas_used = max(gas_used_post_refund, call_data_floor_cost)
-    refund_tx_block_regular = max(gas_used_pre_refund, call_data_floor_cost)
 
     extra_tx_sender = pre.fund_eoa()
     extra_tx_calldata = b"\xff" if extra_tx_data_floor else b""
     extra_tx_intrinsic_gas_cost = intrinsic_cost_calc(
         calldata=extra_tx_calldata
+    )
+    # Block regular gas uses actual charge, not the tx-level floor.
+    extra_tx_block_gas = intrinsic_cost_calc(
+        calldata=extra_tx_calldata,
+        return_cost_deducted_prior_execution=True,
     )
 
     extra_tx = Transaction(
@@ -368,20 +372,28 @@ def test_multi_transaction_gas_accounting(
         expected_receipt={
             "gas_used": refund_tx_gas_used + extra_tx_intrinsic_gas_cost,
         },
-        error=TransactionException.GAS_ALLOWANCE_EXCEEDED
-        if exceed_block_gas_limit
-        else None,
+        error=(
+            TransactionException.GAS_ALLOWANCE_EXCEEDED
+            if exceed_block_gas_limit
+            else None
+        ),
     )
 
     # EIP-8037: block_gas_used = max(sum_regular, sum_state)
     # Extra tx has no state gas, so its state gas contribution = 0
-    block_regular = refund_tx_block_regular + extra_tx_intrinsic_gas_cost
+    block_regular = gas_used_pre_refund + extra_tx_block_gas
     block_state = tx_state_gas
     total_block_gas_used = max(block_regular, block_state)
+    # The block gas_limit must accommodate extra_tx's full gas_limit (which
+    # may be floor-inclusive) even though block gas_used uses the lower actual
+    # charge. For exceed_block_gas_limit=True we set the limit below
+    # total_block_gas_used to test that the extra_tx fails.
     if exceed_block_gas_limit:
         environment_gas_limit = total_block_gas_used - 1
     else:
-        environment_gas_limit = total_block_gas_used
+        environment_gas_limit = (
+            gas_used_pre_refund + extra_tx_intrinsic_gas_cost
+        )
 
     txs = [refund_tx, extra_tx]
 
@@ -450,7 +462,7 @@ class CallDataTestType(Enum):
         "interval that DATA_FLOOR_BETWEEN needs is empty"
     ),
 )
-@pytest.mark.valid_from("EIP7778")
+@pytest.mark.valid_from("EIP8037")
 def test_varying_calldata_costs(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -553,7 +565,7 @@ def test_varying_calldata_costs(
         )
 
     # EIP-8037: block gas_used = max(block_regular_gas, block_state_gas)
-    block_regular = max(call_data_floor_cost, gas_used_pre_refund)
+    block_regular = gas_used_pre_refund
     refund_tx_block_gas_used = max(block_regular, tx_state_gas)
 
     blockchain_test(
@@ -605,7 +617,7 @@ def test_multiple_refund_types_in_one_tx(
     )
 
     # EIP-8037: block gas_used = max(block_regular_gas, block_state_gas)
-    block_regular = max(gas_used_pre_refund, call_data_floor_cost)
+    block_regular = gas_used_pre_refund
     refund_tx_block_gas_used = max(block_regular, tx_state_gas)
 
     blockchain_test(
@@ -621,24 +633,24 @@ def test_multiple_refund_types_in_one_tx(
 
 
 @pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
-@pytest.mark.valid_from("EIP7778")
+@pytest.mark.valid_from("EIP8037")
 def test_mixed_gas_regimes(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
     """
-    Lock in `block.gas_used == sum_i max(pre_refund_i, floor_i)` across a
-    block where each tx hits a different EIP-7778 regime.
+    Lock in block-level gas accounting across a block where each tx hits a
+    different regime.
 
     tx1: SSTORE-set fresh slot (no refund, pre_refund > floor).
     tx2: SSTORE-clear x10 (normal refund, refund not clipped to floor).
-    tx3: 1000 zero-byte calldata to STOP (floor binds upward).
+    tx3: 1000 zero-byte calldata to STOP (floor binds upward for fee only).
 
-    The 2-tx `test_multi_transaction_gas_accounting` covers a refund tx
-    plus a minimal extra tx but never combines a refund-bearing tx with
-    a floor-binding tx in the same block. Per-tx sender balance is also
-    asserted to lock in that the floor-binding tx pays
+    After EIP-8037's calldata-floor alignment, the floor only affects tx-level
+    fee calculation (tx_gas_used = max(post_refund, floor)); block regular gas
+    uses pre-refund gas minus state gas, with no floor applied. Per-tx sender
+    balance is also asserted to lock in that the floor-binding tx pays
     `floor * gas_price`, not `pre_refund * gas_price`.
     """
     intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
@@ -714,25 +726,27 @@ def test_mixed_gas_regimes(
     )
     tx3_floor = data_floor_calc(data=tx3_data)
     assert tx3_floor > tx3_pre_refund, "tx3: floor must bind upward"
-    tx3_contribution = max(tx3_pre_refund, tx3_floor)
+    tx3_fee_gas = max(tx3_pre_refund, tx3_floor)
+    # Block regular gas uses pre-refund only; floor is tx-level only.
+    tx3_block_contribution = tx3_pre_refund
     tx3 = Transaction(
         to=tx3_target,
-        gas_limit=tx3_contribution,
+        gas_limit=tx3_fee_gas,
         sender=tx3_sender,
         data=tx3_data,
         # TODO: gas_used in expected_receipt is ignored by
         # verify_transaction_receipt; only cumulative_gas_used is
         # checked. To be fixed by #2855.
-        expected_receipt={"gas_used": tx3_contribution},
+        expected_receipt={"gas_used": tx3_fee_gas},
     )
     tx3_gas_price = tx3.gas_price if tx3.gas_price else tx3.max_fee_per_gas
     assert tx3_gas_price is not None
     post[tx3_sender] = Account(
-        balance=initial_fund - tx3_contribution * tx3_gas_price
+        balance=initial_fund - tx3_fee_gas * tx3_gas_price
     )
 
     total_gas_used = (
-        tx1_block_contribution + tx2_contribution + tx3_contribution
+        tx1_block_contribution + tx2_contribution + tx3_block_contribution
     )
 
     blockchain_test(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -469,7 +469,7 @@ def test_call_value_transfer_existing_account_no_state_gas(
     create new state, so no state gas is charged.
     """
     # Existing target account
-    target = pre.fund_eoa(amount=0)
+    target = pre.fund_eoa(amount=1)
 
     parent_storage = Storage()
     parent = pre.deploy_contract(
@@ -488,7 +488,10 @@ def test_call_value_transfer_existing_account_no_state_gas(
         sender=pre.fund_eoa(),
     )
 
-    post = {parent: Account(storage=parent_storage)}
+    post = {
+        parent: Account(balance=0, storage=parent_storage),
+        target: Account(balance=2),
+    }
     state_test(pre=pre, post=post, tx=tx)
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1577,3 +1577,81 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
         tx=tx,
         blockchain_test_header_verify=Header(gas_used=sstore_state_gas),
     )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_call_insufficient_balance_refunds_new_account_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Refill NEW_ACCOUNT state gas on a value CALL that fails the balance
+    check before the child frame.
+    """
+    gas_costs = fork.gas_costs()
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    new_account_state_gas = gas_costs.NEW_ACCOUNT
+
+    probe = pre.deploy_contract(code=Op.SSTORE(0, 1))
+
+    probe_stipend = 2 * gas_costs.VERY_LOW + gas_costs.COLD_STORAGE_WRITE
+
+    parent = pre.deploy_contract(
+        code=(
+            Op.POP(Op.CALL(gas=Op.GAS, address=0xDEAD, value=1))
+            + Op.POP(Op.CALL(gas=probe_stipend, address=probe))
+        ),
+        balance=0,
+    )
+
+    reservoir = max(new_account_state_gas, sstore_state_gas)
+
+    tx = Transaction(
+        to=parent,
+        state_gas_reservoir=reservoir,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {probe: Account(storage={0: 1})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_call_value_precompile_halt_refunds_new_account_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Refill NEW_ACCOUNT state gas on a value CALL to an unfunded
+    precompile that halts in the child frame.
+    """
+    gas_costs = fork.gas_costs()
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    new_account_state_gas = gas_costs.NEW_ACCOUNT
+
+    probe = pre.deploy_contract(code=Op.SSTORE(0, 1))
+
+    probe_stipend = 2 * gas_costs.VERY_LOW + gas_costs.COLD_STORAGE_WRITE
+
+    ecpairing = 0x08
+
+    parent = pre.deploy_contract(
+        code=(
+            Op.POP(Op.CALL(1, ecpairing, 1, 0, 0, 0, 0))
+            + Op.POP(Op.CALL(gas=probe_stipend, address=probe))
+        ),
+        balance=1,
+    )
+
+    reservoir = max(new_account_state_gas, sstore_state_gas)
+
+    tx = Transaction(
+        to=parent,
+        state_gas_reservoir=reservoir,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {probe: Account(storage={0: 1})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -558,13 +558,13 @@ def test_delegatecall_reservoir_passing(
     """
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
-    # Library code that writes to slot 0 — runs in parent's context
+    parent_storage = Storage()
+    # Library code runs in parent's context — slot is reserved on
+    # parent_storage so the post check uses the same source of truth.
     library = pre.deploy_contract(
-        code=Op.SSTORE(0, 1),
+        code=Op.SSTORE(parent_storage.store_next(1, "delegated"), 1),
     )
 
-    parent_storage = Storage()
-    parent_storage[0] = 1  # Expect slot 0 = 1 after delegatecall
     parent = pre.deploy_contract(
         code=(Op.DELEGATECALL(gas=100_000, address=library)),
     )
@@ -1418,7 +1418,8 @@ def test_create_oog_during_state_gas_charge(
         ),
     )
 
-    grandchild_code = Op.SSTORE(0, 1)
+    grandchild_storage = Storage()
+    grandchild_code = Op.SSTORE(grandchild_storage.store_next(1, "ran"), 1)
     grandchild = pre.deploy_contract(code=grandchild_code)
 
     grandchild_stipend = grandchild_code.regular_cost(fork)
@@ -1438,7 +1439,7 @@ def test_create_oog_during_state_gas_charge(
 
     state_test(
         pre=pre,
-        post={grandchild: Account(storage={0: 1})},
+        post={grandchild: Account(storage=grandchild_storage)},
         tx=tx,
     )
 
@@ -1510,7 +1511,8 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     gas_costs = fork.gas_costs()
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
-    probe_code = Op.SSTORE(0, 1)
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(probe_storage.store_next(1, "probe_ran"), 1)
 
     if charge_via == "sstore":
         child_code: Bytecode = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
@@ -1549,9 +1551,9 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     # context, so the probe's SSTORE lands on `parent` instead of
     # `probe`.
     if call_opcode == Op.DELEGATECALL:
-        post: dict = {parent: Account(storage={0: 1})}
+        post: dict = {parent: Account(storage=probe_storage)}
     else:
-        post = {probe: Account(storage={0: 1})}
+        post = {probe: Account(storage=probe_storage)}
 
     state_test(
         pre=pre,
@@ -1575,7 +1577,8 @@ def test_call_insufficient_balance_refunds_new_account_state_gas(
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
     new_account_state_gas = gas_costs.NEW_ACCOUNT
 
-    probe_code = Op.SSTORE(0, 1)
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(probe_storage.store_next(1, "probe_ran"), 1)
     probe = pre.deploy_contract(probe_code)
 
     probe_stipend = probe_code.regular_cost(fork)
@@ -1599,7 +1602,7 @@ def test_call_insufficient_balance_refunds_new_account_state_gas(
         sender=pre.fund_eoa(),
     )
 
-    post = {probe: Account(storage={0: 1})}
+    post = {probe: Account(storage=probe_storage)}
     state_test(pre=pre, post=post, tx=tx)
 
 
@@ -1617,7 +1620,8 @@ def test_call_value_precompile_halt_refunds_new_account_state_gas(
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
     new_account_state_gas = gas_costs.NEW_ACCOUNT
 
-    probe_code = Op.SSTORE(0, 1)
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(probe_storage.store_next(1, "probe_ran"), 1)
     probe = pre.deploy_contract(probe_code)
 
     probe_stipend = probe_code.regular_cost(fork)
@@ -1641,5 +1645,5 @@ def test_call_value_precompile_halt_refunds_new_account_state_gas(
         sender=pre.fund_eoa(),
     )
 
-    post = {probe: Account(storage={0: 1})}
+    post = {probe: Account(storage=probe_storage)}
     state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -656,40 +656,26 @@ def test_gas_opcode_excludes_reservoir(
     state_test(pre=pre, post=post, tx=tx)
 
 
-@pytest.mark.parametrize(
-    "target_exists",
-    [
-        pytest.param(True, id="existing_account"),
-        pytest.param(False, id="new_account"),
-    ],
-)
 @pytest.mark.valid_from("EIP8037")
 def test_call_insufficient_balance_returns_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    target_exists: bool,
 ) -> None:
     """
-    Test CALL with insufficient balance returns reservoir to parent.
+    Test CALL with insufficient balance returns the reservoir to parent.
 
-    When a CALL transfers value but the caller has insufficient balance,
-    the call fails before any state gas is charged for the target
-    account. Both gas_left and state_gas_left are returned to the
-    parent frame. The parent can still use the reservoir for a
-    subsequent SSTORE.
+    A value-bearing CALL to an existing account fails the balance check
+    before entering the child frame; gas_left and state_gas_left are
+    returned to the parent, which can still use the reservoir for a
+    later SSTORE. The new-account variant (where NEW_ACCOUNT is charged
+    then refilled on the same failure) is pinned by
+    test_call_insufficient_balance_refunds_new_account_state_gas.
     """
-    gas_costs = fork.gas_costs()
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
-    target: int | Address
-    if target_exists:
-        target = pre.deploy_contract(code=Op.STOP)
-        reservoir = sstore_state_gas
-    else:
-        target = 0xDEAD
-        # New account needs new-account state gas too
-        reservoir = sstore_state_gas + gas_costs.NEW_ACCOUNT
+    target = pre.deploy_contract(code=Op.STOP)
+    reservoir = sstore_state_gas
 
     storage = Storage()
     contract = pre.deploy_contract(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -808,7 +808,7 @@ def test_call_pre_charged_costs_excluded_from_forwarding(
     child_code = Op.SSTORE(child_storage.store_next(1, "child_ran"), 1)
     child = pre.deploy_contract(child_code)
 
-    child_regular_gas = 2 * gas_costs.VERY_LOW + gas_costs.COLD_STORAGE_WRITE
+    child_regular_gas = child_code.regular_cost(fork)
 
     # Memory expansion triggered by ret_size on the wrapper's CALL
     ret_size = 512 * 32  # 512 words
@@ -1399,7 +1399,6 @@ def test_create_oog_during_state_gas_charge(
     SSTORE is forwarded only its regular stipend, so it succeeds
     only if the refund landed in the reservoir (not in `gas_left`).
     """
-    gas_costs = fork.gas_costs()
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
     init_code = Op.STOP
@@ -1419,11 +1418,10 @@ def test_create_oog_during_state_gas_charge(
         ),
     )
 
-    grandchild = pre.deploy_contract(code=Op.SSTORE(0, 1))
+    grandchild_code = Op.SSTORE(0, 1)
+    grandchild = pre.deploy_contract(code=grandchild_code)
 
-    push_cost = 2 * gas_costs.VERY_LOW
-    sstore_regular = gas_costs.COLD_STORAGE_WRITE
-    grandchild_stipend = push_cost + sstore_regular
+    grandchild_stipend = grandchild_code.regular_cost(fork)
 
     parent = pre.deploy_contract(
         code=(
@@ -1512,7 +1510,7 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     gas_costs = fork.gas_costs()
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
-    probe = pre.deploy_contract(code=Op.SSTORE(0, 1))
+    probe_code = Op.SSTORE(0, 1)
 
     if charge_via == "sstore":
         child_code: Bytecode = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
@@ -1527,13 +1525,8 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
         child_state_charge = gas_costs.NEW_ACCOUNT
 
     child = pre.deploy_contract(code=child_code, balance=child_balance)
-
-    # Tight stipend: just enough regular gas for the probe's SSTORE
-    # opcode plus its two stack pushes, leaving no slack to absorb a
-    # state-gas spill.
-    push_cost = 2 * gas_costs.VERY_LOW
-    sstore_regular = gas_costs.COLD_STORAGE_WRITE
-    probe_stipend = push_cost + sstore_regular
+    probe = pre.deploy_contract(probe_code)
+    probe_stipend = probe_code.regular_cost(fork)
 
     parent = pre.deploy_contract(
         code=(
@@ -1582,19 +1575,23 @@ def test_call_insufficient_balance_refunds_new_account_state_gas(
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
     new_account_state_gas = gas_costs.NEW_ACCOUNT
 
-    probe = pre.deploy_contract(code=Op.SSTORE(0, 1))
+    probe_code = Op.SSTORE(0, 1)
+    probe = pre.deploy_contract(probe_code)
 
-    probe_stipend = 2 * gas_costs.VERY_LOW + gas_costs.COLD_STORAGE_WRITE
+    probe_stipend = probe_code.regular_cost(fork)
+
+    non_existent_account = pre.nonexistent_account()
 
     parent = pre.deploy_contract(
         code=(
-            Op.POP(Op.CALL(gas=Op.GAS, address=0xDEAD, value=1))
+            Op.POP(Op.CALL(gas=Op.GAS, address=non_existent_account, value=1))
             + Op.POP(Op.CALL(gas=probe_stipend, address=probe))
         ),
         balance=0,
     )
 
-    reservoir = max(new_account_state_gas, sstore_state_gas)
+    assert new_account_state_gas >= sstore_state_gas
+    reservoir = new_account_state_gas
 
     tx = Transaction(
         to=parent,
@@ -1620,9 +1617,10 @@ def test_call_value_precompile_halt_refunds_new_account_state_gas(
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
     new_account_state_gas = gas_costs.NEW_ACCOUNT
 
-    probe = pre.deploy_contract(code=Op.SSTORE(0, 1))
+    probe_code = Op.SSTORE(0, 1)
+    probe = pre.deploy_contract(probe_code)
 
-    probe_stipend = 2 * gas_costs.VERY_LOW + gas_costs.COLD_STORAGE_WRITE
+    probe_stipend = probe_code.regular_cost(fork)
 
     ecpairing = 0x08
 
@@ -1634,7 +1632,8 @@ def test_call_value_precompile_halt_refunds_new_account_state_gas(
         balance=1,
     )
 
-    reservoir = max(new_account_state_gas, sstore_state_gas)
+    assert new_account_state_gas >= sstore_state_gas
+    reservoir = new_account_state_gas
 
     tx = Transaction(
         to=parent,


### PR DESCRIPTION


## 🗒️ Description
Apply changes from EIP-8037 spec change [#11706](https://github.com/ethereum/EIPs/pull/11706/) that don't conflict with [#11807](https://github.com/ethereum/EIPs/pull/11807)

Update EIP-8037 block gas accounting and CALL state-gas refills

Implements two spec clarifications from EIPs PR #11706:
  1. Calldata floor is tx-level only. Removed the redundant block-level application of the EIP-7623 calldata floor. Block regular gas is now tx_gas_used_before_refund - tx_state_gas, matching EIP-8037's "Integration with EIP-7778" formula.
  1. CALL refunds NEW_ACCOUNT on pre-frame failures. When a value-bearing CALL to a non-existent account fails before the child frame (insufficient balance or stack depth limit), the pre-charged NEW_ACCOUNT state gas is now refunded to the reservoir, matching the spec text.

  Tests in eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py updated to drop calldata-floor terms from block expectations and bumped from valid_from("EIP7778") to valid_from("EIP8037") where the new expectations require the integration rules.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#2915 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.10000birds.com/wp-content/uploads/2024/11/Pygmy-Cupwing_DSC5786_Frasers-Hill-Nov-17-2019-1160x770.jpg)
