### PR TITLE
feat(spec-specs, tests): Implement EIP-2780

### DIFF
--- a/packages/testing/src/execution_testing/__init__.py
+++ b/packages/testing/src/execution_testing/__init__.py
@@ -31,6 +31,7 @@ from .exceptions import (
 )
 from .fixtures import BaseFixture, FixtureCollector
 from .forks import Fork, GasCosts, RefundTypes, TransitionFork
+from .recipient_type import RecipientType
 from .specs import (
     BaseTest,
     BenchmarkTest,
@@ -183,6 +184,7 @@ __all__ = (
     "OpcodeCallArg",
     "Opcodes",
     "ParameterSet",
+    "RecipientType",
     "ReferenceSpec",
     "ReferenceSpecTypes",
     "RefundTypes",

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -32,6 +32,7 @@ from execution_testing.vm import (
     Opcodes,
 )
 
+from ..recipient_type import RecipientType
 from .gas_costs import GasCosts
 
 
@@ -116,6 +117,8 @@ class TransactionIntrinsicCostCalculator(Protocol):
         access_list: List[AccessList] | None = None,
         authorization_list_or_count: Sized | int | None = None,
         return_cost_deducted_prior_execution: bool = False,
+        sends_value: bool = False,
+        recipient_type: RecipientType = RecipientType.CONTRACT,
     ) -> int:
         """
         Return the intrinsic gas cost of a transaction given its properties.
@@ -135,8 +138,59 @@ class TransactionIntrinsicCostCalculator(Protocol):
                                                 that is deducted from the gas
                                                 limit before the transaction
                                                 starts execution.
+          sends_value: Whether the transaction transfers a non-zero value.
+                       Forks that itemize the value-transfer charge in
+                       intrinsic gas use this flag; ignored by older forks.
+          recipient_type: Category of the transaction recipient. Forks
+                          that vary intrinsic gas by recipient kind
+                          (e.g. no access cost for precompiles, no value
+                          charge for self-transfers) use this; ignored
+                          by older forks.
 
         Returns: Gas cost of a transaction
+
+        """
+        pass
+
+
+class TopFrameGasCalculator(Protocol):
+    """
+    A protocol to calculate the additional regular gas charged at the
+    top-level transaction frame, after intrinsic gas is deducted but
+    before EVM execution begins.
+
+    Returns only the regular-gas portion of the post-intrinsic
+    state-aware preparation (e.g. the delegated-recipient access
+    charge). The state-gas portion is exposed separately by
+    ``BaseFork.transaction_top_frame_state_gas`` so tests can model the
+    two-dimensional reservoir explicitly or sum the two via
+    ``oog_budget_lift`` when targeting the spillover boundary.
+
+    Returns 0 for forks that do not perform any such preparation.
+    """
+
+    def __call__(
+        self,
+        *,
+        contract_creation: bool = False,
+        sends_value: bool = False,
+        recipient_type: RecipientType = RecipientType.CONTRACT,
+    ) -> int:
+        """
+        Return the regular gas consumed by top-frame preparation for a
+        transaction at this fork.
+
+        Args:
+          contract_creation: Whether the transaction creates a contract.
+                             Top-frame charges are zero for creates;
+                             equivalent charges are paid via intrinsic
+                             gas.
+          sends_value: Whether the transaction transfers a non-zero
+                       value.
+          recipient_type: Category of the transaction recipient.
+                          Drives the conditional charges.
+
+        Returns: Regular gas added by top-frame preparation.
 
         """
         pass
@@ -697,6 +751,51 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     ) -> int:
         """Return intrinsic state gas (zero pre-Amsterdam)."""
         del contract_creation, authorization_count
+        return 0
+
+    @classmethod
+    def transaction_top_frame_gas_calculator(
+        cls,
+    ) -> TopFrameGasCalculator:
+        """
+        Return a callable that calculates the additional regular gas
+        charged at the top-level transaction frame, after intrinsic
+        gas is deducted but before EVM execution begins.
+
+        Defaults to returning 0 for forks that do not perform such
+        post-intrinsic preparation.
+        """
+
+        def fn(
+            *,
+            contract_creation: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
+        ) -> int:
+            del contract_creation, sends_value, recipient_type
+            return 0
+
+        return fn
+
+    @classmethod
+    def transaction_top_frame_state_gas(
+        cls,
+        *,
+        contract_creation: bool = False,
+        sends_value: bool = False,
+        recipient_type: RecipientType = RecipientType.CONTRACT,
+    ) -> int:
+        """
+        Return the state gas charged at the top-level transaction
+        frame, after intrinsic gas is deducted but before EVM execution
+        begins. Companion to ``transaction_top_frame_gas_calculator``;
+        tests targeting the spillover boundary feed this through
+        ``oog_budget_lift`` to get the equivalent regular-gas budget.
+
+        Defaults to 0 for forks that do not perform such
+        post-intrinsic preparation.
+        """
+        del contract_creation, sends_value, recipient_type
         return 0
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
@@ -1,5 +1,5 @@
 """
-EIP-2780: Reduce intrinsic transaction gas costs.
+EIP-2780: Resource-based intrinsic transaction gas.
 
 Decompose the intrinsic transaction gas into explicit recipient-access
 and value-transfer primitives so that the cost paid before execution

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
@@ -1,0 +1,161 @@
+"""
+EIP-2780: Reduce intrinsic transaction gas costs.
+
+Decompose the intrinsic transaction gas into explicit recipient-access
+and value-transfer primitives so that the cost paid before execution
+reflects the actual work the transaction will perform.
+
+https://eips.ethereum.org/EIPS/eip-2780
+"""
+
+from dataclasses import replace
+from typing import List, Sized
+
+from execution_testing.base_types import AccessList
+from execution_testing.base_types.conversions import BytesConvertible
+
+from .....recipient_type import RecipientType
+from ....base_fork import (
+    BaseFork,
+    TopFrameGasCalculator,
+    TransactionIntrinsicCostCalculator,
+)
+from ....gas_costs import GasCosts
+
+
+class EIP2780(BaseFork):
+    """EIP-2780 class."""
+
+    @classmethod
+    def gas_costs(cls) -> GasCosts:
+        """
+        Lower ``TX_BASE`` to 12_000 to reflect the removal of the
+        bundled recipient access and account-write charges, and add
+        the transfer-log and value-transfer constants.
+        """
+        parent = super(EIP2780, cls).gas_costs()
+        return replace(
+            parent,
+            TX_BASE=12_000,
+            TRANSFER_LOG_COST=1_756,
+            TX_VALUE_COST=4_244,
+        )
+
+    @classmethod
+    def transaction_intrinsic_cost_calculator(
+        cls,
+    ) -> TransactionIntrinsicCostCalculator:
+        """
+        Decompose intrinsic gas into explicit recipient and
+        value-transfer primitives.
+
+        Non-create, non-self targets pay ``COLD_ACCOUNT_ACCESS``
+        unconditionally; access lists do not warm transaction-level
+        accounts. Value-bearing transactions pay
+        ``TRANSFER_LOG_COST`` plus ``TX_VALUE_COST``; self-transfers
+        suppress the value-transfer charge entirely.
+        """
+        super_fn = super(EIP2780, cls).transaction_intrinsic_cost_calculator()
+        gas_costs = cls.gas_costs()
+
+        def fn(
+            *,
+            calldata: BytesConvertible = b"",
+            contract_creation: bool = False,
+            access_list: List[AccessList] | None = None,
+            authorization_list_or_count: Sized | int | None = None,
+            return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
+        ) -> int:
+            intrinsic_cost: int = super_fn(
+                calldata=calldata,
+                contract_creation=contract_creation,
+                access_list=access_list,
+                authorization_list_or_count=authorization_list_or_count,
+                return_cost_deducted_prior_execution=True,
+            )
+
+            is_self_transfer = recipient_type == RecipientType.SELF
+
+            if contract_creation:
+                if sends_value:
+                    intrinsic_cost += gas_costs.TRANSFER_LOG_COST
+            elif not is_self_transfer:
+                intrinsic_cost += gas_costs.COLD_ACCOUNT_ACCESS
+                if sends_value:
+                    intrinsic_cost += (
+                        gas_costs.TRANSFER_LOG_COST + gas_costs.TX_VALUE_COST
+                    )
+
+            if return_cost_deducted_prior_execution:
+                return intrinsic_cost
+
+            transaction_data_floor_cost_calculator = (
+                cls.transaction_data_floor_cost_calculator()
+            )
+            transaction_floor_data_cost = (
+                transaction_data_floor_cost_calculator(
+                    data=calldata, access_list=access_list
+                )
+            )
+            return max(intrinsic_cost, transaction_floor_data_cost)
+
+        return fn
+
+    @classmethod
+    def transaction_top_frame_gas_calculator(
+        cls,
+    ) -> TopFrameGasCalculator:
+        """
+        Return the additional regular gas charged at the top-level
+        transaction frame, after intrinsic gas is deducted but before
+        the EVM dispatches.
+
+        Charges ``COLD_ACCOUNT_ACCESS`` when the recipient is an
+        existing delegated account. The empty-recipient
+        ``NEW_ACCOUNT`` charge is state gas, returned separately by
+        ``transaction_top_frame_state_gas``.
+        """
+        gas_costs = cls.gas_costs()
+
+        def fn(
+            *,
+            contract_creation: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
+        ) -> int:
+            del sends_value
+            if contract_creation:
+                return 0
+
+            if recipient_type == RecipientType.DELEGATION_7702:
+                return gas_costs.COLD_ACCOUNT_ACCESS
+            return 0
+
+        return fn
+
+    @classmethod
+    def transaction_top_frame_state_gas(
+        cls,
+        *,
+        contract_creation: bool = False,
+        sends_value: bool = False,
+        recipient_type: RecipientType = RecipientType.CONTRACT,
+    ) -> int:
+        """
+        Return the state gas charged at the top-level transaction
+        frame. Charges ``NEW_ACCOUNT`` when value is transferred to an
+        empty recipient; zero otherwise. Precompile recipients are
+        exempt: they are protocol-inherent rather than created by a
+        value transfer, so they never trigger ``NEW_ACCOUNT`` even
+        when state-empty.
+        """
+        gas_costs = cls.gas_costs()
+        if contract_creation:
+            return 0
+        if recipient_type == RecipientType.PRECOMPILE:
+            return 0
+        if sends_value and recipient_type == RecipientType.EMPTY_ACCOUNT:
+            return gas_costs.NEW_ACCOUNT
+        return 0

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7981.py
@@ -11,6 +11,7 @@ from typing import List, Sized
 from execution_testing.base_types import AccessList
 from execution_testing.base_types.conversions import BytesConvertible
 
+from .....recipient_type import RecipientType
 from ....base_fork import (
     BaseFork,
     TransactionDataFloorCostCalculator,
@@ -85,7 +86,11 @@ class EIP7981(BaseFork):
             access_list: List[AccessList] | None = None,
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
         ) -> int:
+            del sends_value, recipient_type
+
             intrinsic_cost: int = super_fn(
                 calldata=calldata,
                 contract_creation=contract_creation,

--- a/packages/testing/src/execution_testing/forks/forks/eips/berlin/eip_2930.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/berlin/eip_2930.py
@@ -12,6 +12,7 @@ from typing import List, Sized
 from execution_testing.base_types import AccessList
 from execution_testing.base_types.conversions import BytesConvertible
 
+from .....recipient_type import RecipientType
 from ....base_fork import BaseFork, TransactionIntrinsicCostCalculator
 
 
@@ -45,8 +46,11 @@ class EIP2930(BaseFork):
             access_list: List[AccessList] | None = None,
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
         ) -> int:
             del return_cost_deducted_prior_execution
+            del sends_value, recipient_type
 
             intrinsic_cost: int = super_fn(
                 calldata=calldata,

--- a/packages/testing/src/execution_testing/forks/forks/eips/homestead/eip_2.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/homestead/eip_2.py
@@ -9,6 +9,7 @@ from typing import List, Sized
 from execution_testing.base_types import AccessList
 from execution_testing.base_types.conversions import BytesConvertible
 
+from .....recipient_type import RecipientType
 from ....base_fork import BaseFork, TransactionIntrinsicCostCalculator
 
 
@@ -33,8 +34,11 @@ class EIP2(BaseFork):
             access_list: List[AccessList] | None = None,
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
         ) -> int:
             del return_cost_deducted_prior_execution
+            del sends_value, recipient_type
 
             intrinsic_cost: int = super_fn(
                 calldata=calldata,

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7623.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7623.py
@@ -12,6 +12,7 @@ from typing import List, Sized
 from execution_testing.base_types import AccessList, Bytes
 from execution_testing.base_types.conversions import BytesConvertible
 
+from .....recipient_type import RecipientType
 from ....base_fork import (
     BaseFork,
     CalldataGasCalculator,
@@ -95,7 +96,11 @@ class EIP7623(BaseFork):
             access_list: List[AccessList] | None = None,
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
         ) -> int:
+            del sends_value, recipient_type
+
             intrinsic_cost: int = super_fn(
                 calldata=calldata,
                 contract_creation=contract_creation,

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7702.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7702.py
@@ -13,6 +13,7 @@ from execution_testing.base_types import AccessList
 from execution_testing.base_types.conversions import BytesConvertible
 from execution_testing.vm import OpcodeBase
 
+from .....recipient_type import RecipientType
 from ....base_fork import (
     BaseFork,
     RefundTypes,
@@ -74,7 +75,11 @@ class EIP7702(BaseFork):
             access_list: List[AccessList] | None = None,
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
         ) -> int:
+            del sends_value, recipient_type
+
             intrinsic_cost: int = super_fn(
                 calldata=calldata,
                 contract_creation=contract_creation,

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -21,6 +21,7 @@ from execution_testing.vm import (
     Opcodes,
 )
 
+from ...recipient_type import RecipientType
 from ..base_fork import (
     BaseFeeChangeCalculator,
     BaseFeePerGasCalculator,
@@ -856,8 +857,11 @@ class Frontier(
             access_list: List[AccessList] | None = None,
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
+            sends_value: bool = False,
+            recipient_type: RecipientType = RecipientType.CONTRACT,
         ) -> int:
             del return_cost_deducted_prior_execution
+            del sends_value, recipient_type
 
             assert access_list is None, (
                 f"Access list is not supported in {cls.name()}"

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -36,7 +36,21 @@ class GasCosts:
     CALL_VALUE: int
     CALL_STIPEND: int
     NEW_ACCOUNT: int
+    # Surcharge for the first write to an account leaf; 0 before the
+    # state-access repricing introduces it as a standalone parameter.
     ACCOUNT_WRITE: int = 0
+    # Access cost for a contract-creation slot; 0 before the
+    # state-access repricing introduces it as a standalone parameter.
+    CREATE_ACCESS: int = 0
+    # Per-transfer log cost charged when a value-transferring
+    # transaction emits the synthetic transfer log; 0 before the
+    # intrinsic gas decomposition introduces it.
+    TRANSFER_LOG_COST: int = 0
+    # Per-transfer value cost charged on top of the transfer log when a
+    # non-create transaction transfers a non-zero value to an account
+    # other than the sender; 0 before the intrinsic gas decomposition
+    # introduces it.
+    TX_VALUE_COST: int = 0
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: int

--- a/packages/testing/src/execution_testing/recipient_type.py
+++ b/packages/testing/src/execution_testing/recipient_type.py
@@ -1,0 +1,14 @@
+"""Recipient type enumeration for transaction gas calculations."""
+
+from enum import Enum, auto
+
+
+class RecipientType(Enum):
+    """The type of recipient for a transaction."""
+
+    SELF = auto()
+    EOA = auto()
+    CONTRACT = auto()
+    DELEGATION_7702 = auto()
+    PRECOMPILE = auto()
+    EMPTY_ACCOUNT = auto()

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -12,6 +12,7 @@ from execution_testing.base_types import Account, Address, Hash
 from execution_testing.exceptions import BlockException
 from execution_testing.forks import Berlin, Fork, TransitionFork
 from execution_testing.forks.base_fork import BaseFork
+from execution_testing.recipient_type import RecipientType
 from execution_testing.specs import BlockchainTestFiller, StateTestFiller
 from execution_testing.specs.blockchain import Block
 from execution_testing.test_types import Alloc, Transaction
@@ -406,10 +407,25 @@ def generate_system_contract_error_test(
             # Simple test transaction to verify the block failed to modify the
             # state.
             value_receiver = pre.fund_eoa(amount=0)
+            # value_receiver is empty, so a value transfer to it pays
+            # the value-transfer intrinsic surcharges plus the
+            # top-frame ``NEW_ACCOUNT`` state-gas charge introduced by
+            # EIP-2780. Derive ``gas_limit`` from the fork so the tx
+            # is provisioned correctly across all forks.
+            test_tx_intrinsic_calc = (
+                fork.transaction_intrinsic_cost_calculator()
+            )
+            test_tx_gas_limit = test_tx_intrinsic_calc(
+                sends_value=True,
+                recipient_type=RecipientType.EMPTY_ACCOUNT,
+            ) + fork.transaction_top_frame_state_gas(
+                sends_value=True,
+                recipient_type=RecipientType.EMPTY_ACCOUNT,
+            )
             test_tx = Transaction(
                 to=value_receiver,
                 value=1,
-                gas_limit=100_000,
+                gas_limit=test_tx_gas_limit,
                 sender=pre.fund_eoa(),
             )
             post = Alloc()

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -494,8 +494,9 @@ def check_transaction(
     block_env: vm.BlockEnvironment,
     block_output: vm.BlockOutput,
     tx: Transaction,
+    sender: Address,
     tx_state: TransactionState,
-) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
+) -> Tuple[Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
 
@@ -507,13 +508,13 @@ def check_transaction(
         The block output for the current block.
     tx :
         The transaction.
+    sender :
+        The recovered sender address of the transaction.
     tx_state :
         The transaction state tracker.
 
     Returns
     -------
-    sender_address :
-        The sender of the transaction.
     effective_gas_price :
         The price to charge for gas when the transaction is executed.
     blob_versioned_hashes :
@@ -575,8 +576,7 @@ def check_transaction(
     if tx_blob_gas_used > blob_gas_available:
         raise BlobGasLimitExceededError("blob gas limit exceeded")
 
-    sender_address = recover_sender(block_env.chain_id, tx)
-    sender_account = get_account(tx_state, sender_address)
+    sender_account = get_account(tx_state, sender)
 
     if isinstance(tx, FeeMarketCapableTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
@@ -649,7 +649,6 @@ def check_transaction(
         raise InvalidSenderError("not EOA")
 
     return (
-        sender_address,
         effective_gas_price,
         blob_versioned_hashes,
         tx_blob_gas_used,
@@ -784,6 +783,8 @@ def process_unchecked_system_transaction(
 
     tx_env = vm.TransactionEnvironment(
         origin=SYSTEM_ADDRESS,
+        recipient=target_address,
+        value=U256(0),
         gas_price=block_env.base_fee_per_gas,
         gas=SYSTEM_TRANSACTION_GAS,
         state_gas_reservoir=(
@@ -990,12 +991,12 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    sender = recover_sender(block_env.chain_id, tx)
+    intrinsic = validate_transaction(tx, sender)
 
     intrinsic_gas = intrinsic.regular + intrinsic.state
 
     (
-        sender,
         effective_gas_price,
         blob_versioned_hashes,
         tx_blob_gas_used,
@@ -1003,6 +1004,7 @@ def process_transaction(
         block_env=block_env,
         block_output=block_output,
         tx=tx,
+        sender=sender,
         tx_state=tx_state,
     )
 
@@ -1044,6 +1046,8 @@ def process_transaction(
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,
+        recipient=tx.to,
+        value=tx.value,
         gas_price=effective_gas_price,
         gas=gas,
         state_gas_reservoir=state_gas_reservoir,

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -572,7 +572,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -604,7 +604,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic = calculate_intrinsic_cost(tx)
+    intrinsic = calculate_intrinsic_cost(tx, sender)
     intrinsic_gas = intrinsic.regular + intrinsic.state
     if intrinsic_gas > tx.gas:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
@@ -626,7 +626,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
+def calculate_intrinsic_cost(
+    tx: Transaction, sender: Address
+) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -640,12 +642,18 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     for all operations to be implemented.
 
     The intrinsic cost includes:
-    1. Base cost (`TX_BASE`)
-    2. Cost for data (zero and non-zero bytes)
-    3. Cost for contract creation (if applicable)
-    4. Cost for access list entries (if applicable)
-    5. Cost for authorizations (if applicable)
+    1. Sender cost (`TX_BASE`).
+    2. Recipient cost (`COLD_ACCOUNT_ACCESS` for a non-self-transfer
+       call, or `CREATE_ACCESS` plus `NEW_ACCOUNT` state gas for a
+       contract creation).
+    3. Value cost (`TRANSFER_LOG_COST`, plus `TX_VALUE_COST` for a
+       non-self-transfer call) when ``tx.value > 0``.
+    4. Calldata cost (zero and non-zero bytes).
+    5. Access list entries (if applicable).
+    6. Authorizations (if applicable).
 
+    Self-transfers (``sender == tx.to``) skip the recipient and value
+    charges.
 
     This function takes a transaction and gas_limit as parameters and
     returns the intrinsic regular gas cost, intrinsic state gas cost, and the
@@ -661,13 +669,24 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
 
     data_cost = tokens_in_calldata * GasCosts.TX_DATA_TOKEN_STANDARD
 
-    create_regular_gas = Uint(0)
-    create_state_gas = Uint(0)
-    if tx.to == Bytes0(b""):
-        create_state_gas = StateGasCosts.NEW_ACCOUNT
-        create_regular_gas = GasCosts.CREATE_ACCESS + init_code_cost(
+    is_create = tx.to == Bytes0(b"")
+    is_self_transfer = tx.to == sender
+
+    recipient_regular_gas = Uint(0)
+    recipient_state_gas = Uint(0)
+    if is_create:
+        recipient_regular_gas = GasCosts.CREATE_ACCESS + init_code_cost(
             ulen(tx.data)
         )
+        recipient_state_gas = StateGasCosts.NEW_ACCOUNT
+        if tx.value > U256(0):
+            recipient_regular_gas += GasCosts.TRANSFER_LOG_COST
+    elif not is_self_transfer:
+        recipient_regular_gas = GasCosts.COLD_ACCOUNT_ACCESS
+        if tx.value > U256(0):
+            recipient_regular_gas += (
+                GasCosts.TRANSFER_LOG_COST + GasCosts.TX_VALUE_COST
+            )
 
     access_list_cost = Uint(0)
     tokens_in_access_list = Uint(0)
@@ -709,12 +728,12 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     intrinsic_regular_gas = (
         GasCosts.TX_BASE
         + data_cost
-        + create_regular_gas
+        + recipient_regular_gas
         + access_list_cost
         + auth_regular_gas
     )
 
-    intrinsic_state_gas = create_state_gas + auth_state_gas
+    intrinsic_state_gas = recipient_state_gas + auth_state_gas
 
     return IntrinsicGasCost(
         regular=intrinsic_regular_gas,

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -121,6 +121,8 @@ class TransactionEnvironment:
     """
 
     origin: Address
