### PR TITLE
feat(tests): EIP-8037 SSTORE-set state charge exact-fit spill boundary

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -23,6 +23,7 @@ from execution_testing import (
     AuthorizationTuple,
     Environment,
     Fork,
+    Header,
     Op,
     StateTestFiller,
     Storage,
@@ -158,38 +159,46 @@ def test_charge_spills_to_gas_left(
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "gas_delta",
+    [pytest.param(0, id="exact_fit"), pytest.param(-1, id="one_short")],
+)
 @EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.valid_from("EIP8037")
-def test_charge_oog_both_pools_insufficient(
+def test_charge_spill_boundary(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    gas_delta: int,
 ) -> None:
     """
-    Test OOG when both reservoir and gas_left are insufficient.
+    Test the SSTORE-set state charge at its exact-fit spill boundary.
 
-    Provide just enough gas for intrinsic + SSTORE regular gas but
-    not enough for the state gas charge. Neither the reservoir (empty
-    at TX_MAX_GAS_LIMIT) nor gas_left can cover the cost.
+    With an empty reservoir (in-cap tx) the full state charge spills
+    into gas_left. Sized to exactly the charge the SSTORE succeeds and
+    the block bills it as state gas; one gas short, neither pool can
+    cover the charge and the frame runs out of gas with the slot unset.
     """
-    gas_costs = fork.gas_costs()
-    contract = pre.deploy_contract(
-        code=Op.SSTORE(0, 1),
-    )
+    code = Op.SSTORE(0, 1)
+    contract = pre.deploy_contract(code=code)
 
-    # Tight gas: intrinsic + SSTORE regular gas only
-    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    gas_limit = intrinsic_cost() + gas_costs.COLD_STORAGE_WRITE
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    regular = code.regular_cost(fork)
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
     tx = Transaction(
         to=contract,
-        gas_limit=gas_limit,
+        gas_limit=intrinsic + regular + sstore_state_gas + gas_delta,
         sender=pre.fund_eoa(),
     )
 
-    # OOG — storage unchanged
-    post = {contract: Account(storage={0: 0})}
-    state_test(pre=pre, post=post, tx=tx)
+    header = Header(gas_used=max(intrinsic + regular, sstore_state_gas))
+    state_test(
+        pre=pre,
+        post={contract: Account(storage={0: 1 if gas_delta == 0 else 0})},
+        tx=tx,
+        blockchain_test_header_verify=header if gas_delta == 0 else None,
+    )
 
 
 @EIPChecklist.GasRefundsChanges.Test.RefundCalculation()

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -185,19 +185,24 @@ def test_charge_spill_boundary(
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
     regular = code.regular_cost(fork)
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    gas_limit = intrinsic + regular + sstore_state_gas + gas_delta
 
     tx = Transaction(
         to=contract,
-        gas_limit=intrinsic + regular + sstore_state_gas + gas_delta,
+        gas_limit=gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    header = Header(gas_used=max(intrinsic + regular, sstore_state_gas))
+    header = Header(
+        gas_used=max(intrinsic + regular, sstore_state_gas)
+        if gas_delta == 0
+        else gas_limit
+    )
     state_test(
         pre=pre,
         post={contract: Account(storage={0: 1 if gas_delta == 0 else 0})},
         tx=tx,
-        blockchain_test_header_verify=header if gas_delta == 0 else None,
+        blockchain_test_header_verify=header,
     )
 
 


### PR DESCRIPTION
## 🗒️ Description

Rename test_charge_oog_both_pools_insufficient to test_charge_spill_boundary and parametrize it gas_delta {0, -1}. With an empty reservoir the full SSTORE-set state charge spills into gas_left, so a gas_limit sized to exactly the charge succeeds (the block bills it as state gas) while one gas short runs out of gas with the slot left unset. Adds a direct header gas_used assertion that the prior post-state-only OOG test lacked.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

