### PR TITLE
chore(tests-benchmark, ci): mark test_keccak_max_permutations as slow

### DIFF
--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -19,6 +19,7 @@ from execution_testing import (
 KECCAK_RATE = 136
 
 
+@pytest.mark.slow("Searches for the max-permutation input size")
 def test_keccak_max_permutations(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,


### PR DESCRIPTION
## 🗒️ Description

`test_keccak_max_permutations` is by far the most expensive test in the `bench-gas` smoke check: It fills in ~465s per format, while the next slowest benchmark fills in ~12s. The test searches for the input size that maximizes keccak permutations per block and then fills a maximal block, and that work is repeated per fixture format.

Marking it `@pytest.mark.slow` excludes it from the smoke check (`just bench-gas` and the benchmark sanity checks run `-m "not slow"`), consistent with the existing slow benchmarks `test_blockhash` and `test_bls12_g2_msm`. The release benchmark matrix (`.github/configs/feature.yaml`) does not filter `slow`, so the test still ships in the released fixtures.

## 🔗 Related Issues or PRs

Addresses #2673. Complements #3057 (fill only the `blockchain_test` format in `bench-gas`): Even with that format reduction the test still fills once at ~465s and sets the smoke check's floor, and this marker removes it.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
