### PR TITLE
chore(tests,test-forks): Address #2990 review comments (pkgutil, type: ignore, Spec dataclass)

### DIFF
--- a/packages/testing/src/execution_testing/forks/bytecode.py
+++ b/packages/testing/src/execution_testing/forks/bytecode.py
@@ -1,0 +1,19 @@
+"""Helper to load predeploy contract bytecode bundled as package data."""
+
+import pkgutil
+
+
+def load_contract_bytecode(module_name: str, filename: str) -> bytes:
+    """
+    Load predeploy contract bytecode bundled as package data.
+
+    `module_name` is the importing module's `__name__`; the bytecode is read
+    from a `contracts/<filename>` resource located alongside that module.
+    """
+    resource = f"contracts/{filename}"
+    bytecode = pkgutil.get_data(module_name, resource)
+    if bytecode is None:
+        raise FileNotFoundError(
+            f"Unable to read bytecode `{resource}` from `{module_name}`"
+        )
+    return bytecode

--- a/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_4788.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_4788.py
@@ -43,8 +43,9 @@ class EIP4788(BaseFork):
                 "57602036146024575f5ffd5b5f35801560495762001fff810690"
                 "815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd"
                 "5b62001fff42064281555f359062001fff015500",
-            }
-        } | super(EIP4788, cls).pre_allocation_blockchain()  # type: ignore
+            },
+            **super(EIP4788, cls).pre_allocation_blockchain(),
+        }
 
     @classmethod
     def engine_new_payload_beacon_root(cls) -> bool:

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_2935.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_2935.py
@@ -7,19 +7,17 @@ to allow for stateless execution.
 https://eips.ethereum.org/EIPS/eip-2935
 """
 
-from os.path import realpath
-from pathlib import Path
 from typing import List, Mapping
 
 from execution_testing.base_types import Address
 
 from ....base_fork import BaseFork
+from ....bytecode import load_contract_bytecode
 
-BYTECODE_FILE = (
-    Path(realpath(__file__)).parent / "contracts" / "history_contract.bin"
-)
 HISTORY_STORAGE_ADDRESS = 0x0000F90827F1C53A10CB7A02335B175320002935
-HISTORY_STORAGE_BYTECODE = BYTECODE_FILE.read_bytes()
+HISTORY_STORAGE_BYTECODE = load_contract_bytecode(
+    __name__, "history_contract.bin"
+)
 
 
 class EIP2935(BaseFork):

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_2935.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_2935.py
@@ -40,5 +40,6 @@ class EIP2935(BaseFork):
             HISTORY_STORAGE_ADDRESS: {
                 "nonce": 1,
                 "code": HISTORY_STORAGE_BYTECODE,
-            }
-        } | super(EIP2935, cls).pre_allocation_blockchain()  # type: ignore
+            },
+            **super(EIP2935, cls).pre_allocation_blockchain(),
+        }

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_6110.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_6110.py
@@ -8,19 +8,17 @@ https://eips.ethereum.org/EIPS/eip-6110
 """
 
 from hashlib import sha256
-from os.path import realpath
-from pathlib import Path
 from typing import List, Mapping
 
 from execution_testing.base_types import Address
 
 from ....base_fork import BaseFork
+from ....bytecode import load_contract_bytecode
 
-BYTECODE_FILE = (
-    Path(realpath(__file__)).parent / "contracts" / "deposit_contract.bin"
-)
 DEPOSIT_CONTRACT_ADDRESS = 0x00000000219AB540356CBB839CBE05303D7705FA
-DEPOSIT_CONTRACT_BYTECODE = BYTECODE_FILE.read_bytes()
+DEPOSIT_CONTRACT_BYTECODE = load_contract_bytecode(
+    __name__, "deposit_contract.bin"
+)
 
 
 class EIP6110(BaseFork):

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_6110.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_6110.py
@@ -52,5 +52,6 @@ class EIP6110(BaseFork):
                 "nonce": 1,
                 "code": DEPOSIT_CONTRACT_BYTECODE,
                 "storage": storage,
