### PR TITLE
refactor(spec-specs): derive EIP-8037 state gas used from reservoir/spill

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -186,6 +186,12 @@ class Evm:
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     regular_gas_used: Uint = Uint(0)
     state_gas_spilled: Uint = Uint(0)
+    """
+    Running total of state gas that _spilled_ into `gas_left`: the amount
+    charged against `gas_left` because the `state_gas_left` reservoir was
+    empty at the time of the charge. Repaid to `gas_left` first when
+    refunds or frame rollback unwind those charges.
+    """
 
 
 def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:
@@ -255,16 +261,19 @@ def refill_frame_state_gas(evm: Evm) -> None:
 
 def frame_state_gas_used(evm: Evm) -> int:
     """
-    Return the net state gas a finished frame consumed.
+    Return the net state gas consumed by a finished frame.
 
-    Equal to the reservoir drawn down (`state_gas_reservoir` at entry
-    minus the reservoir now) plus `state_gas_spilled`. May be negative
+    Equal to the reservoir drawn down ([`state_gas_reservoir`][sgr] at entry
+    minus the reservoir now) plus [`state_gas_spilled`][sgs]. May be negative
     when refunds exceed charges.
 
     Parameters
     ----------
     evm :
         The finished frame.
+
+    [sgr]: ref:ethereum.forks.amsterdam.vm.Message.state_gas_reservoir
+    [sgs]: ref:ethereum.forks.amsterdam.vm.Evm.state_gas_spilled
 
     """
     return (

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -186,12 +186,6 @@ class Evm:
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     regular_gas_used: Uint = Uint(0)
     state_gas_spilled: Uint = Uint(0)
-    """
-    Running total of state gas that _spilled_ into `gas_left`: the amount
-    charged against `gas_left` because the `state_gas_left` reservoir was
-    empty at the time of the charge. Repaid to `gas_left` first when
-    refunds or frame rollback unwind those charges.
-    """
 
 
 def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -185,7 +185,6 @@ class Evm:
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     regular_gas_used: Uint = Uint(0)
-    state_gas_used: int = 0
     state_gas_spilled: Uint = Uint(0)
 
 
@@ -210,7 +209,6 @@ def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:
     evm.gas_left += from_gas_left
     evm.state_gas_spilled -= from_gas_left
     evm.state_gas_left += amount - from_gas_left
-    evm.state_gas_used -= int(amount)
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
@@ -234,7 +232,6 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     evm.accessed_addresses.update(child_evm.accessed_addresses)
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
     evm.regular_gas_used += child_evm.regular_gas_used
-    evm.state_gas_used += child_evm.state_gas_used
 
 
 def refill_frame_state_gas(evm: Evm) -> None:
@@ -252,13 +249,29 @@ def refill_frame_state_gas(evm: Evm) -> None:
 
     """
     evm.gas_left += evm.state_gas_spilled
-    evm.state_gas_left = Uint(
-        int(evm.state_gas_left)
-        + evm.state_gas_used
-        - int(evm.state_gas_spilled)
-    )
-    evm.state_gas_used = 0
+    evm.state_gas_left = evm.message.state_gas_reservoir
     evm.state_gas_spilled = Uint(0)
+
+
+def frame_state_gas_used(evm: Evm) -> int:
+    """
+    Return the net state gas a finished frame consumed.
+
+    Equal to the reservoir drawn down (`state_gas_reservoir` at entry
+    minus the reservoir now) plus `state_gas_spilled`. May be negative
+    when refunds exceed charges.
+
+    Parameters
+    ----------
+    evm :
+        The finished frame.
+
+    """
+    return (
+        int(evm.message.state_gas_reservoir)
+        - int(evm.state_gas_left)
+        + int(evm.state_gas_spilled)
+    )
 
 
 def incorporate_child_on_error(
@@ -270,9 +283,8 @@ def incorporate_child_on_error(
 
     The child rolls back its own state gas via `refill_frame_state_gas`
     before returning (on both reverts and exceptional halts), so its
-    `gas_left` and reservoir already reflect the LIFO refill and its
-    `state_gas_used` is zero. The parent therefore only reabsorbs the
-    child's `gas_left` and reservoir.
+    `gas_left` and reservoir already reflect the LIFO refill. The parent
+    therefore only reabsorbs the child's `gas_left` and reservoir.
 
     Parameters
     ----------

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -293,7 +293,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 def charge_state_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from the state gas reservoir, then from
-    `evm.gas_left` when the reservoir is empty, tracking any spill.
+    `evm.gas_left` when the reservoir is empty, tracking any [spill].
 
     Parameters
     ----------
@@ -301,6 +301,8 @@ def charge_state_gas(evm: Evm, amount: Uint) -> None:
         The current EVM.
     amount :
         The amount of state gas the current operation requires.
+
+    [spill]: ref:ethereum.forks.amsterdam.vm.Evm.state_gas_spilled
 
     """
     evm_trace(evm, StateGasAndRefund(int(amount)))

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -293,7 +293,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 def charge_state_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from the state gas reservoir, then from
-    `evm.gas_left` when the reservoir is empty. Records state gas usage.
+    `evm.gas_left` when the reservoir is empty, tracking any spill.
 
     Parameters
     ----------
@@ -314,8 +314,6 @@ def charge_state_gas(evm: Evm, amount: Uint) -> None:
         evm.state_gas_spilled += remainder
     else:
         raise OutOfGasError
-
-    evm.state_gas_used += int(amount)
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -54,7 +54,12 @@ from ..vm.gas import (
     charge_state_gas,
 )
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
-from . import Evm, emit_transfer_log, refill_frame_state_gas
+from . import (
+    Evm,
+    emit_transfer_log,
+    frame_state_gas_used,
+    refill_frame_state_gas,
+)
 from .exceptions import (
     AddressCollision,
     ExceptionalHalt,
@@ -185,7 +190,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         return_data=evm.output,
         state_gas_left=evm.state_gas_left,
         regular_gas_used=evm.regular_gas_used,
-        state_gas_used=evm.state_gas_used,
+        state_gas_used=frame_state_gas_used(evm),
         state_refund=state_refund,
         created_target_alive=target_alive,
     )


### PR DESCRIPTION
## 🗒️ Description

The EIP-8037 reservoir model tracked three running per-frame quantities: the reservoir (`state_gas_left`), the amount spilled into `gas_left` (`state_gas_spilled`), and the net consumed (`state_gas_used`). The third is redundant: at every point a frame's net state gas equals

    (reservoir_at_entry - state_gas_left) + state_gas_spilled

This invariant is preserved by every charge, refund, and child incorporation, so `state_gas_used` no longer needs to be maintained.

Drop the `state_gas_used` field and compute it on demand:

- `charge_state_gas`, `credit_state_gas_refund`, and `incorporate_child_on_success` no longer update the counter.
- `refill_frame_state_gas` resets the reservoir to its frame-entry value `message.state_gas_reservoir` (the LIFO inverse of the frame's charges) instead of folding `state_gas_used` back in.
- New helper `frame_state_gas_used` derives the value at frame end; it is read only when building the `MessageCallOutput`.

Behavior is unchanged. Verified by filling the full Amsterdam suite (6686 passed, 0 failed), producing fixtures identical to the three-counter model.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

