### PR TITLE
feat(tests): CREATE/CREATE2 and CALL clear return data on failed pre-checks

### DIFF
--- a/tests/byzantium/eip211_return_data/test_call.py
+++ b/tests/byzantium/eip211_return_data/test_call.py
@@ -1,0 +1,91 @@
+"""Test CALL return data buffer behavior on pre-check failure."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_211
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_211.git_path
+REFERENCE_SPEC_VERSION = ref_spec_211.version
+
+
+@pytest.mark.valid_from("Byzantium")
+def test_call_clears_return_data_on_insufficient_balance(
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    Test that a CALL clears the return-data buffer even when the call fails the
+    insufficient-balance pre-check and the callee is never entered.
+
+    A CALL whose value exceeds the caller's balance is a "light" failure: it
+    pushes 0 and never executes the callee, but per EIP-211 it must still reset
+    the return-data buffer. A client that skips the reset on this early-return
+    path would leave stale return data from a preceding CALL observable via
+    RETURNDATASIZE/RETURNDATACOPY.
+
+    (The other CALL pre-check -- the 1024 call-stack depth limit -- is not
+    exercised here: since EIP-150's 63/64 gas-forwarding rule, a call chain
+    runs out of gas long before reaching depth 1024, so that branch is
+    effectively unreachable.)
+
+    Storage layout:
+      slot 0 = RETURNDATASIZE after the funded CALL    (expected 32)
+      slot 1 = RETURNDATASIZE after the failing CALL   (expected 0)
+      slot 2 = the failing CALL result                 (expected 0, failure)
+    """
+    slot_rds_after_call = 0
+    slot_rds_after_failed_call = 1
+    slot_failed_call_result = 2
+
+    # Callee returns 32 bytes, so the caller's return-data buffer is 32 bytes.
+    callee = pre.deploy_contract(
+        code=Op.MSTORE(0, 0x11223344) + Op.RETURN(0, 32),
+    )
+
+    # Caller has balance 1, so a CALL with value 2 fails the balance pre-check
+    # before entering the callee.
+    caller = pre.deploy_contract(
+        balance=1,
+        code=(
+            Op.CALL(Op.GAS, callee, 0, 0, 0, 0, 32)
+            + Op.SSTORE(slot_rds_after_call, Op.RETURNDATASIZE)
+            + Op.SSTORE(
+                slot_failed_call_result,
+                Op.CALL(Op.GAS, callee, 2, 0, 0, 0, 0),
+            )
+            + Op.SSTORE(slot_rds_after_failed_call, Op.RETURNDATASIZE)
+            + Op.STOP
+        ),
+        storage={
+            slot_rds_after_call: 0xFF,
+            slot_rds_after_failed_call: 0xFF,
+            slot_failed_call_result: 0xFF,
+        },
+    )
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=caller,
+        gas_limit=1_000_000,
+    )
+
+    state_test(
+        pre=pre,
+        post={
+            caller: Account(
+                storage={
+                    slot_rds_after_call: 32,
+                    slot_rds_after_failed_call: 0,
+                    slot_failed_call_result: 0,
+                }
+            )
+        },
+        tx=tx,
+    )

--- a/tests/byzantium/eip211_return_data/test_call.py
+++ b/tests/byzantium/eip211_return_data/test_call.py
@@ -6,6 +6,7 @@ from execution_testing import (
     Alloc,
     Op,
     StateTestFiller,
+    Storage,
     Transaction,
 )
 
@@ -36,56 +37,48 @@ def test_call_clears_return_data_on_insufficient_balance(
     effectively unreachable.)
 
     Storage layout:
