### PR TITLE
chore(tests): fix failing ported static slow tests for EIP-8038

### DIFF
--- a/tests/ported_static/stStaticCall/test_static_call_change_revert.py
+++ b/tests/ported_static/stStaticCall/test_static_call_change_revert.py
@@ -3,21 +3,17 @@ Test_static_call_change_revert.
 
 Ported from:
 state_tests/stStaticCall/static_callChangeRevertFiller.json
+
+@manually-enhanced: Do not overwrite.
 """
 
 import pytest
 from execution_testing import (
     Account,
-    Address,
     Alloc,
-    Environment,
-    Hash,
     StateTestFiller,
+    Storage,
     Transaction,
-)
-from execution_testing.forks import Fork
-from execution_testing.specs.static_state.expect_section import (
-    resolve_expect_post,
 )
 from execution_testing.vm import Op
 
@@ -29,267 +25,55 @@ REFERENCE_SPEC_VERSION = "N/A"
     ["state_tests/stStaticCall/static_callChangeRevertFiller.json"],
 )
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow
 @pytest.mark.parametrize(
-    "d, g, v",
+    "sstore_in_static,oog",
     [
-        pytest.param(
-            0,
-            0,
-            0,
-            id="d0",
-        ),
-        pytest.param(
-            1,
-            0,
-            0,
-            id="d1",
-        ),
-        pytest.param(
-            2,
-            0,
-            0,
-            id="d2",
-        ),
+        pytest.param(False, False),
+        pytest.param(False, True),
+        pytest.param(True, False),
     ],
 )
-@pytest.mark.pre_alloc_mutable
 def test_static_call_change_revert(
     state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
-    d: int,
-    g: int,
-    v: int,
+    sstore_in_static: bool,
+    oog: bool,
 ) -> None:
     """Test_static_call_change_revert."""
-    coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(amount=0xDE0B6B3A7640000)
+    sender = pre.fund_eoa()
 
-    env = Environment(
-        fee_recipient=coinbase,
-        number=1,
-        timestamp=1000,
-        prev_randao=0x20000,
-        base_fee_per_gas=10,
-        gas_limit=10000000,
-    )
+    subcall_code = Op.MSTORE(offset=0x1, value=0x1)
+    if sstore_in_static:
+        subcall_code += Op.SSTORE(key=0x1, value=Op.SLOAD(key=0x1))
+    subcall_code += Op.STOP
+    subcall_contract = pre.deploy_contract(subcall_code)
 
-    # Source: lll
-    # {  (CALL 350000 (CALLDATALOAD 0) 0 0 0 0 0)  }
-    target = pre.deploy_contract(  # noqa: F841
-        code=Op.CALL(
-            gas=0x55730,
-            address=Op.CALLDATALOAD(offset=0x0),
-            value=0x0,
-            args_offset=0x0,
-            args_size=0x0,
-            ret_offset=0x0,
-            ret_size=0x0,
-        )
-        + Op.STOP,
-        balance=0xDE0B6B3A7640000,
-        nonce=0,
-        address=Address(0x492BB18ADCE7DA2BED3592742FB4E3DF9086FB4C),  # noqa: E501
-    )
-    # Source: lll
-    # { (MSTORE 1 1)  }
-    addr_2 = pre.deploy_contract(  # noqa: F841
-        code=Op.MSTORE(offset=0x1, value=0x1) + Op.STOP,
-        nonce=0,
-        address=Address(0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7),  # noqa: E501
-    )
-    # Source: lll
-    # { (MSTORE 1 1) (SSTORE 1 (SLOAD 1)) }
-    addr_5 = pre.deploy_contract(  # noqa: F841
-        code=Op.MSTORE(offset=0x1, value=0x1)
-        + Op.SSTORE(key=0x1, value=Op.SLOAD(key=0x1))
-        + Op.STOP,
-        nonce=0,
-        address=Address(0x47C4ED3D93429CB8304737E2327B522E8928C9F3),  # noqa: E501
-    )
-    # Source: lll
-    # {  [[ 0 ]] (CALL 100000 <contract:0x1000000000000000000000000000000000000001> 1 0 0 0 0) [[ 1 ]] (STATICCALL 100000 <contract:0x1000000000000000000000000000000000000001> 0 0 0 0) [[ 2 ]] (CALL 100000 <contract:0x1000000000000000000000000000000000000001> 1 0 0 0 0) }  # noqa: E501
-    addr = pre.deploy_contract(  # noqa: F841
-        code=Op.SSTORE(
-            key=0x0,
-            value=Op.CALL(
-                gas=0x186A0,
-                address=0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7,
-                value=0x1,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
+    caller_storage = Storage()
+    caller_code = (
+        Op.SSTORE(
+            key=caller_storage.store_next(not oog),
+            value=Op.CALL(address=subcall_contract, value=0x1),
         )
         + Op.SSTORE(
-            key=0x1,
-            value=Op.STATICCALL(
-                gas=0x186A0,
-                address=0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
+            key=caller_storage.store_next(not oog and not sstore_in_static),
+            value=Op.STATICCALL(address=subcall_contract),
         )
         + Op.SSTORE(
-            key=0x2,
-            value=Op.CALL(
-                gas=0x186A0,
-                address=0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7,
-                value=0x1,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
+            key=caller_storage.store_next(not oog),
+            value=Op.CALL(address=subcall_contract, value=0x1),
         )
-        + Op.STOP,
-        balance=0xDE0B6B3A7640000,
-        nonce=0,
-        address=Address(0xE6F1FDAA1C99007971C641E10AF3A8FAC0B641C8),  # noqa: E501
     )
-    # Source: lll
-    # {  [[ 0 ]] (CALL 100000 <contract:0x1000000000000000000000000000000000000001> 1 0 0 0 0) [[ 1 ]] (STATICCALL 100000 <contract:0x1000000000000000000000000000000000000001> 0 0 0 0) [[ 2 ]] (CALL 100000 <contract:0x1000000000000000000000000000000000000001> 1 0 0 0 0) (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) (EXTCODESIZE 1)) }  # noqa: E501
-    addr_3 = pre.deploy_contract(  # noqa: F841
-        code=Op.SSTORE(
-            key=0x0,
-            value=Op.CALL(
-                gas=0x186A0,
-                address=0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7,
-                value=0x1,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
-        )
-        + Op.SSTORE(
-            key=0x1,
-            value=Op.STATICCALL(
-                gas=0x186A0,
-                address=0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
-        )
-        + Op.SSTORE(
-            key=0x2,
-            value=Op.CALL(
-                gas=0x186A0,
-                address=0xC031FC0AA7B61A5D7D962AFEE8838DEC6948ABB7,
-                value=0x1,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
-        )
-        + Op.JUMPDEST
-        + Op.JUMPI(
-            pc=0x8F, condition=Op.ISZERO(Op.LT(Op.MLOAD(offset=0x80), 0xC350))
-        )
-        + Op.POP(Op.EXTCODESIZE(address=0x1))
-        + Op.MSTORE(offset=0x80, value=Op.ADD(Op.MLOAD(offset=0x80), 0x1))
-        + Op.JUMP(pc=0x73)
-        + Op.JUMPDEST
-        + Op.STOP,
-        balance=0xDE0B6B3A7640000,
-        nonce=0,
-        address=Address(0xEA22EC955AC71D8E4380541212BD20818D704567),  # noqa: E501
-    )
-    # Source: lll
-    # {  [[ 0 ]] (CALL 100000 <contract:0x1000000000000000000000000000000000000002> 1 0 0 0 0) [[ 1 ]] (STATICCALL 100000 <contract:0x1000000000000000000000000000000000000002> 0 0 0 0) [[ 2 ]] (CALL 100000 <contract:0x1000000000000000000000000000000000000002> 1 0 0 0 0) }  # noqa: E501
-    addr_4 = pre.deploy_contract(  # noqa: F841
-        code=Op.SSTORE(
-            key=0x0,
-            value=Op.CALL(
-                gas=0x186A0,
-                address=0x47C4ED3D93429CB8304737E2327B522E8928C9F3,
-                value=0x1,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
-        )
-        + Op.SSTORE(
-            key=0x1,
-            value=Op.STATICCALL(
-                gas=0x186A0,
-                address=0x47C4ED3D93429CB8304737E2327B522E8928C9F3,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
-        )
-        + Op.SSTORE(
-            key=0x2,
-            value=Op.CALL(
-                gas=0x186A0,
-                address=0x47C4ED3D93429CB8304737E2327B522E8928C9F3,
-                value=0x1,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            ),
-        )
-        + Op.STOP,
-        balance=0xDE0B6B3A7640000,
-        nonce=0,
-        address=Address(0x2C004389EDAAE817E664B6D660F46735756B56D3),  # noqa: E501
-    )
+    if oog:
+        caller_code += Op.MLOAD(2**256 - 1)
+    caller_code += Op.STOP
 
-    expect_entries_: list[dict] = [
-        {
-            "indexes": {"data": 0, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {
-                addr: Account(storage={0: 1, 1: 1, 2: 1}),
-                addr_2: Account(balance=2),
-            },
-        },
-        {
-            "indexes": {"data": 1, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {
-                addr_3: Account(storage={0: 0, 1: 0, 2: 0}),
-                addr_2: Account(balance=0),
-            },
-        },
-        {
-            "indexes": {"data": 2, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {
-                addr_4: Account(storage={0: 1, 1: 0, 2: 1}),
-                addr_5: Account(balance=2),
-            },
-        },
-    ]
+    caller_contract = pre.deploy_contract(caller_code, balance=2)
 
-    post, _exc = resolve_expect_post(expect_entries_, d, g, v, fork)
+    post = {
+        caller_contract: Account(storage=caller_storage),
+        subcall_contract: Account(balance=2 if not oog else 0),
+    }
 
-    tx_data = [
-        Hash(addr, left_padding=True),
-        Hash(addr_3, left_padding=True),
-        Hash(addr_4, left_padding=True),
-    ]
-    tx_gas = [1000000]
-    tx_value = [100000]
+    tx = Transaction(sender=sender, to=caller_contract)
 
-    tx = Transaction(
-        sender=sender,
-        to=target,
-        data=tx_data[d],
-        gas_limit=tx_gas[g],
-        value=tx_value[v],
-        error=_exc,
-    )
-
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stStaticCall/test_static_make_money.py
+++ b/tests/ported_static/stStaticCall/test_static_make_money.py
@@ -3,18 +3,12 @@ Test_static_make_money.
 
 Ported from:
 state_tests/stStaticCall/static_makeMoneyFiller.json
+
+@manually-enhanced: Do not overwrite.
 """
 
 import pytest
