### PR TITLE
fix(test-benchmark): address EIP-8037 spec compatibility issues

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -10,4 +10,4 @@ static:
 benchmark:
   impl: geth
   repo: ethereum/go-ethereum
-  ref: master
+  ref: bal-devnet-7

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -5,12 +5,12 @@ mainnet:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
+  fill-params: --fork=Amsterdam --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
   feature_only: true
 
 benchmark_fast:
   evm-type: benchmark
-  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
+  fill-params: --fork=Amsterdam --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
   feature_only: true
 
 glamsterdam-devnet:

--- a/Justfile
+++ b/Justfile
@@ -230,7 +230,7 @@ bench-gas *args:
         --evm-bin="{{ evm_bin }}" \
         --gas-benchmark-values 1 \
         --generate-all-formats \
-        --fork Osaka \
+        --fork Amsterdam \
         -m "not slow" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --output="{{ output_dir }}/bench-gas/fixtures" \
@@ -243,7 +243,7 @@ bench-gas *args:
     @rm -rf tests/json_loader/bench_gas_fixtures
     ln -sfn "{{ output_dir }}/bench-gas/fixtures" tests/json_loader/bench_gas_fixtures
     cd tests/json_loader && uv run --python pypy3.11 pytest \
-        --fork Osaka \
+        --fork Amsterdam \
         --allow-post-state-hash \
         -n auto --maxprocesses 10 --dist=loadfile \
         --basetemp="{{ output_dir }}/bench-gas/json-loader-tmp" \
@@ -256,8 +256,8 @@ bench-opcode *args:
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
         --fixed-opcode-count 1 \
-        --fork Osaka \
-        -m repricing \
+        --fork Amsterdam \
+        -m "repricing and not slow" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not uncachable" \
         --output="{{ output_dir }}/bench-opcode/fixtures" \
@@ -275,10 +275,10 @@ bench-opcode-config *args:
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
         --fixed-opcode-count \
-        --fork Osaka \
-        -m repricing \
+        --fork Amsterdam \
+        -m "repricing and not slow" \
         -n auto --maxprocesses 10 --dist=loadgroup \
-        -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not test_point_evaluation_uncachable" \
+        -k "not test_alt_bn128 and not test_bls12_381 and not test_modexp and not uncachable" \
         --output="{{ output_dir }}/bench-opcode-config/fixtures" \
         --basetemp="{{ output_dir }}/bench-opcode-config/tmp" \
         --log-to "{{ output_dir }}/bench-opcode-config/logs" \

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -461,6 +461,15 @@ class BuiltBlock(CamelModel):
     fork: Fork
     block_access_list: BlockAccessList | None
 
+    def cumulative_gas_used(self) -> int:
+        """Return the last receipt's cumulative gas used."""
+        if not self.result.receipts:
+            return int(self.result.gas_used)
+        cumulative_gas_used = self.result.receipts[-1].cumulative_gas_used
+        if cumulative_gas_used is None:
+            return int(self.result.gas_used)
+        return int(cumulative_gas_used)
+
     def get_fixture_block(
         self, *, include_receipts: bool = True
     ) -> FixtureBlock | InvalidFixtureBlock:
@@ -1116,7 +1125,7 @@ class BlockchainTest(BaseTest):
             block_number = int(built_block.header.number)
             is_last_block = block is self.blocks[-1]
             if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
-                benchmark_gas_used = int(built_block.result.gas_used)
+                benchmark_gas_used = built_block.cumulative_gas_used()
                 benchmark_opcode_count = built_block.result.opcode_count
             if built_block.result.receipts:
                 self.validate_receipt_status(
@@ -1215,7 +1224,7 @@ class BlockchainTest(BaseTest):
             block_number = int(built_block.header.number)
             is_last_block = block is self.blocks[-1]
             if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
-                benchmark_gas_used = int(built_block.result.gas_used)
+                benchmark_gas_used = built_block.cumulative_gas_used()
                 benchmark_opcode_count = built_block.result.opcode_count
             if built_block.result.receipts:
                 self.validate_receipt_status(
@@ -1484,7 +1493,7 @@ class BlockchainTest(BaseTest):
             else:
                 execution_payloads.append(payload)
                 if self.operation_mode == OpMode.BENCHMARKING:
-                    benchmark_gas_used = int(built_block.result.gas_used)
+                    benchmark_gas_used = built_block.cumulative_gas_used()
                     benchmark_opcode_count = built_block.result.opcode_count
             # Overwrite the block_hash apply_new_parent just recorded —
             # it's the FixtureHeader-recomputed RLP hash, which diverges

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -999,7 +999,7 @@ class IteratingBytecode(Bytecode):
         fork: Fork,
         iteration_count: int,
         start_iteration: int,
-        gas_limit: int,
+        gas_limit: int | None,
         compute_gas_limit: int | None = None,
         **intrinsic_cost_kwargs: Any,
     ) -> bool:
@@ -1008,7 +1008,10 @@ class IteratingBytecode(Bytecode):
 
         Returns True when both:
           - The combined regular+state gas (i.e. tx.gas) is <=
-            gas_limit (block-budget constraint).
+            gas_limit (block-budget constraint). A `gas_limit` of None
+            means the combined gas is unbounded, which under EIP-8037 lets
+            the state-gas reservoir grow past the EIP-7825 cap (that cap
+            only applies to regular gas, see `compute_gas_limit`).
           - The regular gas, computed as
             combined - iteration_count * iterating_state_gas,
             respects the compute_gas_limit.
@@ -1021,7 +1024,7 @@ class IteratingBytecode(Bytecode):
             start_iteration=start_iteration,
             **intrinsic_cost_kwargs,
         )