-      slot 0 = RETURNDATASIZE after the funded CALL    (expected 32)
-      slot 1 = RETURNDATASIZE after the failing CALL   (expected 0)
-      slot 2 = the failing CALL result                 (expected 0, failure)
+      slot N = RETURNDATASIZE after the funded CALL    (expected 32)
+      slot N+1 = RETURNDATASIZE after the failing CALL   (expected 0)
+      slot N+2 = the failing CALL result                 (expected 0, failure)
     """
-    slot_rds_after_call = 0
-    slot_rds_after_failed_call = 1
-    slot_failed_call_result = 2
+    storage = Storage()
 
     # Callee returns 32 bytes, so the caller's return-data buffer is 32 bytes.
     callee = pre.deploy_contract(
         code=Op.MSTORE(0, 0x11223344) + Op.RETURN(0, 32),
     )
 
+    init_balance = 1
+
     # Caller has balance 1, so a CALL with value 2 fails the balance pre-check
     # before entering the callee.
     caller = pre.deploy_contract(
-        balance=1,
+        balance=init_balance,
         code=(
-            Op.CALL(Op.GAS, callee, 0, 0, 0, 0, 32)
-            + Op.SSTORE(slot_rds_after_call, Op.RETURNDATASIZE)
+            Op.CALL(gas=Op.GAS, address=callee, ret_size=32)
             + Op.SSTORE(
-                slot_failed_call_result,
-                Op.CALL(Op.GAS, callee, 2, 0, 0, 0, 0),
+                storage.store_next(32, "rds_after_call"), Op.RETURNDATASIZE
             )
-            + Op.SSTORE(slot_rds_after_failed_call, Op.RETURNDATASIZE)
+            + Op.SSTORE(
+                storage.store_next(0, "failed_call_result"),
+                Op.CALL(gas=Op.GAS, address=callee, value=init_balance + 1),
+            )
+            + Op.SSTORE(
+                storage.store_next(0, "rds_after_failed_call"),
+                Op.RETURNDATASIZE,
+            )
             + Op.STOP
         ),
-        storage={
-            slot_rds_after_call: 0xFF,
-            slot_rds_after_failed_call: 0xFF,
-            slot_failed_call_result: 0xFF,
-        },
+        storage=dict.fromkeys(storage, 0xFF),
     )
 
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=caller,
-        gas_limit=1_000_000,
     )
 
     state_test(
         pre=pre,
-        post={
-            caller: Account(
-                storage={
-                    slot_rds_after_call: 32,
-                    slot_rds_after_failed_call: 0,
-                    slot_failed_call_result: 0,
-                }
-            )
-        },
+        post={caller: Account(storage=storage)},
         tx=tx,
     )

--- a/tests/byzantium/eip211_return_data/test_create.py
+++ b/tests/byzantium/eip211_return_data/test_create.py
@@ -1,0 +1,106 @@
+"""Test CREATE/CREATE2 return data buffer behavior on pre-check failure."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_211
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_211.git_path
+REFERENCE_SPEC_VERSION = ref_spec_211.version
+
+
+@pytest.mark.valid_from("Byzantium")
+@pytest.mark.parametrize(
+    "create_type",
+    [
+        pytest.param(Op.CREATE, id="CREATE"),
+        pytest.param(
+            Op.CREATE2,
+            id="CREATE2",
+            marks=pytest.mark.valid_from("Constantinople"),
+        ),
+    ],
+)
+def test_create_clears_return_data_on_insufficient_balance(
+    create_type: Op,
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    Test that entering CREATE/CREATE2 clears the return-data buffer even when
+    the create fails a pre-execution check (insufficient balance) and the
+    initcode never runs.
+
+    Existing return-data tests for CREATE/CREATE2 always execute the initcode
+    (which RETURNs or REVERTs), covering only the post-initcode path. Entering
+    a CREATE must reset the return-data buffer unconditionally, including the
+    depth/nonce/balance pre-checks that abort before any initcode runs. A
+    client that clears the buffer only after those pre-checks would leave stale
+    return data from a preceding CALL via RETURNDATASIZE/RETURNDATACOPY.
+
+    The caller performs a CALL that leaves 32 bytes of return data, then a
+    create with value exceeding its balance (failing the balance pre-check
+    before initcode), and asserts RETURNDATASIZE is 0 afterward.
+
+    Storage layout:
+      slot 0 = RETURNDATASIZE after the CALL    (expected 32)
+      slot 1 = RETURNDATASIZE after the create  (expected 0)
+      slot 2 = the create result address        (expected 0, i.e. failure)
+    """
+    slot_rds_after_call = 0
+    slot_rds_after_create = 1
+    slot_create_result = 2
+
+    # Callee returns 32 bytes, so the caller's return-data buffer is 32 bytes.
+    callee = pre.deploy_contract(
+        code=Op.MSTORE(0, 0x11223344) + Op.RETURN(0, 32),
+    )
+
+    if create_type == Op.CREATE2:
+        create_op = Op.CREATE2(value=2, offset=0, size=0, salt=0)
+    else:
+        create_op = Op.CREATE(value=2, offset=0, size=0)
+
+    # Caller has balance 1, so a create with value 2 fails the balance
+    # pre-check before executing any initcode.
+    caller = pre.deploy_contract(
+        balance=1,
+        code=(
+            Op.CALL(Op.GAS, callee, 0, 0, 0, 0, 32)
+            + Op.SSTORE(slot_rds_after_call, Op.RETURNDATASIZE)
+            + Op.SSTORE(slot_create_result, create_op)
+            + Op.SSTORE(slot_rds_after_create, Op.RETURNDATASIZE)
+            + Op.STOP
+        ),
+        storage={
+            slot_rds_after_call: 0xFF,
+            slot_rds_after_create: 0xFF,
+            slot_create_result: 0xFF,
+        },
+    )
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=caller,
+        gas_limit=1_000_000,
+    )
+
+    state_test(
+        pre=pre,
+        post={
+            caller: Account(
+                storage={
+                    slot_rds_after_call: 32,
+                    slot_rds_after_create: 0,
+                    slot_create_result: 0,
+                }
+            )
+        },
+        tx=tx,
+    )

--- a/tests/byzantium/eip211_return_data/test_create.py
+++ b/tests/byzantium/eip211_return_data/test_create.py
@@ -6,6 +6,7 @@ from execution_testing import (
     Alloc,
     Op,
     StateTestFiller,
+    Storage,
     Transaction,
 )
 
@@ -17,7 +18,7 @@ REFERENCE_SPEC_VERSION = ref_spec_211.version
 
 @pytest.mark.valid_from("Byzantium")
 @pytest.mark.parametrize(
-    "create_type",
+    "create_opcode",
     [
         pytest.param(Op.CREATE, id="CREATE"),
         pytest.param(
@@ -28,7 +29,7 @@ REFERENCE_SPEC_VERSION = ref_spec_211.version
     ],
 )
 def test_create_clears_return_data_on_insufficient_balance(
-    create_type: Op,
+    create_opcode: Op,
     pre: Alloc,
     state_test: StateTestFiller,
 ) -> None:
@@ -49,58 +50,45 @@ def test_create_clears_return_data_on_insufficient_balance(
     before initcode), and asserts RETURNDATASIZE is 0 afterward.
 
     Storage layout:
-      slot 0 = RETURNDATASIZE after the CALL    (expected 32)
-      slot 1 = RETURNDATASIZE after the create  (expected 0)
-      slot 2 = the create result address        (expected 0, i.e. failure)
+      slot N = RETURNDATASIZE after the CALL    (expected 32)
+      slot N+1 = RETURNDATASIZE after the create  (expected 0)
+      slot N+2 = the create result address        (expected 0, i.e. failure)
     """
-    slot_rds_after_call = 0
-    slot_rds_after_create = 1
-    slot_create_result = 2
+    storage = Storage()
 
     # Callee returns 32 bytes, so the caller's return-data buffer is 32 bytes.
     callee = pre.deploy_contract(
         code=Op.MSTORE(0, 0x11223344) + Op.RETURN(0, 32),
     )
 
-    if create_type == Op.CREATE2:
-        create_op = Op.CREATE2(value=2, offset=0, size=0, salt=0)
-    else:
-        create_op = Op.CREATE(value=2, offset=0, size=0)
+    init_balance = 1
+    create_op = create_opcode(value=init_balance + 1)
 
     # Caller has balance 1, so a create with value 2 fails the balance
     # pre-check before executing any initcode.
     caller = pre.deploy_contract(
-        balance=1,
+        balance=init_balance,
         code=(
-            Op.CALL(Op.GAS, callee, 0, 0, 0, 0, 32)
-            + Op.SSTORE(slot_rds_after_call, Op.RETURNDATASIZE)
-            + Op.SSTORE(slot_create_result, create_op)
-            + Op.SSTORE(slot_rds_after_create, Op.RETURNDATASIZE)
+            Op.CALL(gas=Op.GAS, address=callee, ret_size=32)
+            + Op.SSTORE(
+                storage.store_next(32, "rds_after_call"), Op.RETURNDATASIZE
+            )
+            + Op.SSTORE(storage.store_next(0, "create_result"), create_op)
+            + Op.SSTORE(
+                storage.store_next(0, "rds_after_create"), Op.RETURNDATASIZE
+            )
             + Op.STOP
         ),
-        storage={
-            slot_rds_after_call: 0xFF,
-            slot_rds_after_create: 0xFF,
-            slot_create_result: 0xFF,
-        },
+        storage=dict.fromkeys(storage, 0xFF),
     )
 
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=caller,
-        gas_limit=1_000_000,
     )
 
     state_test(
         pre=pre,
-        post={
-            caller: Account(
-                storage={
-                    slot_rds_after_call: 32,
-                    slot_rds_after_create: 0,
-                    slot_create_result: 0,
-                }
-            )
-        },
+        post={caller: Account(storage=storage)},
         tx=tx,
     )


### PR DESCRIPTION
## Motivation

The existing CREATE/CREATE2 return-data tests (e.g. `eip1014_create2/test_create_returndata.py::test_create2_return_data`, the `stCreateTest` returndata ports, and the `eip7610` collision test) all either execute the create's initcode or exercise only the *collision* pre-check. None cover the **depth / nonce / balance pre-check abort** paths, where the create fails **before any initcode runs**.

Per the spec, entering a CREATE always resets the return-data buffer — unconditionally, including those pre-check failures. A client that clears the buffer only *after* the pre-checks would leave stale return data from a preceding CALL observable via `RETURNDATASIZE` / `RETURNDATACOPY`. This is an easy implementation mistake that the current suite does not catch.

## What this adds

A state test (parametrized over `CREATE` and `CREATE2`) that:
1. CALLs a callee returning 32 bytes, so the return-data buffer holds 32 bytes (`RETURNDATASIZE == 32`),
2. executes a create with `value` greater than the creator's balance, failing the **insufficient-balance pre-check** before initcode runs,
3. asserts `RETURNDATASIZE == 0` afterward (buffer cleared), along with the create result being `0`.

A buggy client that only clears the buffer after the balance check returns the stale `32`, which changes the value the contract SSTOREs and is observable in the post-state.

## Verification

Fills cleanly. Verified against an independent client implementation (zevm) which had exactly this bug: it **fails** when the return-data clear happens after the balance pre-check, and **passes** when the clear happens on create entry.

The corresponding client fix that this test exercises: https://github.com/omerfirmak/zevm/pull/37/commits/b200243d53c50229c0ed9662867f31725c819c6e (moves the return-data buffer reset to the top of `create()`, before the depth/nonce/balance pre-checks). This regression was originally found on a `glamsterdam-devnet-5` block, where a CREATE2 failing with "insufficient balance for transfer" left a preceding precompile call's 64-byte return data observable, corrupting downstream gas/state accounting.