### PR TITLE
chore(tooling): clarify state_test preference in write-test skill

### DIFF
--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -8,7 +8,7 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 - Core fixtures: `pre: Alloc` (pre-state builder), `state_test: StateTestFiller`, `blockchain_test: BlockchainTestFiller`, `fork: Fork`
 - Rule: use `state_test` for single-transaction tests; `fill` auto-derives a `blockchain_test` from each, so no coverage is lost.
 - Exception: use `blockchain_test` when the test needs more than one transaction (a `state_test` holds exactly one) or more than one block (e.g. transaction-ordering or fork-transition tests).
-- Anti-pattern: wrapping one transaction in a `Block` to reach `blockchain_test`. A `state_test` can assert a block-header field (`blockchain_test_header_verify=Header(gas_used=...)`), receipt logs (the tx's `expected_receipt`), and reserve state gas (the tx's `state_gas_reservoir=`) without it.
+- Anti-pattern: wrapping one transaction in a `Block` to reach `blockchain_test`. A `state_test` can assert the transaction's gas used and receipt logs (the tx's `expected_receipt=TransactionReceipt(cumulative_gas_used=...)`), reserve state gas (the tx's `state_gas_reservoir=`), and other block-header fields (`blockchain_test_header_verify=Header(...)`) without it.
 
 ## Pre-State Setup
 

--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -6,8 +6,9 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 
 - All test imports come from `execution_testing` — it is the public API
 - Core fixtures: `pre: Alloc` (pre-state builder), `state_test: StateTestFiller`, `blockchain_test: BlockchainTestFiller`, `fork: Fork`
-- Prefer `state_test` for single-tx tests (simpler, avoids block-building false positives); `fill` auto-generates a `blockchain_test` from every `state_test`
-- Use `blockchain_test` only for multi-block scenarios
+- Rule: use `state_test` for single-transaction tests; `fill` auto-derives a `blockchain_test` from each, so no coverage is lost.
+- Exception: use `blockchain_test` when the test needs more than one transaction (a `state_test` holds exactly one) or more than one block (e.g. transaction-ordering or fork-transition tests).
+- Anti-pattern: wrapping one transaction in a `Block` to reach `blockchain_test`. A `state_test` can assert a block-header field (`blockchain_test_header_verify=Header(gas_used=...)`), receipt logs (the tx's `expected_receipt`), and reserve state gas (the tx's `state_gas_reservoir=`) without it.
 
 ## Pre-State Setup
 


### PR DESCRIPTION
## 🗒️ Description

Tighten the `write-test` agent skill to prefer `state_test` for single-transaction tests, and document that block-header (`blockchain_test_header_verify`), receipt-log, and state-gas-reservoir assertions do not require `blockchain_test`.

## 🔗 Related Issues or PRs

Motivation: #3033 and CPerezz/execution-specs#3 and https://github.com/CPerezz/execution-specs/pull/3#pullrequestreview-4555818181  

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![a cat that prefers state_test](https://cataas.com/cat/says/state_test?fontSize=50&fontColor=white)