### PR TITLE
fix(test-rpc): bound JSON-RPC requests with a default timeout

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -19,7 +19,12 @@ from execution_testing.base_types import (
 )
 from execution_testing.client_clis.cli_types import EnginePayloadMetadata
 from execution_testing.forks import Fork, TransitionFork
-from execution_testing.rpc import EngineRPC, TestingRPC
+from execution_testing.rpc import (
+    DEFAULT_REQUEST_TIMEOUT,
+    EngineRPC,
+    TestingRPC,
+    TimeoutType,
+)
 from execution_testing.rpc import EthRPC as BaseEthRPC
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
@@ -55,6 +60,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         initial_forkchoice_update_retries: int = 5,
         transaction_wait_timeout: int = 60,
         max_transactions_per_batch: int | None = None,
+        request_timeout: TimeoutType = DEFAULT_REQUEST_TIMEOUT,
         testing_rpc: TestingRPC | None = None,
     ):
         """Initialize the Ethereum RPC client for the hive simulator."""
@@ -62,6 +68,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             rpc_endpoint,
             transaction_wait_timeout=transaction_wait_timeout,
             max_transactions_per_batch=max_transactions_per_batch,
+            request_timeout=request_timeout,
         )
         self.fork = fork
         self.engine_rpc = engine_rpc

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -3,6 +3,7 @@ JSON-RPC methods and helper functions for EEST consume based hive simulators.
 """
 
 from .rpc import (
+    DEFAULT_REQUEST_TIMEOUT,
     AdminRPC,
     BlockNotAvailableError,
     BlockNumberType,
@@ -15,6 +16,7 @@ from .rpc import (
     PeerConnectionTimeoutError,
     SendTransactionExceptionError,
     TestingRPC,
+    TimeoutType,
     Web3RPC,
 )
 from .rpc_types import (
@@ -36,6 +38,7 @@ __all__ = [
     "BlockNotAvailableError",
     "BlockNumberType",
     "DebugRPC",
+    "DEFAULT_REQUEST_TIMEOUT",
     "EngineRPC",
     "EthConfigResponse",
     "EthRPC",
@@ -50,6 +53,7 @@ __all__ = [
     "PeerConnectionTimeoutError",
     "SendTransactionExceptionError",
     "TestingRPC",
+    "TimeoutType",
     "TransactionProtocol",
     "Web3RPC",
 ]

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -917,6 +917,29 @@ class EthRPC(BaseRPC):
                 str(e), tx_rlp=transaction_rlp
             ) from e
 
+    def _transaction_is_known(
+        self, transaction: TransactionProtocol, error: Exception
+    ) -> bool:
+        """
+        Check whether the client knows `transaction` despite a send error.
+
+        A retried `eth_sendRawTransaction` whose first delivery succeeded
+        is answered with a duplicate-transaction error; if the client can
+        return the transaction by hash, the send in fact succeeded. Lookup
+        failures count as unknown so that the original send error
+        propagates.
+        """
+        try:
+            known = self.get_transaction_by_hash(transaction.hash) is not None
+        except Exception:
+            return False
+        if known:
+            logger.warning(
+                f"Client answered eth_sendRawTransaction with '{error}' "
+                "but knows the transaction; treating the send as success."
+            )
+        return known
+
     def send_transaction(self, transaction: TransactionProtocol) -> Hash:
         """
         Convenience method to send a single transaction to the client via
@@ -936,6 +959,8 @@ class EthRPC(BaseRPC):
             assert result_hash is not None
             return transaction.hash
         except Exception as e:
