### PR TITLE
docs(spec-specs): fix stale Amsterdam fork docstring and comments

### DIFF
--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -4,18 +4,38 @@ deterministic ``CREATE2`` factory predeploy.
 
 ### Changes
 
+- [EIP-2780: Resource-based intrinsic transaction gas][EIP-2780]
+- [EIP-7708: ETH transfers emit a log][EIP-7708]
+- [EIP-7778: Block Gas Accounting without Refunds][EIP-7778]
+- [EIP-7843: SLOTNUM][EIP-7843]
 - [EIP-7928: Block-Level Access Lists][EIP-7928]
 - [EIP-7954: Increase Maximum Contract Size][EIP-7954]
+- [EIP-7976: Increase calldata floor cost][EIP-7976]
+- [EIP-7981: Increase Access List Cost][EIP-7981]
 - [EIP-7997: Deterministic Factory Predeploy][EIP-7997]
+- [EIP-8024: Stack Access Instructions][EIP-8024]
+- [EIP-8037: State Creation Gas Cost Increase][EIP-8037]
+- [EIP-8038: State Access Gas Cost Increase][EIP-8038]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
+- [EIP-8282: Builder Execution Requests][EIP-8282]
 
 ### Releases
 
 [EIP-7773]: https://eips.ethereum.org/EIPS/eip-7773
+[EIP-2780]: https://eips.ethereum.org/EIPS/eip-2780
+[EIP-7708]: https://eips.ethereum.org/EIPS/eip-7708
+[EIP-7778]: https://eips.ethereum.org/EIPS/eip-7778
+[EIP-7843]: https://eips.ethereum.org/EIPS/eip-7843
 [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
 [EIP-7954]: https://eips.ethereum.org/EIPS/eip-7954
+[EIP-7976]: https://eips.ethereum.org/EIPS/eip-7976
+[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
 [EIP-7997]: https://eips.ethereum.org/EIPS/eip-7997
+[EIP-8024]: https://eips.ethereum.org/EIPS/eip-8024
+[EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
+[EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+[EIP-8282]: https://eips.ethereum.org/EIPS/eip-8282
 """
 
 from ethereum.fork_criteria import ForkCriteria, Unscheduled

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1147,6 +1147,8 @@ def process_transaction(
         + tx_output.state_gas_used
         - int(tx_output.state_refund)
     )
+    # Defensive guard for Uint conversion: State refunds never exceed
+    # the state charges so the value is non-negative.
     tx_regular_gas = tx_gas_used_before_refund - Uint(max(0, tx_state_gas))
     block_output.block_gas_used += tx_regular_gas
     block_output.block_state_gas_used += Uint(max(0, tx_state_gas))

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -688,7 +688,7 @@ def selfdestruct(evm: Evm) -> None:
     # Transfer balance
     move_ether(tx_state, originator, beneficiary, originator_balance)
 
-    # Emit transfer or burn log
+    # Emit transfer log
     if beneficiary != originator:
         emit_transfer_log(evm, originator, beneficiary, originator_balance)
 


### PR DESCRIPTION
## 🗒️ Description

Correct documentation-only issues in the Amsterdam fork found during an EELS code review; no behavior change.

- `__init__.py`: the Changes/Releases blocks listed only 4 of the fork's EIPs; add the remaining 10 (2780, 7708, 7778, 7843, 7976, 7981, 8024, 8037, 8038, 8282), cross-checked against the tests/amsterdam suites.
- selfdestruct: the transfer-log comment still said "or burn"; EIP-8246 removed the burn path (emit_burn_log no longer exists).
- process_transaction: note why tx_state_gas is non-negative, so the defensive max(0, ...) clamp is not mistaken for a reachable case.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [ ] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
    ```text
	@manually-enhanced: Do not overwrite. Post-state expectations corrected
	manually (see PR #2784).
	````
