### PR TITLE
fix(test-consume,test-rpc): close RPC sessions on teardown to fix fd leak

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
@@ -1,7 +1,7 @@
 """Common pytest fixtures for the Hive simulators."""
 
 from pathlib import Path
-from typing import Dict, Literal
+from typing import Dict, Generator, Literal
 
 import pytest
 from hive.client import Client
@@ -20,9 +20,10 @@ from ..consume import FixturesSource
 
 
 @pytest.fixture(scope="function")
-def eth_rpc(client: Client) -> EthRPC:
+def eth_rpc(client: Client) -> Generator[EthRPC, None, None]:
     """Initialize ethereum RPC client for the execution client under test."""
-    return EthRPC(f"http://{client.ip}:8545")
+    with EthRPC(f"http://{client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/build_block/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/build_block/conftest.py
@@ -6,7 +6,7 @@ testing via the ``testing_buildBlockV1`` endpoint.
 """
 
 import io
-from typing import Mapping
+from typing import Generator, Mapping
 
 import pytest
 from hive.client import Client
@@ -61,6 +61,7 @@ def genesis_header(fixture: BlockchainEngineFixture) -> FixtureHeader:
 
 
 @pytest.fixture(scope="function")
-def testing_rpc(client: Client) -> TestingRPC:
+def testing_rpc(client: Client) -> Generator[TestingRPC, None, None]:
     """Initialize Testing RPC client for the execution client under test."""
-    return TestingRPC(f"http://{client.ip}:8545")
+    with TestingRPC(f"http://{client.ip}:8545") as rpc:
+        yield rpc

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/engine_api.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/engine_api.py
@@ -1,5 +1,7 @@
 """Pytest fixtures for Engine API RPC clients."""
 
+from typing import Generator
+
 import pytest
 from hive.client import Client
 
@@ -10,7 +12,7 @@ from execution_testing.rpc import EngineRPC
 @pytest.fixture(scope="function")
 def engine_rpc(
     client: Client, client_exception_mapper: ExceptionMapper | None
-) -> EngineRPC:
+) -> Generator[EngineRPC, None, None]:
     """
     Initialize Engine RPC client for the execution client under test.
 
@@ -20,19 +22,24 @@ def engine_rpc(
     validation to map client-specific error messages to standard
     exception types.
 
+    The session is closed on teardown.
+
     Args:
         client: The Hive client instance to connect to.
         client_exception_mapper: Optional exception mapper.
 
-    Returns:
+    Yields:
         Configured EngineRPC instance for making Engine API calls.
 
     """
     if client_exception_mapper:
-        return EngineRPC(
+        rpc = EngineRPC(
             f"http://{client.ip}:8551",
             response_validation_context={
                 "exception_mapper": client_exception_mapper,
             },
         )
-    return EngineRPC(f"http://{client.ip}:8551")
+    else:
+        rpc = EngineRPC(f"http://{client.ip}:8551")
+    with rpc:
+        yield rpc

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/sync/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/sync/conftest.py
@@ -108,21 +108,24 @@ def pytest_collection_modifyitems(
 
 
 @pytest.fixture(scope="function")
-def eth_rpc(client: Client) -> EthRPC:
+def eth_rpc(client: Client) -> Generator[EthRPC, None, None]:
     """Initialize eth RPC client for the execution client under test."""
-    return EthRPC(f"http://{client.ip}:8545")
+    with EthRPC(f"http://{client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")
-def net_rpc(client: Client) -> NetRPC:
+def net_rpc(client: Client) -> Generator[NetRPC, None, None]:
     """Initialize net RPC client for the execution client under test."""
-    return NetRPC(f"http://{client.ip}:8545")
+    with NetRPC(f"http://{client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")
-def admin_rpc(client: Client) -> AdminRPC:
+def admin_rpc(client: Client) -> Generator[AdminRPC, None, None]:
     """Initialize admin RPC client for the execution client under test."""
-    return AdminRPC(f"http://{client.ip}:8545")
+    with AdminRPC(f"http://{client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")
@@ -271,34 +274,40 @@ def sync_client_exception_mapper(
 @pytest.fixture(scope="function")
 def sync_engine_rpc(
     sync_client: Client, sync_client_exception_mapper: ExceptionMapper | None
-) -> EngineRPC:
+) -> Generator[EngineRPC, None, None]:
     """Initialize engine RPC client for the sync client."""
     if sync_client_exception_mapper:
-        return EngineRPC(
+        rpc = EngineRPC(
             f"http://{sync_client.ip}:8551",
             response_validation_context={
                 "exception_mapper": sync_client_exception_mapper,
             },
         )
-    return EngineRPC(f"http://{sync_client.ip}:8551")
+    else:
+        rpc = EngineRPC(f"http://{sync_client.ip}:8551")
+    with rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")
-def sync_eth_rpc(sync_client: Client) -> EthRPC:
+def sync_eth_rpc(sync_client: Client) -> Generator[EthRPC, None, None]:
     """Initialize eth RPC client for the sync client."""
-    return EthRPC(f"http://{sync_client.ip}:8545")
+    with EthRPC(f"http://{sync_client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")
-def sync_net_rpc(sync_client: Client) -> NetRPC:
+def sync_net_rpc(sync_client: Client) -> Generator[NetRPC, None, None]:
     """Initialize net RPC client for the sync client."""
-    return NetRPC(f"http://{sync_client.ip}:8545")
+    with NetRPC(f"http://{sync_client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="function")
-def sync_admin_rpc(sync_client: Client) -> AdminRPC:
+def sync_admin_rpc(sync_client: Client) -> Generator[AdminRPC, None, None]:
     """Initialize admin RPC client for the sync client."""
-    return AdminRPC(f"http://{sync_client.ip}:8545")
+    with AdminRPC(f"http://{sync_client.ip}:8545") as rpc:
+        yield rpc
 
 
 @pytest.fixture(scope="module")

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -8,7 +8,16 @@ import time
 from contextlib import AbstractContextManager, nullcontext
 from itertools import count
 from pprint import pprint
-from typing import Any, Callable, ClassVar, Dict, List, Literal, Sequence
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Self,
+    Sequence,
+)
 
 import requests
 from jwt import encode
@@ -209,6 +218,24 @@ class BaseRPC:
         self.request_id_counter = count(1)
         self.response_validation_context = response_validation_context
         self.session = requests.Session()
+
+    def close(self) -> None:
+        """
+        Close the underlying HTTP session, releasing its pooled sockets.
+
+        RPC instances are typically created per test; closing the session
+        on teardown prevents file descriptors from accumulating across a
+        client that serves many tests.
+        """
+        self.session.close()
+
+    def __enter__(self) -> Self:
+        """Enter the runtime context, returning this RPC instance."""
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Close the HTTP session on context-manager exit."""
+        self.close()
 
     def __init_subclass__(cls, namespace: str | None = None) -> None:
         """

--- a/packages/testing/src/execution_testing/rpc/tests/test_session_lifecycle.py
+++ b/packages/testing/src/execution_testing/rpc/tests/test_session_lifecycle.py
@@ -1,0 +1,23 @@
+"""Test the HTTP session lifecycle of `BaseRPC` clients."""
+
+from unittest.mock import patch
+
+from execution_testing.rpc import EthRPC
+
+
+def test_close_closes_session() -> None:
+    """`close()` closes the underlying HTTP session."""
+    rpc = EthRPC("http://localhost:8545")
+    with patch.object(rpc.session, "close") as session_close:
+        rpc.close()
+    session_close.assert_called_once_with()
+
+
+def test_context_manager_closes_session() -> None:
+    """The context manager yields the instance and closes on exit."""
+    rpc = EthRPC("http://localhost:8545")
+    with patch.object(rpc.session, "close") as session_close:
+        with rpc as entered:
+            assert entered is rpc
+            session_close.assert_not_called()
+    session_close.assert_called_once_with()


### PR DESCRIPTION
## 🗒️ Description

The consume simulators created a `requests.Session` per test that was never closed, so against a reused enginex client the keep-alive sockets accumulated at two file descriptors per test until the worker hit its open-file limit and failed with `OSError: [Errno 24] Too many open files`. `BaseRPC` now owns its session lifecycle (a `close()` method plus context-manager support) and every consume `*_rpc` fixture releases it on teardown, which fixes the leak across the enginex, engine, rlp, sync, and build-block simulators. Unit tests cover the new session lifecycle (`close()` and context-manager exit).

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cat](https://cataas.com/cat)
