### PR TITLE
feat(tests): EIP-8037 code-deposit state gas exact-fit boundary

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -234,17 +234,12 @@ def test_code_deposit_state_gas_scales_with_size(
 
 
 @pytest.mark.parametrize(
-    "gas_delta",
+    ("funding", "gas_delta"),
     [
-        pytest.param(0, id="exact_fit"),
-        pytest.param(-1, id="one_gas_short"),
-    ],
-)
-@pytest.mark.parametrize(
-    "funding",
-    [
-        pytest.param("reservoir", id="reservoir_funded"),
-        pytest.param("spill", id="gas_left_spill"),
+        pytest.param("reservoir", 0, id="reservoir_success"),
+        pytest.param("reservoir", -1, id="reservoir_oog"),
+        pytest.param("spill", 0, id="spill_success"),
+        pytest.param("spill", -1, id="spill_oog"),
     ],
 )
 @EIPChecklist.GasCostChanges.Test.OutOfGas()
@@ -262,9 +257,9 @@ def test_code_deposit_state_gas_exact_fit_boundary(
     A CREATE tx deploys ``code_size`` bytes with ``gas_limit`` set so the
     deposit lands exactly at the available gas (deploys) or one gas short
     (halts: state restored, NEW_ACCOUNT refilled, no code). The two
-    regimes pin the halt billing: over-cap ``reservoir_funded`` rolls the
-    reservoir back so the sender pays the cap; in-cap ``gas_left_spill``
-    burns ``gas_left`` and bills ``gas_limit - NEW_ACCOUNT``. The scaling
+    regimes pin the halt billing: over-cap ``reservoir`` rolls the
+    reservoir back so the sender pays the cap; in-cap ``spill`` burns
+    ``gas_left`` and bills ``gas_limit - NEW_ACCOUNT``. The scaling
     tests assert success only.
     """
     gas_costs = fork.gas_costs()

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -233,6 +233,95 @@ def test_code_deposit_state_gas_scales_with_size(
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "gas_delta",
+    [
+        pytest.param(0, id="exact_fit"),
+        pytest.param(-1, id="one_gas_short"),
+    ],
+)
+@pytest.mark.parametrize(
+    "funding",
+    [
+        pytest.param("reservoir", id="reservoir_funded"),
+        pytest.param("spill", id="gas_left_spill"),
+    ],
+)
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
+@pytest.mark.valid_from("EIP8037")
+def test_code_deposit_state_gas_exact_fit_boundary(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    funding: str,
+    gas_delta: int,
+) -> None:
+    """
+    Pin the code-deposit state gas at its exact-fit boundary.
+
+    A CREATE tx deploys ``code_size`` bytes with ``gas_limit`` set so the
+    deposit lands exactly at the available gas (deploys) or one gas short
+    (halts: state restored, NEW_ACCOUNT refilled, no code). The two
+    regimes pin the halt billing: over-cap ``reservoir_funded`` rolls the
+    reservoir back so the sender pays the cap; in-cap ``gas_left_spill``
+    burns ``gas_left`` and bills ``gas_limit - NEW_ACCOUNT``. The scaling
+    tests assert success only.
+    """
+    gas_costs = fork.gas_costs()
+    cap = fork.transaction_gas_limit_cap()
+    assert cap is not None
+
+    code_size = fork.max_code_size() if funding == "reservoir" else 1000
+
+    words = (code_size + 31) // 32
+    memory_gas = gas_costs.MEMORY_PER_WORD * words + words * words // 512
+    init_code = Op.RETURN(0, code_size)
+    init_exec_regular = init_code.regular_cost(fork) + memory_gas
+    keccak_gas = gas_costs.OPCODE_KECCAK256_PER_WORD * words
+    deposit_state_gas = fork.code_deposit_state_gas(code_size=code_size)
+
+    intrinsic_total = fork.transaction_intrinsic_cost_calculator()(
+        calldata=bytes(init_code),
+        contract_creation=True,
+        return_cost_deducted_prior_execution=True,
+    )
+    exact_fit_gas = (
+        intrinsic_total + init_exec_regular + keccak_gas + deposit_state_gas
+    )
+    if funding == "reservoir":
+        assert exact_fit_gas > cap
+    else:
+        assert exact_fit_gas <= cap
+
+    sender = pre.fund_eoa()
+    created = compute_create_address(address=sender, nonce=0)
+    gas_limit = exact_fit_gas + gas_delta
+
+    post: dict
+    if gas_delta == 0:
+        receipt_gas_used = exact_fit_gas
+        post = {created: Account(code=b"\x00" * code_size)}
+    else:
+        receipt_gas_used = (
+            cap
+            if funding == "reservoir"
+            else gas_limit - gas_costs.NEW_ACCOUNT
+        )
+        post = {created: Account.NONEXISTENT}
+
+    tx = Transaction(
+        to=None,
+        data=init_code,
+        gas_limit=gas_limit,
+        sender=sender,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=receipt_gas_used
+        ),
+    )
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
 @pytest.mark.valid_from("EIP8037")
 def test_repeated_create_same_code_charges_each_account(
     state_test: StateTestFiller,


### PR DESCRIPTION
## 🗒️ Description

Pin the code-deposit state gas charge at its exact-fit gas boundary. A CREATE transaction deploys code via RETURN(0, code_size); after the init code returns, code deposit charges keccak regular gas from gas_left then code_size * COST_PER_STATE_BYTE state gas, reservoir first and spilling into gas_left.

test_code_deposit_state_gas_exact_fit_boundary sets the transaction gas so the deposit charge lands exactly at the available gas (the contract deploys) or one gas short (the deposit halts, NEW_ACCOUNT is refilled, and no code is deployed). The reservoir_funded case uses code_size = MAX_CODE_SIZE so the deposit exceeds the EIP-7825 cap and is drawn reservoir first (the shortfall reduces the reservoir; an over-cap halt bills exactly the cap); the gas_left_spill case uses an in-cap gas limit so the deposit spills wholly from gas_left. The scaling tests vary the size but assert success only, leaving this boundary unpinned.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

