### PR TITLE
fix(spec-tests): register JSON fixture fork marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,7 @@ markers = [
     "json_state_tests: marks tests as json_state_tests (deselect with '-m \"not json_state_tests\"')",
     "vm_test: marks tests as vm_test (deselect with '-m \"not vm_test\"')",
     "eels_base_coverage: Minimized subset selected to preserve high EELS line-coverage parity (select with '-m eels_base_coverage')",
+    "fork: marks JSON fixture tests by fork",
     "repricing: marks tests for gas repricing analysis",
     "stub_parametrize: parametrize test from address stubs by prefix",
 ]


### PR DESCRIPTION
## 🗒️ Description

Register the `fork(name)` pytest marker used by JSON fixture tests.

JSON fixture collection adds `pytest.mark.fork(...)` to collected tests, but the marker was not registered in the root pytest configuration. This caused `PytestUnknownMarkWarning` during pytest runs. Registering the marker in `pyproject.toml` silences the warning without changing test behavior.

## 🔗 Related Issues or PRs

Fixes #1407.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Cute animal picture](https://images.unsplash.com/photo-1529778873920-4da4926a72c2?w=800&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8Y3V0ZSUyMGNhdHxlbnwwfHwwfHx8MA%3D%3D)