### PR TITLE
feat(tests): EIP-8246 creation-tx initcode selfdestruct coverage

### DIFF
--- a/tests/amsterdam/eip8246_selfdestruct_no_burn/test_selfdestruct_no_burn.py
+++ b/tests/amsterdam/eip8246_selfdestruct_no_burn/test_selfdestruct_no_burn.py
@@ -1,4 +1,9 @@
-"""Tests for [EIP-8246: Remove SELFDESTRUCT balance burn](https://eips.ethereum.org/EIPS/eip-8246)."""
+"""
+Tests for [EIP-8246: Remove SELFDESTRUCT balance burn](https://eips.ethereum.org/EIPS/eip-8246).
+
+Further fork-aware EIP-8246 coverage lives in the EIP-6780 selfdestruct
+tests (``tests/cancun/eip6780_selfdestruct``).
+"""
 
 import pytest
 from execution_testing import (
@@ -10,6 +15,7 @@ from execution_testing import (
     Bytecode,
     Hash,
     Op,
+    StateTestFiller,
     Storage,
     Transaction,
     compute_create_address,
@@ -225,3 +231,39 @@ def test_selfdestructing_initcode_preserves_balance(
         },
         blocks=[Block(txs=[selfdestruct_tx, probe_tx])],
     )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(1, id="kept"), pytest.param(0, id="removed")],
+)
+def test_create_transaction_initcode_selfdestruct(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    value: int,
+) -> None:
+    """
+    Depth-0 creation-tx initcode SELFDESTRUCT keeps balance per EIP-8246.
+
+    A creation transaction (``tx.to is None``) whose initcode
+    self-destructs to itself exercises the depth-0 create path. A nonzero
+    endowment is kept as a balance-only account; a zero endowment is
+    removed.
+    """
+    sender = pre.fund_eoa()
+    created = compute_create_address(address=sender, nonce=sender.nonce)
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        value=value,
+        data=Op.SELFDESTRUCT(Op.ADDRESS),
+    )
+    post = {
+        created: (
+            Account(balance=value, nonce=0, code=b"", storage={})
+            if value
+            else Account.NONEXISTENT
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

Most EIP-8246 behavior is already exercised by the fork-aware EIP-6780
selfdestruct tests and by the existing initcode-selfdestruct test in
this suite, both of which self-destruct at depth >= 1. Add the one
uncovered path: a creation transaction (tx.to is None) whose initcode
self-destructs to itself at depth 0. A nonzero endowment is kept as a
balance-only account; a zero endowment is removed by EIP-161.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