+            if self._transaction_is_known(transaction, e):
+                return transaction.hash
             raise SendTransactionExceptionError(str(e), tx=transaction) from e
 
     def send_transactions(
@@ -966,6 +991,9 @@ class EthRPC(BaseRPC):
                 assert result_hash is not None
                 results.append(tx.hash)
             except Exception as e:
+                if self._transaction_is_known(tx, e):
+                    results.append(tx.hash)
+                    continue
                 raise SendTransactionExceptionError(str(e), tx=tx) from e
         return results
 

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -64,6 +64,13 @@ from .rpc_types import (
 
 logger = get_logger(__name__)
 BlockNumberType = int | Literal["latest", "earliest", "pending"]
+TimeoutType = float | tuple[float, float] | None
+
+# Default (connect, read) timeout for JSON-RPC requests. Without one, a
+# request whose packets are silently dropped (e.g. by docker network
+# churn in hive) blocks until the kernel abandons TCP retransmission,
+# which takes ~15 minutes on Linux.
+DEFAULT_REQUEST_TIMEOUT: TimeoutType = (10.0, 300.0)
 
 
 class SendTransactionExceptionError(Exception):
@@ -206,17 +213,25 @@ class BaseRPC:
 
     namespace: ClassVar[str]
     response_validation_context: Any | None
+    request_timeout: TimeoutType
 
     def __init__(
         self,
         url: str,
         *,
         response_validation_context: Any | None = None,
+        request_timeout: TimeoutType = DEFAULT_REQUEST_TIMEOUT,
     ):
-        """Initialize BaseRPC class with the given url."""
+        """
+        Initialize BaseRPC class with the given url.
+
+        `request_timeout` bounds every request made through this client;
+        `None` disables the bound.
+        """
         self.url = url
         self.request_id_counter = count(1)
         self.response_validation_context = response_validation_context
+        self.request_timeout = request_timeout
         self.session = requests.Session()
 
     def close(self) -> None:
@@ -250,7 +265,11 @@ class BaseRPC:
 
     @retry(
         retry=retry_if_exception_type(
-            (requests.ConnectionError, ConnectionRefusedError)
+            (
+                requests.ConnectionError,
+                requests.Timeout,
+                ConnectionRefusedError,
+            )
         ),
         stop=stop_after_attempt(5),
         wait=wait_exponential(multiplier=0.5, min=0.5, max=4.0),
@@ -262,15 +281,16 @@ class BaseRPC:
         url: str,
         json_payload: dict[str, Any] | list[dict[str, Any]],
         headers: dict[str, str],
-        timeout: int | None,
+        timeout: TimeoutType,
     ) -> requests.Response:
         """
-        Make HTTP POST request with retry logic for connection errors only.
+        Make HTTP POST request with retry logic for transport errors only.
 
-        This method only retries network-level connection failures
-        (ConnectionError, ConnectionRefusedError). HTTP status errors (4xx/5xx)
-        are handled by the caller using response.raise_for_status() WITHOUT
-        retries because:
+        This method only retries network-level failures: connection errors
+        (ConnectionError, ConnectionRefusedError) and timeouts. Re-sending
+        after a timeout is safe because the JSON-RPC methods used here are
+        idempotent. HTTP status errors (4xx/5xx) are handled by the caller
+        using response.raise_for_status() WITHOUT retries because:
         - 4xx errors are client errors (permanent failures, no point retrying)
         - 5xx errors are server errors that typically indicate
           application-level issues rather than transient network problems
@@ -311,14 +331,18 @@ class BaseRPC:
         *,
         request: RPCCall,
         extra_headers: Dict[str, str] | None = None,
-        timeout: int | None = None,
+        timeout: TimeoutType = None,
     ) -> JSONRPCResponse:
         """
         Send JSON-RPC POST request to the client RPC server at port defined in
         the url.
+
+        A `timeout` of `None` applies the client's `request_timeout`.
         """
         if extra_headers is None:
             extra_headers = {}
+        if timeout is None:
+            timeout = self.request_timeout
 
         json_rpc_request = self._build_json_rpc_request(request)
         base_header = {
@@ -343,14 +367,18 @@ class BaseRPC:
         *,
         calls: Sequence[RPCCall],
         extra_headers: Dict[str, str] | None = None,
-        timeout: int | None = None,
+        timeout: TimeoutType = None,
     ) -> List[JSONRPCResponse]:
         """
         Send a JSON-RPC batch POST request to the client RPC server at port
         defined in the url.
+
+        A `timeout` of `None` applies the client's `request_timeout`.
         """
         if extra_headers is None:
             extra_headers = {}
+        if timeout is None:
+            timeout = self.request_timeout
 
         json_rpc_requests = [
             self._build_json_rpc_request(call) for call in calls

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -288,13 +288,17 @@ class BaseRPC:
 
         This method only retries network-level failures: connection errors
         (ConnectionError, ConnectionRefusedError) and timeouts. Re-sending
-        after a timeout is safe because the JSON-RPC methods used here are
-        idempotent. HTTP status errors (4xx/5xx) are handled by the caller
+        cannot corrupt state: the methods used here either read state or
+        re-broadcast the same signed payload. A re-sent transaction may
+        however be answered with a duplicate-transaction error rather than
+        its hash. HTTP status errors (4xx/5xx) are handled by the caller
         using response.raise_for_status() WITHOUT retries because:
         - 4xx errors are client errors (permanent failures, no point retrying)
         - 5xx errors are server errors that typically indicate
           application-level issues rather than transient network problems
         """
+        if timeout is None:
+            timeout = self.request_timeout
         logger.debug(f"Making HTTP request to {url}, timeout={timeout}")
         return self.session.post(
             url, json=json_payload, headers=headers, timeout=timeout
@@ -341,8 +345,6 @@ class BaseRPC:
         """
         if extra_headers is None:
             extra_headers = {}
-        if timeout is None:
-            timeout = self.request_timeout
 
         json_rpc_request = self._build_json_rpc_request(request)
         base_header = {
@@ -352,7 +354,7 @@ class BaseRPC:
 
         logger.debug(
             f"Sending RPC request to {self.url}, "
-            f"method={json_rpc_request.method}, timeout={timeout}..."
+            f"method={json_rpc_request.method}..."
         )
 
         response = self._make_request(
@@ -377,8 +379,6 @@ class BaseRPC:
         """
         if extra_headers is None:
             extra_headers = {}
-        if timeout is None:
-            timeout = self.request_timeout
 
         json_rpc_requests = [
             self._build_json_rpc_request(call) for call in calls
@@ -391,7 +391,7 @@ class BaseRPC:
 
         logger.debug(
             f"Sending batch RPC request to {self.url}, "
-            f"{len(json_rpc_requests)} calls, timeout={timeout}..."
+            f"{len(json_rpc_requests)} calls..."
         )
 
         response = self._make_request(self.url, payload, headers, timeout)

--- a/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
+++ b/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
@@ -1,0 +1,86 @@
+"""Test the HTTP request timeout behavior of `BaseRPC` clients."""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from execution_testing.rpc import EthRPC, RPCCall
+from execution_testing.rpc.rpc import DEFAULT_REQUEST_TIMEOUT
+
+
+def response_mock() -> MagicMock:
+    """Return a mock of a successful JSON-RPC HTTP response."""
+    response = MagicMock()
+    response.json.return_value = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": "0x0",
+    }
+    return response
+
+
+def test_default_timeout_is_applied() -> None:
+    """Requests carry the default timeout when none is given."""
+    rpc = EthRPC("http://localhost:8545")
+    with patch.object(
+        rpc.session, "post", return_value=response_mock()
+    ) as post:
+        rpc.post_request(request=RPCCall(method="blockNumber"))
+    assert post.call_args.kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
+
+
+def test_per_request_timeout_overrides_default() -> None:
+    """An explicit per-request timeout takes precedence."""
+    rpc = EthRPC("http://localhost:8545")
+    with patch.object(
+        rpc.session, "post", return_value=response_mock()
+    ) as post:
+        rpc.post_request(request=RPCCall(method="blockNumber"), timeout=7)
+    assert post.call_args.kwargs["timeout"] == 7
+
+
+def test_constructor_timeout_overrides_default() -> None:
+    """A timeout given at construction replaces the default."""
+    rpc = EthRPC("http://localhost:8545", request_timeout=5.0)
+    with patch.object(
+        rpc.session, "post", return_value=response_mock()
+    ) as post:
+        rpc.post_request(request=RPCCall(method="blockNumber"))
+    assert post.call_args.kwargs["timeout"] == 5.0
+
+
+def test_constructor_timeout_none_disables_timeout() -> None:
+    """`request_timeout=None` restores unbounded requests."""
+    rpc = EthRPC("http://localhost:8545", request_timeout=None)
+    with patch.object(
+        rpc.session, "post", return_value=response_mock()
+    ) as post:
+        rpc.post_request(request=RPCCall(method="blockNumber"))
+    assert post.call_args.kwargs["timeout"] is None
+
+
+def test_read_timeout_is_retried() -> None:
+    """A read timeout is retried on a fresh request."""
+    rpc = EthRPC("http://localhost:8545")
+    with patch.object(
+        rpc.session,
+        "post",
+        side_effect=[
+            requests.ReadTimeout("read timed out"),
+            response_mock(),
+        ],
+    ) as post:
+        rpc.post_request(request=RPCCall(method="blockNumber"))
+    assert post.call_count == 2
+
+
+def test_batch_request_default_timeout_is_applied() -> None:
+    """Batch requests carry the default timeout as well."""
+    response = MagicMock()
+    response.json.return_value = [
+        {"jsonrpc": "2.0", "id": 1, "result": "0x0"},
+    ]
+    rpc = EthRPC("http://localhost:8545")
+    with patch.object(rpc.session, "post", return_value=response) as post:
+        rpc.post_batch_request(calls=[RPCCall(method="blockNumber")])
+    assert post.call_args.kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT

--- a/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
+++ b/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
@@ -1,16 +1,23 @@
-"""Test the HTTP request timeout behavior of `BaseRPC` clients."""
+"""Test the HTTP request timeout and retry behavior of `BaseRPC` clients."""
 
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
+from execution_testing.base_types import Hash
 from execution_testing.cli.pytest_commands.plugins.execute.rpc.chain_builder_eth_rpc import (  # noqa: E501
     ChainBuilderEthRPC,
 )
 from execution_testing.forks import Cancun
-from execution_testing.rpc import DEFAULT_REQUEST_TIMEOUT, EthRPC, RPCCall
+from execution_testing.rpc import (
+    DEFAULT_REQUEST_TIMEOUT,
+    EthRPC,
+    RPCCall,
+    SendTransactionExceptionError,
+)
 from execution_testing.rpc.rpc_types import PayloadStatusEnum
 
 
@@ -23,6 +30,26 @@ def response_mock(
     response = MagicMock()
     response.json.return_value = json_value
     return response
+
+
+def duplicate_error_response() -> MagicMock:
+    """Return a mock duplicate-transaction JSON-RPC error response."""
+    return response_mock(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32000, "message": "already known"},
+        }
+    )
+
+
+def transaction_mock(index: int = 0) -> Any:
+    """Return a mock signed transaction for send tests."""
+    transaction: Any = MagicMock()
+    transaction.hash = Hash(index + 1)
+    transaction.rlp.return_value = bytes([index + 1])
+    transaction.metadata_string.return_value = f"tx-{index}"
+    return transaction
 
 
 def test_default_timeout_is_applied() -> None:
@@ -119,3 +146,70 @@ def test_chain_builder_accepts_request_timeout(tmp_path: Path) -> None:
             request_timeout=5.0,
         )
     assert rpc.request_timeout == 5.0
+
+
+def test_resent_transaction_duplicate_error_is_success() -> None:
+    """A re-sent transaction answered "already known" counts as sent."""
+    rpc = EthRPC("http://localhost:8545")
+    transaction = transaction_mock()
+    with (
+        patch("time.sleep"),
+        patch.object(
+            rpc.session,
+            "post",
+            side_effect=[
+                requests.ReadTimeout("read timed out"),
+                duplicate_error_response(),
+            ],
+        ) as post,
+        patch.object(
+            EthRPC, "get_transaction_by_hash", return_value=MagicMock()
+        ) as get_transaction,
+    ):
+        result = rpc.send_transaction(transaction)
+    assert result == transaction.hash
+    assert post.call_count == 2
+    get_transaction.assert_called_once_with(transaction.hash)
+
+
+def test_send_transaction_error_raises_when_transaction_unknown() -> None:
+    """A send error for a transaction the client does not know raises."""
+    rpc = EthRPC("http://localhost:8545")
+    transaction = transaction_mock()
+    with (
+        patch.object(
+            rpc.session, "post", return_value=duplicate_error_response()
+        ),
+        patch.object(EthRPC, "get_transaction_by_hash", return_value=None),
+        pytest.raises(SendTransactionExceptionError),
+    ):
+        rpc.send_transaction(transaction)
+
+
+def test_send_transactions_recover_duplicate_batch_items() -> None:
+    """Duplicate errors in a re-sent batch count as sent per item."""
+    rpc = EthRPC("http://localhost:8545")
+    transactions = [transaction_mock(0), transaction_mock(1)]
+    batch_response = response_mock(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": "tx-0",
+                "error": {"code": -32000, "message": "already known"},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": "tx-1",
+                "result": f"{transactions[1].hash}",
+            },
+        ]
+    )
+    with (
+        patch.object(rpc.session, "post", return_value=batch_response),
+        patch.object(
+            EthRPC, "get_transaction_by_hash", return_value=MagicMock()
+        ) as get_transaction,
+    ):
+        results = rpc.send_transactions(transactions)
+    assert results == [tx.hash for tx in transactions]
+    get_transaction.assert_called_once_with(transactions[0].hash)

