### PR TITLE
refactor(test-benchmark): speed-up the keccak max-permutations search

### DIFF
--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -35,13 +35,11 @@ def test_keccak_max_permutations(
         """Return the keccak attack block hashing `input_length` bytes."""
         return Op.POP(Op.SHA3(Op.PUSH0, Op.DUP1, data_size=input_length))
 
-    # The per-call gas of `POP(SHA3(PUSH0, DUP1, data_size=i))` is affine in
-    # the keccak word count `(i + 31) // 32`: only SHA3's dynamic per-word
-    # cost depends on the input size `i`. Precompute the `i`-independent base
-    # once and add the per-word cost arithmetically below, rather than
-    # rebuilding the bytecode and recomputing its gas cost on every iteration
-    # (which dominated the search runtime). This keeps the discovered
-    # `optimal_input_length`, and therefore the filled fixture, unchanged.
+    # Only SHA3's per-word cost varies with the input size, so the attack
+    # block's per-call gas is affine in the keccak word count. Precompute
+    # the size-independent base once instead of rebuilding the bytecode and
+    # recomputing its gas each iteration (the search's bottleneck); the
+    # discovered `optimal_input_length`, and so the fixture, is unchanged.
     base_iteration_gas_cost = attack_block_for(0).gas_cost(fork)
     keccak_word_gas_cost = fork.gas_costs().OPCODE_KECCAK256_PER_WORD
 
@@ -55,7 +53,7 @@ def test_keccak_max_permutations(
 
     # Guard the affine model: if a future fork reprices keccak non-linearly,
     # fail here instead of silently discovering a different optimum. The
-    # samples straddle the per-word boundary (32) and span the search range.
+    # samples straddle the 32-byte word boundary and span the search range.
     for sample_length in (1, 31, 32, 33, KECCAK_RATE, search_lengths[-1]):
         assert per_call_gas_cost(sample_length) == attack_block_for(
             sample_length

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -31,6 +31,34 @@ def test_keccak_max_permutations(
 
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
 
+    # The per-call gas of `POP(SHA3(PUSH0, DUP1, data_size=i))` is affine in
+    # the keccak word count `(i + 31) // 32`: only SHA3's dynamic per-word
+    # cost depends on the input size `i`. Precompute the `i`-independent base
+    # once and add the per-word cost arithmetically below, rather than
+    # rebuilding the bytecode and recomputing its gas cost on every iteration
+    # (which dominated the search runtime). This keeps the discovered
+    # `optimal_input_length`, and therefore the filled fixture, unchanged.
+    base_iteration_gas_cost = Op.POP(
+        Op.SHA3(Op.PUSH0, Op.DUP1, data_size=0)
+    ).gas_cost(fork)
+    keccak_word_gas_cost = fork.gas_costs().OPCODE_KECCAK256_PER_WORD
+
+    def per_call_gas_cost(input_length: int) -> int:
+        """Return the per-call gas of the keccak attack block."""
+        word_count = (input_length + 31) // 32
+        return base_iteration_gas_cost + keccak_word_gas_cost * word_count
+
+    # Guard the affine model: if a future fork reprices keccak non-linearly,
+    # fail here instead of silently discovering a different optimum. The
+    # samples straddle the per-word boundary (32) and span the search range.
+    for sample_length in (1, 31, 32, 33, KECCAK_RATE, 999_999):
+        assert per_call_gas_cost(sample_length) == Op.POP(
+            Op.SHA3(Op.PUSH0, Op.DUP1, data_size=sample_length)
+        ).gas_cost(fork), (
+            "keccak gas is no longer affine in the input word count; the "
+            "analytic search optimization is invalid for this fork"
+        )
+
     # Discover the optimal input size to maximize keccak-permutations,
     # not to maximize keccak calls.
     # The complication of the discovery arises from
@@ -38,9 +66,8 @@ def test_keccak_max_permutations(
     max_keccak_perm_per_block = 0
     optimal_input_length = 0
     for i in range(1, 1_000_000, 32):
-        # Iteration cost disregarding memory expansion
-        iteration_bytecode = Op.POP(Op.SHA3(Op.PUSH0, Op.DUP1, data_size=i))
-        iteration_gas_cost = iteration_bytecode.gas_cost(fork)
+        # Iteration cost disregarding memory expansion.
+        iteration_gas_cost = per_call_gas_cost(i)
         # From the available gas, we subtract the mem expansion costs
         # considering we know the current input size length i.
         available_gas_after_expansion = max(

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -31,6 +31,10 @@ def test_keccak_max_permutations(
 
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
 
+    def attack_block_for(input_length: int) -> Bytecode:
+        """Return the keccak attack block hashing `input_length` bytes."""
+        return Op.POP(Op.SHA3(Op.PUSH0, Op.DUP1, data_size=input_length))
+
     # The per-call gas of `POP(SHA3(PUSH0, DUP1, data_size=i))` is affine in
     # the keccak word count `(i + 31) // 32`: only SHA3's dynamic per-word
     # cost depends on the input size `i`. Precompute the `i`-independent base
@@ -38,9 +42,7 @@ def test_keccak_max_permutations(
     # rebuilding the bytecode and recomputing its gas cost on every iteration
     # (which dominated the search runtime). This keeps the discovered
     # `optimal_input_length`, and therefore the filled fixture, unchanged.
-    base_iteration_gas_cost = Op.POP(
-        Op.SHA3(Op.PUSH0, Op.DUP1, data_size=0)
-    ).gas_cost(fork)
+    base_iteration_gas_cost = attack_block_for(0).gas_cost(fork)
     keccak_word_gas_cost = fork.gas_costs().OPCODE_KECCAK256_PER_WORD
 
     def per_call_gas_cost(input_length: int) -> int:
@@ -52,8 +54,8 @@ def test_keccak_max_permutations(
     # fail here instead of silently discovering a different optimum. The
     # samples straddle the per-word boundary (32) and span the search range.
     for sample_length in (1, 31, 32, 33, KECCAK_RATE, 999_999):
-        assert per_call_gas_cost(sample_length) == Op.POP(
-            Op.SHA3(Op.PUSH0, Op.DUP1, data_size=sample_length)
+        assert per_call_gas_cost(sample_length) == attack_block_for(
+            sample_length
         ).gas_cost(fork), (
             "keccak gas is no longer affine in the input word count; the "
             "analytic search optimization is invalid for this fork"
@@ -88,9 +90,7 @@ def test_keccak_max_permutations(
         target_opcode=Op.SHA3,
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH20[optimal_input_length],
-            attack_block=Op.POP(
-                Op.SHA3(Op.PUSH0, Op.DUP1, data_size=optimal_input_length)
-            ),
+            attack_block=attack_block_for(optimal_input_length),
         ),
     )
 

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -50,10 +50,13 @@ def test_keccak_max_permutations(
         word_count = (input_length + 31) // 32
         return base_iteration_gas_cost + keccak_word_gas_cost * word_count
 
+    # The input lengths examined by the discovery search below.
+    search_lengths = range(1, 1_000_000, 32)
+
     # Guard the affine model: if a future fork reprices keccak non-linearly,
     # fail here instead of silently discovering a different optimum. The
     # samples straddle the per-word boundary (32) and span the search range.
-    for sample_length in (1, 31, 32, 33, KECCAK_RATE, 999_999):
+    for sample_length in (1, 31, 32, 33, KECCAK_RATE, search_lengths[-1]):
         assert per_call_gas_cost(sample_length) == attack_block_for(
             sample_length
         ).gas_cost(fork), (
@@ -67,7 +70,7 @@ def test_keccak_max_permutations(
     # the non-linear gas cost of memory expansion.
     max_keccak_perm_per_block = 0
     optimal_input_length = 0
-    for i in range(1, 1_000_000, 32):
+    for i in search_lengths:
         # Iteration cost disregarding memory expansion.
         iteration_gas_cost = per_call_gas_cost(i)
         # From the available gas, we subtract the mem expansion costs


### PR DESCRIPTION
## 🗒️ Description

`test_keccak_max_permutations` runs a discovery loop over `range(1, 1_000_000, 32)` to find the input size that maximizes keccak permutations per block. Each of the 31,250 iterations rebuilt the `Op.POP(Op.SHA3(Op.PUSH0, Op.DUP1, data_size=i))` bytecode and recomputed `.gas_cost(fork)`, which dominated the fill at roughly 164s per search.

Only SHA3's dynamic per-word cost depends on the input size `i`, so the per-call gas is affine in the keccak word count: `base + per_word * ((i + 31) // 32)`. This computes `base` once (the gas cost at `data_size=0`) and reads `per_word` from the fork's `GasCosts`, then adds the per-word term arithmetically in the loop. A guard asserts the affine model against the real `.gas_cost(fork)` for sample input sizes, so a future fork that reprices keccak non-linearly fails loudly instead of silently discovering a different optimum.

The discovered `optimal_input_length` is unchanged, so the filled fixtures are byte-identical: filling before and after into separate directories and running `uv run hasher compare` reports no differences at the root or per test. The search drops from roughly 164s to roughly 0.03s, which primarily speeds up release generation: The release benchmark matrix fills this test 21 times (7 gas values times 3 formats), each previously paying the full search.

## 🔗 Related Issues or PRs

Complements #3057 and #3058. Relates to #2673.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


