### PR TITLE
chore(ci,tooling): speed up json-loader job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -140,6 +140,8 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
+        with:
+          python-version: "3.14"
       - uses: ./.github/actions/setup-env
       - name: Fill and run json-loader tests
         run: just json-loader

--- a/Justfile
+++ b/Justfile
@@ -165,6 +165,7 @@ json-loader *args:
         --cov=ethereum \
         --cov-branch \
         --cov-report=term \
+        --durations=50 \
         --cov-fail-under=85
     uv run pytest \
         -m "not slow" \
@@ -174,6 +175,7 @@ json-loader *args:
         --cov-branch \
         --cov-report=term \
         --cov-report "xml:{{ output_dir }}/json-loader/coverage.xml" \
+        --durations=50 \
         --basetemp="{{ output_dir }}/json-loader/tmp" \
         "$@" \
         tests/json_loader

--- a/Justfile
+++ b/Justfile
@@ -169,7 +169,7 @@ json-loader *args:
         --cov-fail-under=85
     uv run pytest \
         -m "not slow" \
-        -n {{ xdist_workers }} --dist=loadgroup \
+        -n {{ xdist_workers }} --dist=loadfile \
         --cov-config=pyproject.toml \
         --cov=ethereum \
         --cov-branch \

--- a/Justfile
+++ b/Justfile
@@ -168,7 +168,7 @@ json-loader *args:
         --cov-fail-under=85
     uv run pytest \
         -m "not slow" \
-        -n auto --maxprocesses 6 --dist=loadfile \
+        -n {{ xdist_workers }} --dist=loadfile \
         --cov-config=pyproject.toml \
         --cov=ethereum \
         --cov-branch \

--- a/Justfile
+++ b/Justfile
@@ -169,7 +169,7 @@ json-loader *args:
         --cov-fail-under=85
     uv run pytest \
         -m "not slow" \
-        -n {{ xdist_workers }} --dist=loadfile \
+        -n {{ xdist_workers }} --dist=loadgroup \
         --cov-config=pyproject.toml \
         --cov=ethereum \
         --cov-branch \

--- a/tests/json_loader/conftest.py
+++ b/tests/json_loader/conftest.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
-from pytest import Collector, Config, Session, fixture
+from pytest import Collector, Config, Session, fixture, mark
 
 from ethereum_spec_tools.evm_tools.t8n import ForkCache
 
@@ -181,7 +181,15 @@ def pytest_configure(config: Config) -> None:
 
 
 def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
-    """Filter test items."""
+    """Assign xdist groups and filter test items."""
+    # Group each fixtures file's cases onto one xdist worker (under
+    # `--dist=loadgroup`) so the file's JSON is parsed once. Tests without a
+    # group (e.g. the slow new-fork CLI tests) then distribute individually
+    # instead of being pinned to one worker as `--dist=loadfile` forced.
+    for item in items:
+        if isinstance(item, FixtureTestItem):
+            item.add_marker(mark.xdist_group(item.fixtures_file.nodeid))
+
     tests_path = config.getoption("tests_path", None)
     if tests_path is None:
         return

--- a/tests/json_loader/conftest.py
+++ b/tests/json_loader/conftest.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
-from pytest import Collector, Config, Session, fixture, mark
+from pytest import Collector, Config, Session, fixture, hookimpl, mark
 
 from ethereum_spec_tools.evm_tools.t8n import ForkCache
 
@@ -180,12 +180,16 @@ def pytest_configure(config: Config) -> None:
     config.stash[desired_forks_key] = desired_forks
 
 
+@hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
     """Assign xdist groups and filter test items."""
     # Group each fixtures file's cases onto one xdist worker (under
     # `--dist=loadgroup`) so the file's JSON is parsed once. Tests without a
     # group (e.g. the slow new-fork CLI tests) then distribute individually
     # instead of being pinned to one worker as `--dist=loadfile` forced.
+    #
+    # `tryfirst=True` is required: xdist reads each item's group before a
+    # default-ordered hook runs, so the marker must be added first.
     for item in items:
         if isinstance(item, FixtureTestItem):
             item.add_marker(mark.xdist_group(item.fixtures_file.nodeid))

--- a/tests/json_loader/conftest.py
+++ b/tests/json_loader/conftest.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
-from pytest import Collector, Config, Session, fixture, hookimpl, mark
+from pytest import Collector, Config, Session, fixture
 
 from ethereum_spec_tools.evm_tools.t8n import ForkCache
 
@@ -180,20 +180,8 @@ def pytest_configure(config: Config) -> None:
     config.stash[desired_forks_key] = desired_forks
 
 
-@hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
-    """Assign xdist groups and filter test items."""
-    # Group each fixtures file's cases onto one xdist worker (under
-    # `--dist=loadgroup`) so the file's JSON is parsed once. Tests without a
-    # group (e.g. the slow new-fork CLI tests) then distribute individually
-    # instead of being pinned to one worker as `--dist=loadfile` forced.
-    #
-    # `tryfirst=True` is required: xdist reads each item's group before a
-    # default-ordered hook runs, so the marker must be added first.
-    for item in items:
-        if isinstance(item, FixtureTestItem):
-            item.add_marker(mark.xdist_group(item.fixtures_file.nodeid))
-
+    """Filter test items."""
     tests_path = config.getoption("tests_path", None)
     if tests_path is None:
         return


### PR DESCRIPTION
## 🗒️ Description

The `json-loader` job takes ~23 min. This PR applies two small quick wins to reduce this:

- Run the job on Python 3.14, matching `fill`, so `coverage` uses `sys.monitoring` instead of the slower C tracer. Coverage was enabled for `json-loader` in #2975, but the job still runs on the default 3.13, reintroducing the C-tracer overhead that #2310 removed elsewhere (see the regression tracked in #2314).
- Run the fixture-consuming `pytest` phase with the same worker count as the fill phase (`-n {{ xdist_workers }}`, which is `auto` in CI). It was pinned to `--maxprocesses 6`, capping it at 6 workers instead of scaling with the runner. The cap carried over from the `tox` configuration in #2555.

## 🔗 Related Issues or PRs

- #2975
- #2310
- #2314

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:cat:
