### PR TITLE
feat: Bogota fork + EIP-7805 engine_newPayloadV6 bump

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -20,5 +20,5 @@ bal:
 
 focil:
   evm-type: eels
-  fill-params: ./tests/bogota/eip7805_focil --until=Amsterdam
+  fill-params: ./tests/bogota/eip7805_focil --from=Bogota
   feature_only: true

--- a/packages/testing/src/execution_testing/forks/forks/eips/bogota/__init__.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/bogota/__init__.py
@@ -1,1 +1,52 @@
 """Listings of all EIPs for Bogotá fork."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from execution_testing.forks.base_fork import BaseFork
+
+__all__ = ["BogotaEIPs"]
+
+if TYPE_CHECKING:
+
+    class BogotaEIPs(BaseFork):
+        """Typing-only stand-in for Bogotá EIP mixins."""
+
+        pass
+else:
+    _prefix = __name__ + "."
+    _bogota_eips = []
+
+    for _importer, _modname, _ispkg in pkgutil.iter_modules(
+        __path__, prefix=_prefix
+    ):
+        if _ispkg or not re.search(r"\.eip_\d+$", _modname):
+            continue
+
+        _module = importlib.import_module(_modname)
+
+        for _name, _obj in inspect.getmembers(_module, inspect.isclass):
+            if re.match(r"^EIP\d+$", _name) and _obj.__module__ == _modname:
+                _bogota_eips.append(_obj)
+
+    _bogota_eips.sort(key=lambda cls: int(cls.__name__[3:]))
+
+    class _BogotaEIPsSentinel:
+        """Expand to the currently available Bogotá EIP mixins."""
+
+        def __mro_entries__(
+            self,
+            bases: tuple[type, ...],
+        ) -> tuple[type, ...]:
+            del bases
+            return tuple(_bogota_eips)
+
+    BogotaEIPs = _BogotaEIPsSentinel()  # type: ignore[misc]
+
+    del _importer, _ispkg, _modname, _module, _name, _obj, _prefix

--- a/packages/testing/src/execution_testing/forks/forks/eips/bogota/eip_7805.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/bogota/eip_7805.py
@@ -1,0 +1,22 @@
+"""
+EIP-7805: Fork-choice enforced Inclusion Lists (FOCIL).
+
+Adds an ``inclusionListTransactions`` parameter to ``engine_newPayloadV6`` and
+bumps ``engine_forkchoiceUpdated`` to V5 so the CL can pass per-committee ILs
+to the EL on the forkchoice-update path.
+
+https://eips.ethereum.org/EIPS/eip-7805
+"""
+
+from ....base_fork import BaseFork
+
+
+class EIP7805(
+    BaseFork,
+    # Engine API method version bumps
+    # New `inclusionListTransactions` parameter on newPayload, and
+    # `engine_getInclusionListV1` introduced on the GET side.
+    engine_new_payload_version_bump=True,
+    engine_forkchoice_updated_version_bump=True,
+):
+    """EIP-7805 class."""

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -36,6 +36,7 @@ from ..base_fork import (
 from ..gas_costs import BASE, HIGH, LOW, MID, VERY_LOW, GasCosts
 from . import eips
 from .eips.amsterdam import AmsterdamEIPs
+from .eips.bogota import BogotaEIPs
 from .helpers import ceiling_division
 
 
@@ -1622,12 +1623,12 @@ class Amsterdam(
 
 
 class Bogota(
-    eips.EIP7805,
+    BogotaEIPs,
     Amsterdam,
     deployed=False,
     transition_tool_name="Amsterdam",
     solc_name="cancun",
 ):
-    """Bogotá fork: Amsterdam + EIP-7805 (FOCIL)."""
+    """Bogotá fork: Amsterdam + Bogotá EIPs (FOCIL)."""
 
     pass

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1619,3 +1619,15 @@ class Amsterdam(
     #  live on mainnet.
 
     pass
+
+
+class Bogota(
+    eips.EIP7805,
+    Amsterdam,
+    deployed=False,
+    transition_tool_name="Amsterdam",
+    solc_name="cancun",
+):
+    """Bogotá fork: Amsterdam + EIP-7805 (FOCIL)."""
+
+    pass

--- a/tests/bogota/eip7805_focil/test_focil.py
+++ b/tests/bogota/eip7805_focil/test_focil.py
@@ -33,7 +33,7 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_7805.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7805.version
 
 pytestmark = [
-    pytest.mark.valid_from("Amsterdam"),
+    pytest.mark.valid_from("Bogota"),
     pytest.mark.blockchain_test_engine_only,
 ]
 


### PR DESCRIPTION
The first tests-focil release fixtures were filling FOCIL tests with `newPayloadVersion: 5` because no EIP class declared the version bump and there was no fork class to host EIP-7805. As a result `consume engine` appended `inclusionListTransactions` as a 5th positional arg to V5, which isn't a wire format defined by any Engine API spec — all clients reject it.

This adds:
- EIP7805 mixin under eips/bogota/ with engine_new_payload_version_bump and engine_forkchoice_updated_version_bump
- Bogota fork class (Amsterdam + EIP7805), reusing Amsterdam's t8n
- Switches FOCIL tests' valid_from marker to Bogota

After refilling, fixtures now use engine_newPayloadV6 / forkchoiceUpdatedV5.

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