+    recipient: Bytes0 | Address
+    value: U256
     gas_price: Uint
     gas: Uint
     state_gas_reservoir: Uint

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -125,8 +125,10 @@ class GasCosts:
     BLOCK_ACCESS_LIST_ITEM: Final[Uint] = Uint(2000)
 
     # Transactions
-    TX_BASE: Final[Uint] = Uint(21000)
+    TX_BASE: Final[Uint] = Uint(12000)
     TX_CREATE: Final[Uint] = Uint(32000)
+    TX_VALUE_COST: Final[Uint] = Uint(4244)
+    TRANSFER_LOG_COST: Final[Uint] = Uint(1756)
     TX_DATA_TOKEN_STANDARD: Final[Uint] = Uint(4)
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(16)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = COLD_ACCOUNT_ACCESS

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -156,7 +156,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
         delegated_address = get_delegated_code_address(message.code)
         if delegated_address is not None:
             message.disable_precompiles = True
-            message.accessed_addresses.add(delegated_address)
             message.code = get_code(
                 tx_state,
                 get_account(tx_state, delegated_address).code_hash,
@@ -306,20 +305,47 @@ def process_message(message: Message) -> Evm:
 
     snapshot = copy_tx_state(tx_state)
 
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            tx_state,
-            message.caller,
-            message.current_target,
-            message.value,
-        )
-        if message.caller != message.current_target:
-            emit_transfer_log(
-                evm, message.caller, message.current_target, message.value
-            )
-
     # Execute message code and handle errors
     try:
