### PR TITLE
test: fix EIP-8037 existing CALL target coverage

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -469,7 +469,7 @@ def test_call_value_transfer_existing_account_no_state_gas(
     create new state, so no state gas is charged.
     """
     # Existing target account
-    target = pre.fund_eoa(amount=0)
+    target = pre.fund_eoa(amount=1)
 
     parent_storage = Storage()
     parent = pre.deploy_contract(
@@ -488,7 +488,10 @@ def test_call_value_transfer_existing_account_no_state_gas(
         sender=pre.fund_eoa(),
     )
 
-    post = {parent: Account(storage=parent_storage)}
+    post = {
+        parent: Account(balance=0, storage=parent_storage),
+        target: Account(balance=2),
+    }
     state_test(pre=pre, post=post, tx=tx)
 
 


### PR DESCRIPTION
## Summary
- make test_call_value_transfer_existing_account_no_state_gas use a genuinely alive target account
- assert the existing target receives the transferred value

## Testing
- uv run fill -m "not slow" -n 1 --dist=loadgroup --skip-index --output=.just/fill/fixtures --no-cov-on-fail --basetemp=.just/fill/tmp --log-to .just/fill/logs --clean --until Amsterdam --durations=10 tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py::test_call_value_transfer_existing_account_no_state_gas

Related to #3005.