### PR TITLE
fix(test-cli): raise a clear error when `gentest` can't find `ruff`

### DIFF
--- a/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
+++ b/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
@@ -85,7 +85,7 @@ def format_code(code: str) -> str:
         config_path = AppConfig().ROOT_DIR.parent / "pyproject.toml"
 
         try:
-            result = subprocess.run(
+            subprocess.run(
                 [
                     str(formatter_path),
                     "format",
@@ -96,6 +96,7 @@ def format_code(code: str) -> str:
                 ],
                 capture_output=True,
                 text=True,
+                check=True,
             )
         except FileNotFoundError as e:
             raise FileNotFoundError(
@@ -104,12 +105,12 @@ def format_code(code: str) -> str:
                 f"the development environment is installed, e.g. with "
                 f"'uv sync'."
             ) from e
-        if result.returncode != 0:
+        except subprocess.CalledProcessError as e:
             raise RuntimeError(
                 f"Error formatting code using formatter '{formatter_path}': "
-                f"returncode={result.returncode}, stdout={result.stdout!r}, "
-                f"stderr={result.stderr!r}"
-            )
+                f"returncode={e.returncode}, stdout={e.stdout!r}, "
+                f"stderr={e.stderr!r}"
+            ) from e
 
         # Return the formatted source code
         return input_file_path.read_text()

--- a/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
+++ b/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
@@ -53,10 +53,10 @@ def get_test_source(provider: Provider, template_path: str) -> str:
 
 def format_code(code: str) -> str:
     """
-    Format the provided Python code using the Black code formatter.
+    Format the provided Python code using the ruff formatter.
 
     This function writes the given code to a temporary Python file, formats it
-    using the Black formatter, and returns the formatted code as a string.
+    using ruff, and returns the formatted code as a string.
 
     Args:
       code (str): The Python code to be formatted.
@@ -84,20 +84,28 @@ def format_code(code: str) -> str:
         # Call ruff to format the file
         config_path = AppConfig().ROOT_DIR.parent / "pyproject.toml"
 
-        result = subprocess.run(
-            [
-                str(formatter_path),
-                "format",
-                str(input_file_path),
-                "--no-cache",
-                "--config",
-                str(config_path),
-            ],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    str(formatter_path),
+                    "format",
+                    str(input_file_path),
+                    "--no-cache",
+                    "--config",
+                    str(config_path),
+                ],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"Could not run the 'ruff' formatter at '{formatter_path}'. "
+                f"gentest requires 'ruff' to format generated tests; ensure "
+                f"the development environment is installed, e.g. with "
+                f"'uv sync'."
+            ) from e
         if result.returncode != 0:
-            raise Exception(
+            raise RuntimeError(
                 f"Error formatting code using formatter '{formatter_path}': "
                 f"returncode={result.returncode}, stdout={result.stdout!r}, "
                 f"stderr={result.stderr!r}"

--- a/packages/testing/src/execution_testing/cli/gentest/tests/test_cli.py
+++ b/packages/testing/src/execution_testing/cli/gentest/tests/test_cli.py
@@ -139,10 +139,14 @@ def test_tx_type(
     monkeypatch.setattr(StateTestProvider, "get_context", get_mock_context)
 
     ## Generate ##
+    # catch_exceptions=False lets any error from gentest propagate with its
+    # full traceback instead of being hidden behind a non-zero exit code.
     gentest_result = runner.invoke(
-        generate, [transaction_hash, generated_py_file]
+        generate,
+        [transaction_hash, generated_py_file],
+        catch_exceptions=False,
     )
-    assert gentest_result.exit_code == 0
+    assert gentest_result.exit_code == 0, gentest_result.output
 
     ## Fill ##
     with open(generated_py_file, "r") as f:


### PR DESCRIPTION
## 🗒️ Description

When `ruff` is missing from the environment, gentest raised an opaque `<Result FileNotFoundError(2, 'No such file or directory')>` that never mentioned `ruff`. The error is now caught and re-raised with a clear hint to install the dev environment.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).