### PR TITLE
fix(tests): EIP-8282 builder request test fixes

### DIFF
--- a/tests/amsterdam/eip8282_builder_execution_requests/test_builder_deposits.py
+++ b/tests/amsterdam/eip8282_builder_execution_requests/test_builder_deposits.py
@@ -160,7 +160,7 @@ MIN_DEPOSIT_GWEI = Spec.BUILDER_MIN_DEPOSIT // 10**9
                                 signature=0x03,
                             )
                             for i in range(
-                                Spec.MAX_DEPOSIT_REQUESTS_PER_BLOCK * 1
+                                Spec.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 1
                             )
                         ],
                     ),

--- a/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
@@ -158,7 +158,8 @@ def test_valid_multi_type_requests(
     """
     blockchain_test(
         genesis_environment=Environment(
-            gas_limit=500_000_000  # We could also bump the global gas limit
+            # Per-type maximums exceed the default block gas limit.
+            gas_limit=500_000_000
         ),
         pre=pre,
         post={},


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

- 574e4635f3: changes the deposit count from MAX * 1 (256, an exact duplicate of the max case) to MAX + 1 (257), so one request genuinely carries over into a second block.
- 9e16e434f5: rewords the stray "We could also bump the global gas limit" note to state why the 500M bump exists

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
