### PR TITLE
feat(tests): EIP-8037 calldata floor binds with an over-cap reservoir

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -71,10 +71,10 @@ def test_calldata_floor_independent_of_state_gas(
     """
     Test calldata floor applies only to regular gas dimension.
 
-    The calldata floor inflates regular gas used for block accounting
-    but does not affect the state gas dimension. A transaction with
-    high calldata and no state operations should succeed even when
-    the floor exceeds actual execution gas.
+    The calldata floor applies only to the sender's bill and does not
+    affect the state gas dimension. A transaction with high calldata
+    and no state operations should succeed even when the floor exceeds
+    actual execution gas.
     """
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -277,8 +277,16 @@ def test_calldata_floor_binds_with_reservoir(
     # Sized so the floor binds while block-regular stays under storage_set.
     calldata = b"\x00" * 5000
     floor = fork.transaction_data_floor_cost_calculator()(data=calldata)
-    assert floor > regular_cost + state_cost, (
-        "calldata floor must exceed execution cost"
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata,
+        return_cost_deducted_prior_execution=True,
+    )
+    tx_regular = intrinsic + regular_cost
+    assert floor > tx_regular + state_cost, (
+        "calldata floor must exceed the sender's pre-floor bill"
+    )
+    assert tx_regular < state_cost, (
+        "block-regular must stay under the state dimension"
     )
 
     contract = pre.deploy_contract(code=code)
@@ -288,7 +296,7 @@ def test_calldata_floor_binds_with_reservoir(
         data=calldata,
         state_gas_reservoir=state_cost,
         sender=pre.fund_eoa(),
-        expected_receipt=TransactionReceipt(gas_used=floor),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=floor),
     )
     state_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -2,9 +2,8 @@
 Test EIP-7623 calldata floor interaction with EIP-8037 state gas.
 
 The calldata floor applies to the regular gas dimension only. It
-does not affect state gas. Block gas accounting uses
-max(tx_regular_gas, calldata_floor) for regular gas and tracks
-state gas separately.
+does not affect state gas. Block gas accounting uses tx_regular_gas
+(without the floor) for regular gas and tracks state gas separately.
 
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
@@ -17,11 +16,13 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     Fork,
+    Header,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
     TransactionException,
+    TransactionReceipt,
 )
 from execution_testing.checklists import EIPChecklist
 
@@ -250,4 +251,42 @@ def test_calldata_floor_applied_to_sender_refund(
         pre=pre,
         blocks=[Block(txs=[tx])],
         post={sender: Account(balance=initial - calldata_floor * gas_price)},
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_calldata_floor_binds_with_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Bind the calldata floor while an over-cap reservoir funds state gas.
+
+    Large calldata makes the EIP-7976 floor the sender's bill, while an
+    over-cap `gas_limit` puts the SSTORE-set state charge in the
+    reservoir. The floor feeds only the receipt; the block accounts
+    regular and state separately, so the header gas_used is the state
+    dimension (not the floor).
+    """
+    storage_set = Op.SSTORE(new_value=1).state_cost(fork)
+    # Sized so the floor binds while block-regular stays under storage_set.
+    calldata = b"\x00" * 5000
+    floor = fork.transaction_data_floor_cost_calculator()(data=calldata)
+
+    storage = Storage()
+    contract = pre.deploy_contract(code=Op.SSTORE(storage.store_next(1), 1))
+
+    tx = Transaction(
+        to=contract,
+        data=calldata,
+        state_gas_reservoir=storage_set,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(gas_used=floor),
+    )
+    state_test(
+        pre=pre,
+        post={contract: Account(storage=storage)},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=storage_set),
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -269,18 +269,24 @@ def test_calldata_floor_binds_with_reservoir(
     regular and state separately, so the header gas_used is the state
     dimension (not the floor).
     """
-    storage_set = Op.SSTORE(new_value=1).state_cost(fork)
+    storage = Storage()
+    code = Op.SSTORE(storage.store_next(1), 1, new_value=1)
+    state_cost = code.state_cost(fork)
+    regular_cost = code.regular_cost(fork)
+
     # Sized so the floor binds while block-regular stays under storage_set.
     calldata = b"\x00" * 5000
     floor = fork.transaction_data_floor_cost_calculator()(data=calldata)
+    assert floor > regular_cost + state_cost, (
+        "calldata floor must exceed execution cost"
+    )
 
-    storage = Storage()
-    contract = pre.deploy_contract(code=Op.SSTORE(storage.store_next(1), 1))
+    contract = pre.deploy_contract(code=code)
 
     tx = Transaction(
         to=contract,
         data=calldata,
-        state_gas_reservoir=storage_set,
+        state_gas_reservoir=state_cost,
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(gas_used=floor),
     )
@@ -288,5 +294,5 @@ def test_calldata_floor_binds_with_reservoir(
         pre=pre,
         post={contract: Account(storage=storage)},
         tx=tx,
-        blockchain_test_header_verify=Header(gas_used=storage_set),
+        blockchain_test_header_verify=Header(gas_used=state_cost),
     )


### PR DESCRIPTION
## 🗒️ Description

A tx with large floor-binding calldata and gas_limit > TX_MAX_GAS_LIMIT does an SSTORE-set funded from the reservoir. The EIP-7976 floor is the sender's bill (receipt cumulative_gas_used = floor), while the block accounts regular and state separately: block-regular excludes the floor, so the header gas_used is the state dimension (97_920), not the floor.

Also fix the stale module docstring that claimed block-regular uses max(tx_regular, floor); the spec/impl apply the floor only to the sender's charge (fork.py:1095 vs :1135).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
