### PR TITLE
perf(test-consume): align enginex engine-API flow and skip redundant genesis check

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
@@ -25,6 +25,18 @@ def eth_rpc(client: Client) -> EthRPC:
     return EthRPC(f"http://{client.ip}:8545")
 
 
+@pytest.fixture(scope="session")
+def genesis_verified_clients() -> set[str]:
+    """
+    Return the set of client ids whose genesis block has been verified.
+
+    Genesis is immutable per client, so the `getBlockByNumber(0)` check only
+    needs to run once per client. In enginex mode a client is reused across a
+    pre-alloc group, letting later tests skip the redundant check.
+    """
+    return set()
+
+
 @pytest.fixture(scope="function")
 def check_live_port(test_suite_name: str) -> Literal[8545, 8551]:
     """Port used by hive to check for liveness of the client."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -15,6 +15,8 @@ responses.
 
 from typing import Union
 
+from hive.client import Client
+
 from execution_testing.exceptions import UndefinedException
 from execution_testing.fixtures import (
     BlockchainEngineFixture,
@@ -46,6 +48,8 @@ def test_blockchain_via_engine(
     timing_data: TimingData,
     eth_rpc: EthRPC,
     engine_rpc: EngineRPC,
+    client: Client,
+    genesis_verified_clients: set[str],
     fixture: Union[BlockchainEngineFixture, BlockchainEngineXFixture],
     strict_exception_matching: bool,
     genesis_header: FixtureHeader,
@@ -60,7 +64,9 @@ def test_blockchain_via_engine(
     Both modes follow the same test sequence for equivalence:
 
     1. Send initial FCU to genesis to establish the chain head.
-    2. Verify the client genesis block hash matches genesis_header.
+    2. Verify the client genesis block hash matches genesis_header. Genesis
+       is immutable per client, so in shared-client (enginex) mode this is
+       done once per client and skipped for later tests in the group.
     3. Execute test fixture blocks using engine_newPayloadVX.
     4. For valid payloads, send FCU to advance the chain head.
     """
@@ -87,21 +93,27 @@ def test_blockchain_via_engine(
                 f"Timed out waiting for forkchoice update to genesis: {e}"
             ) from None
 
