### PR TITLE
chore(test-clients-cli): map ethrex empty-change-set BAL rejection to `INVALID_BLOCK_ACCESS_LIST`

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -173,6 +173,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"exceeding max valid index \d+|"
             r"Failed to RLP decode BAL|"
             r"Block access list .+ not in strictly ascending order.*|"
+            r"Block access list .+ has an empty change set|"
             r"BAL validation failed for (tx \d+|system_tx|withdrawal): .*|"
             r"BAL validation failed: .*|"
             r"absent from BAL|"


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

ethrex correctly rejects an EIP-7928 block whose block access list contains a `SlotChanges` with an empty `slot_changes` list, returning `INVALID` with the message `Block access list storage_changes slot <slot> for account <addr> has an empty change set` (raised by `BlockAccessList::validate_ordering`). The `EthrexExceptionMapper` already recognizes the sibling `validate_ordering` messages (not-in-strictly-ascending-order, in-both-storage_changes-and-storage_reads) but was missing this one, so under strict exception matching `consume` reports `test_bal_invalid_empty_slot_changes[unrelated_slot|demoted_noop]` as failing even though ethrex's behaviour is correct. Add the missing alternative to the `INVALID_BLOCK_ACCESS_LIST` regex.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
