### PR TITLE
fix(deps): constrain scikit-build-core for coincurve source builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -530,6 +530,9 @@ plugins = ["pydantic.mypy"]
 [tool.uv]
 required-version = ">=0.7.0"
 extra-build-dependencies = { ethash = ["setuptools", "cmake>=4.2.1,<5"] }
+# Pin scikit-build-core < 0.10 for coincurve's sdist build on Python 3.13+.
+# See https://github.com/ethereum/execution-specs/pull/3119
+build-constraint-dependencies = ["scikit-build-core<0.10"]
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "ethereum-execution",
     "ethereum-execution-testing",
 ]
+build-constraints = [{ name = "scikit-build-core", specifier = "<0.10" }]
 
 [[package]]
 name = "actionlint-py"


### PR DESCRIPTION
### Description

This was quite a wild (and scary) dependency bug... 

- `coincurve` 20.0.0 has no wheel for Python 3.13+, so uv builds it from the sdist.
- That build sets `cmake.verbose`, which `scikit-build-core` >= 0.10 rejects as a hard error.
- `scikit-build-core` is a PEP 517 build requirement resolved outside `uv.lock`, so pinning `coincurve` doesn't pin it: a new `scikit-build-core` release broke the build with no change on our side.
- The benchmark jobs set `enable-cache: "false"`, so they rebuild `coincurve` from source every run and were first to hit it; other uv jobs still reuse a pre-regression cached wheel and would break on their next cache miss.
- Fix: constrain `scikit-build-core < 0.10` via `build-constraint-dependencies` so the isolated build environment resolves a version that still accepts `cmake.verbose`; `coincurve` stays pinned at 20.0.0.
- Verified locally by forcing a fresh `coincurve` source build on Python 3.13 with the constraint applied.

### Related Issues or PRs
N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

<img width="512" alt="image" src="https://github.com/user-attachments/assets/8bc0c067-479c-4f78-b71f-27b0f3873189" />
