### PR TITLE
chore: update pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,17 @@
-## 🗒️ Description
+### Description
 <!-- Brief description of the changes introduced by this PR -->
 <!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
 
-## 🔗 Related Issues or PRs
+### Related Issues or PRs
 <!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
 N/A.
 
-## ✅ Checklist
-<!-- Please check off all required items. For those that don't apply remove them accordingly. -->
+### Checklist
+<!-- Please check off all items before marking the PR ready for review. -->
 
-- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
-    ```console
-    just static
-    ```
-- [ ] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
-- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
-- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
-- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
-- [ ] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
-    ```text
-	@manually-enhanced: Do not overwrite. Post-state expectations corrected
-	manually (see PR #2784).
-	````
+- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
+- [ ] PR title has the form `<type>(<area>):`, where `<type>` and `<area>` come from an appropriate `C-<type>`, respectively `A-<area>`, label. The title should match the target squash commit message.
 
-#### Cute Animal Picture
+### Cute Animal Picture
 
 ![Put a link to a cute animal picture inside the parenthesis-->]()

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ N/A.
 <!-- Please check off all items before marking the PR ready for review. -->
 
 - [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
-- [ ] PR title has the form `<type>(<area>):`, where `<type>` and `<area>` come from an appropriate `C-<type>`, respectively `A-<area>`, label. The title should match the target squash commit message.
+- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
 
 ### Cute Animal Picture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ When done with changes, ask the user if they'd like to run `/lint` before commit
 - **There is no `main` branch.** Default branch = most active fork (currently `forks/amsterdam`). Run `git remote show origin | grep HEAD` to check.
 - `mainnet` = stable specs for forks live on mainnet
 - PRs target the default branch
-- PRs strictly follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. In the Checklist section, include unchecked items that don't apply — only remove them if they are truly irrelevant to the PR type.
+- PRs strictly follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ## PR Reviews
 

--- a/tests/ported_static/README.md
+++ b/tests/ported_static/README.md
@@ -1,0 +1,13 @@
+# Ported Static Tests
+
+Tests in this directory were auto-converted from the static fillers in
+[ethereum/tests](https://github.com/ethereum/tests) and may be regenerated
+by the conversion tooling.
+
+If you correct a test by hand (e.g. fix its post-state expectations), add
+the following docstring so the file is not overwritten on regeneration:
+
+```text
+@manually-enhanced: Do not overwrite. Post-state expectations corrected
+manually (see PR #2784).
+```


### PR DESCRIPTION
### Description
Trim the PR template checklist to the two items that apply to every PR.

The ported static docstring rule moves to a README within the ported static tests dir.

Use h3 for PR sections. I would like to remove the checklist in the future once we have automated labelling and pr titles.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>):`, where `<type>` and `<area>` come from an appropriate `C-<type>`, respectively `A-<area>`, label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.icegif.com%2Fwp-content%2Fuploads%2F2023%2F06%2Ficegif-1034.gif&f=1&nofb=1&ipt=c2a9e71031e782838972a8ee77ddbdde1febe9522329d7251d22fa35507c084d)
