### PR TITLE
feat(tests): access-list slot warmth survives a failed CREATE2

### DIFF
--- a/tests/berlin/eip2929_gas_cost_increases/test_warm_status_revert.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_warm_status_revert.py
@@ -1,18 +1,25 @@
 """
-Tests that warm/cold access status is reverted when a sub-call reverts.
+Tests for warm/cold access status across reverting sub-frames.
+
+A reverting sub-call rolls back the warm status it introduced; warm status
+from an outer frame, such as the transaction access list, survives a failed
+child, including a reverted CREATE.
 """
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Alloc,
     CodeGasMeasure,
     Conditional,
     Environment,
     Fork,
+    Hash,
     Op,
     StateTestFiller,
     Transaction,
+    compute_create2_address,
 )
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2929.md"
@@ -134,5 +141,57 @@ def test_account_warm_status_reverted_by_subcall(
             sender=sender,
             to=outer,
             gas_limit=1_000_000,
+        ),
+    )
+
+
+@pytest.mark.valid_from("Berlin")
+def test_access_list_slot_warmth_survives_failed_create2(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    An access-list-warmed slot stays warm after a CREATE2 that reverts.
+
+    The tx access list warms `(created, slot 0)` in the root frame. The
+    same value-branching initcode is deployed twice at one CREATE2 address:
+    the first attempt (no value) reverts, the second (with value) records
+    the warmed slot's SLOAD cost. The recorded cost is the warm price,
+    proving the failed create did not drop the access-list warmth.
+    """
+    sload_push_cost = (Op.PUSH1(0) * len(Op.SLOAD.kwargs)).gas_cost(fork)
+    warm_sload_cost = Op.SLOAD(key_warm=True).gas_cost(fork)
+
+    initcode = Conditional(
+        condition=Op.ISZERO(Op.CALLVALUE),
+        if_true=Op.REVERT(offset=0, size=0),
+        if_false=CodeGasMeasure(
+            code=Op.SLOAD(0),
+            overhead_cost=sload_push_cost,
+            extra_stack_items=1,
+            sstore_key=1,
+        )
+        + Op.RETURN(0, 0),
+    )
+    holder = pre.deploy_contract(code=initcode)
+
+    creator = pre.deploy_contract(
+        code=Op.EXTCODECOPY(holder, 0, 0, len(initcode))
+        + Op.POP(Op.CREATE2(value=0, offset=0, size=len(initcode), salt=0))
+        + Op.POP(Op.CREATE2(value=1, offset=0, size=len(initcode), salt=0)),
+        balance=1,
+    )
+    created = compute_create2_address(creator, 0, initcode)
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        post={created: Account(balance=1, storage={1: warm_sload_cost})},
+        tx=Transaction(
+            sender=pre.fund_eoa(),
+            to=creator,
+            gas_limit=1_000_000,
+            access_list=[AccessList(address=created, storage_keys=[Hash(0)])],
         ),
     )

--- a/tests/berlin/eip2929_gas_cost_increases/test_warm_status_revert.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_warm_status_revert.py
@@ -167,7 +167,7 @@ def test_access_list_slot_warmth_survives_failed_create2(
         condition=Op.ISZERO(Op.CALLVALUE),
         if_true=Op.REVERT(offset=0, size=0),
         if_false=CodeGasMeasure(
-            code=Op.SLOAD(0),
+            code=Op.SLOAD(Op.PUSH1(0)),
             overhead_cost=sload_push_cost,
             extra_stack_items=1,
             sstore_key=1,
@@ -178,20 +178,18 @@ def test_access_list_slot_warmth_survives_failed_create2(
 
     creator = pre.deploy_contract(
         code=Op.EXTCODECOPY(holder, 0, 0, len(initcode))
-        + Op.POP(Op.CREATE2(value=0, offset=0, size=len(initcode), salt=0))
-        + Op.POP(Op.CREATE2(value=1, offset=0, size=len(initcode), salt=0)),
+        + Op.POP(Op.CREATE2(value=0, size=len(initcode)))
+        + Op.POP(Op.CREATE2(value=1, size=len(initcode))),
         balance=1,
     )
     created = compute_create2_address(creator, 0, initcode)
 
     state_test(
-        env=Environment(),
         pre=pre,
         post={created: Account(balance=1, storage={1: warm_sload_cost})},
         tx=Transaction(
             sender=pre.fund_eoa(),
             to=creator,
-            gas_limit=1_000_000,
             access_list=[AccessList(address=created, storage_keys=[Hash(0)])],
         ),
     )


### PR DESCRIPTION
## 🗒️ Description

An access list warms `(create2_address, slot)` in the root frame. A CREATE2 whose initcode reverts must not reset that warmth; a second CREATE2 to the same address then observes the slot as warm.

Adds `test_access_list_slot_warmth_survives_failed_create2`: the same value-branching initcode is created twice at one CREATE2 address (first attempt reverts, second records the warmed slot's SLOAD cost). The recorded cost is the warm price.

This covers in-development bug in evmone in Amsterdam branch.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
    ```text
	@manually-enhanced: Do not overwrite. Post-state expectations corrected
	manually (see PR #2784).
	````
