### PR TITLE
feat(tests): EIP-7928 records an absent system contract in the BAL

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip2935.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip2935.py
@@ -441,3 +441,34 @@ def test_bal_2935_invalid_calldata_size(
         blocks=[block_1, block_2],
         post=post_state,
     )
+
+
+@pytest.mark.pre_alloc_mutable()
+def test_bal_2935_absent_contract(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Ensure an undeployed history contract is still recorded in the BAL.
+
+    Overriding the genesis contract with an empty account drops it from the
+    pre-state. The block-start system call reads the now-absent account
+    (recording it) and finds no code to run, so the address is in the BAL
+    with an empty AccountChanges. Unreachable on mainnet,
+    consensus-relevant on custom or test chains.
+    """
+    pre[HISTORY_STORAGE_ADDRESS] = Account(code=b"", nonce=0, balance=0)
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[],
+                expected_block_access_list=BlockAccessListExpectation(
+                    account_expectations={
+                        HISTORY_STORAGE_ADDRESS: BalAccountExpectation.empty(),
+                    }
+                ),
+            )
+        ],
+        post={HISTORY_STORAGE_ADDRESS: Account.NONEXISTENT},
+    )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip4788.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip4788.py
@@ -552,3 +552,34 @@ def test_bal_4788_selfdestruct_to_beacon_root(
             BEACON_ROOTS_ADDRESS: Account(balance=contract_balance),
         },
     )
+
+
+@pytest.mark.pre_alloc_mutable()
+def test_bal_4788_absent_contract(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Ensure an undeployed beacon root contract is still recorded in the BAL.
+
+    Overriding the genesis contract with an empty account drops it from the
+    pre-state. The block-start system call reads the now-absent account
+    (recording it) and finds no code to run, so the address is in the BAL
+    with an empty AccountChanges. Unreachable on mainnet,
+    consensus-relevant on custom or test chains.
+    """
+    pre[BEACON_ROOTS_ADDRESS] = Account(code=b"", nonce=0, balance=0)
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[],
+                expected_block_access_list=BlockAccessListExpectation(
+                    account_expectations={
+                        BEACON_ROOTS_ADDRESS: BalAccountExpectation.empty(),
+                    }
+                ),
+            )
+        ],
+        post={BEACON_ROOTS_ADDRESS: Account.NONEXISTENT},
+    )


### PR DESCRIPTION
## 🗒️ Description

A pre-execution system call reads its target account unconditionally, before any code check, so the address is recorded in the block access list with an empty AccountChanges even when the contract was never deployed.

Adds `test_bal_2935_absent_contract` to the EIP-2935 file and `test_bal_4788_absent_contract` to the EIP-4788 file (alongside their deployed-contract BAL tests): overriding the genesis contract with an empty account drops it from the pre-state, and the block-start system call still records the absent address with an empty AccountChanges (`BalAccountExpectation.empty()`). 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
