### PR TITLE
feat(amsterdam): refund CALL new-account state gas on soft-fail (EIP-8037)

### DIFF
--- a/docs/writing_tests/post_mortems.md
+++ b/docs/writing_tests/post_mortems.md
@@ -72,6 +72,35 @@ None required - the existing framework supported writing these tests.
 
 ---
 
+## 2026-06 - CALL Soft-Fail New-Account State-Gas Refund - Amsterdam
+
+### Description
+
+EIP-8037's specification text states that the new-account state gas charged for a `CALL*` is refilled to the `state_gas_reservoir` (and `execution_state_gas_used` decreases) when the operation is unsuccessful before entering the call frame (insufficient balance or stack depth), and it draws **no distinction** between `CALL*` and `CREATE`/`CREATE2`. The executable spec implemented this refund only for `CREATE`/`CREATE2` (`generic_create`); the `CALL` paths charged the new-account state gas and then retained it on the soft-fail. The mismatch was surfaced by external review (a testing/security discussion triaging an auto-hunt finding that flagged "CALL state gas not refunded on soft-fail"), not by the test suite.
+
+### Root Cause Analysis
+
+- The single existing test for the scenario (`test_call_insufficient_balance_returns_reservoir`) did not isolate the refund: for a fresh target it provisioned the reservoir with `sstore_state_gas + NEW_ACCOUNT`, so the follow-up `SSTORE` succeeded whether or not the new-account charge was refunded. The behavior was pinned only incidentally through the filled post-state root, never as an intent-named assertion.
+- That test's docstring stated "the call fails before any state gas is charged for the target account", which described the EIP prose but contradicted both the executable spec (the charge happens before the balance check) and the test's own reservoir sizing. The contradiction masked the divergence during review.
+- The `CALL*`-vs-`CREATE` symmetry asserted by the prose was assumed covered because both opcodes had insufficient-balance tests; no test compared their refund behavior directly.
+
+### Steps Taken To Avoid Recurrence
+
+- Aligned `call()`/`generic_call()` with the prose (refund the new-account state gas on the insufficient-balance and stack-depth soft-fails, symmetric with `CREATE`).
+- Rewrote `test_call_insufficient_balance_returns_reservoir` so its docstring matches the behavior and its reservoir is sized to require the refund.
+- Added an intent-named regression that reuses the refunded reservoir for a subsequent account-creating `CALL`, pinning the `CALL`/`CREATE` symmetry directly rather than incidentally.
+
+### Implemented Test Case
+
+- `tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py::test_call_softfail_refund_reused_by_new_account_call`
+- `tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py::test_call_insufficient_balance_returns_reservoir`
+
+### Framework/Documentation Changes
+
+- None to the framework. This post-mortem entry documents the miss; the underlying EIP prose vs executable-spec divergence is flagged on the PR for the authors to confirm the intended direction.
+
+---
+
 ## TEMPLATE
 
 ## Date - Title - Fork

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -325,6 +325,12 @@ class GenericCall:
     memory_output_size: U256
     code: Bytes
     disable_precompiles: bool
+    new_account_state_gas: Uint = Uint(0)
+    """
+    EIP-8037 new-account state gas charged before the frame, refunded to
+    the reservoir if the call fails the stack-depth check. Non-zero only
+    for a value-bearing `CALL` to a non-existent account.
+    """
 
 
 def generic_call(evm: Evm, params: GenericCall) -> None:
@@ -338,6 +344,9 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
         evm.gas_left += params.gas
         evm.state_gas_left += params.state_gas_reservoir
+        # EIP-8037: refund new-account state gas charged before the frame
+        # when the stack-depth check fails (symmetric with CREATE).
+        credit_state_gas_refund(evm, params.new_account_state_gas)
         push(evm.stack, U256(0))
         return
 
@@ -457,8 +466,10 @@ def call(evm: Evm) -> None:
     code = get_code(tx_state, code_hash)
 
     charge_gas(evm, extra_gas + extend_memory.cost)
