### PR TITLE
perf(tests): OOG instantly in EIP-8037 failure tests

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -744,9 +744,10 @@ def test_top_level_failure_refunds_execution_state_gas(
     elif failure_mode == "halt":
         code = Op.SSTORE(0, 1) + Op.INVALID
     else:
-        # OOG: perform the SSTORE then spin with JUMPDEST loop until
-        # gas runs out.
-        code = Op.SSTORE(0, 1) + Op.JUMPDEST + Op.JUMP(0x5)
+        # OOG: perform the SSTORE, then consume all remaining gas at
+        # once (a spin loop would execute millions of ops in the EVM
+        # and slow down filling).
+        code = Op.SSTORE(0, 1) + Om.OOG
     contract = pre.deploy_contract(code=code)
 
     tx_gas = gas_limit_cap + sstore_state_gas
@@ -806,7 +807,7 @@ def test_top_level_failure_zeros_block_state_gas(
     elif failure_mode == "halt":
         code = Op.SSTORE(0, 1) + Op.INVALID
     else:
-        code = Op.SSTORE(0, 1) + Op.JUMPDEST + Op.JUMP(0x5)
+        code = Op.SSTORE(0, 1) + Om.OOG
     contract = pre.deploy_contract(code=code)
 
     tx_gas = gas_limit_cap + sstore_state_gas

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -27,6 +27,9 @@ from execution_testing import (
     TransactionException,
     TransactionReceipt,
 )
+from execution_testing import (
+    Macros as Om,
+)
 
 from tests.prague.eip7702_set_code_tx.spec import Spec as Spec7702
 
@@ -1363,7 +1366,9 @@ def test_auth_state_gas_in_header_after_failure(
     elif failure_mode == "halt":
         target = pre.deploy_contract(code=Op.INVALID)
     else:
-        target = pre.deploy_contract(code=Op.JUMPDEST + Op.JUMP(0x0))
+        # Consume all remaining gas at once (a spin loop would execute
+        # millions of ops in the EVM and slow down filling).
+        target = pre.deploy_contract(code=Om.OOG)
 
     if authority_exists:
         signer = pre.fund_eoa()


### PR DESCRIPTION
## 🗒️ Description

The `oog` failure mode in three EIP-8037 test functions burned the full EIP-7825 transaction gas limit cap (16,777,216 gas) in a `JUMPDEST`/`JUMP` spin loop, roughly 1.4M EVM iterations per t8n call. This put the four affected fixtures among the slowest (none `slow` fixtures) in the fill run for Amsterdam at ~19s each in CI:

- `test_state_gas_reservoir.py::test_top_level_failure_refunds_execution_state_gas[oog]`.
- `test_state_gas_reservoir.py::test_top_level_failure_zeros_block_state_gas[oog]`.
- `test_state_gas_set_code.py::test_auth_state_gas_in_header_after_failure[new_account-oog]` and `[existing_account-oog]`.

The gas limit itself cannot shrink: The EIP-8037 state gas reservoir is defined as gas above the cap, so the transaction must carry `cap + reservoir` gas (a first attempt with a small explicit `gas_limit` failed the fill's receipt assertions because a sub-cap limit has no reservoir at all). The spin is what's unnecessary: This PR replaces it with `Om.OOG` (`SHA3(0, 100000000000)`), whose gas charge exceeds any possible remaining gas, so the EVM raises the same `OutOfGasError` and zeroes `gas_left` on the first instruction after the `SSTORE`, without executing millions of ops.

Filling the three test functions (12 fixtures, `--fork Amsterdam -m "not derived_test"`) drops from 64s to 12s locally.

### Fixture impact

Fixtures were compared before/after with `hasher` and a field-by-field JSON diff:

- `revert` and `halt` variants: Consensus content is byte-identical; only the `_info.url` line number moved.
- `oog` variants: Only the deployed contract's code bytes change (spin loop to `PUSH5 0x174876E800, PUSH1 0, SHA3`), which cascades into the contract address, `transaction.to`, `txbytes`, transaction hash, and post-state hash. All gas accounting is untouched: `transaction.gasLimit`, receipt `cumulative_gas_used`, header `gas_used`, and every account balance are identical to the previous fixtures.

The accounting is additionally pinned at fill time by the tests' own `expected_receipt`, `blockchain_test_header_verify`, and post-state assertions, which all pass unchanged.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img height="512" alt="cat saying out of gas" src="https://github.com/user-attachments/assets/ef642815-0e2b-4b73-85f5-b76f95a1366a" />
