### PR TITLE
refactor(spec-specs): rename `inclusion_list_satisfied` field

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -402,7 +402,7 @@ class Result(CamelModel):
     requests: List[Bytes] | None = None
     block_access_list: Bytes | None = None
     block_access_list_hash: Hash | None = None
-    is_inclusion_list_satisfied: bool | None = None
+    inclusion_list_satisfied: bool | None = None
     block_exception: Annotated[
         BlockExceptionWithMessage | UndefinedException | None,
         ExceptionMapperValidator,

--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
@@ -479,4 +479,4 @@ def test_transition_tool_output_parses_inclusion_list_satisfaction() -> None:
         }
     )
 
-    assert output.result.is_inclusion_list_satisfied is False
+    assert output.result.inclusion_list_satisfied is False

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -571,7 +571,7 @@ class BuiltBlock(CamelModel):
             validation_error=self.expected_exception,
             status=(
                 PayloadStatusEnum.INCLUSION_LIST_UNSATISFIED.value
-                if self.result.is_inclusion_list_satisfied is False
+                if self.result.inclusion_list_satisfied is False
                 else None
             ),
             error_code=self.engine_api_error_code,

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -907,13 +907,11 @@ def apply_body(
         process_transaction(block_env, block_output, tx, Uint(i))
 
     # Check if the block satisfies the inclusion list constraints (EIP-7805)
-    block_output.is_inclusion_list_satisfied = (
-        check_inclusion_list_transactions(
-            block_env=block_env,
-            block_output=block_output,
-            transactions=transactions,
-            inclusion_list_transactions=inclusion_list_transactions,
-        )
+    block_output.inclusion_list_satisfied = check_inclusion_list_transactions(
+        block_env=block_env,
+        block_output=block_output,
+        transactions=transactions,
+        inclusion_list_transactions=inclusion_list_transactions,
     )
 
     # EIP-7928: Post-execution operations use index N+1
@@ -1287,7 +1285,7 @@ def check_inclusion_list_transactions(
 
     Returns
     -------
-    is_inclusion_list_satisfied : `bool`
+    inclusion_list_satisfied : `bool`
         True if the block passes the inclusion list check, False otherwise.
 
     """

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -92,7 +92,7 @@ class BlockOutput:
         Hash of all the requests in the block.
     block_access_list: `BlockAccessList`
         The block access list for the block.
-    is_inclusion_list_satisfied : `bool`
+    inclusion_list_satisfied : `bool`
         Whether the block satisfies the inclusion list constraints.
     """
 
@@ -113,7 +113,7 @@ class BlockOutput:
     blob_gas_used: U64 = U64(0)
     requests: List[Bytes] = field(default_factory=list)
     block_access_list: BlockAccessList = field(default_factory=list)
-    is_inclusion_list_satisfied: bool = True
+    inclusion_list_satisfied: bool = True
 
 
 @final

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -211,11 +211,11 @@ class ForkLoad:
         return self._module("fork").check_inclusion_list_transactions
 
     @property
-    def has_is_inclusion_list_satisfied(self) -> bool:
+    def has_inclusion_list_satisfied(self) -> bool:
         """
-        Check if the block output has an `is_inclusion_list_satisfied` field.
+        Check if the block output has an `inclusion_list_satisfied` field.
         """
-        return hasattr(self.BlockOutput, "is_inclusion_list_satisfied")
+        return hasattr(self.BlockOutput, "inclusion_list_satisfied")
 
     @property
     def Block(self) -> Any:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -524,8 +524,8 @@ class T8N(Load):
                     U256(self.options.state_reward), block_env
                 )
 
-        if self.fork.has_is_inclusion_list_satisfied:
-            block_output.is_inclusion_list_satisfied = (
+        if self.fork.has_inclusion_list_satisfied:
+            block_output.inclusion_list_satisfied = (
                 self.fork.check_inclusion_list_transactions(
                     block_env,
                     block_output,

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -340,8 +340,8 @@ class Env:
         """
         self.inclusion_list_transactions = None
 
-        if not t8n.fork.has_is_inclusion_list_satisfied:
-            print("Block does not have an 'is_inclusion_list_satisfied' field")
+        if not t8n.fork.has_inclusion_list_satisfied:
+            print("Block does not have an 'inclusion_list_satisfied' field")
             return
 
         inclusion_list_transactions = []

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -276,7 +276,7 @@ class Result:
     block_exception: Optional[str] = None
     block_access_list: Optional[Any] = None
     block_access_list_hash: Optional[Hash32] = None
-    is_inclusion_list_satisfied: Optional[bool] = None
+    inclusion_list_satisfied: Optional[bool] = None
 
     def get_receipts_from_output(
         self,
@@ -349,9 +349,9 @@ class Result:
                 block_output.block_access_list
             )
 
-        if hasattr(block_output, "is_inclusion_list_satisfied"):
-            self.is_inclusion_list_satisfied = (
-                block_output.is_inclusion_list_satisfied
+        if hasattr(block_output, "inclusion_list_satisfied"):
+            self.inclusion_list_satisfied = (
+                block_output.inclusion_list_satisfied
             )
 
     def json_encode_receipts(self) -> Any:
@@ -446,7 +446,7 @@ class Result:
                 self.block_access_list_hash
             )
 
-        if self.is_inclusion_list_satisfied is not None:
-            data["isInclusionListSatisfied"] = self.is_inclusion_list_satisfied
+        if self.inclusion_list_satisfied is not None:
+            data["isInclusionListSatisfied"] = self.inclusion_list_satisfied
 
         return data


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This PR renames `is_inclusion_list_satisfied` to `inclusion_list_satisfied` according to the latest engine APIs change.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
https://github.com/ethereum/execution-apis/pull/609

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
    ```text
	@manually-enhanced: Do not overwrite. Post-state expectations corrected
	manually (see PR #2784).
	````

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
