### PR TITLE
refactor(specs): 8037 `StateGas`, `RegularGas` and `StateGasPerByte`

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -992,7 +992,7 @@ def process_transaction(
 
     intrinsic = validate_transaction(tx)
 
-    intrinsic_gas = intrinsic.regular + intrinsic.state
+    intrinsic_gas = Uint(intrinsic.regular) + Uint(intrinsic.state)
 
     (
         sender,

--- a/src/ethereum/forks/amsterdam/fork_types.py
+++ b/src/ethereum/forks/amsterdam/fork_types.py
@@ -39,6 +39,8 @@ RegularGas = NewType("RegularGas", Uint)
 StateGas = NewType("StateGas", Uint)
 
 
+@slotted_freezable
+@dataclass
 class StateGasPerByte:
     """
     State gas charged per byte of state growth, per [EIP-8037].
@@ -50,8 +52,7 @@ class StateGasPerByte:
     [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
     """
 
-    def __init__(self, rate: Uint) -> None:
-        self.rate = rate
+    rate: Uint
 
     def __mul__(self, num_bytes: Uint) -> StateGas:
         """Return the state gas for `num_bytes` charged at this rate."""

--- a/src/ethereum/forks/amsterdam/fork_types.py
+++ b/src/ethereum/forks/amsterdam/fork_types.py
@@ -39,6 +39,7 @@ RegularGas = NewType("RegularGas", Uint)
 StateGas = NewType("StateGas", Uint)
 
 
+@final
 @slotted_freezable
 @dataclass
 class StateGasPerByte:

--- a/src/ethereum/forks/amsterdam/fork_types.py
+++ b/src/ethereum/forks/amsterdam/fork_types.py
@@ -12,12 +12,12 @@ Types reused throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import final
+from typing import NewType, final
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes256
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U8, U32, U64, U256
+from ethereum_types.numeric import U8, U32, U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.state import Account, Address
@@ -32,6 +32,34 @@ Position within the set of all changes in a [`Block`].
 VersionedHash = Hash32
 
 Bloom = Bytes256
+
+
+RegularGas = NewType("RegularGas", Uint)
+
+StateGas = NewType("StateGas", Uint)
+
+
+class StateGasPerByte:
+    """
+    State gas charged per byte of state growth, per [EIP-8037].
+
+    A rate, not an amount: deliberately not a `Uint`, since adding a rate to
+    a gas amount is meaningless. Multiplying it by a byte count, in either
+    operand order, yields a `StateGas`.
+
+    [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
+    """
+
+    def __init__(self, rate: Uint) -> None:
+        self.rate = rate
+
+    def __mul__(self, num_bytes: Uint) -> StateGas:
+        """Return the state gas for `num_bytes` charged at this rate."""
+        return StateGas(self.rate * num_bytes)
+
+    def __rmul__(self, num_bytes: Uint) -> StateGas:
+        """Return the state gas for `num_bytes` charged at this rate."""
+        return StateGas(self.rate * num_bytes)
 
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -25,7 +25,12 @@ from .exceptions import (
     InitCodeTooLargeError,
     TransactionTypeError,
 )
-from .fork_types import Authorization, VersionedHash
+from .fork_types import (
+    Authorization,
+    RegularGas,
+    StateGas,
+    VersionedHash,
+)
 
 
 @final
@@ -33,10 +38,10 @@ from .fork_types import Authorization, VersionedHash
 class IntrinsicGasCost:
     """Intrinsic gas costs for a transaction, split by gas type."""
 
-    regular: Uint
+    regular: RegularGas
     """Regular execution gas (calldata, base cost, access list, etc.)."""
 
-    state: Uint
+    state: StateGas
     """
     State growth gas (account creation, storage set, authorization) per
     [EIP-8037].
@@ -44,7 +49,7 @@ class IntrinsicGasCost:
     [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
     """
 
-    calldata_floor: Uint
+    calldata_floor: RegularGas
     """
     Minimum gas cost based on calldata size per [EIP-7623].
 
@@ -605,7 +610,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
-    intrinsic_gas = intrinsic.regular + intrinsic.state
+    intrinsic_gas = Uint(intrinsic.regular) + Uint(intrinsic.state)
     if intrinsic_gas > tx.gas:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
     if intrinsic.calldata_floor > tx.gas:
@@ -717,9 +722,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     intrinsic_state_gas = create_state_gas + auth_state_gas
 
     return IntrinsicGasCost(
-        regular=intrinsic_regular_gas,
-        state=intrinsic_state_gas,
-        calldata_floor=data_floor_gas_cost,
+        regular=RegularGas(intrinsic_regular_gas),
+        state=StateGas(intrinsic_state_gas),
+        calldata_floor=RegularGas(data_floor_gas_cost),
     )
 
 

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -26,7 +26,7 @@ from ethereum.utils.byte import left_pad_zero_bytes
 
 from ..block_access_lists import BlockAccessList, BlockAccessListBuilder
 from ..blocks import Log, Receipt, Withdrawal
-from ..fork_types import Authorization, VersionedHash
+from ..fork_types import Authorization, StateGas, VersionedHash
 from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
 
@@ -189,7 +189,7 @@ class Evm:
     state_gas_spilled: Uint = Uint(0)
 
 
-def credit_state_gas_refund(evm: Evm, amount: Uint) -> None:
+def credit_state_gas_refund(evm: Evm, amount: StateGas) -> None:
     """
     Credit a state gas refund to the local frame, in LIFO order.
 

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -21,6 +21,7 @@ from ethereum.trace import GasAndRefund, StateGasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
 
 from ..blocks import Header
+from ..fork_types import StateGas, StateGasPerByte
 from ..transactions import BlobTransaction, Transaction
 from . import Evm
 from .exceptions import OutOfGasError
@@ -36,17 +37,19 @@ class StateGasCosts:
     state-byte counts that convert into gas via `COST_PER_STATE_BYTE`.
     """
 
-    COST_PER_STATE_BYTE: Final[Uint] = Uint(1530)
+    COST_PER_STATE_BYTE: Final[StateGasPerByte] = StateGasPerByte(Uint(1530))
     STATE_BYTES_PER_NEW_ACCOUNT: Final[Uint] = Uint(120)
     STATE_BYTES_PER_STORAGE_SET: Final[Uint] = Uint(64)
     STATE_BYTES_PER_AUTH_BASE: Final[Uint] = Uint(23)
-    STORAGE_SET: Final[Uint] = (
+    STORAGE_SET: Final[StateGas] = (
         STATE_BYTES_PER_STORAGE_SET * COST_PER_STATE_BYTE
     )
-    NEW_ACCOUNT: Final[Uint] = (
+    NEW_ACCOUNT: Final[StateGas] = (
         STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
     )
-    AUTH_BASE: Final[Uint] = STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
+    AUTH_BASE: Final[StateGas] = (
+        STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
+    )
 
 
 # These values may be patched at runtime by a future gas repricing utility
@@ -290,7 +293,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     evm.regular_gas_used += amount
 
 
-def charge_state_gas(evm: Evm, amount: Uint) -> None:
+def charge_state_gas(evm: Evm, amount: StateGas) -> None:
     """
     Subtracts `amount` from the state gas reservoir, then from
     `evm.gas_left` when the reservoir is empty. Records state gas usage.

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -13,6 +13,7 @@ Implementations of the EVM storage related instructions.
 
 from ethereum_types.numeric import Uint
 
+from ...fork_types import StateGas
 from ...state_tracker import (
     get_storage,
     get_storage_original,
@@ -90,7 +91,7 @@ def sstore(evm: Evm) -> None:
     current_value = get_storage(tx_state, evm.message.current_target, key)
 
     gas_cost = Uint(0)
-    state_gas = Uint(0)
+    state_gas = StateGas(Uint(0))
 
     if (evm.message.current_target, key) not in evm.accessed_storage_keys:
         evm.accessed_storage_keys.add((evm.message.current_target, key))

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -20,6 +20,7 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import StateGas
 from ...state_tracker import (
     account_deployable,
     get_account,
@@ -668,7 +669,7 @@ def selfdestruct(evm: Evm) -> None:
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
-    state_gas = Uint(0)
+    state_gas = StateGas(Uint(0))
     if (
         not is_account_alive(tx_state, beneficiary)
         and get_account(tx_state, evm.message.current_target).balance != 0


### PR DESCRIPTION

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

As suggested in the related issue introduces 3 new types  `StateGas`, `RegularGas` and `StateGasPerByte` to separate gas calculations

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
https://github.com/ethereum/execution-specs/issues/3015

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/abaf6aad-cde2-401a-b2df-e064c215bbd4)