-            }
-        } | super(EIP6110, cls).pre_allocation_blockchain()  # type: ignore
+            },
+            **super(EIP6110, cls).pre_allocation_blockchain(),
+        }

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7002.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7002.py
@@ -7,21 +7,19 @@ layer (0x01) withdrawal credentials.
 https://eips.ethereum.org/EIPS/eip-7002
 """
 
-from os.path import realpath
-from pathlib import Path
 from typing import List, Mapping
 
 from execution_testing.base_types import Address
 
 from ....base_fork import BaseFork
+from ....bytecode import load_contract_bytecode
 
-BYTECODE_FILE = (
-    Path(realpath(__file__)).parent / "contracts" / "withdrawal_request.bin"
-)
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = (
     0x00000961EF480EB55E80D19AD83579A64C007002
 )
-WITHDRAWAL_REQUEST_PREDEPLOY_BYTECODE = BYTECODE_FILE.read_bytes()
+WITHDRAWAL_REQUEST_PREDEPLOY_BYTECODE = load_contract_bytecode(
+    __name__, "withdrawal_request.bin"
+)
 
 
 class EIP7002(BaseFork):

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7002.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7002.py
@@ -43,4 +43,5 @@ class EIP7002(BaseFork):
                 "nonce": 1,
                 "code": WITHDRAWAL_REQUEST_PREDEPLOY_BYTECODE,
             },
-        } | super(EIP7002, cls).pre_allocation_blockchain()  # type: ignore
+            **super(EIP7002, cls).pre_allocation_blockchain(),
+        }

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7251.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7251.py
@@ -6,21 +6,19 @@ Allow validators to consolidate via execution layer requests.
 https://eips.ethereum.org/EIPS/eip-7251
 """
 
-from os.path import realpath
-from pathlib import Path
 from typing import List, Mapping
 
 from execution_testing.base_types import Address
 
 from ....base_fork import BaseFork
+from ....bytecode import load_contract_bytecode
 
-BYTECODE_FILE = (
-    Path(realpath(__file__)).parent / "contracts" / "consolidation_request.bin"
-)
 CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS = (
     0x0000BBDDC7CE488642FB579F8B00F3A590007251
 )
-CONSOLIDATION_REQUEST_PREDEPLOY_BYTECODE = BYTECODE_FILE.read_bytes()
+CONSOLIDATION_REQUEST_PREDEPLOY_BYTECODE = load_contract_bytecode(
+    __name__, "consolidation_request.bin"
+)
 
 
 class EIP7251(BaseFork):

--- a/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7251.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/prague/eip_7251.py
@@ -42,4 +42,5 @@ class EIP7251(BaseFork):
                 "nonce": 1,
                 "code": CONSOLIDATION_REQUEST_PREDEPLOY_BYTECODE,
             },
-        } | super(EIP7251, cls).pre_allocation_blockchain()  # type: ignore
+            **super(EIP7251, cls).pre_allocation_blockchain(),
+        }

--- a/tests/amsterdam/eip7708_eth_transfer_logs/spec.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/spec.py
@@ -18,7 +18,6 @@ ref_spec_7708 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7708 specifications as defined at

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/spec.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/spec.py
@@ -16,7 +16,6 @@ ref_spec_7778 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7778 specifications as defined at

--- a/tests/amsterdam/eip7843_slotnum/spec.py
+++ b/tests/amsterdam/eip7843_slotnum/spec.py
@@ -17,6 +17,5 @@ ref_spec_7843 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """Constants and parameters from EIP-7843."""

--- a/tests/amsterdam/eip7928_block_level_access_lists/spec.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/spec.py
@@ -17,7 +17,6 @@ ref_spec_7928 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """Constants and parameters from EIP-7928."""
 

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/spec.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/spec.py
@@ -17,7 +17,6 @@ ref_spec_7976 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7976 specifications as defined at

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -17,7 +17,6 @@ ref_spec_7981 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7981 specifications as defined at

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
@@ -23,7 +23,6 @@ ref_spec_8024 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """Constants and parameters from EIP-8024."""
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -29,7 +29,6 @@ ref_spec_8037 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Constants and helpers for the EIP-8037 State Creation Gas Cost

--- a/tests/berlin/eip2930_access_list/spec.py
+++ b/tests/berlin/eip2930_access_list/spec.py
@@ -17,7 +17,6 @@ ref_spec_2930 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-2930 specifications as defined at

