### PR TITLE
fix(tooling): honor exported `DOCC_SKIP_DIFFS` in `docs-spec` recipe

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -36,6 +36,7 @@ on:
       - "mkdocs.yml"
       - "uv.lock"
       - "pyproject.toml"
+      - "Justfile"
       - ".github/workflows/docs-build.yaml"
       - ".github/configs/docs-branches.yaml"
 

--- a/Justfile
+++ b/Justfile
@@ -308,7 +308,7 @@ export DYLD_FALLBACK_LIBRARY_PATH := if os() == "macos" { "/opt/homebrew/lib" } 
 
 # Generate documentation for EELS using docc
 [group('docs')]
-docs-spec $DOCC_SKIP_DIFFS="":
+docs-spec $DOCC_SKIP_DIFFS=env_var_or_default("DOCC_SKIP_DIFFS", ""):
     uv run docc --output "{{ output_dir }}/docs-spec"
     uv run python -c 'import pathlib; print("documentation available under file://{0}".format(pathlib.Path(r"{{ output_dir }}") / "docs-spec" / "index.html"))'
 


### PR DESCRIPTION
## 🗒️ Description

This PR fixes a regression that has led to (`on_push`) docs builds taking 20 min instead of the previous ~8 min. This regression was introduced in #2756 (2026-04-28), which added the recipe parameter alongside the new `docs-spec-fast` shortcut.

The `docs-spec` recipe declared `$DOCC_SKIP_DIFFS=""`, whose empty parameter default shadows the environment variable the `Build Spec Docs` CI job exports, so the `DOCC_SKIP_DIFFS=1` set on pull requests and non-default-branch pushes never reached `docc` and the slow per-fork diff render always ran.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