+        # EIP-2780 top-frame charges: applied at the top of a
+        # transaction's call frame, after authorizations and before any
+        # opcode runs. Reads pre-value-transfer state so the
+        # EIP-161-empty check sees the recipient as it was at the start
+        # of the frame. Gated to non-create top-level frames; creates
+        # pay the equivalent NEW_ACCOUNT state gas. Precompile
+        # recipients are exempt from the NEW_ACCOUNT charge: they are
+        # protocol-inherent rather than created by a value transfer.
+        if message.depth == Uint(0) and message.target != Bytes0(b""):
+            recipient = message.current_target
+            recipient_is_precompile = recipient in PRE_COMPILED_CONTRACTS
+            if (
+                message.value > U256(0)
+                and not recipient_is_precompile
+                and not is_account_alive(tx_state, recipient)
+            ):
+                charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
+            recipient_code = get_code(
+                tx_state, get_account(tx_state, recipient).code_hash
+            )
+            delegated_address = get_delegated_code_address(recipient_code)
+            if delegated_address is not None:
+                charge_gas(evm, GasCosts.COLD_ACCOUNT_ACCESS)
+                evm.accessed_addresses.add(delegated_address)
+
+        if message.should_transfer_value and message.value != 0:
+            move_ether(
+                tx_state,
+                message.caller,
+                message.current_target,
+                message.value,
+            )
+            if message.caller != message.current_target:
+                emit_transfer_log(
+                    evm,
+                    message.caller,
+                    message.current_target,
+                    message.value,
+                )
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             if not message.disable_precompiles:
                 evm_trace(evm, PrecompileStart(evm.message.code_address))

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/__init__.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for [EIP-2780: Resource-based intrinsic transaction gas](https://eips.ethereum.org/EIPS/eip-2780)."""

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
@@ -1,0 +1,43 @@
+"""Shared helpers for EIP-2780 tests."""
+
+from execution_testing import Address, Alloc, Op, RecipientType
+
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+
+EOA_INITIAL_BALANCE = 100
+
+RECIPIENT_TYPES_NON_CREATE = [
+    RecipientType.EOA,
+    RecipientType.CONTRACT,
+    RecipientType.EMPTY_ACCOUNT,
+    RecipientType.SELF,
+    RecipientType.DELEGATION_7702,
+]
+
+
+def setup_target(
+    pre: Alloc, recipient_type: RecipientType, sender: Address
+) -> Address:
+    """
+    Allocate a target account matching the given recipient type.
+
+    ``EOA`` targets are pre-funded to ``EOA_INITIAL_BALANCE`` so that
+    post-state balance assertions distinguish a successful value
+    transfer from a no-op.
+    """
+    match recipient_type:
+        case RecipientType.EOA:
+            return pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+        case RecipientType.CONTRACT:
+            return pre.deploy_contract(code=Op.STOP)
+        case RecipientType.EMPTY_ACCOUNT:
+            return pre.fund_eoa(amount=0)
+        case RecipientType.SELF:
+            return sender
+        case RecipientType.DELEGATION_7702:
+            delegated_to = pre.deploy_contract(code=Op.STOP)
+            return pre.deploy_contract(
+                code=Spec7702.delegation_designation(delegated_to)
+            )
+        case _:
+            raise ValueError(f"Unsupported recipient type {recipient_type}")

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/spec.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/spec.py
@@ -1,0 +1,17 @@
+"""Reference spec for [EIP-2780: Resource-based intrinsic transaction gas.](https://eips.ethereum.org/EIPS/eip-2780)."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Reference specification."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_2780 = ReferenceSpec(
+    git_path="EIPS/eip-2780.md",
+    version="4b612eec2ef70611bba3e0819d137dcfb9b6cd81",
+)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_intrinsic_gas_boundary.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_intrinsic_gas_boundary.py
@@ -1,0 +1,69 @@
+"""
+Gas-limit boundary tests for EIP-2780.
+
+Pin transactions one gas below the intrinsic charge layer to verify the
+transaction is rejected by the pre-execution intrinsic gas check at
+that boundary. Top-frame boundary OOGs are covered by the dedicated
+top-frame charge tests in ``test_top_frame_charges.py``.
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Fork,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+    TransactionException,
+)
+
+from .helpers import RECIPIENT_TYPES_NON_CREATE, setup_target
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+@pytest.mark.exception_test
+@pytest.mark.parametrize("recipient_type", RECIPIENT_TYPES_NON_CREATE)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_intrinsic_gas_floor_boundary(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    recipient_type: RecipientType,
+    value: int,
+) -> None:
+    """
+    Reject when ``gas_limit = intrinsic_gas - 1``.
+
+    The transaction never enters the EVM; it is rejected by the
+    pre-execution intrinsic gas check.
+    """
+    sender = pre.fund_eoa(10**18)
+    target = setup_target(pre, recipient_type, sender)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=intrinsic_gas - 1,
+        gas_price=1_000_000_000,
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+    )
+
+    state_test(pre=pre, tx=tx, post={})

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
@@ -1,0 +1,201 @@
+"""
+Dedicated tests for the EIP-2780 top-frame charge layer.
+
+The top-frame layer applies *after* intrinsic gas is deducted but
+*before* the EVM dispatches at the transaction's outermost frame. Two
+charges may fire there, depending on the recipient:
+
+- ``NEW_ACCOUNT`` (state gas) when the recipient is empty and the
+  transaction transfers value.
+- ``COLD_ACCOUNT_ACCESS`` (regular gas) when the recipient holds an
+  EIP-7702 delegation.
+
+Each test parametrizes over the interesting outcomes for that charge:
+running out of gas at the boundary, succeeding through the charge and
+into the EVM, and (for the regular charge) succeeding through the
+charge but reverting from the delegated code.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Fork,
+    Op,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+)
+
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+@pytest.mark.parametrize("outcome", ["oog", "success"])
+def test_top_frame_state_charge(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    outcome: str,
+) -> None:
+    """
+    Recipient is empty and the transaction transfers a non-zero value,
+    so the top-frame fires the ``NEW_ACCOUNT`` state-gas charge.
+
+    - ``oog``: gas limit is one short of covering the state charge.
+      The transaction passes the intrinsic check, enters
+      ``process_message``, and out-of-gases on
+      ``charge_state_gas(NEW_ACCOUNT)`` before any EVM bytecode runs.
+      The sender pays the full ``gas_limit`` and no value is
+      transferred.
+    - ``success``: gas limit covers the state charge. The value
+      transfer brings the recipient into existence and the recipient
+      ends the transaction holding the transferred balance.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+    target = pre.fund_eoa(amount=0)
+
+    value = 1
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    assert top_frame_state_gas > 0, (
+        "top-frame state gas must be non-zero for this scenario"
+    )
+
+    gas_price = 1_000_000_000
+    if outcome == "oog":
+        gas_limit = intrinsic_gas + top_frame_state_gas - 1
+        sender_final_balance = sender_initial_balance - gas_limit * gas_price
+        expected_target: Account | None = None
+    else:
+        total_gas_cost = intrinsic_gas + top_frame_state_gas
+        gas_limit = total_gas_cost + 1000
+        sender_final_balance = (
+            sender_initial_balance - value - total_gas_cost * gas_price
+        )
+        expected_target = Account(balance=value)
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: expected_target,
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize("outcome", ["oog", "success", "evm_reverts"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_regular_charge(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    outcome: str,
+    value: int,
+) -> None:
+    """
+    Recipient is an existing EIP-7702 delegation, so the top-frame
+    fires the ``COLD_ACCOUNT_ACCESS`` regular-gas charge regardless of
+    whether the transaction transfers value.
+
+    - ``oog``: gas limit is one short of covering the regular charge
+      (plus the value-transfer charge when ``value > 0``). The
+      transaction OOGs at ``charge_gas(COLD_ACCOUNT_ACCESS)`` before
+      the delegated code runs. The sender pays the full ``gas_limit``
+      and the recipient keeps its pre-tx state.
+    - ``success``: gas limit covers the regular charge; the delegated
+      code is a ``STOP`` and the transaction lands the value transfer.
+    - ``evm_reverts``: the delegated code reverts immediately. The
+      top-frame charge is consumed before dispatch and the two
+      ``PUSH`` opcodes that feed the ``REVERT`` are paid before the
+      revert; the value transfer is rolled back, the unused EVM
+      budget is returned, and the intrinsic and top-frame gas remain
+      paid.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    revert_code = Op.REVERT(0, 0)
+    if outcome == "evm_reverts":
+        delegated_to = pre.deploy_contract(code=revert_code)
+    else:
+        delegated_to = pre.deploy_contract(code=Op.STOP)
+    target_code = Spec7702.delegation_designation(delegated_to)
+    target = pre.deploy_contract(code=target_code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+    assert top_frame_gas > 0, (
+        "top-frame regular gas must be non-zero for this scenario"
+    )
+
+    gas_price = 1_000_000_000
+    if outcome == "oog":
+        gas_limit = intrinsic_gas + top_frame_gas - 1
+        sender_final_balance = sender_initial_balance - gas_limit * gas_price
+        target_balance = 0
+    elif outcome == "success":
+        total_gas_cost = intrinsic_gas + top_frame_gas
+        gas_limit = total_gas_cost + 1000
+        sender_final_balance = (
+            sender_initial_balance - value - total_gas_cost * gas_price
+        )
+        target_balance = value
+    else:
+        # Two ``PUSH`` opcodes feed ``REVERT`` before it halts.
+        revert_exec_gas = revert_code.gas_cost(fork)
+        gas_used = intrinsic_gas + top_frame_gas + revert_exec_gas
+        gas_limit = gas_used + 1000
+        # Value transfer is rolled back, so the sender keeps the
+        # would-be transferred value. The intrinsic, top-frame, and
+        # pre-revert EVM gas stay paid.
+        sender_final_balance = sender_initial_balance - gas_used * gas_price
+        target_balance = 0
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=target_balance, code=target_code),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
@@ -1,0 +1,363 @@
+"""
+Tests for EIP-2780 Reduce Transaction Intrinsic Cost.
+
+Test gas costs with EIP-2780 for value-moving transactions to:
+- EOAs,
+- contracts,
+- empty accounts,
+- the sender itself,
+- delegated EOAs,
+- newly created contracts, and
+- precompiles.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Address,
+    Alloc,
+    Fork,
+    Initcode,
+    Op,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import (
+    EOA_INITIAL_BALANCE,
+    RECIPIENT_TYPES_NON_CREATE,
+    setup_target,
+)
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+@pytest.mark.parametrize("recipient_type", RECIPIENT_TYPES_NON_CREATE)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_value_moving_transactions(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    recipient_type: RecipientType,
+    value: int,
+) -> None:
+    """
+    Ensure value-moving transactions charge gas correctly across every
+    non-create recipient type.
+
+    Self-transfers are carved out: the sender pays only the recipient
+    -access-free intrinsic and the value is moved to itself, so the
+    sender's post-tx balance reflects only gas. Pre-existing 7702
+    delegations on the recipient surface as an extra top-frame
+    ``COLD_ACCOUNT_ACCESS``; empty recipients trigger the top-frame
+    ``NEW_ACCOUNT`` state charge when value is transferred.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+    target = setup_target(pre, recipient_type, sender)
+
+    target_initial_balance = (
+        EOA_INITIAL_BALANCE if recipient_type == RecipientType.EOA else 0
+    )
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+    # Under the default zero state-gas reservoir, top-frame state gas
+    # spills entirely into regular gas.
+    total_gas_cost = intrinsic_gas + top_frame_gas + top_frame_state_gas
+
+    tx_gas_limit = total_gas_cost + 1000  # add a small buffer
+    gas_price = 1_000_000_000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=tx_gas_limit,
+        gas_price=gas_price,
+    )
+
+    is_self_transfer = recipient_type == RecipientType.SELF
+    sender_value_delta = 0 if is_self_transfer else value
+    sender_final_balance = (
+        sender_initial_balance
+        - sender_value_delta
+        - total_gas_cost * gas_price
+    )
+
+    post: dict[Address, Account | None] = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+    }
+    if not is_self_transfer:
+        if recipient_type == RecipientType.EMPTY_ACCOUNT and value == 0:
+            post[target] = None
+        else:
+            post[target] = Account(balance=target_initial_balance + value)
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+@pytest.mark.parametrize(
+    "tx_reverts",
+    [
+        pytest.param(False, id="success"),
+        pytest.param(True, id="init_reverts"),
+    ],
+)
+def test_value_contract_creation_tx(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    tx_reverts: bool,
+    value: int,
+) -> None:
+    """
+    Test value moving contract creation transactions.
+
+    When the init code succeeds, the contract is deployed with the
+    transferred value and the receipt's ``gas_used`` equals the
+    intrinsic plus the execution gas.
+
+    When the init code reverts, the deploy is rolled back: no code is
+    set, the value transfer is reversed, and the intrinsic
+    ``NEW_ACCOUNT`` state-gas charge is refilled to the reservoir.
+    Under the default zero state-gas reservoir, the refill cancels
+    the spilled-to-regular portion of the intrinsic exactly, so the
+    sender pays only the regular portion of the intrinsic plus the
+    few EVM gas units spent before the revert.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    code_to_deploy = Op.STOP
+    if tx_reverts:
+        # ``PUSH1 0 PUSH1 0 REVERT`` -- aborts immediately, so no
+        # code is deployed.
+        call_data = Op.REVERT(0, 0)
+    else:
+        call_data = Initcode(deploy_code=code_to_deploy)
+    execution_gas = call_data.gas_cost(fork)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=call_data,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+
+    if tx_reverts:
+        # The ``NEW_ACCOUNT`` state portion of the intrinsic is
+        # refilled to the reservoir on revert, so it does not appear
+        # on the receipt.
+        new_account_refund = fork.transaction_intrinsic_state_gas(
+            contract_creation=True,
+        )
+        gas_used = intrinsic_gas + execution_gas - new_account_refund
+        # Value transfer rolled back.
+        sender_value_delta = 0
+        expected_target = None
+    else:
+        gas_used = intrinsic_gas + execution_gas
+        sender_value_delta = value
+        expected_target = Account(code=code_to_deploy, balance=value)
+
+    gas_price = 1_000_000_000
+    gas_limit = intrinsic_gas + execution_gas + 1000
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        value=value,
+        data=call_data,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    expected_target_address = compute_create_address(address=sender, nonce=0)
+    sender_final_balance = (
+        sender_initial_balance - sender_value_delta - gas_used * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        expected_target_address: expected_target,
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+def _precompile_calldata(precompile: Address) -> bytes:
+    """Return minimal valid calldata for the given precompile address."""
+    addr_int = int.from_bytes(precompile, "big")
+
+    if addr_int == 0x0A:
+        # Valid point evaluation input from mainnet tx:
+        # https://etherscan.io/tx/0xcb3dc8f3b14f1cda0c16a619a112102a8ec70dce1b3f1b28272227cf8d5fbb0e
+        return (
+            bytes.fromhex(
+                # versioned_hash (32)
+                "018156B94FE9735E573BAB36DAD05D60FEB720D424CCD20AAF719343C31E4246"
+            )
+            + bytes.fromhex(
+                # z (32)
+                "019123BCB9D06356701F7BE08B4494625B87A7B02EDC566126FB81F6306E915F"
+            )
+            + bytes.fromhex(
+                # y (32)
+                "6C2EB1E94C2532935B8465351BA1BD88EABE2B3FA1AADFF7D1CD816E8315BD38"
+            )
+            + bytes.fromhex(
+                # kzg_commitment (48)
+                "A9546D41993E10DF2A7429B8490394EA9EE62807BAE6F326D1044A51581306F58D4B9DFD5931E044688855280FF3799E"
+            )
+            + bytes.fromhex(
+                # kzg_proof (48)
+                "A2EA83D9391E0EE42E0C650ACC7A1F842A7D385189485DDB4FD54ADE3D9FD50D608167DCA6C776AAD4B8AD5C20691BFE"
+            )
+        )
+
+    precompile_min_input = {
+        0x01: 128,  # ECRECOVER
+        0x02: 0,  # SHA256 (accepts empty)
+        0x03: 0,  # RIPEMD160 (accepts empty)
+        0x04: 0,  # IDENTITY (accepts empty)
+        0x05: 96,  # MODEXP
+        0x06: 128,  # BN256ADD
+        0x07: 96,  # BN256MUL
+        0x08: 0,  # BN256PAIRING (empty is valid)
+        0x09: 213,  # BLAKE2F
+        0x0B: 256,  # BLS12_G1_ADD
+        0x0C: 160,  # BLS12_G1_MSM
+        0x0D: 512,  # BLS12_G2_ADD
+        0x0E: 288,  # BLS12_G2_MSM
+        0x0F: 384,  # BLS12_PAIRING
+        0x10: 64,  # BLS12_MAP_FP_TO_G1
+        0x11: 128,  # BLS12_MAP_FP2_TO_G2
+        0x100: 160,  # P256VERIFY
+    }
+
+    input_size = precompile_min_input.get(addr_int, 0)
+    return bytes([0x00] * input_size if input_size > 0 else [])
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+@pytest.mark.parametrize(
+    "pre_funded",
+    [
+        pytest.param(True, id="pre_funded"),
+        pytest.param(False, id="not_funded"),
+    ],
+)
+@pytest.mark.with_all_precompiles
+def test_value_move_to_precompiles(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    precompile: Address,
+    pre_funded: bool,
+    value: int,
+) -> None:
+    """
+    Ensure value moving transactions to precompiles charge gas correctly.
+
+    Precompile recipients pay the same ``COLD_ACCOUNT_ACCESS`` at
+    intrinsic time as any other non-self target -- access lists do
+    not warm transaction-level accounts. A value transfer to a
+    precompile additionally pays the transfer-log and value-transfer
+    charges. The top-frame ``NEW_ACCOUNT`` state charge is suppressed
+    for precompile recipients: they are protocol-inherent rather than
+    created by a value transfer.
+
+    The ``pre_funded`` parameter exercises both pre-tx states of the
+    precompile address: the ``empty`` variant proves the carve-out is
+    explicit -- without it, a value transfer to an empty precompile
+    would trip the ``NEW_ACCOUNT`` charge that ``is_account_alive``
+    would otherwise demand. The gas limit is pinned to
+    ``intrinsic_gas`` plus a buffer that covers the precompile
+    execution body, so a miscalculated intrinsic or a missing
+    carve-out would trip the gas budget rather than pass silently.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    pre_funded_amount = 0
+    if pre_funded:
+        pre_funded_amount = 1
+        pre.fund_address(precompile, amount=pre_funded_amount)
+
+    tx_data = _precompile_calldata(precompile)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=tx_data,
+        sends_value=bool(value),
+        recipient_type=RecipientType.PRECOMPILE,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    # Precompile execution gas varies per precompile and input; pick
+    # a buffer large enough to cover the most expensive precompile in
+    # the matrix but still well under the ``NEW_ACCOUNT`` state
+    # charge, so a missing carve-out OOGs the ``empty`` variants.
+    precompile_execution_budget = 100_000
+    tx_gas_limit = intrinsic_gas + precompile_execution_budget
+    gas_price = 1_000_000_000
+
+    tx = Transaction(
+        sender=sender,
+        to=precompile,
+        value=value,
+        data=tx_data,
+        gas_limit=tx_gas_limit,
+        gas_price=gas_price,
+    )
+
+    # Exact sender balance is not checked because precompile execution
+    # gas varies; verify value receipt and sender nonce instead.
+    final_precompile_balance = pre_funded_amount + value
+    expected_precompile: Account | None
+    if final_precompile_balance > 0:
+        expected_precompile = Account(balance=final_precompile_balance)
+    else:
+        expected_precompile = None
+    post = {
+        sender: Account(nonce=1),
+        precompile: expected_precompile,
+    }
+
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_with_tx_delegation.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_with_tx_delegation.py
@@ -1,0 +1,339 @@
+"""
+Tests for EIP-2780 x EIP-7702 interaction.
+
+When a type-4 transaction's authorization list installs a delegation on
+``tx.to``, ``set_delegation`` runs before the top-frame check fires.
+That ordering changes which top-frame charges apply:
+
+- ``COLD_ACCOUNT_ACCESS`` for the delegated recipient still fires; the
+  spec charges the access uniformly whenever the recipient holds a
+  delegation prefix at top-frame time, regardless of who installed it.
+- ``NEW_ACCOUNT`` for a value transfer to an otherwise-empty recipient
+  is suppressed implicitly: ``set_delegation`` writes the delegation
+  code and increments the nonce, so ``is_account_alive`` returns
+  ``True`` by the time the top-frame check evaluates it.
+
+A complementary set of scenarios installs the delegation on the
+*sender* (self-sponsored authorization). The authorization's nonce
+must equal the sender's nonce *after* the transaction's nonce
+increment.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    AuthorizationTuple,
+    Fork,
+    Op,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+)
+
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_tx_installs_delegation_on_funded_recipient(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Scenario 1: ``tx.to`` is a funded EOA with no prior delegation.
+    The type-4 transaction's authorization installs delegation on
+    ``tx.to``. The top-frame ``COLD_ACCOUNT_ACCESS`` charge for the
+    now-delegated recipient still fires.
+
+    The pre-existing authority account also produces a
+    ``REFUND_AUTH_PER_EXISTING_ACCOUNT`` state refund.
+    """
+    gsc = fork.gas_costs()
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    target_initial_balance = 100
+    target = pre.fund_eoa(amount=target_initial_balance)
+    delegated_to = pre.deploy_contract(code=Op.STOP)
+
+    auth = AuthorizationTuple(
+        address=delegated_to,
+        nonce=0,
+        signer=target,
+    )
+
+    # Intrinsic sees the recipient in its pre-tx form (funded EOA);
+    # the delegation is materialized later by ``set_delegation`` and
+    # only surfaces at the top-frame check.
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.EOA,
+        authorization_list_or_count=[auth],
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+    # The full intrinsic is deducted upfront. For each existing
+    # authority, ``set_delegation`` refunds ``NEW_ACCOUNT`` into the
+    # state gas reservoir (uncapped) and ``ACCOUNT_WRITE`` into the
+    # regular refund counter (capped at ``gas_used // 5`` by EIP-3529).
+    total_gas_cost = intrinsic_gas + top_frame_gas
+    state_refund = gsc.REFUND_AUTH_PER_EXISTING_ACCOUNT
+    gas_used_pre_regular_refund = total_gas_cost - state_refund
+    regular_refund = min(gsc.ACCOUNT_WRITE, gas_used_pre_regular_refund // 5)
+    gas_used = gas_used_pre_regular_refund - regular_refund
+
+    tx_gas_limit = total_gas_cost + 1000
+    gas_price = 1_000_000_000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        authorization_list=[auth],
+        gas_limit=tx_gas_limit,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+    )
+
+    sender_final_balance = (
+        sender_initial_balance - value - (gas_used * gas_price)
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(
+            nonce=1,
+            balance=target_initial_balance + value,
+            code=Spec7702.delegation_designation(delegated_to),
+        ),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_tx_installs_delegation_on_empty_recipient(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Scenario 2: ``tx.to`` is a non-existent (empty) account. The type-4
+    transaction's authorization installs delegation on ``tx.to``.
+
+    ``set_delegation`` runs before the top-frame check and makes the
+    recipient alive, so the ``NEW_ACCOUNT`` state-gas charge that a
+    value transfer to an empty recipient would otherwise incur is
+    implicitly suppressed. The ``COLD_ACCOUNT_ACCESS`` charge for the
+    now-delegated recipient still fires.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    target = pre.fund_eoa(amount=0)
+    delegated_to = pre.deploy_contract(code=Op.STOP)
+
+    auth = AuthorizationTuple(
+        address=delegated_to,
+        nonce=0,
+        signer=target,
+    )
+
+    # Intrinsic sees the recipient in its pre-tx form (empty); the
+    # delegation is materialized later by ``set_delegation`` and only
+    # surfaces at the top-frame check.
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        authorization_list_or_count=[auth],
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+    # Authority does not pre-exist, so no auth refund applies.
+    total_gas_cost = intrinsic_gas + top_frame_gas
+
+    tx_gas_limit = total_gas_cost + 1000
+    gas_price = 1_000_000_000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        authorization_list=[auth],
+        gas_limit=tx_gas_limit,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+    )
+
+    sender_final_balance = (
+        sender_initial_balance - value - (total_gas_cost * gas_price)
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(
+            nonce=1,
+            balance=value,
+            code=Spec7702.delegation_designation(delegated_to),
+        ),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+@pytest.mark.parametrize(
+    "call_target",
+    [
+        pytest.param("self", id="calls_self"),
+        pytest.param("other_eoa", id="calls_other"),
+    ],
+)
+def test_tx_installs_delegation_on_sender(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    call_target: str,
+    value: int,
+) -> None:
+    """
+    Self-sponsored type-4 transaction: the sender signs an
+    authorization installing delegation on itself, and the
+    authorization's nonce equals the sender's nonce *after* the
+    transaction-side increment (``1``). After ``set_delegation`` the
+    sender holds delegation code and its nonce reaches ``2``.
+
+    Parametrized over the call target:
+
+    - ``calls_self``: ``tx.to == sender``. The intrinsic self-transfer
+      carve-out suppresses the recipient access and value-transfer
+      charges; the top-frame fires ``COLD_ACCOUNT_ACCESS`` because
+      ``set_delegation`` has installed delegation code on the sender
+      by then. The transaction then dispatches into the sender's
+      delegated code.
+    - ``calls_other``: ``tx.to`` is a separate funded EOA. The
+      intrinsic charges include ``COLD_ACCOUNT_ACCESS`` for the
+      recipient (and the value-transfer charges when ``value > 0``).
+      The top-frame fires nothing because the recipient is a plain
+      EOA. The sender's delegation is installed and persists past the
+      transaction without ever being invoked.
+    """
+    gsc = fork.gas_costs()
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    delegated_to = pre.deploy_contract(code=Op.STOP)
+
+    auth = AuthorizationTuple(
+        address=delegated_to,
+        nonce=1,
+        signer=sender,
+    )
+
+    target_initial_balance = 0
+    if call_target == "self":
+        target = sender
+        # Intrinsic carve-out fires (SELF); top-frame fires
+        # ``COLD_ACCOUNT_ACCESS`` because the sender is delegated by
+        # the time the check runs.
+        intrinsic_recipient_type = RecipientType.SELF
+        top_frame_recipient_type = RecipientType.DELEGATION_7702
+    else:
+        target_initial_balance = 100
+        target = pre.fund_eoa(amount=target_initial_balance)
+        # Recipient is a plain EOA, so no carve-out and no top-frame
+        # charge.
+        intrinsic_recipient_type = RecipientType.EOA
+        top_frame_recipient_type = RecipientType.EOA
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=intrinsic_recipient_type,
+        authorization_list_or_count=[auth],
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=top_frame_recipient_type,
+    )
+
+    # Sender is the existing authority, so ``set_delegation`` refunds
+    # ``NEW_ACCOUNT`` to the state-gas reservoir and ``ACCOUNT_WRITE``
+    # to the regular refund counter (the latter capped at
+    # ``gas_used // 5`` by EIP-3529).
+    total_gas_cost = intrinsic_gas + top_frame_gas
+    state_refund = gsc.REFUND_AUTH_PER_EXISTING_ACCOUNT
+    gas_used_pre_regular_refund = total_gas_cost - state_refund
+    regular_refund = min(gsc.ACCOUNT_WRITE, gas_used_pre_regular_refund // 5)
+    gas_used = gas_used_pre_regular_refund - regular_refund
+
+    tx_gas_limit = total_gas_cost + 1000
+    gas_price = 1_000_000_000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        authorization_list=[auth],
+        gas_limit=tx_gas_limit,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+    )
+
+    if call_target == "self":
+        # Value moves sender -> sender, net zero on balance.
+        sender_final_balance = sender_initial_balance - gas_used * gas_price
+        post = {
+            sender: Account(
+                nonce=2,
+                balance=sender_final_balance,
+                code=Spec7702.delegation_designation(delegated_to),
+            ),
+        }
+    else:
+        sender_final_balance = (
+            sender_initial_balance - value - gas_used * gas_price
+        )
+        post = {
+            sender: Account(
+                nonce=2,
+                balance=sender_final_balance,
+                code=Spec7702.delegation_designation(delegated_to),
+            ),
+            target: Account(balance=target_initial_balance + value),
+        }
+
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -1,0 +1,543 @@
+"""
+EIP-2780 invariants for transaction-level account charges.
+
+The recipient and any EIP-7702 delegation target referenced at the
+top-level transaction frame always pay the cold access rate, even when
+the address is otherwise warm, identical to the sender, or refers to
+itself:
+
+- The access list does not warm transaction-level accounts. Listing
+  ``tx.to`` (or a delegation target) pays the access-list cost but
+  does not waive the cold charge.
+- The block coinbase is pre-warmed by the protocol before transaction
+  execution, but tx-level cold charges still fire when ``tx.to`` or a
+  delegation target happens to be the coinbase.
+- Precompile addresses still pay the cold charge.
+- Self-referential delegations (delegation target equal to the
+  sender, the recipient itself, or a precompile) all pay the cold
+  charge; the dispatched EVM frame then runs whatever code lives at
+  the target, including the degenerate cases of empty code (EOA,
+  precompile address) or a delegation prefix that itself decodes as
+  the ``INVALID`` opcode.
+"""
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Account,
+    Address,
+    Alloc,
+    Environment,
+    Fork,
+    Op,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+)
+
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_intrinsic_charges_recipient_in_access_list(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient is listed in the access list. The intrinsic charge still
+    includes ``COLD_ACCOUNT_ACCESS`` for the recipient on top of the
+    access-list cost itself.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    target_initial_balance = 100
+    target = pre.fund_eoa(amount=target_initial_balance)
+    access_list = [AccessList(address=target, storage_keys=[])]
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        sends_value=bool(value),
+        recipient_type=RecipientType.EOA,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    gas_price = 1_000_000_000
+    gas_limit = intrinsic_gas + 1000
+
+    tx = Transaction(
+        ty=1,
+        sender=sender,
+        to=target,
+        value=value,
+        access_list=access_list,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    sender_final_balance = (
+        sender_initial_balance - value - intrinsic_gas * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=target_initial_balance + value),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_intrinsic_charges_recipient_is_coinbase(
+    env: Environment,
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient is the block coinbase, which is implicitly warm before
+    transaction execution. The intrinsic charge still includes
+    ``COLD_ACCOUNT_ACCESS`` for the recipient.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+    target = Address(env.fee_recipient)
+    # Pre-fund coinbase so it is alive at top-frame check time; this
+    # isolates the test to the intrinsic charge invariant and avoids
+    # the orthogonal ``NEW_ACCOUNT`` top-frame state charge that would
+    # otherwise fire for value transfer to an empty recipient.
+    pre.fund_address(target, amount=1)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.EOA,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    gas_price = 1_000_000_000
+    gas_limit = intrinsic_gas + 1000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    # Coinbase also receives miner fees, so its post-tx balance is not
+    # asserted exactly; verifying the sender balance is sufficient to
+    # pin the intrinsic charge.
+    sender_final_balance = (
+        sender_initial_balance - value - intrinsic_gas * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_charges_delegation_in_access_list(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient holds a pre-existing EIP-7702 delegation; the delegation
+    target is listed in the access list. The top-frame still charges
+    ``COLD_ACCOUNT_ACCESS`` for the delegation target on top of the
+    access-list cost itself.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    delegated_to = pre.deploy_contract(code=Op.STOP)
+    target_code = Spec7702.delegation_designation(delegated_to)
+    target = pre.deploy_contract(code=target_code)
+    access_list = [AccessList(address=delegated_to, storage_keys=[])]
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+
+    total_gas_cost = intrinsic_gas + top_frame_gas
+    gas_price = 1_000_000_000
+    gas_limit = total_gas_cost + 1000
+
+    tx = Transaction(
+        ty=1,
+        sender=sender,
+        to=target,
+        value=value,
+        access_list=access_list,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    sender_final_balance = (
+        sender_initial_balance - value - total_gas_cost * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=value, code=target_code),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_charges_delegation_is_coinbase(
+    env: Environment,
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient holds a pre-existing EIP-7702 delegation whose target is
+    the block coinbase. Coinbase is implicitly warm before execution;
+    the top-frame still charges ``COLD_ACCOUNT_ACCESS`` for the
+    delegation target.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    delegated_to = Address(env.fee_recipient)
+    target_code = Spec7702.delegation_designation(delegated_to)
+    target = pre.deploy_contract(code=target_code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+
+    total_gas_cost = intrinsic_gas + top_frame_gas
+    gas_price = 1_000_000_000
+    gas_limit = total_gas_cost + 1000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    # Coinbase also receives miner fees, so its post-tx balance is not
+    # asserted exactly.
+    sender_final_balance = (
+        sender_initial_balance - value - total_gas_cost * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=value, code=target_code),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_sender_is_coinbase(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Sender is the block coinbase. The intrinsic charge is unchanged
+    by sender identity, but the priority-fee payment loops back to
+    the sender, so the net gas cost reduces to ``gas_used *
+    base_fee_per_gas``.
+
+    The coinbase override is wired via a custom ``Environment`` whose
+    ``fee_recipient`` matches the sender's address.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    target_initial_balance = 100
+    target = pre.fund_eoa(amount=target_initial_balance)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.EOA,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    base_fee = 7
+    gas_price = 1_000_000_000
+    gas_limit = intrinsic_gas + 1000
+    # Sender pays the full gas fee upfront and is credited the
+    # priority fee back as the coinbase: net cost is
+    # ``gas_used * base_fee``.
+    sender_final_balance = (
+        sender_initial_balance - value - intrinsic_gas * base_fee
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=target_initial_balance + value),
+    }
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post=post,
+        env=Environment(fee_recipient=sender, base_fee_per_gas=base_fee),
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_charges_delegation_is_sender(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient holds a pre-existing EIP-7702 delegation whose target is
+    the sender (``tx.origin``). The top-frame still charges
+    ``COLD_ACCOUNT_ACCESS`` for the delegation target; the dispatched
+    EVM frame finds the sender's empty EOA code and exits immediately.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    delegated_to = sender
+    target_code = Spec7702.delegation_designation(delegated_to)
+    target = pre.deploy_contract(code=target_code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+
+    total_gas_cost = intrinsic_gas + top_frame_gas
+    gas_price = 1_000_000_000
+    gas_limit = total_gas_cost + 1000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    sender_final_balance = (
+        sender_initial_balance - value - total_gas_cost * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=value, code=target_code),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_charges_delegation_is_recipient(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient holds a pre-existing EIP-7702 delegation pointing back
+    at itself. The top-frame charges ``COLD_ACCOUNT_ACCESS`` for the
+    delegation target (the recipient itself), and then the dispatched
+    EVM frame runs the recipient's code -- which *is* the delegation
+    prefix ``0xef 01 00 <addr>``. The leading ``0xef`` decodes as the
+    ``INVALID`` opcode, consuming the remaining EVM budget. The
+    intrinsic and top-frame gas remain paid; the value transfer is
+    rolled back.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    # Pre-allocate an EOA that delegates to itself. The 1-wei balance
+    # keeps the account alive at top-frame check time so the
+    # ``NEW_ACCOUNT`` charge does not fire.
+    target = pre.fund_eoa(amount=1, delegation="Self")
+    target_code = Spec7702.delegation_designation(target)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+
+    # The dispatched frame burns the entire EVM budget on the
+    # ``INVALID`` opcode and the value transfer is rolled back, so the
+    # sender pays the full ``gas_limit``.
+    gas_price = 1_000_000_000
+    gas_limit = intrinsic_gas + top_frame_gas + 50_000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    sender_final_balance = sender_initial_balance - gas_limit * gas_price
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        # Value transfer rolled back by the ``INVALID``; the pre-tx
+        # 1-wei balance is preserved.
+        target: Account(balance=1, code=target_code),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_charges_delegation_is_precompile(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient holds a pre-existing EIP-7702 delegation pointing at a
+    precompile address (``IDENTITY``, ``0x04``). The top-frame charges
+    ``COLD_ACCOUNT_ACCESS``; the dispatched EVM frame sets
+    ``disable_precompiles = True`` for delegated calls, so the
+    precompile body does not run. The code lookup at the precompile
+    address returns the empty byte string and the frame exits
+    immediately.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    delegated_to = Address(0x04)
+    target_code = Spec7702.delegation_designation(delegated_to)
+    target = pre.deploy_contract(code=target_code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+    )
+
+    total_gas_cost = intrinsic_gas + top_frame_gas
+    gas_price = 1_000_000_000
+    gas_limit = total_gas_cost + 1000
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        gas_price=gas_price,
+    )
+
+    sender_final_balance = (
+        sender_initial_balance - value - total_gas_cost * gas_price
+    )
+
+    post = {
+        sender: Account(nonce=1, balance=sender_final_balance),
+        target: Account(balance=value, code=target_code),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
@@ -9,6 +9,7 @@ from execution_testing import (
     Alloc,
     Fork,
     Op,
+    RecipientType,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
@@ -25,17 +26,29 @@ pytestmark = [pytest.mark.valid_at("EIP7708"), pytest.mark.mainnet]
 def test_simple_transfer_mainnet(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test that a simple ETH transfer emits a transfer log on mainnet."""
     sender = pre.fund_eoa()
     recipient = pre.nonexistent_account()
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    gas_limit = intrinsic_gas + top_frame_state_gas
 
     tx = Transaction(
         ty=0x02,
         sender=sender,
         to=recipient,
         value=1,
-        gas_limit=21_000,
+        gas_limit=gas_limit,
         expected_receipt=TransactionReceipt(
             logs=[transfer_log(sender, recipient, 1)]
         ),

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -28,6 +28,7 @@ from execution_testing import (
     Header,
     Initcode,
     Op,
+    RecipientType,
     StateTestFiller,
     Transaction,
     TransactionException,
@@ -97,7 +98,14 @@ def test_bal_balance_changes(
         calldata=b"",
         contract_creation=False,
         access_list=[],
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
     )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    total_gas_cost = intrinsic_gas_cost + top_frame_state_gas
     # Hard-coded gas price allows to calculate the tx final price
     gas_price = 1_000_000_000
     tx_value = 100
@@ -115,7 +123,7 @@ def test_bal_balance_changes(
 
     # Account for both the value sent and gas cost (gas_price * gas_used)
     alice_final_balance = (
-        alice_initial_balance - tx_value - (intrinsic_gas_cost * gas_price)
+        alice_initial_balance - tx_value - (total_gas_cost * gas_price)
     )
 
     block = Block(
@@ -495,8 +503,15 @@ def test_bal_block_rewards(
         calldata=b"",
         contract_creation=False,
         access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
     )
-    tx_gas_limit = intrinsic_gas + 1000  # add a small buffer
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    expected_gas_used = intrinsic_gas + top_frame_state_gas
+    tx_gas_limit = expected_gas_used + 1000  # add a small buffer
     gas_price = 0xA
     tx_value = 100
     extra_balance = 1000
@@ -516,7 +531,7 @@ def test_bal_block_rewards(
 
     # EIP-1559 fee calculation:
     # - Total gas cost
-    total_gas_cost = intrinsic_gas * gas_price
+    total_gas_cost = expected_gas_used * gas_price
     # - Tip portion
 
     genesis_env = Environment(base_fee_per_gas=0x7)
@@ -525,7 +540,7 @@ def test_bal_block_rewards(
         parent_gas_used=0,
         parent_gas_limit=genesis_env.gas_limit,
     )
-    tip_to_charlie = (gas_price - base_fee_per_gas) * intrinsic_gas
+    tip_to_charlie = (gas_price - base_fee_per_gas) * expected_gas_used
 
     alice_final_balance = alice_initial_balance - tx_value - total_gas_cost
 
@@ -903,7 +918,9 @@ def test_bal_self_transfer(
     alice = pre.fund_eoa(amount=start_balance)
 
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_gas_cost = intrinsic_gas_calculator()
+    intrinsic_gas_cost = intrinsic_gas_calculator(
+        recipient_type=RecipientType.SELF
+    )
 
     tx = Transaction(
         sender=alice,
@@ -947,7 +964,9 @@ def test_bal_zero_value_transfer(
     bob = pre.fund_eoa(amount=100)
 
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_gas_cost = intrinsic_gas_calculator()
+    intrinsic_gas_cost = intrinsic_gas_calculator(
+        recipient_type=RecipientType.EOA
+    )
 
     tx = Transaction(
         sender=alice,
@@ -1538,8 +1557,14 @@ def test_bal_coinbase_zero_tip(
         calldata=b"",
         contract_creation=False,
         access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
     )
-    tx_gas_limit = intrinsic_gas + 1000
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    tx_gas_limit = intrinsic_gas + top_frame_state_gas + 1000
 
     # Calculate base fee
     genesis_env = Environment(base_fee_per_gas=0x7)
@@ -1562,7 +1587,9 @@ def test_bal_coinbase_zero_tip(
     )
 
     alice_final_balance = (
-        alice_initial_balance - tx_value - (intrinsic_gas * base_fee_per_gas)
+        alice_initial_balance
+        - tx_value
+        - ((intrinsic_gas + top_frame_state_gas) * base_fee_per_gas)
     )
 
     block = Block(
@@ -2022,11 +2049,21 @@ def test_bal_multiple_balance_changes_same_account(
     charlie = pre.fund_eoa(amount=0)
 
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    tx_intrinsic_gas = intrinsic_gas_calculator(calldata=b"", access_list=[])
+    tx_intrinsic_gas = intrinsic_gas_calculator(
+        calldata=b"",
+        access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
 
     # bob receives funds in tx0, then spends everything in tx1
     gas_price = 10
-    tx1_gas_cost = tx_intrinsic_gas * gas_price
+    expected_gas_used = tx_intrinsic_gas + top_frame_state_gas
+    tx1_gas_cost = expected_gas_used * gas_price
     spend_amount = 100
     funding_amount = tx1_gas_cost + spend_amount
 
@@ -2034,7 +2071,7 @@ def test_bal_multiple_balance_changes_same_account(
         sender=alice,
         to=bob,
         value=funding_amount,
-        gas_limit=tx_intrinsic_gas,
+        gas_limit=expected_gas_used,
         gas_price=gas_price,
     )
 
@@ -2042,7 +2079,7 @@ def test_bal_multiple_balance_changes_same_account(
         sender=bob,
         to=charlie,
         value=spend_amount,
-        gas_limit=tx_intrinsic_gas,
+        gas_limit=expected_gas_used,
         gas_price=gas_price,
     )
 
@@ -2949,6 +2986,8 @@ def test_bal_cross_tx_funding_chain(
     target = pre.deploy_contract(code=target_code)
 
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    # Last hop (eunice -> target) is a plain CONTRACT call with no
+    # value, so the default intrinsic applies.
     intrinsic_gas = intrinsic_calc()
     eunice_exact_gas = intrinsic_gas + target_code.gas_cost(fork)
     eunice_gas_limit = (
@@ -2957,7 +2996,21 @@ def test_bal_cross_tx_funding_chain(
         else eunice_exact_gas
     )
     eunice_upfront = eunice_gas_limit * gas_price
-    transfer_cost = intrinsic_gas * gas_price
+    # Forwarding hops (alice -> bob, ..., dan -> eunice) transfer value
+    # to recipients that begin empty, so each pays the value-transfer
+    # intrinsic surcharges plus the top-frame ``NEW_ACCOUNT`` state
+    # charge that fires under EIP-2780. With the default zero
+    # state-gas reservoir the latter spills entirely into regular gas.
+    forwarding_intrinsic = intrinsic_calc(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    forwarding_top_frame_state = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    forwarding_gas = forwarding_intrinsic + forwarding_top_frame_state
+    transfer_cost = forwarding_gas * gas_price
 
     # Each sender (including alice) starts with or receives exactly what
     # the next forward + its own gas demands; everyone ends at zero in
@@ -2990,28 +3043,28 @@ def test_bal_cross_tx_funding_chain(
             sender=alice,
             to=bob,
             value=alice_value,
-            gas_limit=intrinsic_gas,
+            gas_limit=forwarding_gas,
             gas_price=gas_price,
         ),
         Transaction(
             sender=bob,
             to=charlie,
             value=bob_value,
-            gas_limit=intrinsic_gas,
+            gas_limit=forwarding_gas,
             gas_price=gas_price,
         ),
         Transaction(
             sender=charlie,
             to=dan,
             value=charlie_value,
-            gas_limit=intrinsic_gas,
+            gas_limit=forwarding_gas,
             gas_price=gas_price,
         ),
         Transaction(
             sender=dan,
             to=eunice,
             value=dan_value,
-            gas_limit=intrinsic_gas,
+            gas_limit=forwarding_gas,
             gas_price=gas_price,
         ),
         Transaction(
@@ -3628,7 +3681,11 @@ def test_bal_gas_limit_boundary(
 
     if with_tx:
         alice = pre.fund_eoa()
-        bob = pre.fund_eoa(amount=0)
+        # Fund bob with 1 wei so the recipient is alive at top-frame
+        # check time; this avoids the EIP-2780 ``NEW_ACCOUNT`` state
+        # charge that would otherwise inflate the tx's gas needs past
+        # the BAL-sized ``block_gas_limit``.
+        bob = pre.fund_eoa(amount=1)
         # alice (sender) + bob (recipient) + coinbase (EIP-3651 warm).
         extra_items += 3
         txs.append(
@@ -3644,10 +3701,10 @@ def test_bal_gas_limit_boundary(
         )
         expected_accounts[bob] = BalAccountExpectation(
             balance_changes=[
-                BalBalanceChange(block_access_index=1, post_balance=1)
+                BalBalanceChange(block_access_index=1, post_balance=2)
             ],
         )
-        post[bob] = Account(balance=1)
+        post[bob] = Account(balance=2)
 
     if with_cl_withdrawal:
         charlie = pre.fund_eoa(amount=0)

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip4895.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip4895.py
@@ -21,6 +21,7 @@ from execution_testing import (
     Header,
     Initcode,
     Op,
+    RecipientType,
     Transaction,
     Withdrawal,
     compute_create_address,
@@ -730,7 +731,15 @@ def test_bal_withdrawal_to_coinbase(
     coinbase = pre.fund_eoa(amount=0)
 
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_gas = intrinsic_gas_calculator()
+    intrinsic_gas = intrinsic_gas_calculator(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    total_intrinsic_gas = intrinsic_gas + top_frame_state_gas
 
     # Calculate tip to coinbase
     genesis_env = Environment(base_fee_per_gas=0x7)
@@ -755,11 +764,11 @@ def test_bal_withdrawal_to_coinbase(
         sender=alice,
         to=bob,
         value=tx_value,
-        gas_limit=intrinsic_gas,
+        gas_limit=total_intrinsic_gas,
         **tx_kwargs,
     )
 
-    tip_to_coinbase = priority_fee * intrinsic_gas
+    tip_to_coinbase = priority_fee * total_intrinsic_gas
     withdrawal_amount = 10
     coinbase_final_balance = tip_to_coinbase + (withdrawal_amount * GWEI)
 

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
@@ -28,6 +28,7 @@ from execution_testing import (
     Header,
     Initcode,
     Op,
+    RecipientType,
     Storage,
     Transaction,
     Withdrawal,
@@ -1464,14 +1465,21 @@ def test_bal_invalid_missing_coinbase(
         calldata=b"",
         contract_creation=False,
         access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
     )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    total_intrinsic_gas = intrinsic_gas + top_frame_state_gas
     gas_price = 0xA
 
     tx = Transaction(
         sender=alice,
         to=bob,
         value=100,
-        gas_limit=intrinsic_gas + 1000,
+        gas_limit=total_intrinsic_gas + 1000,
         gas_price=gas_price,
     )
 
@@ -1481,7 +1489,7 @@ def test_bal_invalid_missing_coinbase(
         parent_gas_used=0,
         parent_gas_limit=genesis_env.gas_limit,
     )
-    tip = (gas_price - base_fee_per_gas) * intrinsic_gas
+    tip = (gas_price - base_fee_per_gas) * total_intrinsic_gas
 
     blockchain_test(
         pre=pre,
@@ -1546,14 +1554,21 @@ def test_bal_invalid_coinbase_balance_value(
         calldata=b"",
         contract_creation=False,
         access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
     )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    total_intrinsic_gas = intrinsic_gas + top_frame_state_gas
     gas_price = 0xA
 
     tx = Transaction(
         sender=alice,
         to=bob,
         value=100,
-        gas_limit=intrinsic_gas + 1000,
+        gas_limit=total_intrinsic_gas + 1000,
         gas_price=gas_price,
     )
 
@@ -1563,7 +1578,7 @@ def test_bal_invalid_coinbase_balance_value(
         parent_gas_used=0,
         parent_gas_limit=genesis_env.gas_limit,
     )
-    tip = (gas_price - base_fee_per_gas) * intrinsic_gas
+    tip = (gas_price - base_fee_per_gas) * total_intrinsic_gas
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_additional_coverage.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_additional_coverage.py
@@ -144,6 +144,11 @@ class TestTokenCalculation:
         expected_intrinsic_cost = gas_costs.TX_BASE + (
             expected_standard_tokens * gas_costs.TX_DATA_TOKEN_STANDARD
         )
+        if fork.is_eip_enabled(2780):
+            # EIP-2780 surfaces an explicit recipient-access charge for
+            # non-self, non-create transactions; the ``to`` fixture
+            # defaults to a deployed contract, so the charge applies.
+            expected_intrinsic_cost += gas_costs.COLD_ACCOUNT_ACCESS
         assert intrinsic_cost_before_execution == expected_intrinsic_cost, (
             f"Intrinsic cost mismatch for {description}: "
             f"{intrinsic_cost_before_execution} != {expected_intrinsic_cost} "

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.valid_at("EIP7976")
 @pytest.mark.parametrize(
     "zero_bytes",
     [
-        pytest.param(100, id="100_zero_bytes"),
+        pytest.param(200, id="200_zero_bytes"),
         pytest.param(1000, id="1000_zero_bytes"),
     ],
 )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -622,7 +622,9 @@ def test_tx_inclusion_at_regular_gas_block_limit_small(
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+    )
 
     block_gas_limit = intrinsic_gas * 2
 
@@ -630,6 +632,7 @@ def test_tx_inclusion_at_regular_gas_block_limit_small(
     filler_tx = Transaction(
         to=filler,
         gas_limit=intrinsic_gas,
+        value=1,
         sender=pre.fund_eoa(),
     )
 
@@ -640,6 +643,7 @@ def test_tx_inclusion_at_regular_gas_block_limit_small(
     second_tx = Transaction(
         to=second,
         gas_limit=second_gas_limit,
+        value=1,
         sender=pre.fund_eoa(),
         error=error,
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2294,7 +2294,7 @@ def test_selfdestruct_in_create_tx_initcode(
     sender = pre.fund_eoa()
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     intrinsic_total = intrinsic_calc(
-        calldata=bytes(initcode), contract_creation=True
+        calldata=bytes(initcode), contract_creation=True, sends_value=True
     )
 
     expected_state = create_state_gas + gas_costs.NEW_ACCOUNT

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -58,6 +58,10 @@ def test_exact_coinbase_fee_simple_sstore(
     # Gas breakdown for tx 1 (SSTORE zero-to-nonzero, no calldata):
     # PUSH1(1) + PUSH1(0) + SSTORE(cold, zero-to-nonzero) + STOP
     intrinsic_regular = gas_costs.TX_BASE
+    if fork.is_eip_enabled(2780):
+        # EIP-2780 surfaces an explicit recipient-access charge for
+        # non-self, non-create transactions on top of ``TX_BASE``.
+        intrinsic_regular += gas_costs.COLD_ACCOUNT_ACCESS
     evm_regular = (
         2 * gas_costs.VERY_LOW  # PUSH1 + PUSH1
         + gas_costs.COLD_STORAGE_WRITE  # SSTORE cold zero-to-nonzero

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -235,6 +235,7 @@ def test_transaction_intrinsic_gas_cost(
         calldata=tx_data,
         contract_creation=contract_creation,
         access_list=access_lists,
+        sends_value=True,
     )
     if not enough_gas:
         tx_gas_limit -= 1

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -9,6 +9,7 @@ from execution_testing import (
     Environment,
     Fork,
     Hash,
+    RecipientType,
     Transaction,
     TransitionFork,
     add_kzg_version,
@@ -333,12 +334,20 @@ def non_zero_blob_gas_used_genesis_block(
     ]
 
     def create_blob_transaction(blob_range: Iterable[int]) -> Transaction:
+        intrinsic_gas = block_fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+            sends_value=True,
+        )
+        top_frame_gas = block_fork.transaction_top_frame_state_gas(
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+            sends_value=True,
+        )
         return Transaction(
             ty=Spec.BLOB_TX_TYPE,
             sender=sender,
             to=empty_account_destination,
             value=1,
-            gas_limit=21_000,
+            gas_limit=intrinsic_gas + top_frame_gas,
             max_fee_per_gas=tx_max_fee_per_gas,
             max_priority_fee_per_gas=0,
             max_fee_per_blob_gas=blob_gas_price_calculator(

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -33,6 +33,7 @@ from execution_testing import (
     Hash,
     Header,
     Op,
+    RecipientType,
     Removable,
     StateTestFiller,
     Storage,
@@ -75,19 +76,93 @@ def destination_account(
     return pre.fund_eoa(destination_account_balance)
 
 
+def _destination_recipient_type(
+    destination_account_code: Bytecode | None,
+    destination_account_balance: int,
+) -> RecipientType:
+    if destination_account_code is not None:
+        return RecipientType.CONTRACT
+    if destination_account_balance == 0:
+        return RecipientType.EMPTY_ACCOUNT
+    return RecipientType.EOA
+
+
 @pytest.fixture
 def tx_gas(
     fork: Fork | TransitionFork,
     tx_calldata: bytes,
     tx_access_list: List[AccessList],
+    tx_value: int,
+    destination_account_code: Bytecode | None,
+    destination_account_balance: int,
 ) -> int:
     """Gas allocated to transactions sent during test."""
+    post_transition_fork = fork.transitions_to()
     tx_intrinsic_cost_calculator = (
-        fork.transitions_to().transaction_intrinsic_cost_calculator()
+        post_transition_fork.transaction_intrinsic_cost_calculator()
     )
-    return tx_intrinsic_cost_calculator(
-        calldata=tx_calldata, access_list=tx_access_list
+    recipient_type = _destination_recipient_type(
+        destination_account_code, destination_account_balance
     )
+    sends_value = tx_value > 0
+    intrinsic = tx_intrinsic_cost_calculator(
+        calldata=tx_calldata,
+        access_list=tx_access_list,
+        recipient_type=recipient_type,
+        sends_value=sends_value,
+    )
+    top_frame_state = post_transition_fork.transaction_top_frame_state_gas(
+        recipient_type=recipient_type,
+        sends_value=sends_value,
+    )
+    return intrinsic + top_frame_state
+
+
+@pytest.fixture
+def tx_gas_per_tx(
+    fork: Fork | TransitionFork,
+    tx_gas: int,
+    tx_calldata: bytes,
+    tx_access_list: List[AccessList],
+    tx_value: int,
+    destination_account_code: Bytecode | None,
+    destination_account_balance: int,
+    blob_hashes_per_tx: List[List[bytes]],
+) -> List[int]:
+    """
+    Gas allocated to each transaction in the block.
+
+    After the first value-sending tx to an initially-empty destination,
+    the recipient is no longer empty, so the EIP-2780 top-frame
+    ``NEW_ACCOUNT`` state-gas charge does not fire on subsequent txs.
+    """
+    n_txs = len(blob_hashes_per_tx)
+    if n_txs <= 1:
+        return [tx_gas] * n_txs
+
+    destination_starts_empty = (
+        destination_account_code is None and destination_account_balance == 0
+    )
+    if destination_starts_empty and tx_value > 0:
+        post_transition_fork = fork.transitions_to()
+        intrinsic_calc = (
+            post_transition_fork.transaction_intrinsic_cost_calculator()
+        )
+        intrinsic = intrinsic_calc(
+            calldata=tx_calldata,
+            access_list=tx_access_list,
+            recipient_type=RecipientType.EOA,
+            sends_value=True,
+        )
+        top_frame_state = post_transition_fork.transaction_top_frame_state_gas(
+            recipient_type=RecipientType.EOA,
+            sends_value=True,
+        )
+        tx_gas_nonempty = intrinsic + top_frame_state
+    else:
+        tx_gas_nonempty = tx_gas
+
+    return [tx_gas] + [tx_gas_nonempty] * (n_txs - 1)
 
 
 @pytest.fixture
@@ -124,7 +199,7 @@ def blob_hashes_per_tx(blobs_per_tx: List[int]) -> List[List[Hash]]:
 @pytest.fixture
 def total_account_minimum_balance(  # noqa: D103
     blob_gas_per_blob: int,
-    tx_gas: int,
+    tx_gas_per_tx: List[int],
     tx_value: int,
     tx_max_fee_per_gas: int,
     tx_max_fee_per_blob_gas: int,
@@ -135,15 +210,17 @@ def total_account_minimum_balance(  # noqa: D103
     transactions in the block of the test.
     """
     minimum_cost = 0
-    for tx_blob_count in [len(x) for x in blob_hashes_per_tx]:
+    for tx_i, tx_blob_count in enumerate(len(x) for x in blob_hashes_per_tx):
         blob_cost = tx_max_fee_per_blob_gas * blob_gas_per_blob * tx_blob_count
-        minimum_cost += (tx_gas * tx_max_fee_per_gas) + tx_value + blob_cost
+        minimum_cost += (
+            (tx_gas_per_tx[tx_i] * tx_max_fee_per_gas) + tx_value + blob_cost
+        )
     return minimum_cost
 
 
 @pytest.fixture
 def total_account_transactions_fee(  # noqa: D103
-    tx_gas: int,
+    tx_gas_per_tx: List[int],
     tx_value: int,
     blob_gas_price: int,
     block_base_fee_per_gas: int,
@@ -156,7 +233,7 @@ def total_account_transactions_fee(  # noqa: D103
     Calculate actual fee for the blob transactions in the block of the test.
     """
     total_cost = 0
-    for tx_blob_count in [len(x) for x in blob_hashes_per_tx]:
+    for tx_i, tx_blob_count in enumerate(len(x) for x in blob_hashes_per_tx):
         blob_cost = blob_gas_price * blob_gas_per_blob * tx_blob_count
         block_producer_fee = (
             tx_max_fee_per_gas - block_base_fee_per_gas
@@ -164,7 +241,7 @@ def total_account_transactions_fee(  # noqa: D103
             else 0
         )
         total_cost += (
-            (tx_gas * (block_base_fee_per_gas + block_producer_fee))
+            tx_gas_per_tx[tx_i] * (block_base_fee_per_gas + block_producer_fee)
             + tx_value
             + blob_cost
         )
@@ -208,7 +285,7 @@ def sender(pre: Alloc, sender_initial_balance: int) -> Address:  # noqa: D103
 def txs(  # noqa: D103
     sender: EOA,
     destination_account: Optional[Address],
-    tx_gas: int,
+    tx_gas_per_tx: List[int],
     tx_value: int,
     tx_calldata: bytes,
     tx_max_fee_per_gas: int,
@@ -225,7 +302,7 @@ def txs(  # noqa: D103
             sender=sender,
             to=destination_account,
             value=tx_value,
-            gas_limit=tx_gas,
+            gas_limit=tx_gas_per_tx[tx_i],
             data=tx_calldata,
             max_fee_per_gas=tx_max_fee_per_gas,
             max_priority_fee_per_gas=tx_max_priority_fee_per_gas,
@@ -754,6 +831,7 @@ def test_sufficient_balance_blob_tx(
 @pytest.mark.valid_from("Cancun")
 def test_sufficient_balance_blob_tx_pre_fund_tx(
     blockchain_test: BlockchainTestFiller,
+    fork: Fork,
     total_account_minimum_balance: int,
     sender: EOA,
     env: Environment,
@@ -773,15 +851,29 @@ def test_sufficient_balance_blob_tx_pre_fund_tx(
     - Transactions with max fee per blob gas lower or higher than the priority
         fee
     """
+    recipient_type = (
+        RecipientType.EOA if sender in pre else RecipientType.EMPTY_ACCOUNT
+    )
+    sends_value = total_account_minimum_balance > 0
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas = intrinsic_calc(
+        recipient_type=recipient_type,
+        sends_value=sends_value,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=recipient_type,
+        sends_value=sends_value,
+    )
+    pre_funding_gas_limit = intrinsic_gas + top_frame_state_gas
     pre_funding_sender = pre.fund_eoa(
-        amount=(21_000 * 100) + total_account_minimum_balance
+        amount=(pre_funding_gas_limit * 100) + total_account_minimum_balance
     )
     txs = [
         Transaction(
             sender=pre_funding_sender,
             to=sender,
             value=total_account_minimum_balance,
-            gas_limit=21_000,
+            gas_limit=pre_funding_gas_limit,
         )
     ] + txs
     blockchain_test(

--- a/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code.py
+++ b/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code.py
@@ -152,6 +152,14 @@ def test_create2_oo_gafter_init_code(
             + (gas_costs.OPCODE_CREATE_BASE - _cancun_create_base)
             - gas_costs.CODE_DEPOSIT_PER_BYTE * _deploy_size
         )
+    # EIP-2780 reshapes the tx intrinsic for non-self non-value txs:
+    # ``TX_BASE`` drops to 12_000 and an explicit
+    # ``COLD_ACCOUNT_ACCESS`` (3_000) recipient charge is added. The
+    # original test was built against Cancun's flat ``TX_BASE`` of
+    # 21_000, so shift the budget by the intrinsic delta to keep the
+    # straddle landing at the same RETURN point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    _oog_lift += intrinsic - 21_000
     tx_gas = [54000 + _oog_lift, 55000 + _oog_lift]
 
     tx = Transaction(

--- a/tests/ported_static/stCreateTest/test_create_oo_gafter_init_code.py
+++ b/tests/ported_static/stCreateTest/test_create_oo_gafter_init_code.py
@@ -148,6 +148,14 @@ def test_create_oo_gafter_init_code(
             + (gas_costs.OPCODE_CREATE_BASE - _cancun_create_base)
             - gas_costs.CODE_DEPOSIT_PER_BYTE * _deploy_size
         )
+    # EIP-2780 reshapes the tx intrinsic for non-self non-value txs:
+    # ``TX_BASE`` drops to 12_000 and an explicit
+    # ``COLD_ACCOUNT_ACCESS`` (3_000) recipient charge is added. The
+    # original test was built against Cancun's flat ``TX_BASE`` of
+    # 21_000, so shift the budget by the intrinsic delta to keep the
+    # straddle landing at the same RETURN point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    _oog_lift += intrinsic - 21_000
     tx_gas = [54000 + _oog_lift, 55000 + _oog_lift]
 
     tx = Transaction(

--- a/tests/ported_static/stEIP150Specific/test_call_and_callcode_consume_more_gas_then_transaction_has.py
+++ b/tests/ported_static/stEIP150Specific/test_call_and_callcode_consume_more_gas_then_transaction_has.py
@@ -3,6 +3,16 @@ Test_call_and_callcode_consume_more_gas_then_transaction_has.
 
 Ported from:
 state_tests/stEIP150Specific/CallAndCallcodeConsumeMoreGasThenTransactionHasFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts
+`storage[8] = 0x8D5B6` captured by `Op.GAS`, which depends on the exact
+post-intrinsic execution budget. The original hardcoded `gas_limit` of
+600_000 was built against Cancun's `TX_BASE` of 21_000; EIP-2780 lowers
+the intrinsic for non-self non-value txs, so `gas_limit` is derived as
+`600_000 + (intrinsic - 21_000)` from `transaction_intrinsic_cost_calculator`
+to shift by the fork intrinsic delta and keep the Op.GAS assertion correct.
+The `- 21_000` is the pre-EIP-2780 baseline intrinsic, so the adjustment
+is exactly 0 pre-repricing. Do not hardcode the literal gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stEIP150Specific/test_call_and_callcode_consume_more_gas_then_transaction_has.py
+++ b/tests/ported_static/stEIP150Specific/test_call_and_callcode_consume_more_gas_then_transaction_has.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_call_and_callcode_consume_more_gas_then_transaction_has(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_and_callcode_consume_more_gas_then_transaction_has."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -83,11 +85,19 @@ def test_call_and_callcode_consume_more_gas_then_transaction_has(
         nonce=0,
     )
 
+    # The original test was built against Cancun's ``TX_BASE`` of
+    # 21_000. EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, so shift ``gas_limit`` by the intrinsic delta to preserve
+    # the post-intrinsic execution budget the Op.GAS storage
+    # assertions depend on.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {target: Account(storage={0: 18, 8: 0x8D5B6, 9: 1, 10: 1})}

--- a/tests/ported_static/stEIP150Specific/test_call_goes_oog_on_second_level.py
+++ b/tests/ported_static/stEIP150Specific/test_call_goes_oog_on_second_level.py
@@ -3,6 +3,14 @@ Test_call_goes_oog_on_second_level.
 
 Ported from:
 state_tests/stEIP150Specific/CallGoesOOGOnSecondLevelFiller.json
+
+@manually-enhanced: Do not overwrite. The `gas_limit` is derived from
+the fork intrinsic calculator instead of the original hardcoded value.
+The test fixes the post-intrinsic budget that the nested Op.GAS storage
+assertions (8: 0x927BE, 8: 0x213FB6) depend on, so it shifts the base
+2_200_000 budget by the intrinsic delta versus the pre-EIP-2780 Cancun
+baseline of 21_000 (`intrinsic - 21_000`). This stays correct across
+the EIP-2780 intrinsic decomposition. Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stEIP150Specific/test_call_goes_oog_on_second_level.py
+++ b/tests/ported_static/stEIP150Specific/test_call_goes_oog_on_second_level.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -29,6 +30,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_call_goes_oog_on_second_level(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_goes_oog_on_second_level."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -93,11 +95,19 @@ def test_call_goes_oog_on_second_level(
         nonce=0,
     )
 
+    # The original test was built against Cancun's ``TX_BASE`` of
+    # 21_000. EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, so shift ``gas_limit`` by the intrinsic delta to preserve
+    # the post-intrinsic execution budget the Op.GAS storage
+    # assertions depend on.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 2_200_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=2200000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stEIP1559/test_low_gas_limit.py
+++ b/tests/ported_static/stEIP1559/test_low_gas_limit.py
@@ -3,6 +3,13 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP1559/lowGasLimitFiller.yml
+
+@manually-enhanced: Do not overwrite. The `-g3` case must sit just below
+the fork intrinsic to trigger `INTRINSIC_GAS_TOO_LOW`. EIP-2780 decomposes
+and lowers the intrinsic, so the original hardcoded `20000` is no longer
+below it; instead derive `intrinsic - 1` from the fork's
+`transaction_intrinsic_cost_calculator()` for the single zero-byte
+calldata so the boundary stays correct across the repricing.
 """
 
 import pytest

--- a/tests/ported_static/stEIP1559/test_low_gas_limit.py
+++ b/tests/ported_static/stEIP1559/test_low_gas_limit.py
@@ -129,7 +129,13 @@ def test_low_gas_limit(
     tx_data = [
         Bytes("00"),
     ]
-    tx_gas = [90000, 50000, 25000, 20000]
+    # -g3 must sit below the fork's intrinsic to trigger
+    # ``INTRINSIC_GAS_TOO_LOW``. EIP-2780 lowers the intrinsic so the
+    # original ``20000`` is no longer below it; derive the boundary.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=Bytes("00"),
+    )
+    tx_gas = [90000, 50000, 25000, intrinsic - 1]
     tx_access_lists: dict[int, list] = {
         0: [],
     }

--- a/tests/ported_static/stEIP2930/test_transaction_costs.py
+++ b/tests/ported_static/stEIP2930/test_transaction_costs.py
@@ -3,6 +3,16 @@ Ori Pomerantz qbzzt1@gmail.com.
 
 Ported from:
 state_tests/stEIP2930/transactionCostsFiller.yml
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance after a STOP-only call. For Amsterdam+ it is derived from
+`fork.transaction_intrinsic_cost_calculator()` (over calldata,
+access_list, and sends_value) as `pre_balance - tx.value -
+intrinsic_gas * gas_price`, instead of a hardcoded literal, so the
+access-list-heavy cases stay correct across the EIP-2780 intrinsic
+decomposition and EIP-7981/EIP-8038 access-list repricing. Pre-Amsterdam
+forks (Cancun/Prague) keep their original hardcoded balances. No
+21_000 baseline or SSTORE-clear constants are subtracted here.
 """
 
 import pytest

--- a/tests/ported_static/stEIP2930/test_transaction_costs.py
+++ b/tests/ported_static/stEIP2930/test_transaction_costs.py
@@ -471,6 +471,7 @@ def test_transaction_costs(
             calldata=tx.data,
             contract_creation=tx.to is None,
             access_list=tx.access_list,
+            sends_value=bool(tx.value),
         )
         post[sender] = Account(
             balance=(

--- a/tests/ported_static/stMemExpandingEIP150Calls/test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_expanding_calls.py
+++ b/tests/ported_static/stMemExpandingEIP150Calls/test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_expanding_calls.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_expanding_calls(  # noqa: E501
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_call_and_callcode_consume_more_gas_then_transaction_has_with_m..."""  # noqa: E501
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -82,11 +84,19 @@ def test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_expand
         nonce=0,
     )
 
+    # The original test was built against Cancun's ``TX_BASE`` of
+    # 21_000. EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, so shift ``gas_limit`` by the intrinsic delta to preserve
+    # the post-intrinsic execution budget the Op.GAS storage
+    # assertion depends on.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stMemExpandingEIP150Calls/test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_expanding_calls.py
+++ b/tests/ported_static/stMemExpandingEIP150Calls/test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_expanding_calls.py
@@ -3,6 +3,14 @@ Test_call_and_callcode_consume_more_gas_then_transaction_has_with_mem_ex...
 
 Ported from:
 state_tests/stMemExpandingEIP150Calls/CallAndCallcodeConsumeMoreGasThenTransactionHasWithMemExpandingCallsFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the
+remaining-gas snapshot stored by `Op.GAS` (slot 8 == 0x8D5B6), which
+fixes the post-intrinsic execution budget. So `gas_limit` is derived
+from the fork as `600_000 + (intrinsic - 21_000)`: it shifts the budget
+by the intrinsic delta from the pre-EIP-2780 Cancun `TX_BASE` baseline
+of 21_000, keeping the budget constant across the EIP-2780 intrinsic
+decomposition and EIP-8038 access repricing. Do not hardcode 600_000.
 """
 
 import pytest

--- a/tests/ported_static/stMemExpandingEIP150Calls/test_delegate_call_on_eip_with_mem_expanding_calls.py
+++ b/tests/ported_static/stMemExpandingEIP150Calls/test_delegate_call_on_eip_with_mem_expanding_calls.py
@@ -3,6 +3,16 @@ Test_delegate_call_on_eip_with_mem_expanding_calls.
 
 Ported from:
 state_tests/stMemExpandingEIP150Calls/DelegateCallOnEIPWithMemExpandingCallsFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the GAS
+opcode value stored at target slot 8 (0x8D5B6), which depends on the
+execution budget left after the intrinsic charge. The original test
+hardcoded `gas_limit` against Cancun's `TX_BASE` of 21_000; EIP-2780
+lowers the intrinsic for non-self non-value txs, so `gas_limit` is
+derived from the fork as `600_000 + (intrinsic - 21_000)`, subtracting
+the pre-EIP-2780 baseline 21_000 so the budget is invariant across the
+intrinsic decomposition and EIP-8038 access repricing. Do not hardcode
+the literal gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stMemExpandingEIP150Calls/test_delegate_call_on_eip_with_mem_expanding_calls.py
+++ b/tests/ported_static/stMemExpandingEIP150Calls/test_delegate_call_on_eip_with_mem_expanding_calls.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_delegate_call_on_eip_with_mem_expanding_calls(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_delegate_call_on_eip_with_mem_expanding_calls."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -69,11 +71,19 @@ def test_delegate_call_on_eip_with_mem_expanding_calls(
         nonce=0,
     )
 
+    # The original test was built against Cancun's ``TX_BASE`` of
+    # 21_000. EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, so shift ``gas_limit`` by the intrinsic delta to preserve
+    # the post-intrinsic execution budget the Op.GAS storage
+    # assertion depends on.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stRefundTest/test_refund50_1.py
+++ b/tests/ported_static/stRefundTest/test_refund50_1.py
@@ -77,15 +77,18 @@ def test_refund50_1(
         gas_limit=100000,
     )
 
-    # EIP-8038 raises each cold SSTORE-clear charge; with the EIP-3529
-    # refund cap binding, gas_used rises by 4/5 of the extra charge.
+    # EIP-8038 raises each cold SSTORE-clear charge and EIP-2780
+    # shifts the tx intrinsic. With the EIP-3529 refund cap binding,
+    # gas_used rises by 4/5 of the gross-gas delta.
     cold_clear_delta = (
         Op.SSTORE.with_metadata(
             key_warm=False, original_value=1, current_value=1, new_value=0
         ).gas_cost(fork)
         - 5000
     )
-    extra_gas_used = 5 * cold_clear_delta * 4 // 5
+    intrinsic_delta = fork.transaction_intrinsic_cost_calculator()() - 21_000
+    gross_delta = 5 * cold_clear_delta + intrinsic_delta
+    extra_gas_used = gross_delta * 4 // 5
 
     post = {
         target: Account(storage={}),

--- a/tests/ported_static/stRefundTest/test_refund_ff.py
+++ b/tests/ported_static/stRefundTest/test_refund_ff.py
@@ -85,7 +85,12 @@ def test_refund_ff(
         ).gas_cost(fork)
         - 7600
     )
+    # EIP-2780 lowers the intrinsic for non-self non-value txs; the
+    # delta is negative on Amsterdam, so it reduces ``gas_used`` and
+    # raises the sender balance correspondingly.
+    intrinsic_delta = fork.transaction_intrinsic_cost_calculator()() - 21_000
+    gas_used_delta = selfdestruct_delta + intrinsic_delta
 
-    post = {sender: Account(balance=0xE8D4A51000 - 1000 * selfdestruct_delta)}
+    post = {sender: Account(balance=0xE8D4A51000 - 1000 * gas_used_delta)}
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_get_ether_back.py
+++ b/tests/ported_static/stRefundTest/test_refund_get_ether_back.py
@@ -76,24 +76,35 @@ def test_refund_get_ether_back(
     )
 
     # Gas used = gross gas minus the capped storage-clear refund. The
-    # non-SSTORE gross gas is fork-invariant: the intrinsic transaction
-    # cost plus the two PUSH1s that feed the single SSTORE (STOP is free).
+    # non-SSTORE gross gas comes from the fork's intrinsic calculator
+    # (covers TX_BASE and any EIP-2780 recipient/value surcharges)
+    # plus the two PUSH1s that feed the single SSTORE (STOP is free).
     gas_costs = fork.gas_costs()
-    base_gross = gas_costs.TX_BASE + 2 * gas_costs.VERY_LOW
+    # ``return_cost_deducted_prior_execution=True`` returns the
+    # upfront-deducted intrinsic only (Prague's calc would otherwise
+    # return ``max(intrinsic, EIP-7623 floor)``).
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(tx.value),
+        return_cost_deducted_prior_execution=True,
+    )
+    base_gross = intrinsic + 2 * gas_costs.VERY_LOW
+    cancun_base_gross = 21_000 + 2 * gas_costs.VERY_LOW
 
-    def clear_gas_used(sstore_charge: int, clear_refund: int) -> int:
-        gross = base_gross + sstore_charge
+    def clear_gas_used(
+        sstore_charge: int, clear_refund: int, gross_base: int
+    ) -> int:
+        gross = gross_base + sstore_charge
         return gross - min(clear_refund, gross // 5)
 
     sstore_charge = Op.SSTORE.with_metadata(
         key_warm=False, original_value=1, current_value=1, new_value=0
     ).gas_cost(fork)
     # Cancun charges 5000 for the clear and refunds 4800; subtracting the
-    # same model evaluated at those constants makes this exactly 0 before
-    # the EIP-8037/8038 repricing.
+    # same model evaluated at those constants and the Cancun base makes
+    # this exactly 0 before the EIP-8037/8038 repricing.
     gas_used_delta = clear_gas_used(
-        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR
-    ) - clear_gas_used(5000, 4800)
+        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR, base_gross
+    ) - clear_gas_used(5000, 4800, cancun_base_gross)
 
     post = {
         target: Account(storage={}, balance=0xDE0B6B3A764000A),

--- a/tests/ported_static/stRefundTest/test_refund_max.py
+++ b/tests/ported_static/stRefundTest/test_refund_max.py
@@ -107,15 +107,18 @@ def test_refund_max(
         access_list=[],
     )
 
-    # EIP-8038 raises each cold SSTORE-clear charge; with the EIP-3529
-    # refund cap binding, gas_used rises by 4/5 of the extra charge.
+    # EIP-8038 raises each cold SSTORE-clear charge and EIP-2780
+    # shifts the tx intrinsic. With the EIP-3529 refund cap binding,
+    # gas_used rises by 4/5 of the gross-gas delta.
     cold_clear_delta = (
         Op.SSTORE.with_metadata(
             key_warm=False, original_value=1, current_value=1, new_value=0
         ).gas_cost(fork)
         - 5000
     )
-    extra_gas_used = 8 * cold_clear_delta * 4 // 5
+    intrinsic_delta = fork.transaction_intrinsic_cost_calculator()() - 21_000
+    gross_delta = 8 * cold_clear_delta + intrinsic_delta
+    extra_gas_used = gross_delta * 4 // 5
 
     post = {sender: Account(balance=0xE8D55F7E90 - 1000 * extra_gas_used)}
 

--- a/tests/ported_static/stRefundTest/test_refund_multimple_suicide.py
+++ b/tests/ported_static/stRefundTest/test_refund_multimple_suicide.py
@@ -3,6 +3,15 @@ Test_refund_multimple_suicide.
 
 Ported from:
 state_tests/stRefundTest/refund_multimpleSuicideFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which the original fixture hardcoded as 0x61EC43A. EIP-2780
+decomposes the intrinsic cost and lowers it for non-self, non-value
+txs, so the balance is derived from the fork model instead: take
+`fork.transaction_intrinsic_cost_calculator()()` minus the pre-EIP-2780
+baseline 21_000, then add `gas_price (10) * |delta|` back to the sender
+(the delta is negative on Amsterdam). This keeps the adjustment exactly
+0 pre-EIP-2780. Do not hardcode the Amsterdam value.
 """
 
 import pytest

--- a/tests/ported_static/stRefundTest/test_refund_multimple_suicide.py
+++ b/tests/ported_static/stRefundTest/test_refund_multimple_suicide.py
@@ -15,6 +15,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +30,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_multimple_suicide(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund_multimple_suicide."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -151,10 +153,14 @@ def test_refund_multimple_suicide(
         gas_limit=300000,
     )
 
+    # EIP-2780 lowers the intrinsic for non-self non-value txs; the
+    # delta is negative on Amsterdam and raises the sender balance by
+    # ``gas_price * |delta|``.
+    intrinsic_delta = fork.transaction_intrinsic_cost_calculator()() - 21_000
     post = {
         target: Account(balance=0xDE0B6B3A7640000),
         coinbase: Account(balance=0),
-        sender: Account(balance=0x61EC43A, nonce=1),
+        sender: Account(balance=0x61EC43A - 10 * intrinsic_delta, nonce=1),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_no_oog_1.py
+++ b/tests/ported_static/stRefundTest/test_refund_no_oog_1.py
@@ -66,37 +66,47 @@ def test_refund_no_oog_1(
         nonce=0,
     )
 
-    # EIP-8038 raises the cold SSTORE-clear charge; bump the gas limit by
-    # the charge delta so the clear still lands exactly at the limit
-    # (the "no out-of-gas" boundary) instead of running out of gas.
+    # EIP-8038 raises the cold SSTORE-clear charge and EIP-2780 shifts
+    # the tx intrinsic; bump the gas limit by both deltas so the clear
+    # still lands exactly at the limit (the "no out-of-gas" boundary)
+    # instead of running out of gas.
     sstore_charge = Op.SSTORE.with_metadata(
         key_warm=False, original_value=1, current_value=1, new_value=0
     ).gas_cost(fork)
     cold_clear_delta = sstore_charge - 5000
+    # ``return_cost_deducted_prior_execution=True`` returns the
+    # upfront-deducted intrinsic only (Prague's calc would otherwise
+    # return ``max(intrinsic, EIP-7623 floor)``).
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        return_cost_deducted_prior_execution=True,
+    )
+    intrinsic_delta = intrinsic - 21_000
 
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=26006 + cold_clear_delta,
+        gas_limit=26006 + cold_clear_delta + intrinsic_delta,
     )
 
     # Gas used = gross gas minus the capped storage-clear refund. The
-    # non-SSTORE gross gas is fork-invariant: the intrinsic transaction
-    # cost plus the two PUSH1s that feed the single SSTORE (STOP is free).
+    # non-SSTORE gross gas comes from the fork's intrinsic calculator
+    # (covers TX_BASE and any EIP-2780 recipient surcharge) plus the
+    # two PUSH1s that feed the single SSTORE (STOP is free).
     gas_costs = fork.gas_costs()
-    base_gross = gas_costs.TX_BASE + 2 * gas_costs.VERY_LOW
+    base_gross = intrinsic + 2 * gas_costs.VERY_LOW
+    cancun_base_gross = 21_000 + 2 * gas_costs.VERY_LOW
 
-    def clear_gas_used(charge: int, clear_refund: int) -> int:
-        gross = base_gross + charge
+    def clear_gas_used(charge: int, clear_refund: int, gross_base: int) -> int:
+        gross = gross_base + charge
         return gross - min(clear_refund, gross // 5)
 
     # Cancun charges 5000 for the clear and refunds 4800; subtracting the
-    # same model evaluated at those constants makes this exactly 0 before
-    # the EIP-8037/8038 repricing.
+    # same model evaluated at those constants and the Cancun base makes
+    # this exactly 0 before the EIP-8037/8038 repricing.
     gas_used_delta = clear_gas_used(
-        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR
-    ) - clear_gas_used(5000, 4800)
+        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR, base_gross
+    ) - clear_gas_used(5000, 4800, cancun_base_gross)
 
     post = {
         target: Account(storage={}),

--- a/tests/ported_static/stRefundTest/test_refund_single_suicide.py
+++ b/tests/ported_static/stRefundTest/test_refund_single_suicide.py
@@ -15,6 +15,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks import Fork
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -29,6 +30,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_refund_single_suicide(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_refund_single_suicide."""
     coinbase = Address(0xEB201D2887816E041F6E807E804F64F3A7A226FE)
@@ -126,10 +128,14 @@ def test_refund_single_suicide(
         gas_limit=300000,
     )
 
+    # EIP-2780 lowers the intrinsic for non-self non-value txs; the
+    # delta is negative on Amsterdam and raises the sender balance by
+    # ``gas_price * |delta|``.
+    intrinsic_delta = fork.transaction_intrinsic_cost_calculator()() - 21_000
     post = {
         target: Account(balance=0xDE0B6B3A7640000),
         coinbase: Account(balance=0),
-        sender: Account(balance=0x1C5AF34, nonce=1),
+        sender: Account(balance=0x1C5AF34 - 10 * intrinsic_delta, nonce=1),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stRefundTest/test_refund_single_suicide.py
+++ b/tests/ported_static/stRefundTest/test_refund_single_suicide.py
@@ -3,6 +3,15 @@ Test_refund_single_suicide.
 
 Ported from:
 state_tests/stRefundTest/refund_singleSuicideFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance, which the original fixture hardcoded. EIP-2780 decomposes the
+intrinsic and lowers it for this non-self, non-value tx, so the balance
+is derived from the fork: ``intrinsic_delta`` subtracts the pre-EIP-2780
+baseline intrinsic 21_000 from the fork's intrinsic calculator (the
+literal 21_000 is the old TX_BASE), making the delta 0 pre-EIP-2780 and
+negative on Amsterdam. The sender balance is then adjusted by
+``gas_price * intrinsic_delta`` (base fee 10). Do not hardcode it.
 """
 
 import pytest

--- a/tests/ported_static/stRefundTest/test_refund_sstore.py
+++ b/tests/ported_static/stRefundTest/test_refund_sstore.py
@@ -80,27 +80,40 @@ def test_refund_sstore(
     )
 
     # Gas used = gross gas minus the capped storage-clear refund. The
-    # non-SSTORE gross gas is fork-invariant: the intrinsic transaction
-    # cost (including the single zero data byte) plus the PUSH1 and DUP1
-    # that feed the SSTORE (STOP is free).
+    # non-SSTORE gross gas comes from the fork's intrinsic calculator
+    # (covers TX_BASE, calldata, and any EIP-2780 recipient surcharge)
+    # plus the PUSH1 and DUP1 that feed the SSTORE (STOP is free).
     gas_costs = fork.gas_costs()
-    base_gross = (
-        gas_costs.TX_BASE + 2 * gas_costs.VERY_LOW + gas_costs.TX_DATA_PER_ZERO
+    # ``return_cost_deducted_prior_execution=True`` returns the
+    # upfront-deducted intrinsic only. Without it, Prague's
+    # ``intrinsic_calc`` returns ``max(intrinsic, EIP-7623 floor)`` —
+    # the floor only binds for data-heavy txs with little execution,
+    # which is not the case here.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=tx.data,
+        return_cost_deducted_prior_execution=True,
     )
+    base_gross = intrinsic + 2 * gas_costs.VERY_LOW
+    # Cancun's intrinsic for this tx shape was 21_004 (TX_BASE +
+    # single zero-byte). Capture it as the baseline so the Cancun
+    # branch of ``gas_used_delta`` evaluates at the original base.
+    cancun_base_gross = 21_004 + 2 * gas_costs.VERY_LOW
 
-    def clear_gas_used(sstore_charge: int, clear_refund: int) -> int:
-        gross = base_gross + sstore_charge
+    def clear_gas_used(
+        sstore_charge: int, clear_refund: int, gross_base: int
+    ) -> int:
+        gross = gross_base + sstore_charge
         return gross - min(clear_refund, gross // 5)
 
     sstore_charge = Op.SSTORE.with_metadata(
         key_warm=False, original_value=24743, current_value=24743, new_value=0
     ).gas_cost(fork)
     # Cancun charges 5000 for the clear and refunds 4800; subtracting the
-    # same model evaluated at those constants makes this exactly 0 before
-    # the EIP-8037/8038 repricing.
+    # same model evaluated at those constants and the Cancun base makes
+    # this exactly 0 before the EIP-8037/8038 repricing.
     gas_used_delta = clear_gas_used(
-        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR
-    ) - clear_gas_used(5000, 4800)
+        sstore_charge, gas_costs.REFUND_STORAGE_CLEAR, base_gross
+    ) - clear_gas_used(5000, 4800, cancun_base_gross)
 
     post = {sender: Account(balance=0xE8D4EE4E00 - 1000 * gas_used_delta)}
 

--- a/tests/ported_static/stTransactionTest/test_high_gas_limit.py
+++ b/tests/ported_static/stTransactionTest/test_high_gas_limit.py
@@ -13,6 +13,8 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
+    RecipientType,
     StateTestFiller,
     Transaction,
 )
@@ -29,6 +31,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_high_gas_limit(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_high_gas_limit."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -49,11 +52,19 @@ def test_high_gas_limit(
         balance=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
     )
 
+    # EIP-2780 charges ``NEW_ACCOUNT`` state gas at the top frame when
+    # value is sent to an empty recipient; with the default zero
+    # state-gas reservoir that charge spills into regular gas, so lift
+    # ``gas_limit`` by exactly that amount (0 on pre-EIP-2780 forks).
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
     tx = Transaction(
         sender=sender,
         to=Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B),
         data=Bytes("3240349548983454"),
-        gas_limit=100000,
+        gas_limit=100000 + top_frame_state_gas,
         value=900,
     )
 

--- a/tests/ported_static/stTransactionTest/test_high_gas_limit.py
+++ b/tests/ported_static/stTransactionTest/test_high_gas_limit.py
@@ -3,6 +3,13 @@ Test_high_gas_limit.
 
 Ported from:
 state_tests/stTransactionTest/HighGasLimitFiller.json
+
+@manually-enhanced: Do not overwrite. The tx sends value to an empty
+recipient, so EIP-2780 charges ``NEW_ACCOUNT`` state gas at the top
+frame; with the default zero state-gas reservoir that charge spills into
+regular gas. Instead of the original hardcoded ``gas_limit``, lift the
+100000 base by ``fork.transaction_top_frame_state_gas`` so the budget
+covers the spillover and stays exactly 0 on pre-EIP-2780 forks.
 """
 
 import pytest

--- a/tests/ported_static/stTransactionTest/test_transaction_sending_to_zero.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_sending_to_zero.py
@@ -3,6 +3,14 @@ Test_transaction_sending_to_zero.
 
 Ported from:
 state_tests/stTransactionTest/TransactionSendingToZeroFiller.json
+
+@manually-enhanced: Do not overwrite. The tx sends value 1 to the empty
+zero address, so EIP-2780 charges NEW_ACCOUNT state gas at the top frame;
+with the default zero reservoir that charge spills into regular gas. The
+`gas_limit` is lifted by `fork.transaction_top_frame_state_gas` for an
+EMPTY_ACCOUNT recipient with `sends_value=True` (0 on pre-EIP-2780
+forks), so the literal 25000 budget stays valid across the repricing. Do
+not collapse the lift back to a hardcoded gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stTransactionTest/test_transaction_sending_to_zero.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_sending_to_zero.py
@@ -13,6 +13,8 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
+    RecipientType,
     StateTestFiller,
     Transaction,
 )
@@ -29,6 +31,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_transaction_sending_to_zero(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_transaction_sending_to_zero."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -47,11 +50,19 @@ def test_transaction_sending_to_zero(
 
     pre[sender] = Account(balance=0x5F5E100)
 
+    # EIP-2780 charges ``NEW_ACCOUNT`` state gas at the top frame when
+    # value is sent to an empty recipient; with the default zero
+    # state-gas reservoir that charge spills into regular gas, so lift
+    # ``gas_limit`` by exactly that amount (0 on pre-EIP-2780 forks).
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
     tx = Transaction(
         sender=sender,
         to=Address(0x0000000000000000000000000000000000000000),
         data=Bytes(""),
-        gas_limit=25000,
+        gas_limit=25000 + top_frame_state_gas,
         value=1,
     )
 

--- a/tests/ported_static/stTransactionTest/test_transaction_to_addressh160minus_one.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_to_addressh160minus_one.py
@@ -3,6 +3,14 @@ Test_transaction_to_addressh160minus_one.
 
 Ported from:
 state_tests/stTransactionTest/TransactionToAddressh160minusOneFiller.json
+
+@manually-enhanced: Do not overwrite. Sending value to the empty 0xff..ff
+recipient triggers EIP-2780's NEW_ACCOUNT top-frame state-gas charge.
+Both the tx and block ``gas_limit`` are lifted by
+``fork.transaction_top_frame_state_gas(EMPTY_ACCOUNT, sends_value=True)``
+so the charge (which spills into regular gas via the zero reservoir)
+fits the budget; this derived value is 0 on pre-EIP-2780 forks, keeping
+the original hardcoded 22000/100000 limits intact there.
 """
 
 import pytest

--- a/tests/ported_static/stTransactionTest/test_transaction_to_addressh160minus_one.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_to_addressh160minus_one.py
@@ -13,6 +13,8 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
+    RecipientType,
     StateTestFiller,
     Transaction,
 )
@@ -31,11 +33,24 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_transaction_to_addressh160minus_one(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_transaction_to_addressh160minus_one."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = EOA(
         key=0xF79127A3004ABDE26A4CBD80C428CB10F829FA11B54D36E7B326F4F4A5927ACF
+    )
+
+    pre[sender] = Account(balance=0x3B9ACA00)
+
+    # EIP-2780 charges ``NEW_ACCOUNT`` state gas at the top frame when
+    # value is sent to an empty recipient; with the default zero
+    # state-gas reservoir that charge spills into regular gas, so lift
+    # ``gas_limit`` by exactly that amount (0 on pre-EIP-2780 forks).
+    # The block ``gas_limit`` must also accommodate the lifted tx.
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
     )
 
     env = Environment(
@@ -44,16 +59,13 @@ def test_transaction_to_addressh160minus_one(
         timestamp=1000,
         prev_randao=0x20000,
         base_fee_per_gas=10,
-        gas_limit=100000,
+        gas_limit=100000 + top_frame_state_gas,
     )
-
-    pre[sender] = Account(balance=0x3B9ACA00)
-
     tx = Transaction(
         sender=sender,
         to=Address(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
         data=Bytes(""),
-        gas_limit=22000,
+        gas_limit=22000 + top_frame_state_gas,
         value=100,
     )
 

--- a/tests/ported_static/stTransactionTest/test_transaction_to_itself.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_to_itself.py
@@ -12,6 +12,8 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
+    RecipientType,
     StateTestFiller,
     Transaction,
 )
@@ -27,6 +29,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_transaction_to_itself(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_transaction_to_itself."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -49,6 +52,19 @@ def test_transaction_to_itself(
         value=1,
     )
 
-    post = {sender: Account(balance=0x3B9795B0, nonce=1)}
+    # EIP-2780 carves out self-transfers from the recipient and
+    # value-transfer surcharges, leaving only ``TX_BASE`` (12_000 on
+    # Amsterdam vs 21_000 on Cancun). Shift the sender balance by
+    # ``gas_price * delta``.
+    intrinsic_delta = (
+        fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.SELF,
+            sends_value=True,
+        )
+        - 21_000
+    )
+    post = {
+        sender: Account(balance=0x3B9795B0 - 10 * intrinsic_delta, nonce=1)
+    }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stTransactionTest/test_transaction_to_itself.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_to_itself.py
@@ -3,6 +3,16 @@ Test_transaction_to_itself.
 
 Ported from:
 state_tests/stTransactionTest/TransactionToItselfFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the sender
+balance after a self-transfer (to == sender). Instead of the original
+hardcoded value, the balance shift is derived from the fork intrinsic
+calculator: ``intrinsic(recipient_type=SELF, sends_value=True) - 21_000``
+is the delta versus the pre-EIP-2780 baseline intrinsic 21_000. EIP-2780
+carves out the recipient and value-transfer surcharges for self-sends,
+dropping the intrinsic to ``TX_BASE`` (12_000 on Amsterdam), so the delta
+is 0 at Cancun and negative afterward. The balance moves by
+``gas_price * intrinsic_delta``. Do not hardcode the Amsterdam value.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call.py
@@ -3,6 +3,14 @@ Test_zero_value_call.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALLFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts storage slot
+0 holds the `Op.GAS` value (0x8D5B6), which depends on the gas remaining
+at a fixed execution point. EIP-2780 lowers the intrinsic for this non-self
+non-value tx, so the gas budget is derived from the fork as
+`600_000 + (intrinsic - 21_000)`: the fork intrinsic minus the
+pre-EIP-2780 baseline 21_000 keeps the post-intrinsic budget fixed at
+Cancun's value across forks. Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call.py
@@ -13,6 +13,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -30,6 +31,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_call(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_call."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -70,11 +72,18 @@ def test_zero_value_call(
         address=Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B),  # noqa: E501
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=contract_0,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_empty_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_empty_paris.py
@@ -3,6 +3,14 @@ Test_zero_value_call_to_empty_paris.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALL_ToEmpty_ParisFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the
+`Op.GAS` value stored at slot 0 (0x8D5B6), which depends on the gas
+remaining at a fixed execution point. To keep that budget constant
+across forks, `gas_limit` is derived as 600_000 plus the fork's intrinsic
+cost minus the pre-EIP-2780 baseline intrinsic of 21_000
+(`intrinsic - 21_000`), since EIP-2780 lowers the intrinsic for non-self
+non-value txs. Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_empty_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_empty_paris.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -29,6 +30,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_call_to_empty_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_call_to_empty_paris."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -65,11 +67,18 @@ def test_zero_value_call_to_empty_paris(
         nonce=0,
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_non_zero_balance.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_non_zero_balance.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -29,6 +30,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_call_to_non_zero_balance(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_call_to_non_zero_balance."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -65,11 +67,18 @@ def test_zero_value_call_to_non_zero_balance(
         nonce=0,
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_non_zero_balance.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_non_zero_balance.py
@@ -3,6 +3,14 @@ Test_zero_value_call_to_non_zero_balance.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALL_ToNonZeroBalanceFiller.json
+
+@manually-enhanced: Do not overwrite. Slot 0 stores `Op.GAS` and is
+asserted at a fixed `0x8D5B6`, so the post-intrinsic execution budget
+must stay constant across forks. The `gas_limit` is derived from the
+fork intrinsic via `fork.transaction_intrinsic_cost_calculator()()`
+minus the pre-EIP-2780 baseline `21_000`, leaving exactly 600_000 for
+execution (the adjustment is 0 pre-EIP-2780). Do not hardcode the
+gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_one_storage_key_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_one_storage_key_paris.py
@@ -13,6 +13,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -32,6 +33,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_call_to_one_storage_key_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_call_to_one_storage_key_paris."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -73,11 +75,18 @@ def test_zero_value_call_to_one_storage_key_paris(
         address=Address(0xF202BAE278AC09857F5A56991C7A4679632F5841),  # noqa: E501
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_one_storage_key_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_call_to_one_storage_key_paris.py
@@ -3,6 +3,15 @@ Test_zero_value_call_to_one_storage_key_paris.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALL_ToOneStorageKey_ParisFiller.json
+
+@manually-enhanced: Do not overwrite. The contract stores `Op.GAS` into
+slot 0, asserting `0x8D5B6` remaining at a fixed execution point, so the
+tx gas budget must track the intrinsic across forks. `gas_limit` is
+derived as `600_000 + (intrinsic - 21_000)`, where `intrinsic` comes from
+`fork.transaction_intrinsic_cost_calculator()`; subtracting the
+pre-EIP-2780 baseline intrinsic 21_000 keeps the post-intrinsic execution
+budget fixed when EIP-2780 lowers the intrinsic for non-value, non-self
+txs. Do not hardcode the literal gas limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode.py
@@ -3,6 +3,15 @@ Test_zero_value_callcode.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALLCODEFiller.json
+
+@manually-enhanced: Do not overwrite. The contract stores `Op.GAS` at
+slot 0 (asserted as 0x8D5B6), so the post-state depends on the gas left
+at a fixed execution point. The tx gas budget is derived from the fork
+gas model instead of a hardcoded literal: `gas_limit = 600_000 +
+(intrinsic - 21_000)` adds back whatever EIP-2780 shaved off the
+intrinsic for this non-self non-value tx (subtracting the pre-EIP-2780
+baseline 21_000) so the 600_000 post-intrinsic execution budget, and
+thus the stored GAS value, stays invariant across forks.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode.py
@@ -13,6 +13,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -30,6 +31,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_callcode(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_callcode."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -70,11 +72,18 @@ def test_zero_value_callcode(
         address=Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B),  # noqa: E501
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=contract_0,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_empty_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_empty_paris.py
@@ -3,6 +3,15 @@ Test_zero_value_callcode_to_empty_paris.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALLCODE_ToEmpty_ParisFiller.json
+
+@manually-enhanced: Do not overwrite. The target stores `Op.GAS` into
+slot 0 and the post-state asserts it as a fixed value (0x8D5B6), so the
+remaining gas at that point must be fork-invariant. The `gas_limit` is
+derived as `600_000 + (intrinsic - 21_000)` from the fork intrinsic
+calculator instead of a hardcoded number: subtracting the pre-EIP-2780
+baseline intrinsic of 21_000 keeps a constant 600_000 post-intrinsic
+execution budget when EIP-2780 lowers the intrinsic for non-self
+non-value txs. Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_empty_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_empty_paris.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_callcode_to_empty_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_callcode_to_empty_paris."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -67,11 +69,18 @@ def test_zero_value_callcode_to_empty_paris(
         nonce=0,
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_non_zero_balance.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_non_zero_balance.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_callcode_to_non_zero_balance(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_callcode_to_non_zero_balance."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -67,11 +69,18 @@ def test_zero_value_callcode_to_non_zero_balance(
         nonce=0,
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_non_zero_balance.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_non_zero_balance.py
@@ -3,6 +3,17 @@ Test_zero_value_callcode_to_non_zero_balance.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALLCODE_ToNonZeroBalanceFiller.json
+
+@manually-enhanced: Do not overwrite. The post-state asserts the
+`Op.GAS` value stored at slot 0 (0x8D5B6), which depends on the gas
+remaining at a fixed execution point. To hold that point constant, the
+`gas_limit` is derived from the fork gas model rather than hardcoded:
+`gas_limit = 600_000 + (intrinsic - 21_000)`, where `intrinsic` comes
+from `fork.transaction_intrinsic_cost_calculator()`. Subtracting the
+pre-EIP-2780 baseline intrinsic 21_000 keeps the post-intrinsic
+execution budget at 600_000 across the EIP-2780 intrinsic
+decomposition (which lowers the intrinsic for non-self, non-value txs).
+Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_one_storage_key_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_one_storage_key_paris.py
@@ -3,6 +3,16 @@ Test_zero_value_callcode_to_one_storage_key_paris.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_CALLCODE_ToOneStorageKey_ParisFiller.json
+
+@manually-enhanced: Do not overwrite. The contract's first SSTORE records
+`Op.GAS`, so the slot-0 post value (`0x8D5B6`) pins the remaining gas at a
+fixed execution point. To keep that budget constant as the intrinsic
+shifts, `gas_limit` is derived from the fork intrinsic calculator rather
+than hardcoded: `600_000 + (intrinsic - 21_000)`, where `21_000` is the
+pre-EIP-2780 baseline intrinsic. EIP-2780 lowers the intrinsic for this
+non-self, zero-value tx, so the `- 21_000` term keeps the post-intrinsic
+execution budget (and thus the `Op.GAS` assertion) correct across forks.
+Do not replace the calculator-derived value with a literal.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_one_storage_key_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_callcode_to_one_storage_key_paris.py
@@ -13,6 +13,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -32,6 +33,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_callcode_to_one_storage_key_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_callcode_to_one_storage_key_paris."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -73,11 +75,18 @@ def test_zero_value_callcode_to_one_storage_key_paris(
         address=Address(0xA93AE635B4FA4D618045C019AC32ED9ADC8F54EA),  # noqa: E501
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall.py
@@ -13,6 +13,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -30,6 +31,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_delegatecall(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_delegatecall."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -69,11 +71,18 @@ def test_zero_value_delegatecall(
         address=Address(0xB94F5374FCE5EDBC8E2A8697C15331677E6EBF0B),  # noqa: E501
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=contract_0,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall.py
@@ -3,6 +3,16 @@ Test_zero_value_delegatecall.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_DELEGATECALLFiller.json
+
+@manually-enhanced: Do not overwrite. The `gas_limit` is derived from
+the fork intrinsic calculator instead of a hardcoded literal, so the
+post-intrinsic execution budget stays fixed at 600_000 across forks:
+`gas_limit = 600_000 + (intrinsic - 21_000)`, where `21_000` is the
+pre-EIP-2780 baseline intrinsic. EIP-2780 lowers the intrinsic for
+non-self, non-value txs, and the `SSTORE(0, GAS)` post assertion
+(`0x8D5B6`) pins `Op.GAS` at a fixed execution point, so the remaining
+gas after the intrinsic deduction must not shift. Do not hardcode the
+gas limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_empty_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_empty_paris.py
@@ -3,6 +3,16 @@ Test_zero_value_delegatecall_to_empty_paris.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_DELEGATECALL_ToEmpty_ParisFiller.json
+
+@manually-enhanced: Do not overwrite. The contract records `Op.GAS` into
+storage slot 0, and the post-state asserts that value (`0x8D5B6`), so the
+gas remaining at that fixed execution point must stay constant across
+forks. The `gas_limit` is therefore derived from the fork as
+`600_000 + (fork.transaction_intrinsic_cost_calculator()() - 21_000)`:
+it re-adds the 600k post-intrinsic execution budget onto the fork
+intrinsic and subtracts the pre-EIP-2780 baseline intrinsic `21_000`,
+which EIP-2780 lowers for non-self non-value txs. Do not hardcode the
+gas limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_empty_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_empty_paris.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_delegatecall_to_empty_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_delegatecall_to_empty_paris."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -66,11 +68,18 @@ def test_zero_value_delegatecall_to_empty_paris(
         nonce=0,
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_non_zero_balance.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_non_zero_balance.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_delegatecall_to_non_zero_balance(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_delegatecall_to_non_zero_balance."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -66,11 +68,18 @@ def test_zero_value_delegatecall_to_non_zero_balance(
         nonce=0,
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_non_zero_balance.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_non_zero_balance.py
@@ -3,6 +3,16 @@ Test_zero_value_delegatecall_to_non_zero_balance.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_DELEGATECALL_ToNonZeroBalanceFiller.json
+
+@manually-enhanced: Do not overwrite. The contract stores `Op.GAS` into
+slot 0 (asserted as 0x8D5B6), so the gas remaining at that fixed
+execution point must be fork-invariant. The `gas_limit` is derived from
+the fork: `600_000 + (intrinsic - 21_000)`, where `intrinsic` comes from
+`fork.transaction_intrinsic_cost_calculator()()` and 21_000 is the
+pre-EIP-2780 baseline intrinsic. EIP-2780's intrinsic decomposition
+lowers the intrinsic for non-self non-value txs, so subtracting the old
+21_000 literal keeps the post-intrinsic execution budget (600_000)
+constant. Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_one_storage_key_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_one_storage_key_paris.py
@@ -13,6 +13,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
 )
@@ -32,6 +33,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 def test_zero_value_delegatecall_to_one_storage_key_paris(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test_zero_value_delegatecall_to_one_storage_key_paris."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
@@ -72,11 +74,18 @@ def test_zero_value_delegatecall_to_one_storage_key_paris(
         address=Address(0xC8881A7E48D37B4A4CDD6338CE7076D6A116283D),  # noqa: E501
     )
 
+    # Preserve Cancun's post-intrinsic execution budget across
+    # forks; EIP-2780 lowers the intrinsic for non-self non-value
+    # txs, and the Op.GAS storage assertion depends on the
+    # remaining gas at a fixed execution point.
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = 600_000 + (intrinsic - 21_000)
+
     tx = Transaction(
         sender=sender,
         to=target,
         data=Bytes(""),
-        gas_limit=600000,
+        gas_limit=gas_limit,
     )
 
     post = {

--- a/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_one_storage_key_paris.py
+++ b/tests/ported_static/stZeroCallsTest/test_zero_value_delegatecall_to_one_storage_key_paris.py
@@ -3,6 +3,16 @@ Test_zero_value_delegatecall_to_one_storage_key_paris.
 
 Ported from:
 state_tests/stZeroCallsTest/ZeroValue_DELEGATECALL_ToOneStorageKey_ParisFiller.json
+
+@manually-enhanced: Do not overwrite. Slot 0 asserts the `Op.GAS`
+value (0x8D5B6) captured by the first SSTORE, so the gas remaining at
+that fixed execution point must be constant across forks. The
+`gas_limit` is derived from the fork intrinsic calculator
+(`fork.transaction_intrinsic_cost_calculator()()`) as
+`600_000 + (intrinsic - 21_000)`: subtracting the pre-EIP-2780
+baseline intrinsic 21_000 keeps the post-intrinsic execution budget
+fixed at 600_000 even as EIP-2780 lowers the intrinsic for
+non-value, non-self calls. Do not hardcode the gas_limit.
 """
 
 import pytest

--- a/tests/ported_static/vmTests/test_suicide.py
+++ b/tests/ported_static/vmTests/test_suicide.py
@@ -148,11 +148,14 @@ def test_suicide(
     # The CALL into the self-destructing contract touches a cold, already
     # existing account; EIP-8038 raises that cold account-access surcharge
     # from 2600 to 3000. The SELFDESTRUCT beneficiary is warm and
-    # non-empty, so its charge is unchanged. The sender pays this extra
-    # gas at the base fee (no priority fee), so its balance drops by the
-    # account-access delta times the gas price.
+    # non-empty, so its charge is unchanged. EIP-2780 separately reshapes
+    # the tx intrinsic for this non-self non-value call. The sender pays
+    # the combined delta at the base fee (no priority fee).
     cold_account_access_delta = fork.gas_costs().COLD_ACCOUNT_ACCESS - 2600
-    caller_balance = 0x5AF31075D9DE - 10 * cold_account_access_delta
+    intrinsic_delta = fork.transaction_intrinsic_cost_calculator()() - 21_000
+    caller_balance = (
+        0x5AF31075D9DE - 10 * cold_account_access_delta - 10 * intrinsic_delta
+    )
 
     expect_entries_: list[dict] = [
         {

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -36,6 +36,7 @@ from execution_testing import (
     Hash,
     Initcode,
     Op,
+    RecipientType,
     Requests,
     StateTestFiller,
     Storage,
@@ -4027,13 +4028,16 @@ def test_many_delegations(
         max_gas = tx_gas_limit_cap
     else:
         max_gas = env.gas_limit
-    gas_for_delegations = max_gas - 21_000 - 20_000 - (3 * 2)
+
+    success_slot = 1
+    entry_code = Op.SSTORE(success_slot, 1) + Op.STOP
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    entry_code_gas = entry_code.gas_cost(fork)
+    gas_for_delegations = max_gas - intrinsic_gas - entry_code_gas
 
     gas_costs = fork.gas_costs()
     delegation_count = gas_for_delegations // gas_costs.AUTH_PER_EMPTY_ACCOUNT
 
-    success_slot = 1
-    entry_code = Op.SSTORE(success_slot, 1) + Op.STOP
     entry_address = pre.deploy_contract(entry_code)
 
     signers = [pre.fund_eoa(signer_balance) for _ in range(delegation_count)]
@@ -4124,6 +4128,7 @@ def test_invalid_transaction_after_authorization(
 def test_authorization_reusing_nonce(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test an authorization reusing the same nonce as a prior transaction
@@ -4132,11 +4137,34 @@ def test_authorization_reusing_nonce(
     auth_signer = pre.fund_eoa()
     sender = pre.fund_eoa()
     recipient = pre.fund_eoa(amount=0)
+
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+    # Tx1: value transfer to an empty recipient -- pays the intrinsic
+    # value-transfer surcharges plus the top-frame ``NEW_ACCOUNT``
+    # state-gas charge.
+    tx1_intrinsic = intrinsic_gas_calculator(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+    tx1_top_frame_state = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+    tx1_gas = tx1_intrinsic + tx1_top_frame_state
+
+    # Tx2: recipient is now alive (received 1 wei in tx1), so the
+    # recipient is an EOA and no top-frame charge fires. The auth
+    # list adds one ``AUTH_PER_EMPTY_ACCOUNT`` to intrinsic.
+    tx2_gas = intrinsic_gas_calculator(
+        recipient_type=RecipientType.EOA,
+        authorization_list_or_count=1,
+    )
+
     txs = [
         Transaction(
             sender=auth_signer,
             nonce=0,
-            gas_limit=21_000,
+            gas_limit=tx1_gas,
             to=recipient,
             value=1,
         ),
@@ -4144,6 +4172,7 @@ def test_authorization_reusing_nonce(
             sender=sender,
             to=recipient,
             value=0,
+            gas_limit=tx2_gas,
             authorization_list=[
                 AuthorizationTuple(
                     address=Address(1),

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -16,6 +16,7 @@ from execution_testing import (
     Fork,
     Hash,
     Op,
+    RecipientType,
     Transaction,
     TransactionException,
     Withdrawal,
@@ -69,11 +70,16 @@ class TestUseValueInTx:
         return pre.fund_eoa(0)
 
     @pytest.fixture
-    def tx(self, sender: EOA, recipient: EOA) -> Transaction:  # noqa: D102
+    def tx(  # noqa: D102
+        self, sender: EOA, recipient: EOA, fork: Fork
+    ) -> Transaction:
         # Transaction sent from the `sender`, which has 1 wei balance at start
+        gas_limit = fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.EOA,
+        )
         return Transaction(
             gas_price=ONE_GWEI,
-            gas_limit=21_000,
+            gas_limit=gas_limit,
             to=recipient,
             sender=sender,
         )


### PR DESCRIPTION
## 🗒️ Description

This is an exact clone of @gurukamath's PR here for EIP-2780: https://github.com/danceratopz/execution-specs/pull/59.

> 1. Implement EIP-2780
> 2. Update the testing framework
> 3. Add EIP-2780 specific tests
> 4. Fix broken tests
> 5. Fix broken ported_static tests (This one is a bit of a claude oneshot which I have not reviewed very well). Would be happy to hear alternative approches here).

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.icegif.com%2Fwp-content%2Fuploads%2F2023%2F06%2Ficegif-1034.gif&f=1&nofb=1&ipt=c2a9e71031e782838972a8ee77ddbdde1febe9522329d7251d22fa35507c084d)
