### PR TITLE
feat(tests): EIP-8037 SELFDESTRUCT new-account state gas spill and refill

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -33,37 +33,52 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 
+@pytest.mark.parametrize(
+    "funding",
+    [
+        pytest.param("reservoir", id="reservoir"),
+        pytest.param("spill", id="spill"),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
-def test_selfdestruct_new_beneficiary_charges_state_gas(
+def test_selfdestruct_new_beneficiary_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    funding: str,
 ) -> None:
     """
-    Test SELFDESTRUCT to non-existent beneficiary charges state gas.
+    Test SELFDESTRUCT to a non-existent beneficiary bills NEW_ACCOUNT.
 
-    When the beneficiary does not exist and the originator has nonzero
-    balance, SELFDESTRUCT charges new-account state gas for
-    creating the new beneficiary account.
+    A contract with nonzero balance self-destructs to a non-alive
+    beneficiary, charging new-account state gas. The charge is billed
+    identically whether drawn from the reservoir (out-of-cap tx) or
+    spilled into `gas_left` (in-cap tx): the block bills NEW_ACCOUNT in
+    the state dimension and the beneficiary is created.
     """
-    gas_costs = fork.gas_costs()
-    new_account_state_gas = gas_costs.NEW_ACCOUNT
-
-    # Non-existent beneficiary
+    new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
     beneficiary = 0xDEAD
 
     contract = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary),
-        balance=1,
+        code=Op.SELFDESTRUCT(beneficiary), balance=1
     )
-
     tx = Transaction(
         to=contract,
-        state_gas_reservoir=new_account_state_gas,
         sender=pre.fund_eoa(),
+        state_gas_reservoir=(
+            new_account_state_gas if funding == "reservoir" else 0
+        ),
     )
 
-    state_test(pre=pre, post={}, tx=tx)
+    state_test(
+        pre=pre,
+        post={
+            beneficiary: Account(balance=1),
+            contract: Account(balance=0),
+        },
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=new_account_state_gas),
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -116,37 +131,6 @@ def test_selfdestruct_zero_balance_no_state_gas(
     tx = Transaction(
         to=contract,
         state_gas_reservoir=0,
-        sender=pre.fund_eoa(),
-    )
-
-    state_test(pre=pre, post={}, tx=tx)
-
-
-@pytest.mark.valid_from("EIP8037")
-def test_selfdestruct_state_gas_from_reservoir(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Test SELFDESTRUCT state gas drawn from reservoir.
-
-    Provide gas above TX_MAX_GAS_LIMIT so the new account state gas
-    for the non-existent beneficiary is drawn from the reservoir.
-    """
-    gas_costs = fork.gas_costs()
-    new_account_state_gas = gas_costs.NEW_ACCOUNT
-
-    beneficiary = 0xDEAD
-
-    contract = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary),
-        balance=1,
-    )
-
-    tx = Transaction(
-        to=contract,
-        state_gas_reservoir=new_account_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -235,35 +219,6 @@ def test_selfdestruct_new_beneficiary_header_gas_used(
             Block(txs=[tx]),
         ],
         post={caller: Account(storage=storage)},
-    )
-
-
-@pytest.mark.valid_from("EIP8037")
-def test_selfdestruct_new_beneficiary_state_gas_spilled(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Verify SELFDESTRUCT bills a spilled NEW_ACCOUNT charge as state gas.
-
-    With an empty reservoir (in-cap tx) the charge spills into
-    `gas_left` and is consumed on the successful self-destruct halt, so
-    the beneficiary is created and the block bills the full state cost.
-    """
-    new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
-    beneficiary = 0xDEAD
-
-    contract = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary), balance=1
-    )
-    tx = Transaction(to=contract, sender=pre.fund_eoa())
-
-    state_test(
-        pre=pre,
-        post={beneficiary: Account(balance=1), contract: Account(balance=0)},
-        tx=tx,
-        blockchain_test_header_verify=Header(gas_used=new_account_state_gas),
     )
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -238,6 +238,70 @@ def test_selfdestruct_new_beneficiary_header_gas_used(
     )
 
 
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_new_beneficiary_state_gas_spilled(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify SELFDESTRUCT bills a spilled NEW_ACCOUNT charge as state gas.
+
+    With an empty reservoir (in-cap tx) the charge spills into
+    `gas_left` and is consumed on the successful self-destruct halt, so
+    the beneficiary is created and the block bills the full state cost.
+    """
+    new_account_state_gas = fork.gas_costs().NEW_ACCOUNT
+    beneficiary = 0xDEAD
+
+    contract = pre.deploy_contract(
+        code=Op.SELFDESTRUCT(beneficiary), balance=1
+    )
+    tx = Transaction(to=contract, sender=pre.fund_eoa())
+
+    state_test(
+        pre=pre,
+        post={beneficiary: Account(balance=1), contract: Account(balance=0)},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=new_account_state_gas),
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_state_gas_refilled_on_ancestor_revert(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify SELFDESTRUCT state gas is refilled when an ancestor reverts.
+
+    The inner frame spills the NEW_ACCOUNT charge and self-destructs
+    successfully, then the caller reverts: the beneficiary creation
+    rolls back and the spilled charge is refilled, so only regular gas
+    is billed.
+    """
+    beneficiary = 0xDEAD
+    inner_code = Op.SELFDESTRUCT(beneficiary)
+    inner = pre.deploy_contract(code=inner_code, balance=1)
+    caller_code = Op.POP(Op.CALL(gas=Op.GAS, address=inner)) + Op.REVERT(0, 0)
+    caller = pre.deploy_contract(code=caller_code)
+
+    expected_regular = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + caller_code.gas_cost(fork)
+        + inner_code.gas_cost(fork)
+    )
+    tx = Transaction(to=caller, sender=pre.fund_eoa())
+
+    state_test(
+        pre=pre,
+        post={beneficiary: Account.NONEXISTENT, inner: Account(balance=1)},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=expected_regular),
+    )
+
+
 @pytest.mark.parametrize(
     "num_slots",
     [

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -33,13 +33,7 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 
-@pytest.mark.parametrize(
-    "funding",
-    [
-        pytest.param("reservoir", id="reservoir"),
-        pytest.param("spill", id="spill"),
-    ],
-)
+@pytest.mark.parametrize("funding", ["reservoir", "spill"])
 @pytest.mark.valid_from("EIP8037")
 def test_selfdestruct_new_beneficiary_state_gas(
     state_test: StateTestFiller,


### PR DESCRIPTION
## 🗒️ Description

SELFDESTRUCT to a non-alive beneficiary charges NEW_ACCOUNT state gas in the self-destructing frame. Existing tests cover only the reservoir-funded path; with an empty reservoir the charge spills into gas_left, and that spill/halt/revert behavior was untested for the SELFDESTRUCT charge-site (it is covered for SSTORE and CALL/CREATE).

Add two cases, both with an empty reservoir (in-cap tx, full spill):

- consumed on the self-destruct halt: the frame halts successfully, the beneficiary is created, and the block bills the spilled charge as state gas (header gas_used = NEW_ACCOUNT).
- refilled on an ancestor revert: the SELFDESTRUCT sub-frame succeeds but the caller reverts, so the beneficiary creation rolls back and the spilled charge is refilled, leaving only regular gas billed.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

