### PR TITLE
fix(deps,tooling): move `ruff` to testing package deps for `gentest`

### DIFF
--- a/packages/testing/pyproject.toml
+++ b/packages/testing/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "semver>=3.0.1,<4",
     "pydantic>=2.12.3,<3",
     "rich>=13.7.0,<15",
+    "ruff==0.13.2",
     "filelock>=3.15.1,<4",
     "ethereum-types>=0.4.1,<0.5",
     "pyyaml>=6.0.2,<7",
@@ -66,7 +67,7 @@ test = [
     "pytest-cov>=4.1.0,<5",
 ]
 lint = [
-    "ruff==0.13.2",
+    # ruff is included in package deps for gentest
     "mypy==1.20.0",
     "types-requests>=2.31,<2.33",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1080,6 +1080,7 @@ dependencies = [
     { name = "requests" },
     { name = "requests-unixsocket2" },
     { name = "rich" },
+    { name = "ruff" },
     { name = "semver" },
     { name = "tenacity" },
     { name = "trie" },
@@ -1091,12 +1092,10 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest-cov" },
-    { name = "ruff" },
     { name = "types-requests" },
 ]
 lint = [
     { name = "mypy" },
-    { name = "ruff" },
     { name = "types-requests" },
 ]
 test = [
@@ -1134,6 +1133,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0,<3" },
     { name = "requests-unixsocket2", specifier = ">=0.4.0" },
     { name = "rich", specifier = ">=13.7.0,<15" },
+    { name = "ruff", specifier = "==0.13.2" },
     { name = "semver", specifier = ">=3.0.1,<4" },
     { name = "tenacity", specifier = ">=9.0.0,<10" },
     { name = "trie", specifier = ">=3.1.0,<4" },
@@ -1145,12 +1145,10 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = "==1.20.0" },
     { name = "pytest-cov", specifier = ">=4.1.0,<5" },
-    { name = "ruff", specifier = "==0.13.2" },
     { name = "types-requests", specifier = ">=2.31,<2.33" },
 ]
 lint = [
     { name = "mypy", specifier = "==1.20.0" },
-    { name = "ruff", specifier = "==0.13.2" },
     { name = "types-requests", specifier = ">=2.31,<2.33" },
 ]
 test = [{ name = "pytest-cov", specifier = ">=4.1.0,<5" }]


### PR DESCRIPTION
## 🗒️ Description
Adds `ruff` to `testing`'s package dependencies as you can't run `gentest` without it. This fixes up the `just test-tests-mypy` recipes issues in #3004.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Required by:
- #3004.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture
<img width="993" height="634" alt="image" src="https://github.com/user-attachments/assets/60e4de12-536a-415e-a4ec-0c128558acab" />


