### PR TITLE
chore(testing): silence pytest collection warnings

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -110,6 +110,8 @@ def merge_partial_fixture_files(output_dir: Path) -> None:
 class TestInfo:
     """Contains test information from the current node."""
 
+    __test__ = False  # stop pytest from collecting this class as a test
+
     name: str  # pytest: Item.name, e.g. test_paris_one[fork_Paris-state_test]
     id: str  # pytest: Item.nodeid, e.g.
     # tests/paris/test_module_paris.py::test_paris_one[...]

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -1533,6 +1533,8 @@ class TestingRPC(BaseRPC):
     testing-only methods like ``testing_buildBlockV1``.
     """
 
+    __test__ = False  # stop pytest from collecting this class as a test
+
     def build_block(
         self,
         parent_block_hash: Hash,

--- a/packages/testing/src/execution_testing/test_types/phase_manager.py
+++ b/packages/testing/src/execution_testing/test_types/phase_manager.py
@@ -8,6 +8,8 @@ from typing import ClassVar, Iterator, Optional
 class TestPhase(str, Enum):
     """Test phase for state and blockchain tests."""
 
+    __test__ = False  # stop pytest from collecting this class as a test
+
     SETUP = "setup"
     # TODO: Change string to "execution", remain as "testing" for backwards
     # compatibility


### PR DESCRIPTION
## 🗒️ Description
Add `__test__ = False` to `TestingRPC`, `TestInfo`, and `TestPhase` to silence the `PytestCollectionWarning`s emitted during `just test-tests` runs, where pytest name-matches these `Test`-prefixed framework classes during collection.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![I am not a test](https://cataas.com/cat/says/I%20am%20not%20a%20test?fontSize=40&fontColor=white)