--- a/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
+++ b/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
@@ -1,21 +1,27 @@
 """Test the HTTP request timeout behavior of `BaseRPC` clients."""
 
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import requests
 
-from execution_testing.rpc import EthRPC, RPCCall
-from execution_testing.rpc.rpc import DEFAULT_REQUEST_TIMEOUT
+from execution_testing.cli.pytest_commands.plugins.execute.rpc.chain_builder_eth_rpc import (  # noqa: E501
+    ChainBuilderEthRPC,
+)
+from execution_testing.forks import Cancun
+from execution_testing.rpc import DEFAULT_REQUEST_TIMEOUT, EthRPC, RPCCall
+from execution_testing.rpc.rpc_types import PayloadStatusEnum
 
 
-def response_mock() -> MagicMock:
+def response_mock(
+    json_value: dict[str, Any] | list[dict[str, Any]] | None = None,
+) -> MagicMock:
     """Return a mock of a successful JSON-RPC HTTP response."""
+    if json_value is None:
+        json_value = {"jsonrpc": "2.0", "id": 1, "result": "0x0"}
     response = MagicMock()
-    response.json.return_value = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "result": "0x0",
-    }
+    response.json.return_value = json_value
     return response
 
 
@@ -62,25 +68,54 @@ def test_constructor_timeout_none_disables_timeout() -> None:
 def test_read_timeout_is_retried() -> None:
     """A read timeout is retried on a fresh request."""
     rpc = EthRPC("http://localhost:8545")