-    with timing_data.time("Get genesis block"):
-        logger.info("Calling getBlockByNumber to get genesis block...")
-        genesis_block = eth_rpc.get_block_by_number(0)
-        assert genesis_block is not None, "genesis_block is None"
-        if genesis_block["hash"] != str(genesis_header.block_hash):
-            expected = genesis_header.block_hash
-            got = genesis_block["hash"]
-            logger.fail(
-                f"Genesis block hash mismatch. "
-                f"Expected: {expected}, Got: {got}"
-            )
-            raise GenesisBlockMismatchExceptionError(
-                expected_header=genesis_header,
-                got_genesis_block=genesis_block,
-            )
+    if client.id not in genesis_verified_clients:
+        with timing_data.time("Get genesis block"):
+            logger.info("Calling getBlockByNumber to get genesis block...")
+            genesis_block = eth_rpc.get_block_by_number(0)
+            assert genesis_block is not None, "genesis_block is None"
+            if genesis_block["hash"] != str(genesis_header.block_hash):
+                expected = genesis_header.block_hash
+                got = genesis_block["hash"]
+                logger.fail(
+                    f"Genesis block hash mismatch. "
+                    f"Expected: {expected}, Got: {got}"
+                )
+                raise GenesisBlockMismatchExceptionError(
+                    expected_header=genesis_header,
+                    got_genesis_block=genesis_block,
+                )
+        # Genesis is immutable per client, so verify it once per client. In
+        # shared-client (enginex) mode the same client serves every test in a
+        # pre-alloc group, so later tests skip the redundant getBlockByNumber
+        # round-trip; per-test clients get a fresh id each test and re-verify.
+        genesis_verified_clients.add(client.id)
 
     with timing_data.time("Payloads execution") as total_payload_timing:
         logger.info(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -53,53 +53,39 @@ def test_blockchain_via_engine(
     """
     Execute blockchain test fixtures against a client using the Engine API.
 
-    This function supports two modes:
+    This function supports both engine mode (`BlockchainEngineFixture`)
+    with per-test clients and enginex mode (`BlockchainEngineXFixture`)
+    with client reuse across tests sharing a pre-alloc group.
 
-    1. **Engine Mode** (`BlockchainEngineFixture`):
-       - Uses per-test clients (started fresh for each test).
-       - Always performs initial FCU to genesis.
-       - Always performs FCU after valid payloads.
-       - genesis_header comes from fixture.genesis (via fixture).
-       - needs_genesis_init is always True (via fixture).
+    Both modes follow the same test sequence for equivalence:
 
-    2. **EngineX Mode** (`BlockchainEngineXFixture`):
-       - Reuses clients across tests with same pre-alloc group.
-       - Skips initial FCU for reused clients.
-       - Skips FCU after valid payloads to keep client at genesis.
-       - genesis_header comes from separate pre_alloc_group fixture.
-       - needs_genesis_init is False for reused clients.
-
-    Steps:
-    1. Check the client genesis block hash matches genesis_header.block_hash
-    2. Execute test fixture blocks using engine_newPayloadVX
-    3. For valid payloads, perform forkchoice update to finalize chain
-       (unless client is being reused, in which case skip FCU)
+    1. Send initial FCU to genesis to establish the chain head.
+    2. Verify the client genesis block hash matches genesis_header.
+    3. Execute test fixture blocks using engine_newPayloadVX.
+    4. For valid payloads, send FCU to advance the chain head.
     """
-    if isinstance(fixture, BlockchainEngineFixture):
-        with timing_data.time("Initial forkchoice update"):
-            logger.info(
-                "Sending initial forkchoice update to genesis block..."
+    with timing_data.time("Initial forkchoice update"):
+        logger.info("Sending initial forkchoice update to genesis block...")
+        try:
+            response = engine_rpc.forkchoice_updated_with_retry(
+                forkchoice_state=ForkchoiceState(
+                    head_block_hash=genesis_header.block_hash,
+                ),
+                forkchoice_version=fixture.payloads[
+                    0
+                ].forkchoice_updated_version,
+                max_attempts=30,
+                wait_fixed=1.0,
             )
-            try:
-                response = engine_rpc.forkchoice_updated_with_retry(
-                    forkchoice_state=ForkchoiceState(
-                        head_block_hash=fixture.genesis.block_hash,
-                    ),
-                    forkchoice_version=fixture.payloads[
-                        0
-                    ].forkchoice_updated_version,
-                    max_attempts=30,
-                    wait_fixed=1.0,
-                )
-                if response.payload_status.status != PayloadStatusEnum.VALID:
-                    raise LoggedError(
-                        f"Unexpected status on forkchoice updated to genesis: "
-                        f"{response.payload_status.status}"
-                    )
-            except ForkchoiceUpdateTimeoutError as e:
+            if response.payload_status.status != PayloadStatusEnum.VALID:
                 raise LoggedError(
-                    f"Timed out waiting for forkchoice update to genesis: {e}"
-                ) from None
+                    f"Unexpected status on forkchoice updated to genesis: "
+                    f"{response.payload_status.status}"
+                )
+        except ForkchoiceUpdateTimeoutError as e:
+            raise LoggedError(
+                f"Timed out waiting for forkchoice update to genesis: {e}"
+            ) from None
 
     with timing_data.time("Get genesis block"):
         logger.info("Calling getBlockByNumber to get genesis block...")
@@ -214,9 +200,7 @@ def test_blockchain_via_engine(
                                 f"expected: {payload.error_code}"
                             ) from e
 
-                if payload.valid() and isinstance(
-                    fixture, BlockchainEngineFixture
-                ):
+                if payload.valid():
                     with payload_timing.time(
                         f"engine_forkchoiceUpdatedV{payload.forkchoice_updated_version}"
                     ):


### PR DESCRIPTION
## 🗒️ Description

Two enginex preamble changes to `test_via_engine.py`, developed together and kept in one PR because they touch the same code:

- `chore`: Align the enginex engine-API flow with the engine simulator. Enginex now always sends the initial forkchoice update to genesis and the forkchoice update after each valid payload instead of skipping them for reused clients, so both modes follow the same sequence.
- `perf`: Skip the redundant `getBlockByNumber(0)` genesis verification on reused clients. Genesis is immutable per client, so it is verified once per client instead of once per test, removing one RPC round-trip from the large majority of enginex tests.

Measured with go-ethereum and four workers over the full fixture release, skipping the genesis check cut wall-clock from `51:15` to `38:29` (about 25% faster) with identical results in both runs (`248 failed, 50316 passed`), confirming the change is behavior-preserving. Both runs used the same two commands, differing only in whether the genesis-skip was applied:

```console
./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/master.yaml --docker.buildoutput --sim.loglevel 5
uv run consume enginex --input=fixtures/ -n 4 -v
```

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cat](https://cataas.com/cat)
