### PR TITLE
feat(tests): verify EIP-7997 factory nonce persists across fork-transition

### DIFF
--- a/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_factory.py
+++ b/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_factory.py
@@ -515,7 +515,6 @@ def test_factory_access_list_prewarming(
             overhead_cost=overhead,
             extra_stack_items=1,
             sstore_key=first_slot,
-            stop=False,
         )
         + CodeGasMeasure(
             code=measured_code,

--- a/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
+++ b/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
@@ -16,6 +16,13 @@ from execution_testing import (
     Transaction,
     compute_create2_address,
 )
+from execution_testing.test_types.block_access_list.account_changes import (
+    BalNonceChange,
+)
+from execution_testing.test_types.block_access_list.expectations import (
+    BalAccountExpectation,
+    BlockAccessListExpectation,
+)
 
 from .spec import Spec, ref_spec_7997
 
@@ -50,14 +57,14 @@ def test_factory_deploys_across_transition(
     )
     sender = pre.fund_eoa()
 
-    runtime_code = Op.RETURN(0, 1)  # Deploys contract only contains Op.STOP
+    runtime_code = Op.RETURN(0, 1)
     initcode = Initcode(deploy_code=runtime_code)
 
-    timestamps = [FORK_TIMESTAMP - 1, FORK_TIMESTAMP]
+    timestamps = [FORK_TIMESTAMP - 1, FORK_TIMESTAMP, FORK_TIMESTAMP + 1]
 
     blocks = []
     deployed = {}
-    for timestamp in timestamps:
+    for i, timestamp in enumerate(timestamps):
         blocks.append(
             Block(
                 timestamp=timestamp,
@@ -68,6 +75,18 @@ def test_factory_deploys_across_transition(
                         data=Hash(timestamp) + bytes(initcode),
                     )
                 ],
+                expected_block_access_list=BlockAccessListExpectation(
+                    account_expectations={
+                        factory: BalAccountExpectation(
+                            nonce_changes=[
+                                BalNonceChange(
+                                    block_access_index=1,
+                                    post_nonce=pre_fork_nonce + i + 1,
+                                )
+                            ],
+                        ),
+                    }
+                ),
             )
         )
         deployed[compute_create2_address(factory, timestamp, initcode)] = (

--- a/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
+++ b/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
@@ -10,7 +10,11 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Hash,
+    Initcode,
+    Op,
     Transaction,
+    compute_create2_address,
 )
 
 from .spec import Spec, ref_spec_7997
@@ -24,25 +28,20 @@ FORK_TIMESTAMP = 15_000
 @pytest.mark.valid_at_transition_to("Amsterdam")
 @pytest.mark.pre_alloc_mutable
 @pytest.mark.parametrize("pre_fork_nonce", [1, 2, 32])