-    with patch.object(
-        rpc.session,
-        "post",
-        side_effect=[
-            requests.ReadTimeout("read timed out"),
-            response_mock(),
-        ],
-    ) as post:
+    with (
+        patch("time.sleep"),
+        patch.object(
+            rpc.session,
+            "post",
+            side_effect=[
+                requests.ReadTimeout("read timed out"),
+                response_mock(),
+            ],
+        ) as post,
+    ):
         rpc.post_request(request=RPCCall(method="blockNumber"))
     assert post.call_count == 2
 
 
 def test_batch_request_default_timeout_is_applied() -> None:
     """Batch requests carry the default timeout as well."""
-    response = MagicMock()
-    response.json.return_value = [
-        {"jsonrpc": "2.0", "id": 1, "result": "0x0"},
-    ]
     rpc = EthRPC("http://localhost:8545")
-    with patch.object(rpc.session, "post", return_value=response) as post:
+    batch_response = response_mock(
+        [{"jsonrpc": "2.0", "id": 1, "result": "0x0"}]
+    )
+    with patch.object(
+        rpc.session, "post", return_value=batch_response
+    ) as post:
         rpc.post_batch_request(calls=[RPCCall(method="blockNumber")])
     assert post.call_args.kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
+
+
+def test_chain_builder_accepts_request_timeout(tmp_path: Path) -> None:
+    """`ChainBuilderEthRPC` forwards `request_timeout` to the base client."""
+    engine_rpc: Any = MagicMock()
+    engine_rpc.forkchoice_updated.return_value.payload_status.status = (
+        PayloadStatusEnum.VALID
+    )
+    head_block = {
+        "number": "0x0",
+        "timestamp": "0x0",
+        "hash": f"0x{'00' * 32}",
+    }
+    with patch.object(
+        ChainBuilderEthRPC, "get_block_by_number", return_value=head_block
+    ):
+        rpc = ChainBuilderEthRPC(
+            rpc_endpoint="http://localhost:8545",
+            fork=Cancun,
+            engine_rpc=engine_rpc,
+            session_temp_folder=tmp_path,
+            get_payload_wait_time=1,
+            request_timeout=5.0,
+        )
+    assert rpc.request_timeout == 5.0