--- a/tests/byzantium/eip196_ec_add_mul/spec.py
+++ b/tests/byzantium/eip196_ec_add_mul/spec.py
@@ -45,7 +45,6 @@ class PointG1(BytesConcatenation):
         return FP(self.x) + FP(self.y)
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-196 specification (https://eips.ethereum.org/EIPS/eip-196)

--- a/tests/byzantium/eip197_ec_pairing/spec.py
+++ b/tests/byzantium/eip197_ec_pairing/spec.py
@@ -25,7 +25,6 @@ class PointG2(BytesConcatenation):
         return FP(self.x[0]) + FP(self.x[1]) + FP(self.y[0]) + FP(self.y[1])
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-197 specification

--- a/tests/cancun/eip1153_tstore/spec.py
+++ b/tests/cancun/eip1153_tstore/spec.py
@@ -16,7 +16,6 @@ ref_spec_1153 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-1153 specifications as defined at

--- a/tests/cancun/eip4788_beacon_root/spec.py
+++ b/tests/cancun/eip4788_beacon_root/spec.py
@@ -19,7 +19,6 @@ ref_spec_4788 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-4788 specifications as defined at

--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -53,7 +53,6 @@ ref_spec_4844 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-4844 specifications as defined at

--- a/tests/constantinople/eip1014_create2/spec.py
+++ b/tests/constantinople/eip1014_create2/spec.py
@@ -16,7 +16,6 @@ ref_spec_1014 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-1014 specifications as defined at

--- a/tests/constantinople/eip145_bitwise_shift/spec.py
+++ b/tests/constantinople/eip145_bitwise_shift/spec.py
@@ -16,7 +16,6 @@ ref_spec_145 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-145 specifications as defined at

--- a/tests/frontier/identity_precompile/spec.py
+++ b/tests/frontier/identity_precompile/spec.py
@@ -1,11 +1,8 @@
 """Defines spec constants for the IDENTITY precompile."""
 
-from dataclasses import dataclass
-
 from execution_testing import Address
 
 
-@dataclass(frozen=True)
 class Spec:
     """Parameters for the IDENTITY precompile (frontier)."""
 

--- a/tests/frontier/precompiles/spec.py
+++ b/tests/frontier/precompiles/spec.py
@@ -25,7 +25,6 @@ class EcrecoverInput(BytesConcatenation):
         )
 
 
-@dataclass(frozen=True)
 class Spec:
     """Parameters for the frontier precompiles."""
 

--- a/tests/istanbul/eip152_blake2/spec.py
+++ b/tests/istanbul/eip152_blake2/spec.py
@@ -17,7 +17,6 @@ ref_spec_152 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-152 specifications as defined at

--- a/tests/osaka/eip7594_peerdas/spec.py
+++ b/tests/osaka/eip7594_peerdas/spec.py
@@ -16,7 +16,6 @@ ref_spec_7594 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7594 specifications as defined at

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/spec.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/spec.py
@@ -17,7 +17,6 @@ ref_spec_7825 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Constants and helpers for the EIP-7825 Transaction Gas Limit Cap tests.