-        if combined > gas_limit:
+        if gas_limit is not None and combined > gas_limit:
             return False
         if compute_gas_limit is not None:
             compute = combined - iteration_count * self.iterating_state_gas
@@ -1033,7 +1036,7 @@ class IteratingBytecode(Bytecode):
         self,
         *,
         fork: Fork,
-        gas_limit: int,
+        gas_limit: int | None,
         start_iteration: int,
         compute_gas_limit: int | None = None,
         **intrinsic_cost_kwargs: Any,
@@ -1158,6 +1161,12 @@ class IteratingBytecode(Bytecode):
             # No limit, all iterations fit in a single transaction.
             yield total_iterations
             return
+        # Under EIP-8037 the EIP-7825 cap is a regular-gas limit only; state
+        # gas is bounded separately by `tx.gas`, so leave the combined gas
+        # uncapped and let the regular-gas check (compute_gas_limit) bind.
+        combined_gas_limit = (
+            None if fork.state_gas_reservoir_enabled() else gas_limit_cap
+        )
         remaining_iterations = total_iterations
         best_iterations: int | None = None
         constant_intrinsic_gas_cost = self._intrinsic_cost_is_constant(
@@ -1168,7 +1177,7 @@ class IteratingBytecode(Bytecode):
             if best_iterations is None or not constant_intrinsic_gas_cost:
                 best_iterations, _ = self._binary_search_iterations(
                     fork=fork,
-                    gas_limit=gas_limit_cap,
+                    gas_limit=combined_gas_limit,
                     compute_gas_limit=gas_limit_cap,
                     start_iteration=start_iteration,
                     **intrinsic_cost_kwargs,

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -448,6 +448,9 @@ class CustomSizedContractFactory(IteratingBytecode):
             iterating=iterating,
             iterating_subcall=initcode,
             cleanup=cleanup,
+            iterating_state_gas=(
+                iterating.state_cost(fork) + initcode.state_cost(fork)
+            ),
         )
         instance.initcode = initcode
         # Cache the address to avoid expensive recomputation
@@ -474,8 +477,10 @@ class CustomSizedContractFactory(IteratingBytecode):
     ) -> Generator[ContractDeploymentTransaction, None, None]:
         """
         Create a list of transactions calling the factory to create the
-        given number of contracts, each capped tx properly capped by the
-        gas limit cap of the fork.
+        given number of contracts, each transaction capped by the fork's
+        regular-gas limit cap (EIP-7825). Under EIP-8037 the per-byte code
+        deposit is state gas drawn from a separate reservoir, so the split
+        bounds regular gas only and lets the combined gas exceed the cap.
         """
         to = self.address()
 

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -405,15 +405,13 @@ def test_mod_arithmetic(
         )
         + Op.POP
     )