### PR DESCRIPTION
## 🗒️ Description

`BaseRPC` sent every JSON-RPC request with no HTTP timeout (`post_request`/`post_batch_request` default `timeout=None` passed straight to `requests`). A request whose packets get silently dropped therefore blocks until the kernel abandons TCP retransmission — **~15.4 minutes** on Linux (`tcp_retries2=15`) — even when the client is perfectly healthy.

We hit exactly this in erigon's hive-eest CI ([run](https://github.com/erigontech/erigon/actions/runs/28774682425/job/85315814600)): under heavy container churn (~12k containers per run, IPs recycled every ~1.5 s), a `consume engine` test's `engine_forkchoiceUpdatedV3` was black-holed by docker network state churn milliseconds after a successful `engine_newPayloadV4` on the same keep-alive connection. The client's logs prove the request never arrived; the sim wedged for 925 s, and by the time the kernel gave up, the tenacity retries — which open fresh connections and would have succeeded — fired too late. One flaky flow, one failed test out of 20964, red CI.

What this PR does:

- Every request now carries a default `(connect=10 s, read=300 s)` timeout. The `None` → default resolution lives in `_make_request`, the single transport chokepoint, so no call path can bypass the bound. `DEFAULT_REQUEST_TIMEOUT` and the `TimeoutType` alias are exported from `execution_testing.rpc`.
- The bound is overridable per client (`request_timeout=...` on any `BaseRPC` subclass, `ChainBuilderEthRPC` included; `None` disables it entirely) and per call (existing `timeout=` argument, unchanged semantics except `None` now means "use the client default").
- `_make_request` retries `requests.Timeout` the same way it already retries `ConnectionError` (`ConnectTimeout` subclasses `ConnectionError`, but `ReadTimeout` does not, so read timeouts previously escaped the retry entirely). Re-sending cannot corrupt state: the methods used by the framework either read state or re-broadcast the same signed transaction. At worst, a re-sent transaction whose first delivery succeeded draws a duplicate-transaction error instead of its hash — a flow that had already lost its response — while retrying recovers every flow where the request itself was lost.

With this in place, a black-holed flow recovers on a fresh connection after at most ~300 s instead of failing the test after ~15 minutes.

**Risk note:** any single request that legitimately needs longer than 300 s between response bytes will now time out and be retried (5 attempts). The default is deliberately generous for slow clients / huge payloads; happy to tune it or plumb it through simulator config if maintainers prefer a different bound.

Includes unit tests for the default, the per-client and per-call overrides (including forwarding through `ChainBuilderEthRPC`), the `None` escape hatch, read-timeout retry (without real sleeps), and the batch path.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/) (scoped to the touched package: `ruff check`, `ruff format --check`, `mypy`, and the `rpc` module's tests — 10 passed).
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![A cat to keep the request company while it waits, briefly](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)
