### PR TITLE
chore(ci): run benchmark sanity checks on size-xl-x64 runner

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,6 +71,8 @@ jobs:
         with:
           enable-cache: "false"
 
+      - uses: ./.github/actions/setup-env
+
       - name: Install PyPy for bench-gas json_loader verify
         if: matrix.recipe == 'bench-gas'
         shell: bash

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,8 +35,6 @@ jobs:
           submodules: true
 
       - uses: ./.github/actions/setup-uv
-        with:
-          enable-cache: "false"
 
       - uses: ./.github/actions/build-evm-base
         id: evm-builder
@@ -68,8 +66,6 @@ jobs:
           submodules: true
 
       - uses: ./.github/actions/setup-uv
-        with:
-          enable-cache: "false"
 
       - uses: ./.github/actions/setup-env
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -51,7 +51,7 @@ jobs:
   sanity-checks:
     name: ${{ matrix.name }}
     needs: [unit-tests]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr, size-xl-x64]
     strategy:
       fail-fast: false
       matrix:

--- a/Justfile
+++ b/Justfile
@@ -230,7 +230,8 @@ bench-gas *args:
         --generate-all-formats \
         --fork Osaka \
         -m "not slow" \
-        -n auto --maxprocesses 10 --dist=loadgroup \
+        -n auto --dist=loadgroup \
+        --durations=100 \
         --output="{{ output_dir }}/bench-gas/fixtures" \
         --basetemp="{{ output_dir }}/bench-gas/tmp" \
         --log-to "{{ output_dir }}/bench-gas/logs" \
@@ -243,7 +244,7 @@ bench-gas *args:
     cd tests/json_loader && uv run --python pypy3.11 pytest \
         --fork Osaka \
         --allow-post-state-hash \
-        -n auto --maxprocesses 10 --dist=loadfile \
+        -n auto --dist=loadfile \
         --basetemp="{{ output_dir }}/bench-gas/json-loader-tmp" \
         bench_gas_fixtures
 
@@ -256,7 +257,8 @@ bench-opcode *args:
         --fixed-opcode-count 1 \
         --fork Osaka \
         -m repricing \
-        -n auto --maxprocesses 10 --dist=loadgroup \
+        -n auto --dist=loadgroup \
+        --durations=100 \
         -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not uncachable" \
         --output="{{ output_dir }}/bench-opcode/fixtures" \
         --basetemp="{{ output_dir }}/bench-opcode/tmp" \
@@ -275,7 +277,8 @@ bench-opcode-config *args:
         --fixed-opcode-count \
         --fork Osaka \
         -m repricing \
-        -n auto --maxprocesses 10 --dist=loadgroup \
+        -n auto --dist=loadgroup \
+        --durations=100 \
         -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not test_point_evaluation_uncachable" \
         --output="{{ output_dir }}/bench-opcode-config/fixtures" \
         --basetemp="{{ output_dir }}/bench-opcode-config/tmp" \


### PR DESCRIPTION
## 🗒️ Description

Run the benchmark `sanity-checks` jobs (`Benchmark Gas Values`, `Fixed Opcode Count CLI`, `Fixed Opcode Count Config`) on the `size-xl-x64` self-hosted runner instead of `ubuntu-latest`.

The standard `ubuntu-latest` runner only exposes 2 cores, so `fill`/`pytest` with `-n auto --maxprocesses 10` was capped at 2 workers, making `Benchmark Gas Values` take roughly 28 minutes. The XL runner has enough cores for `-n auto` to scale toward the existing `--maxprocesses 10` cap, matching the runner already used by `test.yaml`.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