-    # Construct the final code. Because of the usage of PUSH32 the code segment
-    # is very long, so don't try to include multiple of these.
-    code = (
-        code_constant_pool
-        + Op.JUMPDEST
-        + code_segment
-        + Op.JUMP(len(code_constant_pool))
-    )
-    assert (max_code_size - len(code_segment)) < len(code) <= max_code_size
+
+    code_prefix = code_constant_pool + Op.JUMPDEST
+    code_suffix = Op.JUMP(len(code_constant_pool))
+    overhead = len(code_prefix) + len(code_suffix)
+    num_segments = (max_code_size - overhead) // len(code_segment)
+    code = code_prefix + code_segment * num_segments + code_suffix
+    assert len(code) <= max_code_size
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -259,6 +259,7 @@ def test_storage_access_cold(
     gas_benchmark_value: int,
     tx_gas_limit: int,
     tx_result: TransactionResult,
+    fixed_opcode_count: float | None,
 ) -> None:
     """
     Benchmark cold storage slot accesses using EIP-7702 delegation.
@@ -283,12 +284,16 @@ def test_storage_access_cold(
         return Hash(start_iteration) + Hash(iteration_count)
 
     # Number of slots that can be processed in the execution phase
-    num_target_slots = sum(
-        executor_code.tx_iterations_by_gas_limit(
-            fork=fork,
-            gas_limit=gas_benchmark_value,
-            calldata=calldata_generator,
+    num_target_slots = (
+        sum(
+            executor_code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                calldata=calldata_generator,
+            )
         )
+        if fixed_opcode_count is None
+        else int(fixed_opcode_count * 1000)
     )
 
     blocks = []
@@ -350,22 +355,39 @@ def test_storage_access_cold(
         tx_gas_limit_delta = (
             -1 if tx_result == TransactionResult.OUT_OF_GAS else 0
         )
-        exec_txs = list(
-            executor_code.transactions_by_gas_limit(
-                fork=fork,
-                gas_limit=gas_benchmark_value,
-                sender=pre.fund_eoa(),
-                to=authority,
-                calldata=calldata_generator,
-                start_iteration=1,
-                tx_gas_limit_delta=tx_gas_limit_delta,
+        if fixed_opcode_count is not None:
+            exec_txs = list(
+                executor_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=num_target_slots,
+                    sender=pre.fund_eoa(),
+                    to=authority,
+                    calldata=calldata_generator,
+                    start_iteration=1,
+                    tx_gas_limit_delta=tx_gas_limit_delta,
+                )
             )
-        )
+        else:
+            exec_txs = list(
+                executor_code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=gas_benchmark_value,
+                    sender=pre.fund_eoa(),
+                    to=authority,
+                    calldata=calldata_generator,
+                    start_iteration=1,
+                    tx_gas_limit_delta=tx_gas_limit_delta,
+                )
+            )
         for exec_tx in exec_txs:
             if tx_result == TransactionResult.OUT_OF_GAS:
                 expected_gas_used += exec_tx.gas_limit
             else:
                 expected_gas_used += exec_tx.gas_cost
+        if tx_result != TransactionResult.SUCCESS:
+            expected_gas_used -= (
+                num_target_slots * executor_code.iterating.state_cost(fork)
+            )
 
     blocks.append(Block(txs=exec_txs))
 
@@ -422,6 +444,7 @@ def test_storage_access_warm(
     storage_action: StorageAction,
     gas_benchmark_value: int,
     tx_gas_limit: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark warm storage slot accesses."""
     blocks = []