+    new_account_state_gas = Uint(0)
     if value != 0 and not is_account_alive(tx_state, to):
-        charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
+        new_account_state_gas = StateGasCosts.NEW_ACCOUNT
+        charge_state_gas(evm, new_account_state_gas)
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -483,6 +494,10 @@ def call(evm: Evm) -> None:
         evm.return_data = b""
         evm.gas_left += message_call_gas.sub_call
         evm.state_gas_left += call_state_gas_reservoir
+        # EIP-8037: the new-account state gas is charged before the value
+        # transfer; an insufficient-balance soft-fail never enters the
+        # frame, so refund it to the reservoir (symmetric with CREATE).
+        credit_state_gas_refund(evm, new_account_state_gas)
     else:
         generic_call(
             evm,
@@ -501,6 +516,7 @@ def call(evm: Evm) -> None:
                 memory_output_size=memory_output_size,
                 code=code,
                 disable_precompiles=is_delegated,
+                new_account_state_gas=new_account_state_gas,
             ),
         )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -668,25 +668,26 @@ def test_call_insufficient_balance_returns_reservoir(
     target_exists: bool,
 ) -> None:
     """
-    Test CALL with insufficient balance returns reservoir to parent.
+    Test CALL with insufficient balance refunds state gas to the parent.
 
     When a CALL transfers value but the caller has insufficient balance,
-    the call fails before any state gas is charged for the target
-    account. Both gas_left and state_gas_left are returned to the
-    parent frame. The parent can still use the reservoir for a
-    subsequent SSTORE.
+    the operation is unsuccessful before entering the call frame. Any
+    new-account state gas charged for a fresh target is refunded to the
+    reservoir (EIP-8037, symmetric with CREATE), and the forwarded
+    gas_left is returned too. The parent can still use the reservoir for
+    a subsequent SSTORE.
     """
-    gas_costs = fork.gas_costs()
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
     target: int | Address
     if target_exists:
         target = pre.deploy_contract(code=Op.STOP)
-        reservoir = sstore_state_gas
     else:
         target = 0xDEAD
-        # New account needs new-account state gas too
-        reservoir = sstore_state_gas + gas_costs.NEW_ACCOUNT
+
+    # Any fresh-target new-account state gas is refunded on the soft-fail,
+    # so a reservoir sized for the SSTORE alone suffices in both cases.
+    reservoir = sstore_state_gas
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -696,7 +697,8 @@ def test_call_insufficient_balance_returns_reservoir(
                 storage.store_next(0, "call_fails"),
                 Op.CALL(100_000, target, 1, 0, 0, 0, 0),
             )
-            # Reservoir should be returned — SSTORE still works
+            # Reservoir returned (incl. refunded new-account gas) — the
+            # following SSTORE still has its state gas available.
             + Op.SSTORE(storage.store_next(1, "sstore_after"), 1)
         ),
     )
