### PR TITLE
feat(tests): EIP-8037 CREATE-onto-alive refunds NEW_ACCOUNT to gas_left

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2282,7 +2282,6 @@ def test_create_tx_collision_refunds_reservoir(
     )
 
 
-@pytest.mark.pre_alloc_mutable()
 @pytest.mark.valid_from("EIP8037")
 def test_create_onto_alive_refunds_to_gas_left(
     state_test: StateTestFiller,
@@ -2305,7 +2304,7 @@ def test_create_onto_alive_refunds_to_gas_left(
         code=create + Op.SSTORE(storage.store_next(1), 1)
     )
     target = compute_create2_address(address=contract, salt=salt, initcode=b"")
-    pre[target] = Account(balance=1)
+    pre.fund_address(target, amount=1)
 
     gas_limit = (
         fork.transaction_intrinsic_cost_calculator()()

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2282,6 +2282,45 @@ def test_create_tx_collision_refunds_reservoir(
     )
 
 
+@pytest.mark.pre_alloc_mutable()
+@pytest.mark.valid_from("EIP8037")
+def test_create_onto_alive_refunds_to_gas_left(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify a refunded CREATE NEW_ACCOUNT charge returns to gas_left.
+
+    A CREATE2 onto an already-alive (pre-funded, code-less) address
+    spills the NEW_ACCOUNT charge from the empty reservoir into
+    gas_left, succeeds, and refunds it. `gas_limit` leaves exactly
+    `NEW_ACCOUNT` after the create, so the following SSTORE runs only
+    if the refund returned to gas_left (LIFO) rather than the reservoir.
+    """
+    salt = 0
+    create = Op.POP(Op.CREATE2(0, 0, 0, salt))
+    storage = Storage()
+    contract = pre.deploy_contract(
+        code=create + Op.SSTORE(storage.store_next(1), 1)
+    )
+    target = compute_create2_address(address=contract, salt=salt, initcode=b"")
+    pre[target] = Account(balance=1)
+
+    gas_limit = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + create.regular_cost(fork)
+        + fork.gas_costs().NEW_ACCOUNT
+    )
+    tx = Transaction(to=contract, gas_limit=gas_limit, sender=pre.fund_eoa())
+
+    post = {
+        contract: Account(storage=storage),
+        target: Account(nonce=1, balance=1),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
 @pytest.mark.parametrize(
     "initcode_size_delta",
     [


### PR DESCRIPTION
## 🗒️ Description

A CREATE2 onto an already-alive (pre-funded, code-less) address spills the NEW_ACCOUNT state charge from the empty reservoir into gas_left, succeeds, and refunds it. EIP-8037 source-based refunds are LIFO, so the spilled charge must return to gas_left, not the reservoir.

gas_limit is sized so the refunded NEW_ACCOUNT is exactly the gas left after the create, so the following SSTORE runs only if the refund landed in gas_left. A reservoir-only refund leaves gas_left at zero, out-of-gases the SSTORE, and diverges on the state root.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