-def test_existing_factory_preserved_across_transition(
+def test_factory_deploys_across_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     pre_fork_nonce: int,
 ) -> None:
     """
-    A factory already present at `FACTORY_ADDRESS` must be left untouched by
-    the Amsterdam transition.
+    A pre-existing factory keeps deploying contracts across the Amsterdam
+    transition, with its nonce accruing normally.
 
-    EIP-7997 requires the chain state to include the factory with nonce 1 and
-    the canonical runtime code, but its Backwards Compatibility section states
-    that on chains which already have the factory, satisfying the requirement
-    is a no-op. A client that re-applies the requirement at the transition -
-    resetting the nonce of an already-deployed (and possibly already-used)
-    factory back to 1 - corrupts the state root at the transition block.
-
-    The factory is seeded pre-fork with `pre_fork_nonce` (1 being the EIP
-    value, and 2/32 representing nonces accrued from earlier CREATE2
-    deployments) and must keep that exact nonce once the fork activates.
+    Asserting that final nonce is what catches the glamsterdam-devnet-6 bug: a
+    client that re-injects EIP-7997 at the transition resets the already-used
+    factory back to nonce 1, diverging the post-state root. Deployment success
+    alone cannot catch it, since the `CREATE2` address does not depend on the
+    factory nonce.
     """
     factory = pre.deploy_contract(
         code=Spec.FACTORY_BYTECODE,
@@ -50,27 +49,39 @@ def test_existing_factory_preserved_across_transition(
         nonce=pre_fork_nonce,
     )
     sender = pre.fund_eoa()
-    receiver = pre.fund_eoa(amount=0)
 
-    blocks = [
-        Block(  # pre-fork block
-            timestamp=FORK_TIMESTAMP - 1,
-            txs=[
-                Transaction(sender=sender, to=receiver, value=1, gas_price=10)
-            ],
-        ),
-        Block(  # Amsterdam transition block
-            timestamp=FORK_TIMESTAMP,
-            txs=[
-                Transaction(sender=sender, to=receiver, value=1, gas_price=10)
-            ],
-        ),
-    ]
+    runtime_code = Op.RETURN(0, 1)  # Deploys contract only contains Op.STOP
+    initcode = Initcode(deploy_code=runtime_code)
+
+    timestamps = [FORK_TIMESTAMP - 1, FORK_TIMESTAMP]
+
+    blocks = []
+    deployed = {}
+    for timestamp in timestamps:
+        blocks.append(
+            Block(
+                timestamp=timestamp,
+                txs=[
+                    Transaction(
+                        sender=sender,
+                        to=factory,
+                        data=Hash(timestamp) + bytes(initcode),
+                    )
+                ],
+            )
+        )
+        deployed[compute_create2_address(factory, timestamp, initcode)] = (
+            Account(nonce=1, code=bytes(runtime_code))
+        )
 
     blockchain_test(
         pre=pre,
         blocks=blocks,
         post={
-            factory: Account(nonce=pre_fork_nonce, code=Spec.FACTORY_BYTECODE),
+            **deployed,
+            factory: Account(
+                nonce=pre_fork_nonce + len(timestamps),
+                code=Spec.FACTORY_BYTECODE,
+            ),
         },
     )

--- a/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
+++ b/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
@@ -1,0 +1,76 @@
+"""
+Fork-transition tests for
+[EIP-7997: Deterministic Factory Predeploy](https://eips.ethereum.org/EIPS/eip-7997).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Transaction,
+)
+
+from .spec import Spec, ref_spec_7997
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7997.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7997.version
+
+FORK_TIMESTAMP = 15_000
+
+
+@pytest.mark.valid_at_transition_to("Amsterdam")
+@pytest.mark.pre_alloc_mutable
+@pytest.mark.parametrize("pre_fork_nonce", [1, 2, 32])
+def test_existing_factory_preserved_across_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    pre_fork_nonce: int,
+) -> None:
+    """
+    A factory already present at `FACTORY_ADDRESS` must be left untouched by
+    the Amsterdam transition.
+
+    EIP-7997 requires the chain state to include the factory with nonce 1 and
+    the canonical runtime code, but its Backwards Compatibility section states
+    that on chains which already have the factory, satisfying the requirement
+    is a no-op. A client that re-applies the requirement at the transition -
+    resetting the nonce of an already-deployed (and possibly already-used)
+    factory back to 1 - corrupts the state root at the transition block.
+
+    The factory is seeded pre-fork with `pre_fork_nonce` (1 being the EIP
+    value, and 2/32 representing nonces accrued from earlier CREATE2
+    deployments) and must keep that exact nonce once the fork activates.
+    """
+    factory = pre.deploy_contract(
+        code=Spec.FACTORY_BYTECODE,
+        address=Address(Spec.FACTORY_ADDRESS),
+        nonce=pre_fork_nonce,
+    )
+    sender = pre.fund_eoa()
+    receiver = pre.fund_eoa(amount=0)
+
+    blocks = [
+        Block(  # pre-fork block
+            timestamp=FORK_TIMESTAMP - 1,
+            txs=[
+                Transaction(sender=sender, to=receiver, value=1, gas_price=10)
+            ],
+        ),
+        Block(  # Amsterdam transition block
+            timestamp=FORK_TIMESTAMP,
+            txs=[
+                Transaction(sender=sender, to=receiver, value=1, gas_price=10)
+            ],
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={
+            factory: Account(nonce=pre_fork_nonce, code=Spec.FACTORY_BYTECODE),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add fork transition tests to EIP-7997.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Supersedes PR #3066

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