@@ -708,6 +710,63 @@ def test_call_insufficient_balance_returns_reservoir(
     )
 
     post = {contract: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_call_softfail_refund_reused_by_new_account_call(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Refunded CALL soft-fail state gas is reusable, like CREATE.
+
+    EIP-8037 refunds the new-account state gas when a value-`CALL` is
+    unsuccessful before entering the frame, with no `CALL*`-vs-`CREATE`
+    distinction. This pins that symmetry: a contract funded with exactly
+    one new-account's worth of reservoir first does a value-`CALL` that
+    soft-fails on insufficient balance (charging then refunding the
+    new-account state gas), then a second value-`CALL` that actually
+    creates a new account. The second creation can only draw its
+    new-account state gas from the reservoir if the first call refunded
+    it.
+    """
+    new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
+
+    underfunded_target = Address(0xAAAA)
+    created_target = Address(0xBBBB)
+
+    storage = Storage()
+    contract = pre.deploy_contract(
+        balance=1,
+        code=(
+            # value=2 > balance=1 -> insufficient-balance soft-fail;
+            # charges then refunds the new-account state gas.
+            Op.SSTORE(
+                storage.store_next(0, "softfail"),
+                Op.CALL(100_000, underfunded_target, 2, 0, 0, 0, 0),
+            )
+            # value=1 == balance -> succeeds, creates the account and
+            # draws new-account state gas from the refunded reservoir.
+            + Op.SSTORE(
+                storage.store_next(1, "creates_account"),
+                Op.CALL(100_000, created_target, 1, 0, 0, 0, 0),
+            )
+        ),
+    )
+
+    tx = Transaction(
+        to=contract,
+        state_gas_reservoir=new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        contract: Account(balance=0, storage=storage),
+        created_target: Account(balance=1),
+        underfunded_target: Account.NONEXISTENT,
+    }
     state_test(pre=pre, post=post, tx=tx)
 
 


### PR DESCRIPTION
## 🗒️ Description

EIP-8037's prose says the new-account **state gas** charged for a `CALL*`
is refilled to the `state_gas_reservoir` (and `execution_state_gas_used`
decreases) when the operation is unsuccessful before entering the call
frame, and it draws **no distinction** between `CALL*` and
`CREATE`/`CREATE2` ([Specification], "Gas accounting for new accounts"):

> If the respective call frame reverts or halts exceptionally or if the
> operation is unsuccessful before entering the call frame (e.g., due to
> insufficient balance or due to the stack depth), the charged state-gas
> is refilled back to the `state_gas_reservoir` and
> `execution_state_gas_used` decreases by the same amount.

The executable spec only honored this for `CREATE`/`CREATE2`:
`generic_create` calls `credit_state_gas_refund(evm, NEW_ACCOUNT)` on
each early-fail path (depth / balance / nonce / collision / child-revert).
The `CALL` paths charged `NEW_ACCOUNT` (`call()`, before the balance
check) but on the soft-fail restored only the child reservoir — the
new-account charge was **retained**, contrary to the prose.

This PR aligns `call()` with the prose:

- capture the charged amount in `call()` and refund it on the
  insufficient-balance soft-fail (symmetric with `CREATE`);
- thread it through `GenericCall` so the stack-depth soft-fail in
  `generic_call()` refunds it too.

`CALLCODE`/`DELEGATECALL`/`STATICCALL` never charge new-account state gas
(self/alive target, or no value), so they are unaffected —
`new_account_state_gas` defaults to `0`, making the refund a no-op.

**Tests:** `test_call_insufficient_balance_returns_reservoir` is updated
(the fresh-target reservoir no longer needs the extra new-account
allowance; the docstring previously claimed "the call fails before any
state gas is charged", which contradicted both the code and its own
reservoir sizing). A new `test_call_softfail_refund_reused_by_new_account_call`
pins the `CALL`/`CREATE` symmetry by reusing the refunded reservoir for a
subsequent account-creating `CALL`.

### ⚠️ Note for reviewers — this intentionally diverges from current clients

This is a **prose-alignment** change. As of `bal-devnet-7`, geth
(`9e04883a`), revm (`ab5e3a4c`), besu, and nethermind all **retain** the
charge on a value-`CALL` soft-fail (verified: identical `gasUsed 213,920`
/ post-state root for the minimal case), matching the *previous*
executable-spec behavior, not the prose. So this PR makes EELS follow the
EIP text and, for now, diverge from the clients.

Either the prose is authoritative (this PR; clients would then need to
follow) or the prior behavior is intended (and EIP-8037's text should
instead be amended to state the `CALL*`-vs-`CREATE` asymmetry explicitly,
consistent with legacy `CALL` value-failure semantics). Flagging so the
text and the executable spec say the same thing before activation —
happy to invert this into a test-only PR that keeps current behavior if
the authors decide the prose should change instead.

Scope is `forks/amsterdam` only (the sole fork with EIP-8037).

[Specification]: https://eips.ethereum.org/EIPS/eip-8037

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.

#### Cute Animal Picture

![cute animal](https://cataas.com/cat)
