### PR TITLE
feat(spec-specs, tests): charge EIP-8037 account creation at access

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -356,13 +356,14 @@ class EIP8037(BaseFork):
     ) -> int:
         """
         Calculate the CREATE and CREATE2 state gas cost, which is
-        `NEW_ACCOUNT`. Before EIP-8037 this was folded into
-        `OPCODE_CREATE_BASE`. Under EIP-8037 it is exposed here so that
-        `OPCODE_CREATE_BASE` stays regular only and matches the spec
-        EVM constant.
+        `NEW_ACCOUNT` (if the account did not exist before).
+        Before EIP-8037 this was folded into `OPCODE_CREATE_BASE`. Under
+        EIP-8037 it is exposed here so that `OPCODE_CREATE_BASE` stays regular
+        only and matches the spec EVM constant.
         """
-        del opcode
-        return gas_costs.NEW_ACCOUNT
+        if opcode.metadata["account_new"]:
+            return gas_costs.NEW_ACCOUNT
+        return 0
 
     @classmethod
     def _calculate_selfdestruct_state_gas(

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -5425,6 +5425,7 @@ class Opcodes(Opcode, Enum):
     - init_code_size: size of the initialization code in bytes (default: 0)
     - new_memory_size: memory size after expansion in bytes (default: 0)
     - old_memory_size: memory size before expansion in bytes (default: 0)
+    - account_new: whether creating a new account (default: True)
 
     Source: [evm.codes/#F0](https://www.evm.codes/#F0)
     """
@@ -5765,6 +5766,7 @@ class Opcodes(Opcode, Enum):
     - init_code_size: size of the initialization code in bytes (default: 0)
     - new_memory_size: memory size after expansion in bytes (default: 0)
     - old_memory_size: memory size before expansion in bytes (default: 0)
+    - account_new: whether creating a new account (default: True)
 
     Source: [evm.codes/#F5](https://www.evm.codes/#F5)
     """

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -5381,6 +5381,7 @@ class Opcodes(Opcode, Enum):
             "init_code_size": 0,
             "new_memory_size": 0,
             "old_memory_size": 0,
+            "account_new": True,
         },
     )
     """
@@ -5718,6 +5719,7 @@ class Opcodes(Opcode, Enum):
             "init_code_size": 0,
             "new_memory_size": 0,
             "old_memory_size": 0,
+            "account_new": True,
         },
     )
     """

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -84,23 +84,11 @@ def generic_create(
     if memory_size > U256(MAX_INIT_CODE_SIZE):
         raise OutOfGasError
 
-    # Charge state gas for account creation (pay-before-execute).
-    # Refunded to the reservoir on any failure path below.
-    charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
-
     tx_state = evm.message.tx_env.state
 
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-
-    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= create_message_gas
-
-    # Move full reservoir to child (no 63/64 rule for state gas). Parent's
-    # `state_gas_left` is zeroed and restored when the child returns.
-    create_message_state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_left = Uint(0)
 
     evm.return_data = b""
 
@@ -112,26 +100,32 @@ def generic_create(
         or sender.nonce == Uint(2**64 - 1)
         or evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT
     ):
-        evm.gas_left += create_message_gas
-        evm.state_gas_left += create_message_state_gas_reservoir
-        credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         push(evm.stack, U256(0))
         return
 
     evm.accessed_addresses.add(contract_address)
 
     if not account_deployable(tx_state, contract_address):
-        increment_nonce(tx_state, evm.message.current_target)
+        increment_nonce(tx_state, sender_address)
+        create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+        evm.gas_left -= create_message_gas
         evm.regular_gas_used += create_message_gas
-        evm.state_gas_left += create_message_state_gas_reservoir
-        # Address collision — no account created, refund state gas.
-        credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         push(evm.stack, U256(0))
         return
 
-    target_alive = is_account_alive(tx_state, contract_address)
+    new_account_charged = not is_account_alive(tx_state, contract_address)
+    if new_account_charged:
+        charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
 
-    increment_nonce(tx_state, evm.message.current_target)
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= create_message_gas
+
+    # Move full reservoir to child (no 63/64 rule for state gas). Parent's
+    # `state_gas_left` is zeroed and restored when the child returns.
+    create_message_state_gas_reservoir = evm.state_gas_left
+    evm.state_gas_left = Uint(0)
+
+    increment_nonce(tx_state, sender_address)
 
     child_message = Message(
         block_env=evm.message.block_env,
@@ -157,14 +151,12 @@ def generic_create(
 
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
-        # No account created, refund parent's CREATE state gas.
-        credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+        if new_account_charged:
+            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
         incorporate_child_on_success(evm, child_evm)
-        if target_alive:
-            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
         evm.return_data = b""
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -105,20 +105,24 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    if not account_deployable(tx_state, contract_address):
-        increment_nonce(tx_state, sender_address)
-        create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-        evm.gas_left -= create_message_gas
-        evm.regular_gas_used += create_message_gas
-        push(evm.stack, U256(0))
-        return
-
+    # The charge is decided by existence alone, independently of the
+    # collision outcome.
     new_account_charged = not is_account_alive(tx_state, contract_address)
     if new_account_charged:
         charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
+
+    if not account_deployable(tx_state, contract_address):
+        increment_nonce(tx_state, sender_address)
+        evm.regular_gas_used += create_message_gas
+        # A storage-only collision target is non-existent: charged
+        # above, refilled here.
+        if new_account_charged:
+            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+        push(evm.stack, U256(0))
+        return
 
     # Move full reservoir to child (no 63/64 rule for state gas). Parent's
     # `state_gas_left` is zeroed and restored when the child returns.

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -3298,8 +3298,10 @@ def test_bal_create_and_oog(
     CREATE/CREATE2 OOG boundary test at three gas levels.
 
     OOG_BEFORE_TARGET_ACCESS and OOG_AFTER_TARGET_ACCESS differ by
-    exactly 1 gas, proving the static cost boundary: below it the
-    created address is NOT in BAL, at it the address IS in BAL.
+    exactly 1 gas, proving the pre-access cost boundary: below it the
+    created address is NOT in BAL, at it the address IS in BAL. Under
+    EIP-8037 charge-at-access this boundary excludes NEW_ACCOUNT, which
+    is charged at the access rather than before it.
     """
     alice = pre.fund_eoa()
 
@@ -3344,14 +3346,19 @@ def test_bal_create_and_oog(
     create_static_cost = factory_mstore.gas_cost(
         fork
     ) + factory_create.gas_cost(fork)
+    # Under EIP-8037 charge-at-access the NEW_ACCOUNT state gas is charged
+    # at the destination access, not before it, so the pre-access cost that
+    # gates whether the address is read excludes it. `gas_cost` folds
+    # NEW_ACCOUNT into the create opcode total, so strip it back out.
+    pre_access_cost = create_static_cost - fork.gas_costs().NEW_ACCOUNT
 
     if oog_boundary == OutOfGasBoundary.OOG_BEFORE_TARGET_ACCESS:
-        # 1 gas short of CREATE static cost — no state access
-        gas_limit = intrinsic_cost + create_static_cost - 1
+        # 1 gas short of the pre-access cost — no state access
+        gas_limit = intrinsic_cost + pre_access_cost - 1
     elif oog_boundary == OutOfGasBoundary.OOG_AFTER_TARGET_ACCESS:
-        # Exactly the CREATE static cost — address accessed, child
-        # frame gets 0 gas, CREATE fails, sink forces OOG after access
-        gas_limit = intrinsic_cost + create_static_cost
+        # Exactly the pre-access cost — address accessed, then the
+        # NEW_ACCOUNT charge OOGs after access
+        gas_limit = intrinsic_cost + pre_access_cost
     else:
         # Full success: static cost + child frame (63/64 rule) +
         # SSTORE + gas sink.

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -3298,10 +3298,8 @@ def test_bal_create_and_oog(
     CREATE/CREATE2 OOG boundary test at three gas levels.
 
     OOG_BEFORE_TARGET_ACCESS and OOG_AFTER_TARGET_ACCESS differ by
-    exactly 1 gas, proving the pre-access cost boundary: below it the
-    created address is NOT in BAL, at it the address IS in BAL. Under
-    EIP-8037 charge-at-access this boundary excludes NEW_ACCOUNT, which
-    is charged at the access rather than before it.
+    exactly 1 gas, proving the static cost boundary: below it the
+    created address is NOT in BAL, at it the address IS in BAL.
     """
     alice = pre.fund_eoa()
 
@@ -3316,6 +3314,7 @@ def test_bal_create_and_oog(
         offset=32 - len(init_code_bytes),
         size=len(init_code_bytes),
         init_code_size=len(init_code_bytes),
+        account_new=False,
     )
     factory_sstore = Op.SSTORE(0x00, 1)
     oog_sink_memory_size = 10000 * 32
@@ -3341,24 +3340,21 @@ def test_bal_create_and_oog(
         initcode=init_code_bytes,
         opcode=create_opcode,
     )
+    # Pre-fund the address so no new account is created
+    pre.fund_address(created_address, 1)
 
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
     create_static_cost = factory_mstore.gas_cost(
         fork
     ) + factory_create.gas_cost(fork)
-    # Under EIP-8037 charge-at-access the NEW_ACCOUNT state gas is charged
-    # at the destination access, not before it, so the pre-access cost that
-    # gates whether the address is read excludes it. `gas_cost` folds
-    # NEW_ACCOUNT into the create opcode total, so strip it back out.
-    pre_access_cost = create_static_cost - fork.gas_costs().NEW_ACCOUNT
 
     if oog_boundary == OutOfGasBoundary.OOG_BEFORE_TARGET_ACCESS:
-        # 1 gas short of the pre-access cost — no state access
-        gas_limit = intrinsic_cost + pre_access_cost - 1
+        # 1 gas short of CREATE static cost — no state access
+        gas_limit = intrinsic_cost + create_static_cost - 1
     elif oog_boundary == OutOfGasBoundary.OOG_AFTER_TARGET_ACCESS:
-        # Exactly the pre-access cost — address accessed, then the
-        # NEW_ACCOUNT charge OOGs after access
-        gas_limit = intrinsic_cost + pre_access_cost
+        # Exactly the CREATE static cost — address accessed, child
+        # frame gets 0 gas, CREATE fails, sink forces OOG after access
+        gas_limit = intrinsic_cost + create_static_cost
     else:
         # Full success: static cost + child frame (63/64 rule) +
         # SSTORE + gas sink.
@@ -3395,7 +3391,7 @@ def test_bal_create_and_oog(
         post = {
             alice: Account(nonce=1),
             factory: Account(nonce=1, storage={0x00: 0xDEAD}),
-            created_address: Account.NONEXISTENT,
+            created_address: Account(balance=1, code=b"", nonce=0),
         }
     elif oog_boundary == OutOfGasBoundary.OOG_AFTER_TARGET_ACCESS:
         # Created address IS in BAL (accessed during collision check),
@@ -3413,7 +3409,7 @@ def test_bal_create_and_oog(
         post = {
             alice: Account(nonce=1),
             factory: Account(nonce=1, storage={0x00: 0xDEAD}),
-            created_address: Account.NONEXISTENT,
+            created_address: Account(balance=1, code=b"", nonce=0),
         }
     else:
         # SUCCESS: created address in BAL with nonce and code changes
@@ -3453,7 +3449,7 @@ def test_bal_create_and_oog(
         post = {
             alice: Account(nonce=1),
             factory: Account(nonce=2, storage={0x00: 1}),
-            created_address: Account(code=Op.STOP),
+            created_address: Account(balance=1, code=Op.STOP, nonce=1),
         }
 
     blockchain_test(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2899,73 +2899,50 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     """
     init_code = Op.STOP
     mstore_value, size = init_code_at_high_bytes(init_code)
-    salt = 0
-
-    create_call = (
-        create_opcode(value=0, offset=0, size=size, salt=salt)
-        if create_opcode == Op.CREATE2
-        else create_opcode(value=0, offset=0, size=size)
-    )
-    factory_code = Op.MSTORE(0, mstore_value) + Op.POP(create_call) + Op.STOP
+    factory_create_code = Op.MSTORE(
+        0, mstore_value, new_memory_size=32
+    ) + create_opcode(value=0, offset=0, size=size, account_new=False)
+    factory_post_create_code = Op.POP + Op.STOP
+    factory_code = factory_create_code + factory_post_create_code
     factory = pre.deploy_contract(code=factory_code)
 
     collision_target = compute_create_address(
         address=factory,
         nonce=1,
-        salt=salt,
+        salt=0,
         initcode=bytes(init_code),
         opcode=create_opcode,
     )
     pre.deploy_contract(code=Op.STOP, address=collision_target)
-
-    # Fixed-size budget so the forwarded create_message_gas is
-    # deterministic and the baseline below is reproducible.
-    gas_limit = 250_000
-
-    tx = Transaction(
-        to=factory,
-        gas_limit=gas_limit,
-        sender=pre.fund_eoa(),
-    )
 
     # CPSB-agnostic baseline: block_state_gas is zero for this tx (the
     # existent collision target is not charged), so header.gas_used
     # equals the regular-gas total. Decompose the parent + inner frame
     # accounting from fork APIs so the baseline tracks future cost
     # changes automatically.
-    intrinsic = fork.transaction_intrinsic_cost_calculator()()
-    new_account = fork.gas_costs().NEW_ACCOUNT
-    create_base = fork.gas_costs().OPCODE_CREATE_BASE
-    # POP + STOP run in the parent frame after CREATE returns; their
-    # cost comes out of the 1/64 retained gas.
-    post_create_static = (Op.POP + Op.STOP).gas_cost(fork)
-    # factory_code.gas_cost(fork) folds NEW_ACCOUNT into the CREATE op
-    # (state gas is treated as part of the opcode total). Strip it
-    # back out and split off the post-CREATE tail to isolate the
-    # pre-CREATE static gas.
-    factory_pre_create = (
-        factory_code.gas_cost(fork)
-        - new_account
-        - create_base
-        - post_create_static
+    gas_used_until_collision = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + factory_create_code.gas_cost(fork)
     )
-    # MSTORE writes the initcode at memory[0:32] (one word).
-    memory_expansion = fork.memory_expansion_gas_calculator()(new_bytes=32)
-    # gas_left at the CREATE split. The collision target is existent, so no
-    # account-creation charge is applied before the 63/64 split.
-    gas_at_create = (
-        gas_limit
-        - intrinsic
-        - factory_pre_create
-        - memory_expansion
-        - create_base
-    )
+    # Fixed-size budget so the forwarded create_message_gas is
+    # deterministic and the baseline below is reproducible.
+    gas_limit = gas_used_until_collision * 2
+    # Remaining gas can be derived due to the fixed gas limit
+    gas_at_create = gas_limit - gas_used_until_collision
     # Inner burns 63/64 of the available gas on collision; the parent
     # retains 1/64. Post-CREATE consumes from the retained pool. A
     # mutation that drops the burned forwarded gas from regular
     # accounting would reduce this baseline.
     retained = gas_at_create // 64
-    baseline_gas_used = gas_limit - retained + post_create_static
+    gas_post_create = factory_post_create_code.gas_cost(fork)
+    assert retained >= gas_post_create
+    baseline_gas_used = gas_limit - retained + gas_post_create
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
 
     blockchain_test(
         pre=pre,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2929,7 +2929,7 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     )
 
     # CPSB-agnostic baseline: block_state_gas is zero for this tx (the
-    # collision refunds the NEW_ACCOUNT state charge), so header.gas_used
+    # existent collision target is not charged), so header.gas_used
     # equals the regular-gas total. Decompose the parent + inner frame
     # accounting from fork APIs so the baseline tracks future cost
     # changes automatically.
@@ -2951,23 +2951,21 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     )
     # MSTORE writes the initcode at memory[0:32] (one word).
     memory_expansion = fork.memory_expansion_gas_calculator()(new_bytes=32)
-    # gas_left at the moment NEW_ACCOUNT spills into the regular pool
-    # (reservoir is empty for tx_gas_limit < TX_MAX_GAS_LIMIT).
-    gas_at_create_after_state = (
+    # gas_left at the CREATE split. The collision target is existent, so no
+    # account-creation charge is applied before the 63/64 split.
+    gas_at_create = (
         gas_limit
         - intrinsic
         - factory_pre_create
         - memory_expansion
         - create_base
-        - new_account
     )
     # Inner burns 63/64 of the available gas on collision; the parent
-    # retains 1/64. The state-spill of NEW_ACCOUNT is refunded back to
-    # gas_left on collision (nets zero). Post-CREATE consumes from the
-    # retained pool. A mutation that drops the burned forwarded gas
-    # from regular accounting would reduce this baseline.
-    retained = gas_at_create_after_state // 64
-    baseline_gas_used = gas_limit - retained - new_account + post_create_static
+    # retains 1/64. Post-CREATE consumes from the retained pool. A
+    # mutation that drops the burned forwarded gas from regular
+    # accounting would reduce this baseline.
+    retained = gas_at_create // 64
+    baseline_gas_used = gas_limit - retained + post_create_static
 
     blockchain_test(
         pre=pre,


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Implements the EIP-8037 charge at access model for `CREATE`/`CREATE2` and creation transactions from ethereum/EIPs#11858.

Account creation state gas is now charged conditionally at the destination access, before the 63/64ths split, rather than charged unconditionally before the create frame and refilled. Failing a pre access check (balance, nonce, stack depth) reads no destination and charges nothing, an already alive target charges nothing, the charge is decided by existence alone, so a storage only collision is charged and refilled, and a failed create frame still refills.

Creation transactions follow the same rule: the create component of the intrinsic state gas is seeded into the reservoir rather than pre-consumed, charged at the deployment-address access only if the destination does not exist, and refilled on failure.

The storage only collision is untestable, the fixture loader rejects empty with storage pre state accounts (`StateWithEmptyAccount`), hence the codecov patch miss on the refill lines.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
ethereum/EIPs#11858

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/KEzW7ALwfUAAAAAM/cat-what.gif)



