### PR TITLE
perf(spec-specs): Run Blake2 compression on plain `int` words

### DIFF
--- a/src/ethereum/crypto/blake2.py
+++ b/src/ethereum/crypto/blake2.py
@@ -2,6 +2,7 @@
 
 import struct
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Final, List, Tuple, final
 
 from ethereum_types.numeric import Uint
@@ -40,48 +41,48 @@ class Blake2:
     https://datatracker.ietf.org/doc/html/rfc7693
     """
 
-    w: Uint
-    mask_bits: Uint
+    w: int
+    mask_bits: int
     word_format: str
 
-    R1: Uint
-    R2: Uint
-    R3: Uint
-    R4: Uint
+    R1: int
+    R2: int
+    R3: int
+    R4: int
 
-    @property
-    def max_word(self) -> Uint:
+    @cached_property
+    def max_word(self) -> int:
         """
         Largest value for a given Blake2 flavor.
         """
-        return Uint(2) ** self.w
+        return 2**self.w
 
-    @property
-    def w_R1(self) -> Uint:
+    @cached_property
+    def w_R1(self) -> int:
         """
         (w - R1) value for a given Blake2 flavor.
         Used in the function G.
         """
         return self.w - self.R1
 
-    @property
-    def w_R2(self) -> Uint:
+    @cached_property
+    def w_R2(self) -> int:
         """
         (w - R2) value for a given Blake2 flavor.
         Used in the function G.
         """
         return self.w - self.R2
 
-    @property
-    def w_R3(self) -> Uint:
+    @cached_property
+    def w_R3(self) -> int:
         """
         (w - R3) value for a given Blake2 flavor.
         Used in the function G.
         """
         return self.w - self.R3
 
-    @property
-    def w_R4(self) -> Uint:
+    @cached_property
+    def w_R4(self) -> int:
         """
         (w - R4) value for a given Blake2 flavor.
         Used in the function G.
@@ -101,26 +102,26 @@ class Blake2:
         (10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0),
     )
 
