### PR TITLE
refactor(spec-specs): rename `inclusion_list_satisfied` field - part 2

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
@@ -474,7 +474,7 @@ def test_transition_tool_output_parses_inclusion_list_satisfaction() -> None:
                 "logsBloom": Bloom(0).hex(),
                 "receipts": [],
                 "gasUsed": hex(0),
-                "isInclusionListSatisfied": False,
+                "inclusionListSatisfied": False,
             },
         }
     )

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -447,6 +447,6 @@ class Result:
             )
 
         if self.inclusion_list_satisfied is not None:
-            data["isInclusionListSatisfied"] = self.inclusion_list_satisfied
+            data["inclusionListSatisfied"] = self.inclusion_list_satisfied
 
         return data


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This PR renames the missing `inclusion_list_satisfied` field.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
https://github.com/ethereum/execution-specs/pull/3092

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
    ```text
	@manually-enhanced: Do not overwrite. Post-state expectations corrected
	manually (see PR #2784).
	````

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
