### PR TITLE
refactor(test-tools): Remove `CodeGasMeasure` footgun (stop)

### DIFF
--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -161,7 +161,6 @@ class CodeGasMeasure(Bytecode):
         overhead_cost: int = 0,
         extra_stack_items: int = 0,
         sstore_key: int | Bytes = 0,
-        stop: bool = True,
     ) -> Self:
         """Assemble the bytecode that measures gas usage."""
         res = Op.GAS + code + Op.GAS
@@ -180,8 +179,6 @@ class CodeGasMeasure(Bytecode):
             + Op.SWAP1
             + Op.SSTORE(sstore_key, Op.SUB)
         )
-        if stop:
-            res += Op.STOP
 
         instance = super().__new__(cls, res)
         instance.code = code

--- a/tests/berlin/eip2929_gas_cost_increases/test_warm_status_revert.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_warm_status_revert.py
@@ -49,7 +49,6 @@ def test_storage_warm_status_reverted_by_subcall(
         overhead_cost=sload_push_cost,
         extra_stack_items=1,
         sstore_key=1,
-        stop=False,
     )
 
     # Also verify storage[0] value (should still be 1).

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -288,7 +288,6 @@ def test_repeated_address_acl(
         overhead_cost=sload_push_cost,
         extra_stack_items=1,  # SLOAD pushes 1 item to the stack
         sstore_key=0,
-        stop=False,  # Because it's the first CodeGasMeasure
     )
 
     sload1_measure = CodeGasMeasure(

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -42,7 +42,6 @@ def test_call_large_offset_mstore(
         overhead_cost=call_push_cost,
         extra_stack_items=1,  # Because CALL pushes 1 item to the stack
         sstore_key=0,
-        stop=False,  # Because it's the first CodeGasMeasure
     )
     mstore_measure = CodeGasMeasure(
         code=Op.MSTORE(offset=mem_offset, value=1),
@@ -110,8 +109,6 @@ def test_call_memory_expands_on_early_revert(
         # Because CALL pushes 1 item to the stack
         extra_stack_items=1,
         sstore_key=0,
-        # Because it's the first CodeGasMeasure
-        stop=False,
     )
     mstore_measure = CodeGasMeasure(
         # Low offset for not expanding memory

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -130,13 +130,10 @@ def test_clz_gas_cost(
 ) -> None:
     """Test CLZ opcode gas cost."""
     contract_address = pre.deploy_contract(
-        Op.SSTORE(
-            0,
-            CodeGasMeasure(
-                code=Op.CLZ(Op.PUSH1(1)),
-                extra_stack_items=1,
-                overhead_cost=Op.PUSH1.gas_cost(fork),
-            ),
+        CodeGasMeasure(
+            code=Op.CLZ(Op.PUSH1(1)),
+            extra_stack_items=1,
+            overhead_cost=Op.PUSH1.gas_cost(fork),
         ),
         storage={"0x00": "0xdeadbeef"},
     )

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -1099,7 +1099,6 @@ def test_account_warming(
                 overhead_cost=overhead_cost,
                 extra_stack_items=1,
                 sstore_key=check_address,
-                stop=False,
             )
             for check_address in addresses_to_check
         )

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -1498,14 +1498,12 @@ def test_set_code_address_and_authority_warm_state(
         overhead_cost=overhead_cost,
         extra_stack_items=1,
         sstore_key=slot_set_code_to_warm_state,
-        stop=False,
     )
     code_gas_measure_authority = CodeGasMeasure(
         code=call_opcode(address=auth_signer),
         overhead_cost=overhead_cost,
         extra_stack_items=1,
         sstore_key=slot_authority_warm_state,
-        stop=False,
     )
 
     callee_code = Bytecode()


### PR DESCRIPTION
## 🗒️ Description

Remove the `stop` parameter from `CodeGasMeasure`, since it causes more issues than advantages.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
