### PR TITLE
refactor(spec-specs): move priority-fee check to validate_transaction

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -50,7 +50,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -583,10 +582,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -537,8 +537,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -590,7 +590,9 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     and a `NonceOverflowError` exception if the nonce overflows.
     It also raises an `InitCodeTooLargeError` if the code
     size of a contract creation transaction exceeds the maximum allowed
-    size.
+    size, and a `PriorityFeeGreaterThanMaxFeeError` if the maximum
+    priority fee per gas of a fee market transaction exceeds its maximum
+    fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, ExecutionGas, VersionedHash
@@ -614,6 +615,11 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
         )
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/arrow_glacier/fork.py
+++ b/src/ethereum/forks/arrow_glacier/fork.py
@@ -37,7 +37,6 @@ from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
     InsufficientMaxFeePerGasError,
-    PriorityFeeGreaterThanMaxFeeError,
     WrongChainIdError,
 )
 from .state_tracker import (
@@ -475,8 +474,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
 
@@ -495,10 +492,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/arrow_glacier/transactions.py
+++ b/src/ethereum/forks/arrow_glacier/transactions.py
@@ -21,7 +21,10 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import TransactionTypeError
+from .exceptions import (
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 
 
 @final
@@ -317,7 +320,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     gas cost of the transaction after validation. It throws an
     `InsufficientTransactionGasError` exception if the transaction does not
     provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
-    exception if the nonce is greater than `2**64 - 2`.
+    exception if the nonce is greater than `2**64 - 2`. It also raises a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -326,6 +331,11 @@ def validate_transaction(tx: Transaction) -> Uint:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
     return intrinsic_gas
 
 

--- a/src/ethereum/forks/bpo1/fork.py
+++ b/src/ethereum/forks/bpo1/fork.py
@@ -42,7 +42,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -446,8 +445,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -490,10 +487,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
@@ -562,7 +563,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -578,6 +581,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/bpo2/fork.py
+++ b/src/ethereum/forks/bpo2/fork.py
@@ -42,7 +42,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -446,8 +445,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -490,10 +487,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
@@ -562,7 +563,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -578,6 +581,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/bpo3/fork.py
+++ b/src/ethereum/forks/bpo3/fork.py
@@ -42,7 +42,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -446,8 +445,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -490,10 +487,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
@@ -562,7 +563,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -578,6 +581,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/bpo4/fork.py
+++ b/src/ethereum/forks/bpo4/fork.py
@@ -42,7 +42,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -446,8 +445,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -490,10 +487,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
@@ -562,7 +563,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -578,6 +581,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/bpo5/fork.py
+++ b/src/ethereum/forks/bpo5/fork.py
@@ -42,7 +42,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -446,8 +445,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -490,10 +487,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
@@ -562,7 +563,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -578,6 +581,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/cancun/fork.py
+++ b/src/ethereum/forks/cancun/fork.py
@@ -40,7 +40,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -414,8 +413,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -453,10 +450,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/cancun/transactions.py
+++ b/src/ethereum/forks/cancun/transactions.py
@@ -21,7 +21,11 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import InitCodeTooLargeError, TransactionTypeError
+from .exceptions import (
+    InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 from .fork_types import VersionedHash
 
 
@@ -434,7 +438,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
     exception if the nonce is greater than `2**64 - 2`. It also raises an
     `InitCodeTooLargeError` if the code size of a contract creation transaction
-    exceeds the maximum allowed size.
+    exceeds the maximum allowed size, and a `PriorityFeeGreaterThanMaxFeeError`
+    if the maximum priority fee per gas of a fee market transaction exceeds
+    its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -447,6 +453,11 @@ def validate_transaction(tx: Transaction) -> Uint:
         raise InitCodeTooLargeError("Code size too large")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic_gas
 

--- a/src/ethereum/forks/gray_glacier/fork.py
+++ b/src/ethereum/forks/gray_glacier/fork.py
@@ -37,7 +37,6 @@ from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
     InsufficientMaxFeePerGasError,
-    PriorityFeeGreaterThanMaxFeeError,
     WrongChainIdError,
 )
 from .state_tracker import (
@@ -475,8 +474,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError:
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
 
@@ -495,10 +492,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/gray_glacier/transactions.py
+++ b/src/ethereum/forks/gray_glacier/transactions.py
@@ -21,7 +21,10 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import TransactionTypeError
+from .exceptions import (
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 
 
 @final
@@ -317,7 +320,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     gas cost of the transaction after validation. It throws an
     `InsufficientTransactionGasError` exception if the transaction does not
     provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
-    exception if the nonce is greater than `2**64 - 2`.
+    exception if the nonce is greater than `2**64 - 2`. It also raises a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -326,6 +331,11 @@ def validate_transaction(tx: Transaction) -> Uint:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
     return intrinsic_gas
 
 

--- a/src/ethereum/forks/london/fork.py
+++ b/src/ethereum/forks/london/fork.py
@@ -38,7 +38,6 @@ from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
     InsufficientMaxFeePerGasError,
-    PriorityFeeGreaterThanMaxFeeError,
     WrongChainIdError,
 )
 from .state_tracker import (
@@ -484,8 +483,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError:
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
 
@@ -504,10 +501,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/london/transactions.py
+++ b/src/ethereum/forks/london/transactions.py
@@ -21,7 +21,10 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import TransactionTypeError
+from .exceptions import (
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 
 
 @final
@@ -317,7 +320,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     gas cost of the transaction after validation. It throws an
     `InsufficientTransactionGasError` exception if the transaction does not
     provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
-    exception if the nonce is greater than `2**64 - 2`.
+    exception if the nonce is greater than `2**64 - 2`. It also raises a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -326,6 +331,11 @@ def validate_transaction(tx: Transaction) -> Uint:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
     return intrinsic_gas
 
 

--- a/src/ethereum/forks/osaka/fork.py
+++ b/src/ethereum/forks/osaka/fork.py
@@ -42,7 +42,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -446,8 +445,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -490,10 +487,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -23,6 +23,7 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
@@ -566,7 +567,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -582,6 +585,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/paris/fork.py
+++ b/src/ethereum/forks/paris/fork.py
@@ -36,7 +36,6 @@ from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
     InsufficientMaxFeePerGasError,
-    PriorityFeeGreaterThanMaxFeeError,
     WrongChainIdError,
 )
 from .state_tracker import (
@@ -374,8 +373,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
 
@@ -394,10 +391,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/paris/transactions.py
+++ b/src/ethereum/forks/paris/transactions.py
@@ -21,7 +21,10 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import TransactionTypeError
+from .exceptions import (
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 
 
 @final
@@ -317,7 +320,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     gas cost of the transaction after validation. It throws an
     `InsufficientTransactionGasError` exception if the transaction does not
     provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
-    exception if the nonce is greater than `2**64 - 2`.
+    exception if the nonce is greater than `2**64 - 2`. It also raises a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -326,6 +331,11 @@ def validate_transaction(tx: Transaction) -> Uint:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
     return intrinsic_gas
 
 

--- a/src/ethereum/forks/prague/fork.py
+++ b/src/ethereum/forks/prague/fork.py
@@ -41,7 +41,6 @@ from .exceptions import (
     InsufficientMaxFeePerGasError,
     InvalidBlobVersionedHashError,
     NoBlobDataError,
-    PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
     WrongChainIdError,
 )
@@ -436,8 +435,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
     InsufficientMaxFeePerBlobGasError :
@@ -478,10 +475,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketCapableTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -21,7 +21,11 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import InitCodeTooLargeError, TransactionTypeError
+from .exceptions import (
+    InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 from .fork_types import Authorization, VersionedHash
 
 
@@ -559,7 +563,9 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     the transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce is greater than
     `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
-    a contract creation transaction exceeds the maximum allowed size.
+    a contract creation transaction exceeds the maximum allowed size, and a
+    `PriorityFeeGreaterThanMaxFeeError` if the maximum priority fee per gas
+    of a fee market transaction exceeds its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -573,6 +579,11 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InitCodeTooLargeError("Code size too large")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketCapableTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic
 

--- a/src/ethereum/forks/shanghai/fork.py
+++ b/src/ethereum/forks/shanghai/fork.py
@@ -36,7 +36,6 @@ from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
     InsufficientMaxFeePerGasError,
-    PriorityFeeGreaterThanMaxFeeError,
     WrongChainIdError,
 )
 from .state_tracker import (
@@ -378,8 +377,6 @@ def check_transaction(
         If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
         If the maximum fee per gas is insufficient for the transaction.
 
@@ -398,10 +395,6 @@ def check_transaction(
     sender_account = get_account(tx_state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
-        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise PriorityFeeGreaterThanMaxFeeError(
-                "priority fee greater than max fee"
-            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
             raise InsufficientMaxFeePerGasError(
                 tx.max_fee_per_gas, block_env.base_fee_per_gas

--- a/src/ethereum/forks/shanghai/transactions.py
+++ b/src/ethereum/forks/shanghai/transactions.py
@@ -21,7 +21,11 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
-from .exceptions import InitCodeTooLargeError, TransactionTypeError
+from .exceptions import (
+    InitCodeTooLargeError,
+    PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeError,
+)
 
 
 @final
@@ -322,7 +326,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
     exception if the nonce is greater than `2**64 - 2`. It also raises an
     `InitCodeTooLargeError` if the code size of a contract creation transaction
-    exceeds the maximum allowed size.
+    exceeds the maximum allowed size, and a `PriorityFeeGreaterThanMaxFeeError`
+    if the maximum priority fee per gas of a fee market transaction exceeds
+    its maximum fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -335,6 +341,11 @@ def validate_transaction(tx: Transaction) -> Uint:
         raise InitCodeTooLargeError("Code size too large")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
+    if isinstance(tx, FeeMarketTransaction):
+        if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
 
     return intrinsic_gas
 


### PR DESCRIPTION
## 🗒️ Description
Moves the stateless check `tx.max_fee_per_gas < tx.max_priority_fee_per_gas`
from `check_transaction` (stateful layer) to `validate_transaction`
(stateless layer) in all fee-market forks (london through amsterdam,
including the glacier and BPO forks).

- The check only compares two fields on the transaction and needs no block
context, so it belongs in the stateless layer. The remaining checks in that
block use `block_env.base_fee_per_gas` and correctly stay in
`check_transaction`.

- In `validate_transaction` the check is guarded by an
`isinstance(tx, FeeMarketCapableTransaction)` check so legacy transactions are
unaffected. The now-unused import is removed from `fork.py`.

- Mirrors client behavior: nethermind runs this check statelessly in
`TxValidator.IsWellFormed` during block validation; geth runs it statelessly
at txpool admission (and again in `preCheck` during state transition).

- Filled the tests covering `PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS`
(`tip_too_high`, `set_code_transaction_fee_validations`) before and after:
fixtures are identical. Pre-cancun forks are not fillable, so those were
smoke-tested directly: every fork's `validate_transaction` rejects inverted
fee caps with `PriorityFeeGreaterThanMaxFeeError` and accepts sane ones.

## 🔗 Related Issues
- Fixes #2976
## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.