--- a/tests/osaka/eip7883_modexp_gas_increase/spec.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/spec.py
@@ -26,7 +26,6 @@ def ceiling_division(a: int, b: int) -> int:
     return -(a // -b)
 
 
-@dataclass(frozen=True)
 class Spec:
     """Constants and helpers for the ModExp gas cost calculation."""
 

--- a/tests/osaka/eip7918_blob_reserve_price/spec.py
+++ b/tests/osaka/eip7918_blob_reserve_price/spec.py
@@ -21,7 +21,6 @@ ref_spec_7918 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec(EIP4844Spec):
     """
     Parameters from the EIP-7918 specifications. Extends EIP-4844 spec with the

--- a/tests/osaka/eip7934_block_rlp_limit/spec.py
+++ b/tests/osaka/eip7934_block_rlp_limit/spec.py
@@ -16,7 +16,6 @@ ref_spec_7934 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7934 specifications as defined at

--- a/tests/osaka/eip7939_count_leading_zeros/spec.py
+++ b/tests/osaka/eip7939_count_leading_zeros/spec.py
@@ -16,7 +16,6 @@ ref_spec_7939 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """Constants and helpers for the CLZ opcode."""
 

--- a/tests/osaka/eip7951_p256verify_precompiles/spec.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/spec.py
@@ -65,7 +65,6 @@ class H(FieldElement):
     pass
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7951 specifications as defined at

--- a/tests/prague/eip2537_bls_12_381_precompiles/spec.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/spec.py
@@ -95,7 +95,6 @@ class Scalar(BytesConcatenation):
         return self.x.to_bytes(32, byteorder="big")
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-2537 specifications as defined at

--- a/tests/prague/eip2935_historical_block_hashes_from_state/spec.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/spec.py
@@ -16,7 +16,6 @@ ref_spec_2935 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-2935 specifications as defined at

--- a/tests/prague/eip6110_deposits/spec.py
+++ b/tests/prague/eip6110_deposits/spec.py
@@ -16,7 +16,6 @@ ref_spec_6110 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-6110 specifications as defined at

--- a/tests/prague/eip7002_el_triggerable_withdrawals/spec.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/spec.py
@@ -23,7 +23,6 @@ ref_spec_7002 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7002 specifications as defined at

--- a/tests/prague/eip7251_consolidations/spec.py
+++ b/tests/prague/eip7251_consolidations/spec.py
@@ -19,7 +19,6 @@ ref_spec_7251 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7251 specifications as defined at

--- a/tests/prague/eip7623_increase_calldata_cost/spec.py
+++ b/tests/prague/eip7623_increase_calldata_cost/spec.py
@@ -17,7 +17,6 @@ ref_spec_7623 = ReferenceSpec(
 
 
 # Constants
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7623 specifications as defined at

--- a/tests/prague/eip7702_set_code_tx/spec.py
+++ b/tests/prague/eip7702_set_code_tx/spec.py
@@ -18,7 +18,6 @@ ref_spec_7702 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Parameters from the EIP-7702 specifications as defined at

--- a/tests/shanghai/eip3860_initcode/spec.py
+++ b/tests/shanghai/eip3860_initcode/spec.py
@@ -16,7 +16,6 @@ ref_spec_3860 = ReferenceSpec(
 )
 
 
-@dataclass(frozen=True)
 class Spec:
     """
     Define parameters from the EIP-3860 specifications.


### PR DESCRIPTION
## 🗒️ Description

Follow-up cleanups addressing @SamWilsn review comments from #2990. Three independent refactors:

### 1. Load contract binaries via `pkgutil.get_data`

Replace the `Path(realpath(__file__)).parent / "contracts" / "...".read_bytes()` pattern used to load system-contract bytecode in the fork definitions with `pkgutil.get_data`, accessing the `.bin` files as proper package data. Reading via `__file__` only works when the package is installed unpacked on disk; it breaks when `execution_testing` is imported from a zip/wheel or any non-extracted location. The `.bin` files are already declared as package data (`"execution_testing.forks" = ["forks/eips/**/*.bin"]`), so `pkgutil.get_data` is the correct, install-layout-independent way to read them.

- Add `forks/bytecode.py` with a reusable helper, `load_contract_bytecode(module_name, filename)`, which reads `contracts/<filename>` relative to the calling module and raises if the resource is missing.
- Migrate the EIP-2935, EIP-6110, EIP-7002, and EIP-7251 fork definitions to use it, dropping the now-unused `os.path.realpath` / `pathlib.Path` imports.

### 2. Drop `# type: ignore` on `pre_allocation_blockchain` merges

The `{...} | super().pre_allocation_blockchain()` merge required a `# type: ignore` because `dict.__or__` is typed to only accept another `dict`, not the abstract `Mapping` return type, even though the value is a real `dict` at runtime. Merging via `**` unpacking (`{..., **super().pre_allocation_blockchain()}`) is accepted by mypy with identical runtime semantics, so the suppression can be removed. Applied across EIP-4788, EIP-6110, EIP-2935, EIP-7002, and EIP-7251.

### 3. Remove inert `@dataclass(frozen=True)` from constant-only `Spec` classes

The per-EIP `Spec` classes are pure constant namespaces — never instantiated, their members are un-annotated class variables (so not even dataclass fields), and they are never serialized. `@dataclass(frozen=True)` therefore provides no benefit (`frozen` only guards instance attribute assignment, which never happens). Removed the decorator from every `class Spec` across the test suite (34 `spec.py` files), and dropped the `dataclass` import where `Spec` was its only user. `ReferenceSpec` and other genuine dataclasses are left untouched.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.scotsman.com/webimg/b25lY21zOjk5ZDQ2NzY0LTBhNzMtNDM4ZS04ZmNjLTdhYjE1OWYzZDQ1OTo0YmQ4OTE1Yy04NmE0LTQzOTgtODY1ZS02NTY1ZDYyZjk1NzA=.jpg?crop=3:2,smart&trim=&width=640&quality=70&enable=upscale)
