### PR TITLE
fix(testing): clear watch screen via Console, not deprecated os.system

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/watcher.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/watcher.py
@@ -1,6 +1,5 @@
 """File watcher implementation for --watch flag functionality."""
 
-import os
 import subprocess
 import time
 from pathlib import Path
@@ -84,7 +83,7 @@ class FileWatcher:
 
                 if current_mtimes != file_mtimes:
                     if not self.verbose:
-                        os.system("clear" if os.name != "nt" else "cls")
+                        self.console.clear()
                     self.console.print(
                         "[yellow]File changes detected, "
                         "re-running...[/yellow]\n"


### PR DESCRIPTION
## 🗒️ Description

mypy's `deprecated` error code (enabled in pyproject.toml) flags the `os.system` call in the `--watch` file watcher. Use the Rich `Console.clear()` the watcher already holds instead of shelling out to `clear`/`cls`; it is cross-platform and removes the last `os` use, so drop `import os`.

Why CI does not catch this: typeshed marks `os.system` `@deprecated` only for `sys.version_info >= (3, 14)`, and `[tool.mypy]` pins no `python_version`, so mypy targets whatever interpreter runs it. The `static` CI job has no setup-python step (unlike the fill jobs, which pin 3.14) and runs mypy under the runner default, CPython 3.13, where the marker is inactive. Local dev on 3.14 sees the error; CI stays green.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [ ] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: Add the following docstring to manually enhanced tests from `./tests/ported_static/`:
    ```text
	@manually-enhanced: Do not overwrite. Post-state expectations corrected
	manually (see PR #2784).
	````
