### PR TITLE
refactor(spec-specs): credit CREATE refund before child incorporation

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -162,9 +162,12 @@ def generic_create(
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
-        incorporate_child_on_success(evm, child_evm)
         if target_alive:
+            # Target already existed: no new account, refund the state gas.
+            # Credit before incorporating the child so the refund reverses
+            # the parent's own spill only (as the error path does).
             credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+        incorporate_child_on_success(evm, child_evm)
         evm.return_data = b""
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
 


### PR DESCRIPTION
## 🗒️ Description

On the CREATE success path, generic_create credited the NEW_ACCOUNT state-gas refund (target-already-alive case) after incorporate_child_on_success, which folds the child's spill into the parent. The refund's LIFO gas_left/reservoir split was therefore computed against the combined parent+child spill, unlike the error path (whose incorporate_child_on_error does not fold the child's spill).

Credit before incorporating the child so the refund reverses only the parent's own NEW_ACCOUNT spill, matching the error path. The split is tx-unobservable: the total refund is preserved, and over-cap frames carry gas_left near TX_MAX_GAS_LIMIT so the routing never gates a downstream charge. Verified by filling the eip8037 suite: 1567 fixtures byte-for-byte identical before and after.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [ ] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
    ```text
	@manually-enhanced: Do not overwrite. Post-state expectations corrected
	manually (see PR #2784).
	````