-    IV: Tuple[Uint, ...] = (
-        Uint(0x6A09E667F3BCC908),
-        Uint(0xBB67AE8584CAA73B),
-        Uint(0x3C6EF372FE94F82B),
-        Uint(0xA54FF53A5F1D36F1),
-        Uint(0x510E527FADE682D1),
-        Uint(0x9B05688C2B3E6C1F),
-        Uint(0x1F83D9ABFB41BD6B),
-        Uint(0x5BE0CD19137E2179),
+    IV: Tuple[int, ...] = (
+        0x6A09E667F3BCC908,
+        0xBB67AE8584CAA73B,
+        0x3C6EF372FE94F82B,
+        0xA54FF53A5F1D36F1,
+        0x510E527FADE682D1,
+        0x9B05688C2B3E6C1F,
+        0x1F83D9ABFB41BD6B,
+        0x5BE0CD19137E2179,
     )
 
-    MIX_TABLE: Final[Tuple[Tuple[Uint, Uint, Uint, Uint], ...]] = (
-        (Uint(0), Uint(4), Uint(8), Uint(12)),
-        (Uint(1), Uint(5), Uint(9), Uint(13)),
-        (Uint(2), Uint(6), Uint(10), Uint(14)),
-        (Uint(3), Uint(7), Uint(11), Uint(15)),
-        (Uint(0), Uint(5), Uint(10), Uint(15)),
-        (Uint(1), Uint(6), Uint(11), Uint(12)),
-        (Uint(2), Uint(7), Uint(8), Uint(13)),
-        (Uint(3), Uint(4), Uint(9), Uint(14)),
+    MIX_TABLE: Final[Tuple[Tuple[int, int, int, int], ...]] = (
+        (0, 4, 8, 12),
+        (1, 5, 9, 13),
+        (2, 6, 10, 14),
+        (3, 7, 11, 15),
+        (0, 5, 10, 15),
+        (1, 6, 11, 12),
+        (2, 7, 8, 13),
+        (3, 4, 9, 14),
     )
 
     @property
@@ -150,8 +151,8 @@ class Blake2:
         return (rounds, h, m, t_0, t_1, f)
 
     def G(
-        self, v: List, a: Uint, b: Uint, c: Uint, d: Uint, x: Uint, y: Uint
-    ) -> List:
+        self, v: List[int], a: int, b: int, c: int, d: int, x: int, y: int
+    ) -> List[int]:
         """
         The mixing function used in Blake2.
 
@@ -217,13 +218,17 @@ class Blake2:
             The final block indicator flag. An 8-bit word
 
         """
-        # Initialize local work vector v[0..15]
-        v = [Uint(0)] * 16
-        v[0:8] = h  # First half from state
-        v[8:15] = self.IV  # Second half from IV
+        # The mixing below runs `num_rounds` times, which may be in the
+        # millions, so it works on plain `int` words: the bounds checking
+        # `Uint` performs on every operation is too slow for this loop.
+        h_words = [int(word) for word in h]
+        m_words = [int(word) for word in m]
 
-        v[12] = t_0 ^ self.IV[4]  # Low word of the offset
-        v[13] = t_1 ^ self.IV[5]  # High word of the offset
+        # Initialize local work vector v[0..15]
+        v = h_words + list(self.IV)  # State first, then IV
+
+        v[12] = int(t_0) ^ self.IV[4]  # Low word of the offset
+        v[13] = int(t_1) ^ self.IV[5]  # High word of the offset
 
         if f:
             v[14] = v[14] ^ self.mask_bits  # Invert all bits for last block
@@ -234,16 +239,16 @@ class Blake2:
             # wraps around to the beginning
             s = self.sigma[r % self.sigma_len]
 
-            v = self.G(v, *self.MIX_TABLE[0], m[s[0]], m[s[1]])
-            v = self.G(v, *self.MIX_TABLE[1], m[s[2]], m[s[3]])
-            v = self.G(v, *self.MIX_TABLE[2], m[s[4]], m[s[5]])
-            v = self.G(v, *self.MIX_TABLE[3], m[s[6]], m[s[7]])
-            v = self.G(v, *self.MIX_TABLE[4], m[s[8]], m[s[9]])
-            v = self.G(v, *self.MIX_TABLE[5], m[s[10]], m[s[11]])
-            v = self.G(v, *self.MIX_TABLE[6], m[s[12]], m[s[13]])
-            v = self.G(v, *self.MIX_TABLE[7], m[s[14]], m[s[15]])
+            v = self.G(v, *self.MIX_TABLE[0], m_words[s[0]], m_words[s[1]])
+            v = self.G(v, *self.MIX_TABLE[1], m_words[s[2]], m_words[s[3]])
+            v = self.G(v, *self.MIX_TABLE[2], m_words[s[4]], m_words[s[5]])
+            v = self.G(v, *self.MIX_TABLE[3], m_words[s[6]], m_words[s[7]])
+            v = self.G(v, *self.MIX_TABLE[4], m_words[s[8]], m_words[s[9]])
+            v = self.G(v, *self.MIX_TABLE[5], m_words[s[10]], m_words[s[11]])
+            v = self.G(v, *self.MIX_TABLE[6], m_words[s[12]], m_words[s[13]])
+            v = self.G(v, *self.MIX_TABLE[7], m_words[s[14]], m_words[s[15]])
 
-        result_message_words = (h[i] ^ v[i] ^ v[i + 8] for i in range(8))
+        result_message_words = (h_words[i] ^ v[i] ^ v[i + 8] for i in range(8))
         return struct.pack("<8%s" % self.word_format, *result_message_words)
 
 
@@ -256,11 +261,11 @@ class Blake2b(Blake2):
     This version is used in the pre-compiled contract.
     """
 
-    w: Uint = Uint(64)
-    mask_bits: Uint = Uint(0xFFFFFFFFFFFFFFFF)
+    w: int = 64
+    mask_bits: int = 0xFFFFFFFFFFFFFFFF
     word_format: str = "Q"
 
-    R1: Uint = Uint(32)
-    R2: Uint = Uint(24)
-    R3: Uint = Uint(16)
-    R4: Uint = Uint(63)
+    R1: int = 32
+    R2: int = 24
+    R3: int = 16
+    R4: int = 63

--- a/tests/istanbul/eip152_blake2/test_blake2.py
+++ b/tests/istanbul/eip152_blake2/test_blake2.py
@@ -286,7 +286,6 @@ pytestmark = pytest.mark.ported_from(
         ),
     ],
 )
-@pytest.mark.slow()
 def test_blake2b(
     state_test: StateTestFiller,
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description

`test_blake2b_large_gas_limit` (EIP-152, `rounds=100_000`) holds the top three slots in the fill run's slowest-test list at ~21s per fixture format. Profiling showed `Blake2.compress` spending nearly all of its time constructing `Uint` objects: every `+`/`^`/`>>`/`<<`/`%` in the mixing loop allocates and bounds-checks a new `Uint` (~43M constructions per 100k rounds), and the `max_word` property recomputed `Uint(2) ** self.w` on every access.

This PR runs the compression on plain `int` words:

- `compress` converts the `Uint` state and message words to `int` once on entry; `G` mixes plain `int`s. The arithmetic expressions in `G` are textually unchanged.
- The class configuration (`w`, `mask_bits`, `R1`..`R4`), `IV`, and `MIX_TABLE` hold plain `int`s; `max_word` and `w_R1`..`w_R4` become `cached_property`s.
- The public interface is unchanged: `get_blake2_parameters` still returns `Uint` values (the precompile's gas math relies on this) and `compress` keeps its signature.

`compress` on the 100k-round test vector drops from 66s to 3.4s; filling `tests/istanbul/eip152_blake2/` (`--fork Amsterdam -m "not derived_test"`) drops from 62s to 18s. Any other test touching the `blake2f` precompile benefits as well.

A follow-up commit removes the now-stale `slow` marker from `test_blake2b`: The worst of its 66 marked cases fills in 0.88s locally post-fix, in the same band as the module's unmarked tests, so the `-m "not slow"` CI jobs now cover the basic EIP-152 vectors. `test_blake2b_large_gas_limit` keeps the marker (its 100k-round cases still fill in 2.3-4.3s locally) and its 8M-round cases remain skipped; fixtures verified unchanged via `hasher`.

### Correctness

- Fixtures are byte-identical: Before/after fills of `tests/istanbul/eip152_blake2/` (`--fork Amsterdam -m "not derived_test"`, 73 fixtures) produce the same `hasher` root hash, `0x9e30eaf1a70989c1fedb752999c9494bbcfb55ecf6f1369d8f7ae3670b937573`.
- The old and new `compress` were also cross-checked standalone for equal output at rounds 0, 1, 12, 100, and 100k.

### Why the constants change type too

Two variants that keep partial `Uint` usage show that residual casts in the hot loop give back a large share of the win (10k rounds, identical output in all variants; absolute factors vary with machine load between sessions, the variant ordering is the stable result):

| Variant | Time | Speedup |
| ------- | ----: | ------: |
| Original (all `Uint`) | 1.073s | 1.0x |
| This PR | 0.100s | 10.7x |
| This PR, but `@property` instead of `@cached_property` | 0.155s | 6.9x |
| This PR, but `MIX_TABLE` entries as `Uint` | 0.179s | 6.0x |

`MIX_TABLE` values are used as list indices ~22 times per `G` call and each `Uint` subscript dispatches through `__index__`; `max_word` is read 6 times per `G` call, 4.8M times per 100k rounds. Beyond cost, the value domains cannot be half-converted: Mixed `int`/`Uint` arithmetic either raises or promotes results back into `Uint`, reinstating the per-operation construction this PR removes.

### Readability

- The `G` mixing body and all docstrings are unchanged, so the correspondence to RFC 7693 reads exactly as before, and the literal tables lose 32 `Uint(...)` wrappers.
- The trade-off: This module no longer gets `Uint`'s runtime unsigned-range checking; a comment in `compress` marks the deviation and why. The normative fork precompiles (`vm/precompiled_contracts/blake2f.py`) are untouched.
- Incidental fix: The old work-vector setup (`v[8:15] = self.IV` assigns 8 elements into a 7-element slice) silently grew the 16-element list to 17 with a dead trailing element; the new construction is exact.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Uint-free and fast](https://cataas.com/cat/says/Uint-free%20and%20fast?fontSize=44&fontColor=white)
