### PR TITLE
refactor(test-benchmark): deploy contract gas usage

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -261,7 +261,12 @@ def _compute_deploy_gas_limit(
 
     # Regular portion, bound by the gas cap.
     regular_gas = intrinsic_regular_gas
-    regular_gas += deploy_code_size * gas_costs.CODE_DEPOSIT_PER_BYTE
+    if fork.state_gas_reservoir_enabled():
+        regular_gas += gas_costs.OPCODE_KECCAK256_PER_WORD * (
+            (deploy_code_size + 31) // 32
+        )
+    else:
+        regular_gas += deploy_code_size * gas_costs.CODE_DEPOSIT_PER_BYTE
     regular_gas += memory_expansion_gas_calculator(
         new_bytes=len(bytes(initcode))
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -41,6 +41,7 @@ from execution_testing.forks import (
     TransitionFork,
 )
 from execution_testing.logging import get_logger
+from execution_testing.recipient_type import RecipientType
 from execution_testing.rpc import DebugRPC, EngineRPC, EthRPC
 from execution_testing.specs.blockchain import (
     payload_metadata_to_fixture,
@@ -413,7 +414,14 @@ def sender_fund_refund_gas_limit(
 ) -> int:
     """Intrinsic gas for the funding tx, derived from the fork."""
     fork = session_fork.fork_at(block_number=0, timestamp=0)
-    return fork.transaction_intrinsic_cost_calculator()()
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    return intrinsic + fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Problem
Stateful filler fails immediately, geth rejects the setup block with: `intrinsic gas too low: have 15000, want 21000`

### Root cause
The funding transaction gas limit is calculated as bare intrinsic cost (15,000), but funding txs transfer value to empty EOAs, which costs more:
- 21,000 regular gas (12,000 base + 3,000 cold account + 6,000 value transfer)
- 183,600 state gas (EIP-8037 account creation charge)

Total: 204,600, thus 15,000 limit is too low for any client.

## Fix

Calculate gas for what the transaction actually is (value transfer to empty account):

```python
intrinsic = fork.transaction_intrinsic_cost_calculator()(
    sends_value=True,
    recipient_type=RecipientType.EMPTY_ACCOUNT,
)
return intrinsic + fork.transaction_top_frame_state_gas(
    sends_value=True,
    recipient_type=RecipientType.EMPTY_ACCOUNT,
)
```

| Fork | Before | After |
|------|--------|-------|
| Amsterdam | 15,000 ❌ | **204,600** ✓ |
| Osaka/Prague | 21,000 | 21,000 (unchanged) |

### Verification

Please download benchmarkoor and add this configuration file, follow the instruction:

```
# Build benchmarkoor
make build-core

# Build datadirs and eest payloads
./bin/benchmarkoor build --config examples/configuration/simple.yaml --force
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
