### PR TITLE
chore(tooling): fix fill-tests skill and evm-bin help

### DIFF
--- a/.claude/commands/fill-tests.md
+++ b/.claude/commands/fill-tests.md
@@ -19,7 +19,7 @@ uv run fill --collect-only tests/                      # Dry run: list tests wit
 - `-k "pattern"` — filter tests by name pattern
 - `-m "marker"` — filter by pytest marker (e.g. `-m state_test`, `-m blockchain_test`)
 - `-n auto --maxprocesses N` — parallel execution (use `--dist=loadgroup`)
-- `--evm-bin PATH` — specify t8n tool (default: `ethereum-spec-evm-resolver`)
+- `--evm-bin PATH` — t8n tool; defaults to the in-repo EELS Python spec (`src/ethereum/`)
 - `--verify-fixtures` — verify generated fixtures against geth blocktest
 - `--generate-all-formats` — generate all fixture formats (2-phase)
 
@@ -37,19 +37,9 @@ uv run fill --collect-only tests/                      # Dry run: list tests wit
 
 ## Benchmark Tests
 
-- Must use `-m benchmark` — benchmark tests are excluded by default
-- Require evmone as backend: `--evm-bin=evmone-t8n`
-- Default benchmark fork is Prague (set in `tests/benchmark/conftest.py`)
-- Gas values mode: `--gas-benchmark-values 1,10,100` (values in millions of gas)
-- Fixed opcode count mode: `--fixed-opcode-count 1,10,100` (values in thousands)
-- These two modes are **mutually exclusive**
-- Use `--generate-pre-alloc-groups` for stateful benchmarks
-
-## Static Tests (Legacy)
-
-- `uv run fill --fill-static-tests tests/static/` — fills YAML/JSON fillers from `ethereum/tests`
-- Legacy only — do NOT add new static fillers. Use Python tests instead
-- Useful to check if spec changes broke how legacy tests fill
+- Excluded from a broad `tests/` run: include them by targeting a `tests/benchmark/...` path, or add `--include-benchmark` when also collecting `tests/`.
+- Pick a mode (mutually exclusive): `--gas-benchmark-values 1,10,100` (millions of gas) or `--fixed-opcode-count 1,10,100` (thousands). These parametrize the tests, e.g. `...[fork_Prague-blockchain_test-benchmark-gas-value_1M]`.
+- Backend is optional: omitting `--evm-bin` runs the slow in-repo EELS Python spec; `--evm-bin=evmone-t8n` or `--evm-bin=evm` (geth, used by `just bench-gas`) are faster.
 
 ## Fixture Formats
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -433,7 +433,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help=(
             "Path to an evm executable (or name of an executable in the "
-            "PATH) that provides `t8n`. Default: `ethereum-spec-evm-resolver`."
+            "PATH) that provides `t8n`. Defaults to the in-repo EELS "
+            "Python spec (`src/ethereum/`)."
         ),
     )
     evm_group.addoption(


### PR DESCRIPTION
## 🗒️ Description

Fix the fill-tests skill:
1. Remove mention of `ethereum-spec-evm-resolver`.
2. Remove `-m benchmark`: this is out of date and no longer required.
3. Remove `uv run fill --fill-static-tests tests/static/`: the YAML no longer exists in the repo.

Claude stumbled over 2. during #3060.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

