### PR TITLE
fix(test-types,test-forks): import `ethereum` lazily so xdist fill coverage measures it

### DIFF
--- a/packages/testing/src/execution_testing/base_types/base_types.py
+++ b/packages/testing/src/execution_testing/base_types/base_types.py
@@ -13,7 +13,6 @@ from typing import (
     TypeVar,
 )
 
-from ethereum.crypto.hash import keccak256 as _keccak256
 from pydantic import GetCoreSchemaHandler, StringConstraints
 from pydantic_core.core_schema import (
     PlainValidatorFunctionSchema,
@@ -201,6 +200,12 @@ class Bytes(bytes, ToStringSchema):
 
     def keccak256(self) -> "Hash":
         """Return the keccak256 hash of the opcode byte representation."""
+        # Imported lazily so that merely importing the test framework does not
+        # import the `ethereum` package: on xdist workers that import would
+        # happen before pytest-cov starts the worker's coverage session,
+        # making coverage report `ethereum` as "module-not-measured".
+        from ethereum.crypto.hash import keccak256 as _keccak256
+
         return Hash(_keccak256(self))
 
     def sha256(self) -> "Hash":

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -627,8 +627,6 @@ def pytest_configure(config: pytest.Config) -> None:
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
 
-    # The unsupported-fork set is computed lazily in `get_unsupported_forks`
-    # (see its docstring for why it is deferred out of `pytest_configure`).
 
 
 def get_unsupported_forks(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -628,7 +628,6 @@ def pytest_configure(config: pytest.Config) -> None:
         )
 
 
-
 def get_unsupported_forks(
     config: pytest.Config,
 ) -> FrozenSet[Fork | TransitionFork]:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -24,7 +24,7 @@ from typing import (
 
 import pytest
 from _pytest.mark.structures import ParameterSet
-from pytest import Mark, Metafunc
+from pytest import Mark, Metafunc, StashKey
 
 from execution_testing.client_clis import TransitionTool
 from execution_testing.forks import (
@@ -45,6 +45,10 @@ from execution_testing.logging import (
 )
 
 logger = get_logger(__name__)
+
+# Session-scoped cache for the lazily-computed unsupported-fork set
+# (see `get_unsupported_forks`).
+unsupported_forks_key: StashKey[FrozenSet[Fork | TransitionFork]] = StashKey()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -636,15 +640,13 @@ def get_unsupported_forks(
     """
     Return the selected forks not supported by the configured t8n tool.
 
-    The result is computed once and cached on ``config``. Computation is
+    The result is computed once and cached in ``config.stash``. Computation is
     deferred out of ``pytest_configure`` (where it previously lived) so that
     the ``ethereum`` package, imported when the t8n tool is queried, is only
     imported after pytest-cov has started the xdist worker's coverage session.
     Importing it earlier left it "previously imported, but not measured".
     """
-    cached: FrozenSet[Fork | TransitionFork] | None = getattr(
-        config, "_unsupported_forks", None
-    )
+    cached = config.stash.get(unsupported_forks_key, None)
     if cached is not None:
         return cached
 
@@ -661,7 +663,7 @@ def get_unsupported_forks(
         )
         logger.debug(f"List of unsupported forks: {list(unsupported_forks)}")
 
-    config._unsupported_forks = unsupported_forks  # type: ignore[attr-defined]
+    config.stash[unsupported_forks_key] = unsupported_forks
     return unsupported_forks
 
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    FrozenSet,
     Iterable,
     Iterator,
     List,
@@ -622,18 +623,46 @@ def pytest_configure(config: pytest.Config) -> None:
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
 
-    config.unsupported_forks: Set[Fork | TransitionFork] = set()  # type: ignore
+    # The set of unsupported forks is computed lazily (see
+    # `get_unsupported_forks`) rather than here: querying the t8n tool imports
+    # the `ethereum` package, and on xdist workers `pytest_configure` runs
+    # before pytest-cov starts the worker's coverage session, which would make
+    # coverage report `ethereum` as "module-not-measured".
+
+
+def get_unsupported_forks(
+    config: pytest.Config,
+) -> FrozenSet[Fork | TransitionFork]:
+    """
+    Return the selected forks not supported by the configured t8n tool.
+
+    The result is computed once and cached on ``config``. Computation is
+    deferred out of ``pytest_configure`` (where it previously lived) so that
+    the ``ethereum`` package, imported when the t8n tool is queried, is only
+    imported after pytest-cov has started the xdist worker's coverage session.
+    Importing it earlier left it "previously imported, but not measured".
+    """
+    cached: FrozenSet[Fork | TransitionFork] | None = getattr(
+        config, "_unsupported_forks", None
+    )
+    if cached is not None:
+        return cached
+
+    selected_fork_set: Set[Fork | TransitionFork] = config.selected_fork_set  # type: ignore[attr-defined]
     t8n: TransitionTool | None = getattr(config, "t8n", None)
-    if t8n:
-        config.unsupported_forks = frozenset(  # type: ignore
+    if t8n is None:
+        unsupported_forks: FrozenSet[Fork | TransitionFork] = frozenset()
+    else:
+        unsupported_forks = frozenset(
             fork
             for fork in selected_fork_set
             if not t8n.is_fork_supported(fork.transitions_from())
             or not t8n.is_fork_supported(fork.transitions_to())
         )
-        logger.debug(
-            f"List of unsupported forks: {list(config.unsupported_forks)}"  # type: ignore
-        )
+        logger.debug(f"List of unsupported forks: {list(unsupported_forks)}")
+
+    config._unsupported_forks = unsupported_forks  # type: ignore[attr-defined]
+    return unsupported_forks
 
 
 @pytest.hookimpl(trylast=True)
@@ -653,7 +682,7 @@ def pytest_report_header(config: pytest.Config, start_path: Any) -> List[str]:
             + reset
         ),
     ]
-    unsupported_forks: Set[Fork | TransitionFork] = config.unsupported_forks  # type: ignore[attr-defined]
+    unsupported_forks = get_unsupported_forks(config)
     if unsupported_forks:
         t8n_name = config.t8n.__class__.__name__  # type: ignore[attr-defined]
         excluded = ", ".join(f.name() for f in sorted(unsupported_forks))
@@ -1293,10 +1322,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if "fork" not in metafunc.fixturenames:
         return
 
-    unsupported_forks: Set[Fork | TransitionFork] = (
-        metafunc.config.unsupported_forks  # type: ignore
-    )
-    intersection_set -= unsupported_forks
+    intersection_set -= get_unsupported_forks(metafunc.config)
 
     if not intersection_set:
         if metafunc.config.getoption("verbose") >= 2:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -627,11 +627,8 @@ def pytest_configure(config: pytest.Config) -> None:
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
 
-    # The set of unsupported forks is computed lazily (see
-    # `get_unsupported_forks`) rather than here: querying the t8n tool imports
-    # the `ethereum` package, and on xdist workers `pytest_configure` runs
-    # before pytest-cov starts the worker's coverage session, which would make
-    # coverage report `ethereum` as "module-not-measured".
+    # The unsupported-fork set is computed lazily in `get_unsupported_forks`
+    # (see its docstring for why it is deferred out of `pytest_configure`).
 
 
 def get_unsupported_forks(

--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -71,6 +71,11 @@ class ExecutionSpecsTransitionTool(TransitionTool):
 
     def version(self) -> str:
         """Version of the t8n tool."""
+        # Read the version from the installed package metadata instead of
+        # `ethereum.__version__`. This method is called during the filler's
+        # `pytest_configure`, which on xdist workers runs before pytest-cov
+        # starts measuring; importing `ethereum` here (even lazily) would make
+        # coverage report it as "module-not-measured".
         from importlib.metadata import version
 
         return version("ethereum-execution")

--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -71,11 +71,8 @@ class ExecutionSpecsTransitionTool(TransitionTool):
 
     def version(self) -> str:
         """Version of the t8n tool."""
-        # Read the version from the installed package metadata instead of
-        # `ethereum.__version__`. This method is called during the filler's
-        # `pytest_configure`, which on xdist workers runs before pytest-cov
-        # starts measuring; importing `ethereum` here (even lazily) would make
-        # coverage report it as "module-not-measured".
+        # Use package metadata rather than `ethereum.__version__` to avoid
+        # importing `ethereum` here (see `__init__` for why it must stay lazy).
         from importlib.metadata import version
 
         return version("ethereum-execution")

--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -6,12 +6,8 @@ import json
 import tempfile
 from io import StringIO
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional
 
-import ethereum
-from ethereum_spec_tools.evm_tools import create_parser
-from ethereum_spec_tools.evm_tools.t8n import T8N, ForkCache
-from ethereum_spec_tools.evm_tools.utils import get_supported_forks
 from typing_extensions import override
 
 from execution_testing.client_clis.cli_types import TransitionToolOutput
@@ -31,6 +27,9 @@ from execution_testing.exceptions import (
 )
 from execution_testing.forks import Fork
 
+if TYPE_CHECKING:
+    from ethereum_spec_tools.evm_tools.t8n import ForkCache
+
 
 class ExecutionSpecsTransitionTool(TransitionTool):
     """Implementation of the EELS T8N for execution-spec-tests."""
@@ -49,18 +48,37 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         self.exception_mapper = ExecutionSpecsExceptionMapper()
         self.trace = trace
         self._info_metadata: Optional[Dict[str, Any]] = {}
-        self.fork_cache = ForkCache()
+        # Defer importing the `ethereum` package (see `fork_cache` and
+        # `version`) until the tool is actually used. The tool is constructed
+        # during `pytest_configure`, which on xdist workers runs *before*
+        # pytest-cov starts the worker's coverage session; importing `ethereum`
+        # here would make coverage report it as "module-not-measured".
+        self._fork_cache: Optional["ForkCache"] = None
+
+    @property
+    def fork_cache(self) -> "ForkCache":
+        """Lazily import and instantiate the EELS fork cache on first use."""
+        if self._fork_cache is None:
+            from ethereum_spec_tools.evm_tools.t8n import ForkCache
+
+            self._fork_cache = ForkCache()
+        return self._fork_cache
 
     @override
     def shutdown(self) -> None:
-        self.fork_cache.__exit__()
+        if self._fork_cache is not None:
+            self._fork_cache.__exit__()
 
     def version(self) -> str:
         """Version of the t8n tool."""
-        return ethereum.__version__
+        from importlib.metadata import version
+
+        return version("ethereum-execution")
 
     def is_fork_supported(self, fork: Fork) -> bool:
         """Return True if the fork is supported by the tool."""
+        from ethereum_spec_tools.evm_tools.utils import get_supported_forks
+
         return fork.transition_tool_name() in get_supported_forks()
 
     def _evaluate(
@@ -74,6 +92,9 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         """
         Evaluate using the EELS T8N entry point.
         """
+        from ethereum_spec_tools.evm_tools import create_parser
+        from ethereum_spec_tools.evm_tools.t8n import T8N
+
         del slow_request, profiler
         request_data = transition_tool_data.get_request_data()
         request_data_json = request_data.model_dump(

--- a/packages/testing/src/execution_testing/test_types/trie.py
+++ b/packages/testing/src/execution_testing/test_types/trie.py
@@ -18,12 +18,25 @@ from typing import (
     cast,
 )
 
-from ethereum.crypto.hash import keccak256
 from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes, Bytes20, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 from typing_extensions import assert_type
+
+
+def keccak256(buffer: bytes | bytearray) -> Bytes32:
+    """
+    Compute the keccak256 hash of ``buffer``.
+
+    The spec implementation is imported lazily so that importing this module
+    does not import the ``ethereum`` package: on xdist workers that import
+    would otherwise happen before pytest-cov starts the worker's coverage
+    session, making coverage report ``ethereum`` as "module-not-measured".
+    """
+    from ethereum.crypto.hash import keccak256 as _keccak256
+
+    return _keccak256(buffer)
 
 
 @slotted_freezable


### PR DESCRIPTION
## 🗒️ Description

This PR improves the coverage measurement for `ethereum` and fixes the following warning that every `fill` job logs, once per pytest-xdist worker:

> `CoverageWarning: Module ethereum was previously imported, but not measured (module-not-measured)`

<img width="1862" height="644" alt="image" src="https://github.com/user-attachments/assets/9eb3f85e-1f7f-452a-9202-55d2c39722a1" />
From https://github.com/ethereum/execution-specs/actions/runs/28472970517/job/84390462134

### Root cause

pytest-cov starts an xdist **worker's** coverage session late — in `pytest_sessionstart`. The `execution_testing` framework, however, imports the measured `ethereum` package at **import time**, well before that, from four module locations:

- `base_types` and `test_types.trie` import `ethereum.crypto.hash.keccak256` at module level — executed as soon as the `fill` CLI and its plugins are imported;
- `ExecutionSpecsTransitionTool` imports the EELS t8n (`T8N` / `ForkCache` / `create_parser` / `get_supported_forks` / `ethereum`) at module level, and the `forks` plugin calls `t8n.is_fork_supported()` from `pytest_configure`.

So by the time a worker starts measuring, `ethereum` is already in `sys.modules`. `pytest-cov`'s `Central`/`DistMaster` engines suppress this warning; `DistWorker` does not — hence it surfaces only on xdist workers.

### Coverage impact

~~Pre-importing the **source package** also makes coverage **under-count** `ethereum` — in **every** mode, `-n 0` and `-n 1` alike.~~

~~On a small sample, deferring the import raises the measured statement total from **36,926 → 39,000** (+2,074 across 152 files). The xdist warning was the visible symptom of a measurement gap that affected all runs.~~ 

**Update:** the ~2,074 figure above was a measurement error (the "baseline" was a dirty checkout). A same-checkout A/B shows the statement **denominator is unchanged** (39,000). The real effect is small and **constant**: `fill` measures **~300 more `ethereum` statements** — the import-time/header lines of modules loaded before the worker's coverage starts — ≈304 on a narrow Frontier slice and ≈303 on a 2,709-test Frontier→Cancun run, so it does not scale with the test set. At <1% it rounds to a ~0% codecov diff (see [comment](https://github.com/ethereum/execution-specs/pull/3059#issuecomment-4832391239)).

### The fix

Defer all four `ethereum` imports to first use, so they run after the worker's coverage session has started (collection / test execution / the `trylast` report header). Specifically: lazy `keccak256` imports; a lazy `ForkCache` property + in-function t8n imports + `importlib.metadata` for the tool version; and a lazily-computed, cached unsupported-fork set. **Nothing is silenced** — no `filterwarnings`, no `--disable-warnings`, no `disable_warnings`.

### Results

- `module-not-measured` gone — verified on the minimal repro, repeated `-n 4` runs, and a 2,709-test Frontier→Cancun fill.
- `-n 0` and `-n 1` report identical coverage; `fill` measures ~300 more `ethereum` statements (import-time lines) on the same 39,000-statement denominator — a constant <1% gain, not test-set-dependent.
- `eels_base_coverage` `--cov-fail-under=85` gate passes (91.45%).
- 637 framework unit tests pass; `just static` clean.

> ⚠️ **For reviewers:** the statement denominator is unchanged; the coverage % moves by <1% (≈0% codecov diff), and the `--cov-fail-under=85` gate still passes comfortably (91.45%).

### Alternative considered

A runner-only approach was prototyped (start coverage earlier via `COVERAGE_PROCESS_START` + a dedicated `coverage_fill.cfg` in the `Justfile`, dropping pytest-cov's `--cov` and combining manually). It works, but we preferred fixing the source because it:

- removes the warning for *every* `--cov=ethereum` invocation, not just the `just fill` recipe (direct `pytest`/`fill` runs, `json-loader`, IDE runs, contributors);
- keeps the pytest-cov integration rather than hand-rolling `coverage erase/combine/report/xml` and a second coverage config to keep in sync with `pyproject.toml`;
- addresses the actual root cause — a test framework shouldn't import the package-under-test at import time.

<sub>The prototype lives on a local branch `fix-coverage-warnings-start-coverage-earlier` (currently based off the wrong base), kept only for reference.</sub>

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory — no user-facing change.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