@@ -463,7 +486,11 @@ def test_storage_access_warm(
     contract_address = compute_create_address(address=sender_addr, nonce=0)
 
     with TestPhaseManager.execution():
-        num_exec_txs = math.ceil(gas_benchmark_value / tx_gas_limit)
+        num_exec_txs = (
+            math.ceil(gas_benchmark_value / tx_gas_limit)
+            if fixed_opcode_count is None
+            else 1
+        )
         txs = []
         for i in range(num_exec_txs):
             gas_limit = min(

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -13,6 +13,8 @@ Supported Opcodes:
 - SELFDESTRUCT
 """
 
+from typing import Any
+
 import pytest
 from execution_testing import (
     AccessList,
@@ -30,7 +32,6 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
     TestPhaseManager,
-    Transaction,
     While,
     compute_create2_address,
     compute_create_address,
@@ -48,64 +49,118 @@ def test_contract_calling_many_addresses(
     opcode: Op,
     access_warm: bool,
     gas_benchmark_value: int,
-    tx_gas_limit: int,
+    fixed_opcode_count: float | None,
 ) -> None:
-    """Benchmark a contract that calls many addresses."""
-    warm_start_addr = 2**80 - 1
-    setup = Op.PUSH20(warm_start_addr) if access_warm else Op.GAS
+    """Benchmark a contract that calls many distinct addresses."""
+    start_addr = 2**80 - 1
 
-    def loop(threshold: int) -> Bytecode:
-        return (
-            Op.JUMPDEST
-            + opcode(address=Op.DUP6, value=transfer_amount)
-            + Op.SWAP1
-            + Op.SUB
-            + Op.JUMPI(Op.GT(Op.GAS, threshold), len(setup))
-        )
+    value_transfer = transfer_amount > 0
+    # Only CALL creates accounts on value transfer (CALLCODE doesn't).
+    account_creation = value_transfer and opcode == Op.CALL
 
-    cost = loop(0xFFFF).gas_cost(fork)
-    code = setup + loop(cost)
-
-    contract_addr = pre.deploy_contract(
-        code=code,
-        balance=10**18 if transfer_amount > 0 else 0,
+    setup = (
+        Op.ADD(1, Op.CALLDATALOAD(32))  # [end+1 = limit]
+        + Op.CALLDATALOAD(0)  # [start = index, limit]
     )
 
-    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_cost = intrinsic_cost_calc()
-    access_list_addr_cost = fork.gas_costs().TX_ACCESS_LIST_ADDRESS
-
-    txs = []
-    remaining_gas = gas_benchmark_value
-    while remaining_gas > intrinsic_cost:
-        per_tx_gas = min(tx_gas_limit, remaining_gas)
-        remaining_gas -= per_tx_gas
-
-        access_list = None
-        if access_warm:
-            iterations = (per_tx_gas - intrinsic_cost) // (
-                access_list_addr_cost + cost
+    iterating = While(
+        body=Op.POP(
+            opcode(
+                address=Op.ADD(start_addr, Op.DUP6),
+                value=transfer_amount,
+                # gas accounting
+                address_warm=access_warm,
+                value_transfer=value_transfer,
+                account_new=account_creation,
             )
-            if iterations <= 0:
-                break
-            access_list = [
-                AccessList(
-                    address=Address(warm_start_addr - i),
-                    storage_keys=[],
-                )
-                for i in range(iterations)
-            ]
+        ),
+        condition=Op.PUSH1(1)  # [1, index, limit]
+        + Op.ADD  # [index+1, limit]
+        + Op.DUP1  # [index+1, index+1, limit]
+        + Op.DUP3  # [limit, index+1, index+1, limit]
+        + Op.GT,  # [limit > index+1, index+1, limit]
+    )
+    code = IteratingBytecode(
+        setup=setup,
+        iterating=iterating,
+        cleanup=Op.STOP,
+        iterating_state_gas=iterating.state_cost(fork),
+    )
 
-        txs.append(
-            Transaction(
-                to=contract_addr,
-                sender=pre.fund_eoa(),
-                gas_limit=per_tx_gas,
-                access_list=access_list,
+    contract_address = pre.deploy_contract(
+        code=code,
+        balance=10**9 if value_transfer else 0,
+    )
+
+    def calldata(iteration_count: int, start_iteration: int) -> bytes:
+        index_end = start_iteration + iteration_count - 1
+        return Hash(start_iteration) + Hash(index_end)
+
+    def access_list(
+        iteration_count: int, start_iteration: int
+    ) -> list[AccessList]:
+        return [
+            AccessList(address=Address(start_addr + i), storage_keys=[])
+            for i in range(start_iteration, start_iteration + iteration_count)
+        ]
+
+    tx_kwargs: dict = {
+        "calldata": calldata,
+        "access_list": access_list if access_warm else None,
+    }
+
+    total_iterations = (
+        sum(
+            code.tx_iterations_by_gas_limit(
+                fork=fork, gas_limit=gas_benchmark_value, **tx_kwargs
             )
         )
+        if fixed_opcode_count is None
+        else int(fixed_opcode_count * 1000)
+    )
 
-    benchmark_test(blocks=[Block(txs=txs)])
+    if total_iterations == 0:
+        pytest.skip(
+            "Benchmark gas value cannot cover a single call to the contract."
+        )
+
+    with TestPhaseManager.execution():
+        sender = pre.fund_eoa()
+        if fixed_opcode_count is not None:
+            exec_txs = list(
+                code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=total_iterations,
+                    sender=sender,
+                    to=contract_address,
+                    **tx_kwargs,
+                )
+            )
+        else:
+            exec_txs = list(
+                code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=gas_benchmark_value,
+                    sender=sender,
+                    to=contract_address,
+                    **tx_kwargs,
+                )
+            )
+        total_gas_cost = sum(tx.gas_cost for tx in exec_txs)
+        if value_transfer:
+            total_gas_cost -= fork.gas_costs().CALL_STIPEND * total_iterations
+
+    post = {
+        Address(start_addr + i): Account(balance=transfer_amount)
+        for i in range(total_iterations)
+        if account_creation
+    }
+
+    benchmark_test(
+        post=post,
+        blocks=[Block(txs=exec_txs)],
+        expected_benchmark_gas_used=total_gas_cost,
+    )
 
 
 @pytest.mark.repricing(max_code_size_ratio=0)
@@ -148,90 +203,158 @@ def test_create(
     max_code_size_ratio: float,
     non_zero_data: bool,
     value: int,
+    gas_benchmark_value: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark CREATE and CREATE2 instructions."""
     max_code_size = fork.max_code_size()
 
     code_size = int(max_code_size * max_code_size_ratio)
 
-    # Deploy the initcode template which has following design:
-    # ```
-    # PUSH3(code_size)
-    # [CODECOPY(DUP1) -- Conditional that non_zero_data is True]
-    # RETURN(0, DUP1)
-    # [<pad to code_size>] -- Conditional that non_zero_data is True]
-    # ```
-    code = (
-        Op.PUSH3(code_size)
-        + (Op.CODECOPY(size=Op.DUP1) if non_zero_data else Bytecode())
-        + Op.RETURN(0, Op.DUP1)
+    copy = (
+        Op.CODECOPY(
+            dest_offset=0,
+            offset=0,
+            size=code_size,
+            # gas accounting
+            data_size=code_size,
+            new_memory_size=code_size,
+        )
+        if non_zero_data
+        else Bytecode()
     )
-    if non_zero_data:  # Pad to code_size.
-        code += bytes([i % 256 for i in range(code_size - len(code))])
 
-    initcode_template_contract = pre.deploy_contract(code=code)
+    initcode_body = copy + Op.RETURN(
+        0,
+        code_size,
+        # gas accounting
+        code_deposit_size=code_size,
+        new_memory_size=0 if non_zero_data else code_size,
+    )
 
-    # Create the benchmark contract which has the following design:
-    # ```
-    # PUSH(value)
-    # [EXTCODECOPY(full initcode_template_contract)
-    # -> Conditional that non_zero_data is True]
-    #
-    # JUMPDEST (#)
-    # (CREATE|CREATE2)
-    # (CREATE|CREATE2)
-    # ...
-    # JUMP(#)
-    # ```
+    initcode = initcode_body
+
+    if non_zero_data:  # Pad to code_size so CODECOPY has code_size bytes.
+        initcode += bytes(
+            [i % 256 for i in range(code_size - len(initcode_body))]
+        )
+
+    initcode_template_contract = pre.deploy_contract(code=initcode)
+
+    # CALLDATA[0:32] = start index
+    # CALLDATA[32:64] = end index
     setup = (
-        Op.PUSH3(code_size)
-        + Op.PUSH1(value)
-        + Op.EXTCODECOPY(
+        Op.EXTCODECOPY(
             address=initcode_template_contract,
-            size=Op.DUP2,  # DUP2 refers to the EXTCODESIZE value above.
+            dest_offset=0,
+            offset=0,
+            size=len(initcode),
+            # gas accounting
+            data_size=len(initcode),
+            new_memory_size=len(initcode),
         )
+        + Op.ADD(1, Op.CALLDATALOAD(32))  # [end+1 = limit]
+        + Op.CALLDATALOAD(0)  # [start = index, limit]
     )
 
+    # CREATE2 takes the loop index (stack top) as its salt;
+    salt_kwarg: dict[str, Any] = {}
     if opcode == Op.CREATE2:
-        # For CREATE2, load salt from storage (persist across outer loop calls)
-        # If storage is 0 (first call), use initial salt of 42.
-        # Stack after setup: [..., value, code_size, salt]
-        setup += (
-            Op.SLOAD(0)  # Load saved salt
-            + Op.DUP1  # Duplicate for check
-            + Op.ISZERO  # Check if zero
-            + Op.PUSH1(42)  # Default salt
-            + Op.MUL  # 42 if zero, 0 if not
-            + Op.ADD  # Add to get final salt (saved or 42)
+        salt_kwarg = {"salt": Op.DUP1}
+
+    create_op = opcode(
+        value=value,
+        offset=0,
+        size=len(initcode),
+        init_code_size=len(initcode),
+        **salt_kwarg,
+    )
+
+    loop = While(
+        body=Op.POP(create_op),  # [index, limit]
+        condition=Op.PUSH1(1)  # [1, index, limit]
+        + Op.ADD  # [index+1, limit]
+        + Op.DUP1  # [index+1, index+1, limit]
+        + Op.DUP3  # [limit, index+1, index+1, limit]
+        + Op.GT,  # [limit > index+1, index+1, limit]
+    )
+
+    code = IteratingBytecode(
+        setup=setup,
+        iterating=loop,
+        iterating_subcall=initcode_body,
+        cleanup=Op.STOP,
+        iterating_state_gas=(
+            loop.state_cost(fork) + initcode_body.state_cost(fork)
+        ),
+    )
+
+    contract_address = pre.deploy_contract(
+        code=code,
+        balance=10**9 if value > 0 else 0,
+    )
+
+    def calldata(iteration_count: int, start_iteration: int) -> bytes:
+        index_end = iteration_count + start_iteration - 1
+        return Hash(start_iteration) + Hash(index_end)
+
+    num_contracts = (
+        sum(
+            code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                calldata=calldata,
+            )
+        )
+        if fixed_opcode_count is None
+        else int(fixed_opcode_count * 1000)
+    )
+
+    if num_contracts == 0:
+        pytest.skip(
+            "Benchmark gas value cannot cover a single contract creation."
         )
 
-    attack_block = (
-        # For CREATE:
-        # - DUP2 refers to the EXTOCODESIZE value  pushed in code_prefix.
-        # - DUP3 refers to PUSH1(value) above.
-        Op.POP(Op.CREATE(value=Op.DUP3, offset=0, size=Op.DUP2))
-        if opcode == Op.CREATE
-        # For CREATE2: we manually push the arguments because we leverage the
-        # return value of previous CREATE2 calls as salt for the next CREATE2
-        # call. After CREATE2, save result to storage for next outer loop call.
-        # - DUP4 is targeting the PUSH1(value) from the code_prefix.
-        # - DUP3 is targeting the EXTCODESIZE value pushed in code_prefix.
-        else Op.DUP3
-        + Op.PUSH0
-        + Op.DUP4
-        + Op.CREATE2
-        + Op.DUP1
-        + Op.PUSH0
-        + Op.SSTORE
-    )
+    with TestPhaseManager.execution():
+        sender = pre.fund_eoa()
+        if fixed_opcode_count is not None:
+            exec_txs = list(
+                code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=num_contracts,
+                    sender=sender,
+                    to=contract_address,
+                    calldata=calldata,
+                )
+            )
+        else:
+            exec_txs = list(
+                code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=gas_benchmark_value,
+                    sender=sender,
+                    to=contract_address,
+                    calldata=calldata,
+                )
+            )
+        total_gas_cost = sum(tx.gas_cost for tx in exec_txs)
+
+    post = {
+        compute_create_address(
+            address=contract_address,
+            nonce=1 + i,
+            salt=i,
+            initcode=initcode,
+            opcode=opcode,
+        ): Account(nonce=1)
+        for i in range(num_contracts)
+    }
 
     benchmark_test(
+        post=post,
         target_opcode=opcode,
-        code_generator=JumpLoopGenerator(
-            setup=setup,
-            attack_block=attack_block,
-            contract_balance=1_000_000_000 if value > 0 else 0,
-        ),
+        blocks=[Block(txs=exec_txs)],
+        expected_benchmark_gas_used=total_gas_cost,
     )
 
 
@@ -249,6 +372,7 @@ def test_creates_collisions(
     fork: Fork,
     opcode: Op,
     gas_benchmark_value: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark CREATE and CREATE2 instructions with collisions."""
     # We deploy a "proxy contract" which is the contract that will be called in
@@ -274,9 +398,7 @@ def test_creates_collisions(
     )
     proxy_contract = pre.deploy_contract(code=proxy_contract_code)
 
-    # The CALL to the proxy contract needs at a minimum gas corresponding to
-    # the CREATE(2) plus extra required PUSH0s for arguments.
-    min_gas_required = proxy_contract_code.gas_cost(fork)
+    min_gas_required = proxy_contract_code.regular_cost(fork)
     setup = Op.PUSH20(proxy_contract) + Op.PUSH3(min_gas_required)
     attack_block = Op.POP(
         # DUP7 refers to the PUSH3 above.
@@ -292,9 +414,12 @@ def test_creates_collisions(
         )
         pre.deploy_contract(address=addr, code=Op.INVALID)
     else:
-        # Heuristic to have an upper bound.
-        creation_cost = proxy_contract_code.gas_cost(fork)
-        max_contract_count = 2 * gas_benchmark_value // creation_cost
+        creation_cost = proxy_contract_code.regular_cost(fork)
+        max_contract_count = (
+            2 * gas_benchmark_value // creation_cost
+            if fixed_opcode_count is None
+            else int(fixed_opcode_count * 1000)
+        )
         for nonce in range(max_contract_count):
             addr = compute_create_address(address=proxy_contract, nonce=nonce)
             pre.deploy_contract(address=addr, code=Op.INVALID)
@@ -304,6 +429,7 @@ def test_creates_collisions(
         code_generator=JumpLoopGenerator(
             setup=setup, attack_block=attack_block
         ),
+        skip_gas_used_validation=True,
     )
 
 
@@ -359,6 +485,7 @@ def test_selfdestruct_existing(
     value_bearing: bool,
     fork: Fork,
     gas_benchmark_value: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction for existing contracts."""
     selfdestructable_contract = Op.SELFDESTRUCT(Op.CALLER, address_warm=True)
@@ -454,26 +581,17 @@ def test_selfdestruct_existing(
         index_end = iteration_count + start_iteration - 1
         return Hash(start_iteration) + Hash(index_end)
 
-    # Compute iteration counts and expected gas from the gas model.
-    iteration_counts = list(
-        attack_code.tx_iterations_by_gas_limit(
-            fork=fork,
-            gas_limit=gas_benchmark_value,
-            calldata=calldata,
+    num_contracts = (
+        sum(
+            attack_code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                calldata=calldata,
+            )
         )
+        if fixed_opcode_count is None
+        else int(fixed_opcode_count * 1000)
     )
-    num_contracts = sum(iteration_counts)
-
-    start = 0
-    total_gas_cost = 0
-    for iters in iteration_counts:
-        total_gas_cost += attack_code.tx_gas_cost_by_iteration_count(
-            fork=fork,
-            iteration_count=iters,
-            start_iteration=start,
-            calldata=calldata,
-        )
-        start += iters
 
     def factory_calldata(iteration_count: int, start_iteration: int) -> bytes:
         index_end = iteration_count + start_iteration - 1
@@ -493,15 +611,27 @@ def test_selfdestruct_existing(
 
     with TestPhaseManager.execution():
         attack_sender = pre.fund_eoa()
-        exec_txs = list(
-            attack_code.transactions_by_gas_limit(
-                fork=fork,
-                gas_limit=gas_benchmark_value,
-                sender=attack_sender,
-                to=attack_code_address,
-                calldata=calldata,
+        if fixed_opcode_count is not None:
+            exec_txs = list(
+                attack_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=num_contracts,
+                    sender=attack_sender,
+                    to=attack_code_address,
+                    calldata=calldata,
+                )
             )
-        )
+        else:
+            exec_txs = list(
+                attack_code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=gas_benchmark_value,
+                    sender=attack_sender,
+                    to=attack_code_address,
+                    calldata=calldata,
+                )
+            )
+        total_gas_cost = sum(tx.gas_cost for tx in exec_txs)
 
     post = {}
     for i in range(num_contracts):
@@ -534,6 +664,7 @@ def test_selfdestruct_created(
     value_bearing: bool,
     fork: Fork,
     gas_benchmark_value: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction for contracts created in same tx."""
     selfdestructable_contract = Op.SELFDESTRUCT(Op.CALLER, address_warm=True)
@@ -591,22 +722,16 @@ def test_selfdestruct_created(
         del start_iteration
         return Hash(iteration_count)
 
-    iteration_counts = list(
-        attack_code.tx_iterations_by_gas_limit(
-            fork=fork,
-            gas_limit=gas_benchmark_value,
-            calldata=calldata,
+    num_iterations = (
+        sum(
+            attack_code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                calldata=calldata,
+            )
         )
-    )
-    num_iterations = sum(iteration_counts)
-
-    total_gas_cost = sum(
-        attack_code.tx_gas_cost_by_iteration_count(
-            fork=fork,
-            iteration_count=iters,
-            calldata=calldata,
-        )
-        for iters in iteration_counts
+        if fixed_opcode_count is None
+        else int(fixed_opcode_count * 1000)
     )
 
     attack_code_address = pre.deploy_contract(
@@ -616,15 +741,27 @@ def test_selfdestruct_created(
 
     with TestPhaseManager.execution():
         sender = pre.fund_eoa()
-        exec_txs = list(
-            attack_code.transactions_by_gas_limit(
-                fork=fork,
-                gas_limit=gas_benchmark_value,
-                sender=sender,
-                to=attack_code_address,
-                calldata=calldata,
+        if fixed_opcode_count is not None:
+            exec_txs = list(
+                attack_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=num_iterations,
+                    sender=sender,
+                    to=attack_code_address,
+                    calldata=calldata,
+                )
             )
-        )
+        else:
+            exec_txs = list(
+                attack_code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=gas_benchmark_value,
+                    sender=sender,
+                    to=attack_code_address,
+                    calldata=calldata,
+                )
+            )
+        total_gas_cost = sum(tx.gas_cost for tx in exec_txs)
 
     post = {
         attack_code_address: Account(
@@ -649,6 +786,7 @@ def test_selfdestruct_initcode(
     value_bearing: bool,
     fork: Fork,
     gas_benchmark_value: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction executed in initcode."""
     initcode = Op.SELFDESTRUCT(Op.CALLER, address_warm=True)
@@ -689,22 +827,16 @@ def test_selfdestruct_initcode(
         del start_iteration
         return Hash(iteration_count)
 
-    iteration_counts = list(
-        attack_code.tx_iterations_by_gas_limit(
-            fork=fork,
-            gas_limit=gas_benchmark_value,
-            calldata=calldata,
+    num_iterations = (
+        sum(
+            attack_code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                calldata=calldata,
+            )
         )
-    )
-    num_iterations = sum(iteration_counts)
-
-    total_gas_cost = sum(
-        attack_code.tx_gas_cost_by_iteration_count(
-            fork=fork,
-            iteration_count=iters,
-            calldata=calldata,
-        )
-        for iters in iteration_counts
+        if fixed_opcode_count is None
+        else int(fixed_opcode_count * 1000)
     )
 
     attack_code_address = pre.deploy_contract(
@@ -714,15 +846,27 @@ def test_selfdestruct_initcode(
 
     with TestPhaseManager.execution():
         sender = pre.fund_eoa()
-        exec_txs = list(
-            attack_code.transactions_by_gas_limit(
-                fork=fork,
-                gas_limit=gas_benchmark_value,
-                sender=sender,
-                to=attack_code_address,
-                calldata=calldata,
+        if fixed_opcode_count is not None:
+            exec_txs = list(
+                attack_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=num_iterations,
+                    sender=sender,
+                    to=attack_code_address,
+                    calldata=calldata,
+                )
             )
-        )
+        else:
+            exec_txs = list(
+                attack_code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=gas_benchmark_value,
+                    sender=sender,
+                    to=attack_code_address,
+                    calldata=calldata,
+                )
+            )
+        total_gas_cost = sum(tx.gas_cost for tx in exec_txs)
 
     post = {
         attack_code_address: Account(

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -96,6 +96,7 @@ from tests.prague.eip2537_bls_12_381_precompiles.spec import (
 def test_bls12_381(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
+    gas_benchmark_value: int,
     precompile_address: Address,
     calldata: bytes,
     target: OpcodeTarget,
@@ -103,6 +104,12 @@ def test_bls12_381(
     """Benchmark BLS12_381 precompile."""
     if precompile_address not in fork.precompiles():
         pytest.skip("Precompile not enabled")
+
+    intrinsic_gas_cost = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata
+    )
+    if intrinsic_gas_cost > gas_benchmark_value:
+        pytest.skip("calldata intrinsic gas cost exceeds the gas limit")
 
     attack_block = Op.POP(
         Op.STATICCALL(
@@ -125,6 +132,7 @@ def test_bls12_381(
 def test_bls12_g1_msm(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
+    gas_benchmark_value: int,
     k: int,
 ) -> None:
     """Benchmark BLS12_G1_MSM precompile with varying number of points."""
@@ -137,6 +145,12 @@ def test_bls12_g1_msm(
         (bls12381_spec.Spec.P1 + bls12381_spec.Scalar(bls12381_spec.Spec.Q))
         * k
     )
+
+    intrinsic_gas_cost = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata
+    )
+    if intrinsic_gas_cost > gas_benchmark_value:
+        pytest.skip("k configuration exceeds the gas limit")
 
     attack_block = Op.POP(
         Op.STATICCALL(

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -280,7 +280,7 @@ def total_cost_standard_per_token(fork: Fork) -> int:
 def calldata_generator(
     gas_amount: int,
     zero_byte: int,
-    total_cost_floor_per_token: int,
+    fork: Fork,
 ) -> bytes:
     """Calculate the calldata based on the gas amount and zero byte."""
     # Gas cost calculation based on EIP-7683: (https://eips.ethereum.org/EIPS/eip-7683)
@@ -301,20 +301,9 @@ def calldata_generator(
     #       max(TX_DATA_TOKEN_STANDARD, TX_DATA_TOKEN_FLOOR)
     #   tx.gasUsed = 21000 + tokens_in_calldata * max_token_cost
     #
-    # Since max(TX_DATA_TOKEN_STANDARD, TX_DATA_TOKEN_FLOOR) = 10:
-    #   tx.gasUsed = 21000 + tokens_in_calldata * 10
-    #
-    # Token accounting:
-    #   tokens_in_calldata = zero_bytes + 4 * non_zero_bytes
-    #
-    # So we calculate how many bytes we can fit into calldata based on
-    # available gas.
-    max_tokens_in_calldata = gas_amount // total_cost_floor_per_token
-    num_of_bytes = (
-        max_tokens_in_calldata if zero_byte else max_tokens_in_calldata // 4
-    )
     byte_data = b"\x00" if zero_byte else b"\xff"
-    return byte_data * num_of_bytes
+    gas_per_byte = fork.calldata_gas_calculator()(data=byte_data, floor=True)
+    return byte_data * (gas_amount // gas_per_byte)
 
 
 @pytest.mark.parametrize("zero_byte", [True, False])
@@ -323,7 +312,6 @@ def test_block_full_data(
     pre: Alloc,
     zero_byte: bool,
     intrinsic_cost: int,
-    total_cost_floor_per_token: int,
     gas_benchmark_value: int,
     tx_gas_limit: int,
     fork: Fork,
@@ -339,11 +327,8 @@ def test_block_full_data(
         # Max calldata bytes at 99% of limit (Osaka: 8,388,608 * 0.99 ≈ 8.3 MB)
         safe_calldata_bytes = int(block_rlp_limit * 0.99)
 
-        # convert to gas: zero bytes = 10 gas/byte, non-zero = 40 gas/byte
-        gas_per_byte = (
-            total_cost_floor_per_token
-            if zero_byte
-            else total_cost_floor_per_token * 4
+        gas_per_byte = fork.calldata_gas_calculator()(
+            data=b"\x00" if zero_byte else b"\xff", floor=True
         )
         # For zero bytes: 8.3MB * 10 = 83M gas just for calldata
         max_calldata_gas = safe_calldata_bytes * gas_per_byte
@@ -363,7 +348,7 @@ def test_block_full_data(
         data = calldata_generator(
             gas_available,
             zero_byte,
-            total_cost_floor_per_token,
+            fork,
         )
 
         total_gas_used += fork.transaction_intrinsic_cost_calculator()(
@@ -618,6 +603,18 @@ def test_auth_transaction(
         if fork.is_eip_enabled(7778)
         else total_gas_used - total_refund
     )
+
+    # Authorization state gas refunded to the reservoir per EIP-8037
+    per_auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1
+    )
+    if not empty_authority:
+        per_auth_state_refund = per_auth_state_gas
+    elif zero_delegation:
+        per_auth_state_refund = per_auth_state_gas - fork.create_state_gas()
+    else:
+        per_auth_state_refund = 0
+    expected_gas_usage -= per_auth_state_refund * sum(authorizations_per_tx)
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -149,6 +149,12 @@ def test_unchunkified_bytecode(
                     nonce=1
                 )
 
+    total_deployment_gas = sum(
+        int(tx.gas_limit) for tx in contracts_deployment_txs
+    )
+    if total_deployment_gas > gas_benchmark_value:
+        pytest.skip("contract deployment exceeds the gas benchmark value")
+
     with TestPhaseManager.execution():
         attack_sender = pre.fund_eoa()
         if fixed_opcode_count is not None:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Refactor tests/benchmark/compute for Amsterdam spec: account for EIP-8037 (state-gas reservoir) and EIP-7778 (calldata repricing).

Key changes:

- Split gas accounting into regular-gas and state-gas bounds
- Update IteratingBytecode, CustomSizedContractFactory, and gas measurement
- Add skip guards for scenarios exceeding --gas-benchmark-values
- Point CI to Amsterdam; use bal-devnet-7 geth reference

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Issue #2913 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
