### PR TITLE
fix(clients): map ethrex invalid signature v/r/s rejections to INVALID_SIGNATURE_VRS

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -61,6 +61,11 @@ class EthrexExceptionMapper(ExceptionMapper):
         ),
     }
     mapping_regex = {
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            r"Couldn't recover addresses with error: invalid signature|"
+            r"Error decoding field 'signature_y_parity' of type bool: "
+            r"MalformedBoolean"
+        ),
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
             r"(?i)priority fee.* is greater than max fee.*"
         ),


### PR DESCRIPTION
Adds an `INVALID_SIGNATURE_VRS` mapping to `EthrexExceptionMapper`.

The `test_bad_v_r_s` cases all expect `TransactionException.INVALID_SIGNATURE_VRS`. ethrex rejects them but with two unmapped messages:

- typed txs: `Error decoding field 'signature_y_parity' of type bool: MalformedBoolean`
- legacy txs: `Couldn't recover addresses with error: invalid signature`

The `y_parity` value is the signature's `v`, so mapping its decode error to `INVALID_SIGNATURE_VRS` is correct. Matching is additive (the mapper returns all matches), so the existing `RLP_STRUCTURES_ENCODING` match still holds and nothing regresses.

The 2 legacy `v=34` cases are excluded on purpose: ethrex rejects those with `Insufficient account funds`, which is an ethrex-side bug, not a mapping gap.