### PR TITLE
feat(tests): add EIP-211 return data buffer tests for SELFDESTRUCT

### DIFF
--- a/tests/byzantium/eip211_return_data/__init__.py
+++ b/tests/byzantium/eip211_return_data/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EIP-211 return data buffer behavior."""

--- a/tests/byzantium/eip211_return_data/spec.py
+++ b/tests/byzantium/eip211_return_data/spec.py
@@ -1,0 +1,17 @@
+"""Defines EIP-211 specification reference."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_211 = ReferenceSpec(
+    git_path="EIPS/eip-211.md",
+    version="N/A",
+)

--- a/tests/byzantium/eip211_return_data/test_selfdestruct.py
+++ b/tests/byzantium/eip211_return_data/test_selfdestruct.py
@@ -32,19 +32,19 @@ def test_selfdestruct_clears_return_data(
     )
 
     selfdestructs = pre.deploy_contract(
-        code=Op.POP(Op.CALL(gas=100_000, address=returns_32, ret_size=0))
+        code=Op.POP(Op.CALL(address=returns_32, ret_size=0))
         + Op.SELFDESTRUCT(Op.CALLER)
     )
 
     caller = pre.deploy_contract(
         code=Op.SSTORE(
             0,
-            Op.CALL(gas=200_000, address=selfdestructs, ret_size=0),
+            Op.CALL(address=selfdestructs, ret_size=0),
         )
         + Op.SSTORE(1, Op.RETURNDATASIZE)
     )
 
-    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=1_000_000)
+    tx = Transaction(sender=pre.fund_eoa(), to=caller)
 
     state_test(
         pre=pre,

--- a/tests/byzantium/eip211_return_data/test_selfdestruct.py
+++ b/tests/byzantium/eip211_return_data/test_selfdestruct.py
@@ -1,0 +1,53 @@
+"""Test SELFDESTRUCT return data buffer behavior."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_211
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_211.git_path
+REFERENCE_SPEC_VERSION = ref_spec_211.version
+
+
+@pytest.mark.valid_from("Byzantium")
+def test_selfdestruct_clears_return_data(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test SELFDESTRUCT returns empty data after an inner call returns data.
+
+    The selfdestructing contract first performs a call that leaves 32 bytes in
+    its own return-data buffer. The outer caller must still observe empty
+    return data from the selfdestructing call.
+    """
+    returns_32 = pre.deploy_contract(
+        code=Op.MSTORE(0, 0x112233) + Op.RETURN(0, 32)
+    )
+
+    selfdestructs = pre.deploy_contract(
+        code=Op.POP(Op.CALL(gas=100_000, address=returns_32, ret_size=0))
+        + Op.SELFDESTRUCT(Op.CALLER)
+    )
+
+    caller = pre.deploy_contract(
+        code=Op.SSTORE(
+            0,
+            Op.CALL(gas=200_000, address=selfdestructs, ret_size=0),
+        )
+        + Op.SSTORE(1, Op.RETURNDATASIZE)
+    )
+
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=1_000_000)
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={caller: Account(storage={0: 1, 1: 0})},
+    )


### PR DESCRIPTION
## 🗒️ Description
Adds EIP-211 return-data buffer coverage for calls that end in `SELFDESTRUCT`.

The new Byzantium test creates a nested-call scenario where a contract first receives 32 bytes of return data from an inner call, then exits via `SELFDESTRUCT`. The outer caller verifies that the `SELFDESTRUCT` call succeeds but exposes an empty return-data buffer, asserting `RETURNDATASIZE == 0`.

## 🔗 Related Issues or PRs
Situation discovered by a new guest program (zevm) running a `glamsterdam-devnet-5` block. [See Discord thread](https://discord.com/channels/595666850260713488/1516884559797551204/1517284128285003826).

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
