### PR TITLE
fix(test-fill): fix `derived_test` marking for single-format tests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Self, Set, Type
 import pytest
 import xdist
 from _pytest.compat import NotSetType
+from _pytest.mark.structures import ParameterSet
 from _pytest.terminal import TerminalReporter
 from filelock import FileLock
 from pytest_metadata.plugin import metadata_key
@@ -1779,20 +1780,36 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     FillerFile.collect() in ./static_filler.py for more details.
     """
     session: FillingSession = metafunc.config.filling_session  # type: ignore[attr-defined]
+    markers = list(metafunc.definition.iter_markers())
     for test_type in BaseTest.spec_types.values():
         if test_type.pytest_parameter_name() in metafunc.fixturenames:
-            parameters = []
-            for i, format_with_or_without_label in enumerate(
-                test_type.supported_fixture_formats
-            ):
+            parameters: List[ParameterSet] = []
+            for (
+                format_with_or_without_label
+            ) in test_type.supported_fixture_formats:
                 if not session.should_generate_format(
                     format_with_or_without_label
+                ):
+                    continue
+                fixture_format = (
+                    format_with_or_without_label.format
+                    if isinstance(
+                        format_with_or_without_label, LabeledFixtureFormat
+                    )
+                    else format_with_or_without_label
+                )
+                if test_type.discard_fixture_format_by_marks(
+                    fixture_format, markers
                 ):
                     continue
                 parameter = labeled_format_parameter_set(
                     format_with_or_without_label
                 )
-                if i > 0:
+                # The first surviving format is the test's primary; the
+                # rest are derived from it (e.g. a BlockchainTest derived
+                # from a StateTest) and can be deselected with
+                # `-m "not derived_test"`.
+                if parameters:
                     parameter.marks.append(pytest.mark.derived_test)  # type: ignore
                 parameters.append(parameter)
             metafunc.parametrize(
@@ -1857,9 +1874,9 @@ def pytest_collection_modifyitems(
         if fixture_format.discard_fixture_format_by_marks(fork, markers):
             items_for_removal.append(i)
             continue
-        if spec_type.discard_fixture_format_by_marks(
-            fixture_format, fork, markers
-        ):
+        # Only static tests can be discarded here: dynamic tests never
+        # generate discarded formats (see pytest_generate_tests above).
+        if spec_type.discard_fixture_format_by_marks(fixture_format, markers):
             items_for_removal.append(i)
             continue
         for marker in markers:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_derived_test_marker.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_derived_test_marker.py
@@ -1,0 +1,179 @@
+"""
+Test that the `derived_test` marker tracks the first fixture format that is
+actually generated for a test, not merely the first entry in
+``supported_fixture_formats``.
+
+Two ways the positional-first format can drop out, leaving a fixture that
+used to be tagged ``derived_test`` purely because of its list position:
+
+1. A single-format marker such as ``blockchain_test_engine_only`` discards
+   the test's default (primary) format.
+2. A session-level format filter (e.g. a ``--generate-pre-alloc-groups``
+   session, which only generates EngineX fixtures) excludes the primary
+   format from parametrization entirely.
+
+In both cases the surviving format is the test's effective primary, so it
+must stay unmarked and remain selectable via ``-m "not derived_test"``.
+"""
+
+import textwrap
+
+import pytest
+
+# A post-Paris fork is required: pre-Paris hive/engine fixtures are removed
+# during collection (see `pytest_collection_modifyitems` in filler.py), which
+# would empty a `blockchain_test_engine_only` test regardless of this marker.
+FORK = "Prague"
+
+ENGINE_ONLY_MODULE = textwrap.dedent(
+    f"""\
+    import pytest
+
+    @pytest.mark.valid_at("{FORK}")
+    @pytest.mark.blockchain_test_engine_only
+    def test_case(blockchain_test) -> None:
+        pass
+    """
+)
+
+NORMAL_BLOCKCHAIN_MODULE = textwrap.dedent(
+    f"""\
+    import pytest
+
+    @pytest.mark.valid_at("{FORK}")
+    def test_case(blockchain_test) -> None:
+        pass
+    """
+)
+
+STATE_ONLY_MODULE = textwrap.dedent(
+    f"""\
+    import pytest
+
+    @pytest.mark.valid_at("{FORK}")
+    @pytest.mark.state_test_only
+    def test_case(state_test) -> None:
+        pass
+    """
+)
+
+NORMAL_STATE_MODULE = textwrap.dedent(
+    f"""\
+    import pytest
+
+    @pytest.mark.valid_at("{FORK}")
+    def test_case(state_test) -> None:
+        pass
+    """
+)
+
+TEST_MODULE_DIR = "tests/prague/dummy_test_module"
+
+
+def write_test_module(pytester: pytest.Pytester, module_source: str) -> None:
+    """
+    Write a test module and the fill ini file to the pytester directory.
+    """
+    module_dir = pytester.path / TEST_MODULE_DIR
+    module_dir.mkdir(parents=True)
+    (module_dir / "test_dummy.py").write_text(module_source)
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+
+
+@pytest.mark.parametrize(
+    "module_source,present,absent",
+    [
+        pytest.param(
+            ENGINE_ONLY_MODULE,
+            "-blockchain_test_engine]",
+            "-blockchain_test]",
+            id="engine_only_survivor_is_primary",
+        ),
+        pytest.param(
+            NORMAL_BLOCKCHAIN_MODULE,
+            "-blockchain_test]",
+            "-blockchain_test_engine]",
+            id="normal_test_still_marks_derived",
+        ),
+        pytest.param(
+            STATE_ONLY_MODULE,
+            "-state_test]",
+            "-blockchain_test_from_state_test]",
+            id="state_only_survivor_is_primary",
+        ),
+    ],
+)
+def test_not_derived_test_selects_primary_survivor(
+    pytester: pytest.Pytester,
+    module_source: str,
+    present: str,
+    absent: str,
+) -> None:
+    """
+    Collect with ``-m "not derived_test"`` and assert the test's primary
+    (first surviving) fixture format is selected while its derived formats are
+    not.
+    """
+    write_test_module(pytester, module_source)
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        FORK,
+        "-m",
+        "not derived_test",
+        TEST_MODULE_DIR,
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0, f"Collection failed:\n{result.outlines}"
+    assert any(present in line for line in result.outlines), (
+        f"Expected {present!r} to be collected:\n{result.outlines}"
+    )
+    assert not any(absent in line for line in result.outlines), (
+        f"Expected {absent!r} to be absent under `not derived_test`:\n"
+        f"{result.outlines}"
+    )
+
+
+def test_not_derived_test_selects_session_filter_survivor(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Collect a plain state test in a ``--generate-pre-alloc-groups`` session
+    with ``-m "not derived_test"`` and assert that the only format generated
+    in this session (EngineX) is selected as the test's primary.
+
+    The session-level format filter (``should_generate_format``) excludes all
+    other formats before parametrization, so the EngineX fixture must not
+    inherit a ``derived_test`` mark from its position in
+    ``supported_fixture_formats``.
+    """
+    write_test_module(pytester, NORMAL_STATE_MODULE)
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        FORK,
+        "--generate-pre-alloc-groups",
+        "-m",
+        "not derived_test",
+        TEST_MODULE_DIR,
+        "--collect-only",
+        "-q",
+    )
+
+    engine_x = "-blockchain_test_engine_x_from_state_test]"
+    assert result.ret == 0, f"Collection failed:\n{result.outlines}"
+    assert any(engine_x in line for line in result.outlines), (
+        f"Expected {engine_x!r} to be collected:\n{result.outlines}"
+    )
+    assert not any("-state_test]" in line for line in result.outlines), (
+        "Expected the state test format to be excluded by the session "
+        f"format filter:\n{result.outlines}"
+    )

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -142,14 +142,13 @@ class BaseTest(BaseModel):
     def discard_fixture_format_by_marks(
         cls,
         fixture_format: FixtureFormat,
-        fork: Fork | TransitionFork,
         markers: List[pytest.Mark],
     ) -> bool:
         """
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
-        del fork, fixture_format, markers
+        del fixture_format, markers
         return False
 
     @classmethod

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -38,7 +38,7 @@ from execution_testing.fixtures import (
     FixtureFormat,
     LabeledFixtureFormat,
 )
-from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks import Fork
 from execution_testing.test_types import Alloc, Environment, Transaction
 from execution_testing.vm import Bytecode, Op
 
@@ -421,15 +421,12 @@ class BenchmarkTest(BaseTest):
     def discard_fixture_format_by_marks(
         cls,
         fixture_format: FixtureFormat,
-        fork: Fork | TransitionFork,
         markers: List[pytest.Mark],
     ) -> bool:
         """
         Discard a fixture format from filling if the
         appropriate marker is used.
         """
-        del fork
-
         if "blockchain_test_only" in [m.name for m in markers]:
             return fixture_format != BlockchainFixture
         if "blockchain_test_engine_only" in [m.name for m in markers]:

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -83,7 +83,7 @@ from execution_testing.fixtures.common import (
     FixtureTransactionReceipt,
 )
 from execution_testing.fixtures.post_verifications import PostVerifications
-from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks import Fork
 from execution_testing.test_types import (
     Alloc,
     Environment,
@@ -740,15 +740,12 @@ class BlockchainTest(BaseTest):
     def discard_fixture_format_by_marks(
         cls,
         fixture_format: FixtureFormat,
-        fork: Fork | TransitionFork,
         markers: List[pytest.Mark],
     ) -> bool:
         """
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
-        del fork
-
         marker_names = [m.name for m in markers]
         if (
             fixture_format != BlockchainFixture

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -46,7 +46,7 @@ from execution_testing.fixtures.state import (
     FixtureTransaction,
     FixtureTransactionReceipt,
 )
-from execution_testing.forks import Fork, TransitionFork
+from execution_testing.forks import Fork
 from execution_testing.logging import (
     get_logger,
 )
@@ -233,15 +233,12 @@ class StateTest(BaseTest):
     def discard_fixture_format_by_marks(
         cls,
         fixture_format: FixtureFormat,
-        fork: Fork | TransitionFork,
         markers: List[pytest.Mark],
     ) -> bool:
         """
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
-        del fork
-
         if "state_test_only" in [m.name for m in markers]:
             return fixture_format != StateFixture
         return False


### PR DESCRIPTION
## 🗒️ Description
`pytest_generate_tests` marked every fixture format after the first in `supported_fixture_formats` as `derived_test` purely by list position, so a test whose first format is dropped, either by a single-format marker such as `blockchain_test_engine_only` or by a session-level format filter such as `--generate-pre-alloc-groups`, had all of its surviving formats marked `derived_test` and was deselected entirely by `-m "not derived_test"`. This PR applies the spec-level marker discard directly in `pytest_generate_tests` so that the first generated parameter is the primary and remains unmarked, drops the unused `fork` argument from `BaseTest.discard_fixture_format_by_marks()`, and adds pytester tests covering both scenarios.

## 🔗 Related Issues or PRs
Unblocks the use of `-m "not slow and not derived_test"` in #3096, see [this review comment](https://github.com/ethereum/execution-specs/pull/3096#discussion_r3527529480).

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![I'm the primary now](https://cataas.com/cat/cute/says/I%27m%20the%20primary%20now?fontSize=40&fontColor=white)
