### PR TITLE
chore(ci): wait for all coverage uploads before codecov reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  notify:
+    after_n_builds: 6
+comment:
+  after_n_builds: 6
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
## 🗒️ Description

Stops the Codecov `patch` check from false-failing on a single fork's partial uploads by waiting for all coverage uploads before it evaluates (`after_n_builds`), committed as a `codecov.yml` because the Codecov UI's repository YAML is read-only and its only editable web config is the org-wide Global YAML (which would affect every `ethereum` repo).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
