### PR TITLE
feat(specs): Implement EIP-8268 Storage Roots In Block Access Lists

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -21,7 +21,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.merkle_patricia_trie import EMPTY_TRIE_ROOT
+from ethereum.merkle_patricia_trie import root, trie_set
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
 from .exceptions import BlockAccessListGasLimitExceededError
@@ -579,9 +579,27 @@ def block_access_list_to_rlp(
     return tuple(encoded_accounts)
 
 
+def post_block_storage_root(
+    block_state: BlockState,
+    address: Address,
+) -> StorageRoot:
+    """
+    Compute the account's post-block storage trie root for EIP-8268.
+    """
+    storage_trie = block_state.pre_state.copy_storage_trie(address)
+
+    for key, value in block_state.storage_writes.get(address, {}).items():
+        trie_set(storage_trie, key, value)
+
+    if storage_trie._data == {}:
+        return Bytes()
+
+    return Bytes32(root(storage_trie))
+
+
 def _build_from_builder(
     builder: BlockAccessListBuilder,
-    storage_roots: Dict[Address, Hash32],
+    block_state: BlockState,
 ) -> BlockAccessList:
     """
     Build the final [`BlockAccessList`] from a builder (internal helper).
@@ -631,11 +649,7 @@ def _build_from_builder(
 
         storage_root: Optional[StorageRoot] = None
         if storage_changes or balance_changes or nonce_changes or code_changes:
-            trie_root = storage_roots[address]
-            if trie_root == EMPTY_TRIE_ROOT:
-                storage_root = Bytes()
-            else:
-                storage_root = Bytes32(trie_root)
+            storage_root = post_block_storage_root(block_state, address)
 
         account_change = AccountChanges(
             address=address,
@@ -766,21 +780,7 @@ def build_block_access_list(
     for address in block_state.account_reads:
         add_touched_account(builder, address)
 
-    state_changed_addresses = {
-        address
-        for address, account_data in builder.accounts.items()
-        if (
-            account_data.storage_changes
-            or account_data.balance_changes
-            or account_data.nonce_changes
-            or account_data.code_changes
-        )
-    }
-    storage_roots = block_state.pre_state.compute_storage_roots(
-        block_state.storage_writes, addresses=state_changed_addresses
-    )
-
-    return _build_from_builder(builder, storage_roots)
+    return _build_from_builder(builder, block_state)
 
 
 def hash_block_access_list(

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -15,12 +15,13 @@ See [`BlockAccessList`][bal] for more detail.
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, Tuple, TypeAlias, final
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.merkle_patricia_trie import EMPTY_TRIE_ROOT
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
 from .exceptions import BlockAccessListGasLimitExceededError
@@ -208,6 +209,16 @@ class AccountChanges:
     code_changes: Tuple[CodeChange, ...]
     """
     Writes to the code of the associated [`Account`].
+
+    [`Account`]: ref:ethereum.state.Account
+    """
+
+    storage_root: Optional[Bytes]
+    """
+    Root of the associated [`Account`]'s post-block storage trie.
+
+    Present only when at least one state-change list is non-empty. Empty
+    post-block storage tries are encoded as the empty byte string.
 
     [`Account`]: ref:ethereum.state.Account
     """
@@ -515,8 +526,53 @@ def add_touched_account(
     ensure_account(builder, address)
 
 
+def _has_state_changes(account: AccountChanges) -> bool:
+    """
+    Return ``True`` if ``account`` contains any state change.
+    """
+    return (
+        account.storage_changes != ()
+        or account.balance_changes != ()
+        or account.nonce_changes != ()
+        or account.code_changes != ()
+    )
+
+
+def block_access_list_to_rlp(
+    block_access_list: BlockAccessList,
+) -> Tuple[Tuple[Extended, ...], ...]:
+    """
+    Convert a [`BlockAccessList`] to its canonical RLP structure.
+
+    Per EIP-8268, state-changing entries include a trailing ``storage_root``;
+    access-only entries keep the six-field EIP-7928 layout.
+    """
+    encoded_accounts = []
+
+    for account in block_access_list:
+        account_items: List[Extended] = [
+            account.address,
+            account.storage_changes,
+            account.storage_reads,
+            account.balance_changes,
+            account.nonce_changes,
+            account.code_changes,
+        ]
+
+        if _has_state_changes(account):
+            assert account.storage_root is not None
+            account_items.append(account.storage_root)
+        else:
+            assert account.storage_root is None
+
+        encoded_accounts.append(tuple(account_items))
+
+    return tuple(encoded_accounts)
+
+
 def _build_from_builder(
     builder: BlockAccessListBuilder,
+    storage_roots: Dict[Address, Hash32],
 ) -> BlockAccessList:
     """
     Build the final [`BlockAccessList`] from a builder (internal helper).
@@ -564,6 +620,14 @@ def _build_from_builder(
         storage_changes.sort(key=lambda x: x.slot)
         storage_reads.sort()
 
+        storage_root: Optional[Bytes] = None
+        if storage_changes or balance_changes or nonce_changes or code_changes:
+            trie_root = storage_roots[address]
+            if trie_root == EMPTY_TRIE_ROOT:
+                storage_root = Bytes()
+            else:
+                storage_root = Bytes(trie_root)
+
         account_change = AccountChanges(
             address=address,
             storage_changes=tuple(storage_changes),
@@ -571,6 +635,7 @@ def _build_from_builder(
             balance_changes=balance_changes,
             nonce_changes=nonce_changes,
             code_changes=code_changes,
+            storage_root=storage_root,
         )
 
         block_access_list.append(account_change)
@@ -692,7 +757,21 @@ def build_block_access_list(
     for address in block_state.account_reads:
         add_touched_account(builder, address)
 
-    return _build_from_builder(builder)
+    state_changed_addresses = {
+        address
+        for address, account_data in builder.accounts.items()
+        if (
+            account_data.storage_changes
+            or account_data.balance_changes
+            or account_data.nonce_changes
+            or account_data.code_changes
+        )
+    }
+    storage_roots = block_state.pre_state.compute_storage_roots(
+        block_state.storage_writes, addresses=state_changed_addresses
+    )
+
+    return _build_from_builder(builder, storage_roots)
 
 
 def hash_block_access_list(
@@ -701,7 +780,7 @@ def hash_block_access_list(
     """
     Compute the hash of a Block Access List.
     """
-    return keccak256(rlp.encode(block_access_list))
+    return keccak256(rlp.encode(block_access_list_to_rlp(block_access_list)))
 
 
 def validate_block_access_list_gas_limit(

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -28,6 +28,14 @@ from .exceptions import BlockAccessListGasLimitExceededError
 from .fork_types import BlockAccessIndex
 from .state_tracker import BlockState, TransactionState, get_code
 
+StorageRoot: TypeAlias = Bytes | Bytes32
+"""
+Post-block storage trie root encoded in an account's block access list entry.
+
+Empty post-block storage tries are encoded as the empty byte string. Non-empty
+storage tries are encoded as their 32-byte trie root.
+"""
+
 
 @final
 @slotted_freezable
@@ -213,12 +221,13 @@ class AccountChanges:
     [`Account`]: ref:ethereum.state.Account
     """
 
-    storage_root: Optional[Bytes]
+    storage_root: Optional[StorageRoot]
     """
     Root of the associated [`Account`]'s post-block storage trie.
 
     Present only when at least one state-change list is non-empty. Empty
-    post-block storage tries are encoded as the empty byte string.
+    post-block storage tries are encoded as the empty byte string; non-empty
+    storage tries are encoded as bytes32.
 
     [`Account`]: ref:ethereum.state.Account
     """
@@ -620,13 +629,13 @@ def _build_from_builder(
         storage_changes.sort(key=lambda x: x.slot)
         storage_reads.sort()
 
-        storage_root: Optional[Bytes] = None
+        storage_root: Optional[StorageRoot] = None
         if storage_changes or balance_changes or nonce_changes or code_changes:
             trie_root = storage_roots[address]
             if trie_root == EMPTY_TRIE_ROOT:
                 storage_root = Bytes()
             else:
-                storage_root = Bytes(trie_root)
+                storage_root = Bytes32(trie_root)
 
         account_change = AccountChanges(
             address=address,

--- a/src/ethereum/state.py
+++ b/src/ethereum/state.py
@@ -151,6 +151,24 @@ class PreState(Protocol):
         """
         ...
 
+    def compute_storage_roots(
+        self,
+        storage_changes: Dict[Address, Dict[Bytes32, U256]],
+        storage_clears: AbstractSet[Address] = frozenset(),
+        addresses: AbstractSet[Address] = frozenset(),
+    ) -> Dict[Address, Root]:
+        """
+        Compute post-change storage roots for changed accounts.
+
+        ``storage_clears`` lists addresses whose pre-existing storage
+        tries must be dropped before ``storage_changes`` is applied.
+
+        Return a mapping containing every address in ``storage_changes``,
+        ``storage_clears``, and ``addresses``. Addresses with empty
+        post-change storage are mapped to ``EMPTY_TRIE_ROOT``.
+        """
+        ...
+
 
 @final
 @dataclass
@@ -254,6 +272,42 @@ class State:
         state_root_value = root(main_trie, get_storage_root=get_storage_root)
 
         return state_root_value, []
+
+    def compute_storage_roots(
+        self,
+        storage_changes: Dict[Address, Dict[Bytes32, U256]],
+        storage_clears: AbstractSet[Address] = frozenset(),
+        addresses: AbstractSet[Address] = frozenset(),
+    ) -> Dict[Address, Root]:
+        """
+        Compute post-change storage roots for changed accounts.
+        """
+        storage_tries = {
+            k: copy_trie(v)
+            for k, v in self._storage_tries.items()
+            if k not in storage_clears
+        }
+
+        for address, slots in storage_changes.items():
+            trie = storage_tries.get(address)
+            if trie is None:
+                trie = Trie(secured=True, default=U256(0))
+                storage_tries[address] = trie
+            for key, value in slots.items():
+                trie_set(trie, key, value)
+            if trie._data == {}:
+                del storage_tries[address]
+
+        storage_roots: Dict[Address, Root] = {}
+        for address in (
+            set(storage_changes) | set(storage_clears) | set(addresses)
+        ):
+            if address in storage_tries:
+                storage_roots[address] = root(storage_tries[address])
+            else:
+                storage_roots[address] = EMPTY_TRIE_ROOT
+
+        return storage_roots
 
 
 def close_state(state: State) -> None:

--- a/src/ethereum/state.py
+++ b/src/ethereum/state.py
@@ -133,6 +133,14 @@ class PreState(Protocol):
         """
         ...
 
+    def copy_storage_trie(self, address: Address) -> Trie[Bytes32, U256]:
+        """
+        Copy an account's storage trie.
+
+        Return an empty storage trie if the account has no storage.
+        """
+        ...
+
     def compute_state_root_and_trie_changes(
         self,
         account_changes: Dict[Address, Optional[Account]],
@@ -148,24 +156,6 @@ class PreState(Protocol):
 
         Return the new state root together with the internal trie nodes
         that were created or modified.
-        """
-        ...
-
-    def compute_storage_roots(
-        self,
-        storage_changes: Dict[Address, Dict[Bytes32, U256]],
-        storage_clears: AbstractSet[Address] = frozenset(),
-        addresses: AbstractSet[Address] = frozenset(),
-    ) -> Dict[Address, Root]:
-        """
-        Compute post-change storage roots for changed accounts.
-
-        ``storage_clears`` lists addresses whose pre-existing storage
-        tries must be dropped before ``storage_changes`` is applied.
-
-        Return a mapping containing every address in ``storage_changes``,
-        ``storage_clears``, and ``addresses``. Addresses with empty
-        post-change storage are mapped to ``EMPTY_TRIE_ROOT``.
         """
         ...
 
@@ -228,6 +218,15 @@ class State:
         """
         return address in self._storage_tries
 
+    def copy_storage_trie(self, address: Address) -> Trie[Bytes32, U256]:
+        """
+        Copy an account's storage trie.
+        """
+        trie = self._storage_tries.get(address)
+        if trie is None:
+            return Trie(secured=True, default=U256(0))
+        return copy_trie(trie)
+
     def compute_state_root_and_trie_changes(
         self,
         account_changes: Dict[Address, Optional[Account]],
@@ -272,42 +271,6 @@ class State:
         state_root_value = root(main_trie, get_storage_root=get_storage_root)
 
         return state_root_value, []
-
-    def compute_storage_roots(
-        self,
-        storage_changes: Dict[Address, Dict[Bytes32, U256]],
-        storage_clears: AbstractSet[Address] = frozenset(),
-        addresses: AbstractSet[Address] = frozenset(),
-    ) -> Dict[Address, Root]:
-        """
-        Compute post-change storage roots for changed accounts.
-        """
-        storage_tries = {
-            k: copy_trie(v)
-            for k, v in self._storage_tries.items()
-            if k not in storage_clears
-        }
-
-        for address, slots in storage_changes.items():
-            trie = storage_tries.get(address)
-            if trie is None:
-                trie = Trie(secured=True, default=U256(0))
-                storage_tries[address] = trie
-            for key, value in slots.items():
-                trie_set(trie, key, value)
-            if trie._data == {}:
-                del storage_tries[address]
-
-        storage_roots: Dict[Address, Root] = {}
-        for address in (
-            set(storage_changes) | set(storage_clears) | set(addresses)
-        ):
-            if address in storage_tries:
-                storage_roots[address] = root(storage_tries[address])
-            else:
-                storage_roots[address] = EMPTY_TRIE_ROOT
-
-        return storage_roots
 
 
 def close_state(state: State) -> None:

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -150,6 +150,11 @@ class ForkLoad:
         return self._module("block_access_lists").hash_block_access_list
 
     @property
+    def block_access_list_to_rlp(self) -> Any:
+        """block_access_list_to_rlp function of the fork."""
+        return self._module("block_access_lists").block_access_list_to_rlp
+
+    @property
     def has_hash_block_access_list(self) -> bool:
         """Check if the fork has a `hash_block_access_list` function."""
         try:

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -275,6 +275,7 @@ class Result:
     requests: Optional[List[Bytes]] = None
     block_exception: Optional[str] = None
     block_access_list: Optional[Any] = None
+    block_access_list_rlp: Optional[Bytes] = None
     block_access_list_hash: Optional[Hash32] = None
 
     def get_receipts_from_output(
@@ -344,6 +345,11 @@ class Result:
 
         if hasattr(block_output, "block_access_list"):
             self.block_access_list = block_output.block_access_list
+            self.block_access_list_rlp = rlp.encode(
+                t8n.fork.block_access_list_to_rlp(
+                    block_output.block_access_list
+                )
+            )
             self.block_access_list_hash = t8n.fork.hash_block_access_list(
                 block_output.block_access_list
             )
@@ -428,12 +434,10 @@ class Result:
         if self.block_exception is not None:
             data["blockException"] = self.block_exception
 
-        if self.block_access_list is not None:
+        if self.block_access_list_rlp is not None:
             # Output BAL as RLP-encoded hex bytes; the testing framework
             # handles JSON serialization.
-            data["blockAccessList"] = encode_to_hex(
-                rlp.encode(self.block_access_list)
-            )
+            data["blockAccessList"] = encode_to_hex(self.block_access_list_rlp)
 
         if self.block_access_list_hash is not None:
             data["blockAccessListHash"] = encode_to_hex(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Implement EIP-8268: Storage Roots In Block-Level Access Lists.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2017/01/adorable-sugar-gliders-5874ee9340623__700.jpg)
