### PR TITLE
feat(tests): extend block-gas inclusion boundary test to Osaka

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -605,6 +605,9 @@ def test_tx_gas_limit_block_boundary(
         pytest.param(1, id="exceeds", marks=pytest.mark.exception_test),
     ],
 )
+# Cumulative block-gas inclusion is a pre-existing rule, not an
+# EIP-8037 novelty. Floor is Osaka only because the gas-cap guard
+# below relies on EIP-7825's transaction_gas_limit_cap().
 @pytest.mark.valid_from("Osaka")
 def test_tx_inclusion_at_regular_gas_block_limit_small(
     blockchain_test: BlockchainTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -605,7 +605,7 @@ def test_tx_gas_limit_block_boundary(
         pytest.param(1, id="exceeds", marks=pytest.mark.exception_test),
     ],
 )
-@pytest.mark.valid_from("EIP8037")
+@pytest.mark.valid_from("Osaka")
 def test_tx_inclusion_at_regular_gas_block_limit_small(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -656,6 +656,9 @@ def test_tx_inclusion_at_regular_gas_block_limit_small(
                 txs=filler_txs + [excess_tx],
                 gas_limit=block_gas_limit,
                 exception=error,
+                header_verify=Header(gas_used=block_gas_limit)
+                if not error
+                else None,
             )
         ],
         post={},


### PR DESCRIPTION
## 🗒️ Description

The regular-gas cumulative inclusion gate probed by
test_tx_inclusion_at_regular_gas_block_limit_small (reject a tx whose
gas_limit exceeds block.gas_limit minus the cumulative gas used, strict
>) is the pre-existing block-gas rule, not an EIP-8037 novelty, and its
construction (filler txs plus a bare-STOP excess tx) is fork-agnostic.
Lower its valid_from from EIP8037 to Osaka to add the missing
pre-Amsterdam fixtures.

The sibling test_tx_gas_larger_than_block_gas_limit does not cover this
boundary: its Op.INVALID txs consume their full gas, so the block's
final gas_used <= limit check, not the inclusion gate, decides validity.

Also pin the accepted case with header_verify(gas_used=block_gas_limit),
so the positive branch checks the produced block gas rather than only
that the block is valid.

Verified filling at Osaka (block_gas_limit=42_000; exceeds rejected with
GAS_ALLOWANCE_EXCEEDED) and Amsterdam (block_gas_limit=63_000).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
