### PR TITLE
chore(ci): speed up bench-gas by filling only the `blockchain_test` format

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -221,17 +221,30 @@ test-ci-scripts *args:
 
 # --- Benchmarks ---
 
-# Fill benchmark tests with --gas-benchmark-values, then verify with EELS
+# Smoke-test benchmark tests: fill blockchain_test fixtures, then verify against EELS.
 [group('benchmark tests')]
 bench-gas *args:
     @mkdir -p "{{ output_dir }}/bench-gas/tmp" "{{ output_dir }}/bench-gas/logs"
-    @echo "==> Step 1/2: Filling benchmark fixtures with configured EVM (EVM_BIN={{ evm_bin }})"
+    @echo "==> Step 1/3: Generating pre-alloc groups (smoke-tests the BlockchainEngineX path)"
+    uv run fill \
+        --generate-pre-alloc-groups \
+        --evm-bin="{{ evm_bin }}" \
+        --gas-benchmark-values 1 \
+        --fork Osaka \
+        -m "not slow" \
+        -n auto --maxprocesses 10 --dist=loadgroup \
+        --output="{{ output_dir }}/bench-gas/pre-alloc" \
+        --basetemp="{{ output_dir }}/bench-gas/tmp" \
+        --log-to "{{ output_dir }}/bench-gas/logs" \
+        --clean \
+        "$@" \
+        tests/benchmark/compute
+    @echo "==> Step 2/3: Filling blockchain_test fixtures with configured EVM (EVM_BIN={{ evm_bin }})"
     uv run fill \
         --evm-bin="{{ evm_bin }}" \
         --gas-benchmark-values 1 \
-        --generate-all-formats \
         --fork Osaka \
-        -m "not slow" \
+        -m "blockchain_test and (not derived_test) and (not slow)" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --output="{{ output_dir }}/bench-gas/fixtures" \
         --basetemp="{{ output_dir }}/bench-gas/tmp" \
@@ -239,10 +252,10 @@ bench-gas *args:
         --clean \
         "$@" \
         tests/benchmark/compute
-    @echo "==> Step 2/2: Running filled fixtures against EELS via json_loader"
+    @echo "==> Step 3/3: Running filled fixtures against EELS via json_loader"
     @rm -rf tests/json_loader/bench_gas_fixtures
     ln -sfn "{{ output_dir }}/bench-gas/fixtures" tests/json_loader/bench_gas_fixtures
-    cd tests/json_loader && uv run --python pypy3.11 pytest \
+    cd tests/json_loader && uv run --python pypy3.11 --no-dev --group test pytest \
         --fork Osaka \
         --allow-post-state-hash \
         -n auto --maxprocesses 10 --dist=loadfile \

--- a/Justfile
+++ b/Justfile
@@ -246,6 +246,7 @@ bench-gas *args:
         --fork Osaka \
         -m "blockchain_test and (not derived_test) and (not slow)" \
         -n auto --maxprocesses 10 --dist=loadgroup \
+        --durations=20 \
         --output="{{ output_dir }}/bench-gas/fixtures" \
         --basetemp="{{ output_dir }}/bench-gas/tmp" \
         --log-to "{{ output_dir }}/bench-gas/logs" \
@@ -259,6 +260,7 @@ bench-gas *args:
         --fork Osaka \
         --allow-post-state-hash \
         -n auto --maxprocesses 10 --dist=loadfile \
+        --durations=20 \
         --basetemp="{{ output_dir }}/bench-gas/json-loader-tmp" \
         bench_gas_fixtures
 


### PR DESCRIPTION
## 🗒️ Description

`bench-gas` (the `Benchmark Gas Values` leg of the `Benchmarking` workflow) is the longest job in CI. It is a correctness smoke check: It fills the `tests/benchmark/compute` suite with the configured EVM (geth) and replays the fixtures through EELS, confirming the two implementations agree. It is not the released benchmark artifact, which is built separately from the release matrix in `.github/configs/feature.yaml` and is left untouched here.

This PR restructures the recipe into three steps:

1. `fill --generate-pre-alloc-groups`: Generate the pre-allocation groups. This keeps the `BlockchainEngineX` code path smoke-tested, since pre-alloc generation is the part unique to the all-formats run and where its risk is concentrated.
2. `fill -m "blockchain_test and (not derived_test) and (not slow)"`: Fill only the `blockchain_test` format, the one EELS consumes.
3. Replay the fixtures through EELS via `json_loader`. Added `--no-dev --group test` so the PyPy environment builds without the dev Rust crates, matching the `fill-pypy` recipe.


## 🔗 Related Issues or PRs

Addresses #2673. Alternative to #2693 (accepting float `--gas-benchmark-values`): Lowering the gas value cannot help, since it is floored at roughly 0.9M by the most expensive single benchmark op, and fill time is dominated by per-format generation rather than gas magnitude. Also an alternative to #3012 (running on a larger runner), which did not improve the time because the two-phase fill does not scale with cores.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