-from execution_testing import (
-    Account,
-    Address,
-    Alloc,
-    Bytes,
-    Environment,
-    StateTestFiller,
-    Transaction,
-)
+from execution_testing import Account, Alloc, StateTestFiller, Transaction
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -25,65 +19,47 @@ REFERENCE_SPEC_VERSION = "N/A"
     ["state_tests/stStaticCall/static_makeMoneyFiller.json"],
 )
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow
-@pytest.mark.pre_alloc_mutable
 def test_static_make_money(
     state_test: StateTestFiller,
     pre: Alloc,
 ) -> None:
     """Test_static_make_money."""
-    coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(amount=0x5F5E100)
+    sender = pre.fund_eoa()
 
-    env = Environment(
-        fee_recipient=coinbase,
-        number=1,
-        timestamp=1000,
-        prev_randao=0x20000,
-        base_fee_per_gas=10,
-        gas_limit=1000000,
-    )
+    contracts_starting_balance = 1
 
-    # Source: raw
-    # 0x600160015532600255
-    addr = pre.deploy_contract(  # noqa: F841
+    subcall_contract = pre.deploy_contract(  # noqa: F841
         code=Op.SSTORE(key=0x1, value=0x1)
         + Op.SSTORE(key=0x2, value=Op.ORIGIN),
-        balance=0xDE0B6B3A7640000,
-        nonce=0,
+        balance=contracts_starting_balance,
     )
-    # Source: lll
-    # { (MSTORE 0 0x601080600c6000396000f20060003554156009570060203560003555) (STATICCALL 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffec <contract:0xaaaaaaaaace5edbc8e2a8697c15331677e6ebf0b> 0 0 0 0) }  # noqa: E501
-    target = pre.deploy_contract(  # noqa: F841
+    entry_contract = pre.deploy_contract(  # noqa: F841
         code=Op.MSTORE(
             offset=0x0,
             value=0x601080600C6000396000F20060003554156009570060203560003555,
         )
         + Op.STATICCALL(
-            gas=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEC,  # noqa: E501
-            address=addr,
-            args_offset=0x0,
-            args_size=0x0,
-            ret_offset=0x0,
-            ret_size=0x0,
+            gas=2**256 - 20,
+            address=subcall_contract,
         )
         + Op.STOP,
-        balance=0xDE0B6B3A7640000,
-        nonce=0,
+        balance=contracts_starting_balance,
     )
 
-    tx = Transaction(
-        sender=sender,
-        to=target,
-        data=Bytes(""),
-        gas_limit=228500,
-        value=10,
-    )
+    tx_value = 1
+    tx = Transaction(sender=sender, to=entry_contract, value=tx_value)
 
     post = {
-        target: Account(balance=0xDE0B6B3A764000A),
-        sender: Account(balance=0x5D38038),
-        addr: Account(balance=0xDE0B6B3A7640000),
+        entry_contract: Account(
+            balance=contracts_starting_balance + tx_value,
+        ),
+        subcall_contract: Account(
+            balance=contracts_starting_balance,
+            storage={
+                1: 0,
+                2: 0,
+            },
+        ),
     }
 
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stStaticCall/test_static_raw_call_gas_ask.py
+++ b/tests/ported_static/stStaticCall/test_static_raw_call_gas_ask.py
@@ -8,17 +8,12 @@ state_tests/stStaticCall/static_RawCallGasAskFiller.json
 import pytest
 from execution_testing import (
     Account,
-    Address,
     Alloc,
-    Environment,
-    Hash,
+    CodeGasMeasure,
     StateTestFiller,
     Transaction,
 )
 from execution_testing.forks import Fork
-from execution_testing.specs.static_state.expect_section import (
-    resolve_expect_post,
-)
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
@@ -31,198 +26,48 @@ REFERENCE_SPEC_VERSION = "N/A"
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "d, g, v",
+    "mem_expansion",
     [
-        pytest.param(
-            0,
-            0,
-            0,
-            id="d0",
-        ),
-        pytest.param(
-            1,
-            0,
-            0,
-            id="d1",
-        ),
-        pytest.param(
-            2,
-            0,
-            0,
-            id="d2",
-        ),
-        pytest.param(
-            3,
-            0,
-            0,
-            id="d3",
-        ),
+        pytest.param(False, id="without_mem_expansion"),
+        pytest.param(True, id="with_mem_expansion"),
     ],
 )
 @pytest.mark.pre_alloc_mutable
 def test_static_raw_call_gas_ask(
     state_test: StateTestFiller,
     pre: Alloc,
+    mem_expansion: bool,
     fork: Fork,
-    d: int,
-    g: int,
-    v: int,
 ) -> None:
     """Test_static_raw_call_gas_ask."""
-    coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    contract_0 = Address(0x094F5374FCE5EDBC8E2A8697C15331677E6EBF0B)
-    contract_1 = Address(0x1000000000000000000000000000000000000000)
-    contract_2 = Address(0x1000000000000000000000000000000000000001)
-    contract_3 = Address(0x2000000000000000000000000000000000000001)
-    contract_4 = Address(0x3000000000000000000000000000000000000001)
-    contract_5 = Address(0x4000000000000000000000000000000000000001)
-    sender = pre.fund_eoa(amount=0xE8D4A51000)
+    sender = pre.fund_eoa()
 
-    env = Environment(
-        fee_recipient=coinbase,
-        number=1,
-        timestamp=1000,
-        prev_randao=0x20000,
-        base_fee_per_gas=10,
-        gas_limit=10000000,
-    )
+    subcall_code = Op.MSTORE(0, Op.GAS, new_memory_size=32) + Op.STOP
+    subcall_contract = pre.deploy_contract(code=subcall_code)
 
-    # Source: lll
-    # { (MSTORE 0 (GAS)) }
-    contract_0 = pre.deploy_contract(  # noqa: F841
-        code=Op.MSTORE(offset=0x0, value=Op.GAS) + Op.STOP,
-        nonce=0,
-        address=Address(0x094F5374FCE5EDBC8E2A8697C15331677E6EBF0B),  # noqa: E501
-    )
-    # Source: lll
-    # { (CALL (GAS) (CALLDATALOAD 0) 0 0 0 0 0) }
-    contract_1 = pre.deploy_contract(  # noqa: F841
-        code=Op.CALL(
-            gas=Op.GAS,
-            address=Op.CALLDATALOAD(offset=0x0),
-            value=0x0,
-            args_offset=0x0,
-            args_size=0x0,
-            ret_offset=0x0,
-            ret_size=0x0,
+    mem_expansion_size = 0x1F40
+    static_call_code = (
+        Op.STATICCALL(
+            address=subcall_contract,
+            args_size=mem_expansion_size,
+            ret_size=mem_expansion_size,
+            new_memory_size=mem_expansion_size,
         )
-        + Op.STOP,
-        balance=0xE8D4A51000,
-        nonce=0,
-        address=Address(0x1000000000000000000000000000000000000000),  # noqa: E501
-    )
-    # Source: lll
-    # { (STATICCALL 130000 0x094f5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0) [[1]] (GAS) }  # noqa: E501
-    contract_3 = pre.deploy_contract(  # noqa: F841
-        code=Op.POP(
-            Op.STATICCALL(
-                gas=0x1FBD0,
-                address=0x94F5374FCE5EDBC8E2A8697C15331677E6EBF0B,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            )
+        if mem_expansion
+        else Op.STATICCALL(
+            address=subcall_contract,
         )
-        + Op.SSTORE(key=0x1, value=Op.GAS)
-        + Op.STOP,
-        nonce=0,
-        address=Address(0x2000000000000000000000000000000000000001),  # noqa: E501
     )
-    # Source: lll
-    # { (STATICCALL 130000 0x094f5374fce5edbc8e2a8697c15331677e6ebf0b 0 8000 0 8000) [[1]] (GAS) }  # noqa: E501
-    contract_5 = pre.deploy_contract(  # noqa: F841
-        code=Op.POP(
-            Op.STATICCALL(
-                gas=0x1FBD0,
-                address=0x94F5374FCE5EDBC8E2A8697C15331677E6EBF0B,
-                args_offset=0x0,
-                args_size=0x1F40,
-                ret_offset=0x0,
-                ret_size=0x1F40,
-            )
-        )
-        + Op.SSTORE(key=0x1, value=Op.GAS)
-        + Op.STOP,
-        nonce=0,
-        address=Address(0x4000000000000000000000000000000000000001),  # noqa: E501
-    )
-    # Source: lll
-    # { (STATICCALL 3000000 0x094f5374fce5edbc8e2a8697c15331677e6ebf0b 0 8000 0 8000) [[1]] (GAS) }  # noqa: E501
-    contract_4 = pre.deploy_contract(  # noqa: F841
-        code=Op.POP(
-            Op.STATICCALL(
-                gas=0x2DC6C0,
-                address=0x94F5374FCE5EDBC8E2A8697C15331677E6EBF0B,
-                args_offset=0x0,
-                args_size=0x1F40,
-                ret_offset=0x0,
-                ret_size=0x1F40,
-            )
-        )
-        + Op.SSTORE(key=0x1, value=Op.GAS)
-        + Op.STOP,
-        nonce=0,
-        address=Address(0x3000000000000000000000000000000000000001),  # noqa: E501
-    )
-    # Source: lll
-    # {  (STATICCALL 3000000 0x094f5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0) [[1]] (GAS) }  # noqa: E501
-    contract_2 = pre.deploy_contract(  # noqa: F841
-        code=Op.POP(
-            Op.STATICCALL(
-                gas=0x2DC6C0,
-                address=0x94F5374FCE5EDBC8E2A8697C15331677E6EBF0B,
-                args_offset=0x0,
-                args_size=0x0,
-                ret_offset=0x0,
-                ret_size=0x0,
-            )
-        )
-        + Op.SSTORE(key=0x1, value=Op.GAS)
-        + Op.STOP,
-        nonce=0,
-        address=Address(0x1000000000000000000000000000000000000001),  # noqa: E501
+    static_call_contract = pre.deploy_contract(
+        code=CodeGasMeasure(
+            code=static_call_code,
+            extra_stack_items=1,
+            sstore_key=1,
+        ),
     )
 
-    expect_entries_: list[dict] = [
-        {
-            "indexes": {"data": 0, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_2: Account(storage={1: 0xE9F83})},
-        },
-        {
-            "indexes": {"data": 1, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_3: Account(storage={1: 0xE9F83})},
-        },
-        {
-            "indexes": {"data": 2, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_4: Account(storage={1: 0xE9C1B})},
-        },
-        {
-            "indexes": {"data": 3, "gas": -1, "value": -1},
-            "network": [">=Cancun"],
-            "result": {contract_5: Account(storage={1: 0xE9C1B})},
-        },
-    ]
+    gas_cost = static_call_code.gas_cost(fork) + subcall_code.gas_cost(fork)
+    post = {static_call_contract: Account(storage={1: gas_cost})}
+    tx = Transaction(sender=sender, to=static_call_contract)
 
-    post, _exc = resolve_expect_post(expect_entries_, d, g, v, fork)
-
-    tx_data = [
-        Hash(contract_2, left_padding=True),
-        Hash(contract_3, left_padding=True),
-        Hash(contract_4, left_padding=True),
-        Hash(contract_5, left_padding=True),
-    ]
-    tx_gas = [1000000]
-
-    tx = Transaction(
-        sender=sender,
-        to=contract_1,
-        data=tx_data[d],
-        gas_limit=tx_gas[g],
-        error=_exc,
-    )
-
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

This is an exact copy of @marioevz's PR: https://github.com/danceratopz/execution-specs/pull/58, to fix the slow ported static tests for EIP-8038.

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2F38.media.tumblr.com%2Fc17814adef0efed511165cf27241058d%2Ftumblr_n8dqjtDGFo1rve2pqo1_500.gif&f=1&nofb=1&ipt=9e26818d49fa8b4e27c59a84e6c080c4f9086ec0ec48a843ded89f68ca87ca1c)
