### PR TITLE
chore(test-client-clis): map erigon INVALID_SIGNATURE_VRS exception

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -54,6 +54,9 @@ class ErigonExceptionMapper(ExceptionMapper):
         TransactionException.NONCE_MISMATCH_TOO_HIGH: "nonce too high",
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "gas limit reached",
         TransactionException.INVALID_CHAINID: "invalid chain id for signer",
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            "invalid transaction v, r, s values"
+        ),
         TransactionException.TYPE_3_TX_PRE_FORK: (
             "blob txn is not supported by signer"
         ),


### PR DESCRIPTION
Erigon rejects bad-signature transactions with "invalid transaction v, r, s values" (types.ErrInvalidSig), but ErigonExceptionMapper had no entry for TransactionException.INVALID_SIGNATURE_VRS. As a result consume-engine / consume-rlp report "Undefined exception message" for the frontier/validation/test_transaction::test_bad_v_r_s cases (24 per fork, surfaced by the tests@v20.0.0 fixtures). Add the substring mapping.

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
