### PR TITLE
feat(tests): EIP-8037 CALL new-account state gas exact-fit boundary

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -28,6 +28,7 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionReceipt,
     compute_create2_address,
     compute_create_address,
 )
@@ -1508,15 +1509,20 @@ def test_call_new_account_state_gas_boundary(
         + gas_costs.CALL_VALUE
         + gas_costs.NEW_ACCOUNT
     )
-    tx = Transaction(
-        to=caller, gas_limit=exact_fit + gas_delta, sender=pre.fund_eoa()
-    )
-
     post: dict
     if gas_delta == 0:
+        gas_used = exact_fit - gas_costs.CALL_STIPEND
         post = {target: Account(balance=1), caller: Account(balance=0)}
     else:
+        gas_used = exact_fit + gas_delta
         post = {target: Account.NONEXISTENT, caller: Account(balance=1)}
+
+    tx = Transaction(
+        to=caller,
+        gas_limit=exact_fit + gas_delta,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
 
     state_test(pre=pre, post=post, tx=tx)
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -1481,6 +1481,47 @@ def test_call_new_account_no_regular_account_creation_cost(
 
 
 @pytest.mark.parametrize(
+    "gas_delta",
+    [pytest.param(0, id="exact_fit"), pytest.param(-1, id="one_short")],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_call_new_account_state_gas_boundary(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_delta: int,
+) -> None:
+    """
+    Pin the CALL new-account state charge at its exact-fit spill
+    boundary. At `exact_fit` the charge just fits and the target is
+    materialized; one gas short the caller frame goes out of gas, so
+    nothing is created and the value transfer is rolled back.
+    """
+    gas_costs = fork.gas_costs()
+    target = 0xDEAD
+    caller_code = Op.CALL(gas=0, address=target, value=1) + Op.STOP
+    caller = pre.deploy_contract(code=caller_code, balance=1)
+
+    exact_fit = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + caller_code.gas_cost(fork)
+        + gas_costs.CALL_VALUE
+        + gas_costs.NEW_ACCOUNT
+    )
+    tx = Transaction(
+        to=caller, gas_limit=exact_fit + gas_delta, sender=pre.fund_eoa()
+    )
+
+    post: dict
+    if gas_delta == 0:
+        post = {target: Account(balance=1), caller: Account(balance=0)}
+    else:
+        post = {target: Account.NONEXISTENT, caller: Account(balance=1)}
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
     "call_opcode,charge_via",
     [
         pytest.param(Op.CALL, "sstore", id="call_sstore_charge"),


### PR DESCRIPTION
## 🗒️ Description

A value CALL to a non-alive account charges NEW_ACCOUNT state gas (STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE = 183_600) in the caller frame. With an empty reservoir the charge spills into gas_left, so the caller must hold at least that much regular gas at the charge.

This test sets gas_limit so the charge lands exactly at the available gas (the CALL succeeds and the target is materialized) and one gas short (the caller frame goes out of gas, so the target is never created and the value transfer is rolled back). It is the CALL counterpart of test_code_deposit_state_gas_exact_fit_boundary.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

