### PR TITLE
feat(fork-types): add ExecutionGas and StateGas NewType wrappers to amsterdam EVM

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -41,7 +41,12 @@ from .block_access_lists import (
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import WrongChainIdError
-from .fork_types import Authorization, BlockAccessIndex
+from .fork_types import (
+    Authorization,
+    BlockAccessIndex,
+    ExecutionGas,
+    StateGas,
+)
 from .requests import (
     BUILDER_DEPOSIT_REQUEST_TYPE,
     BUILDER_EXIT_REQUEST_TYPE,
@@ -106,7 +111,7 @@ SYSTEM_ADDRESS = hex_to_address("0xfffffffffffffffffffffffffffffffffffffffe")
 BEACON_ROOTS_ADDRESS = hex_to_address(
     "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02"
 )
-SYSTEM_TRANSACTION_GAS = Uint(30000000)
+SYSTEM_TRANSACTION_GAS = ExecutionGas(Uint(30000000))
 SYSTEM_MAX_SSTORES_PER_CALL = Uint(16)
 """
 Upper bound on the number of new storage slots a single system call is
@@ -757,7 +762,7 @@ def process_unchecked_system_transaction(
         gas_limit=SYSTEM_TRANSACTION_GAS,
         effective_gas_price=block_env.base_fee_per_gas,
         execution_gas_grant=SYSTEM_TRANSACTION_GAS,
-        state_gas_reservoir=(
+        state_gas_reservoir=StateGas(
             StateGasCosts.STORAGE_SET * SYSTEM_MAX_SSTORES_PER_CALL
         ),
         calldata_floor=Uint(0),

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -26,7 +26,12 @@ from ethereum.utils.byte import left_pad_zero_bytes
 
 from ..block_access_lists import BlockAccessList, BlockAccessListBuilder
 from ..blocks import Log, Receipt, Withdrawal
-from ..fork_types import Authorization, VersionedHash
+from ..fork_types import (
+    Authorization,
+    ExecutionGas,
+    StateGas,
+    VersionedHash,
+)
 from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
 from .gas import GasMeter
@@ -69,10 +74,10 @@ class BlockOutput:
 
     Contains the following:
 
-    block_gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ExecutionGas`
         Execution gas used for executing all transactions. EIP-8037
         names this counter `block_execution_gas_used`.
-    block_state_gas_used : `ethereum.base_types.Uint`
+    block_state_gas_used : `StateGas`
         State gas used for executing all transactions.
     cumulative_gas_used : `ethereum.base_types.Uint`
         Cumulative gas paid by users (post-refund, post-floor).
@@ -95,8 +100,8 @@ class BlockOutput:
         The block access list for the block.
     """
 
-    block_gas_used: Uint = Uint(0)
-    block_state_gas_used: Uint = Uint(0)
+    block_gas_used: ExecutionGas = ExecutionGas(Uint(0))
+    block_state_gas_used: StateGas = StateGas(Uint(0))
     cumulative_gas_used: Uint = Uint(0)
     transactions_trie: Trie[Bytes, Optional[Bytes | LegacyTransaction]] = (
         field(default_factory=lambda: Trie(secured=False, default=None))
@@ -129,8 +134,8 @@ class TransactionEnvironment:
     value: U256
     gas_limit: Uint
     effective_gas_price: Uint
-    execution_gas_grant: Uint
-    state_gas_reservoir: Uint
+    execution_gas_grant: ExecutionGas
+    state_gas_reservoir: StateGas
     calldata_floor: Uint
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -5,14 +5,14 @@ Set EOA account code.
 from typing import Optional, Set, Tuple
 
 from ethereum_rlp import rlp
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidSignatureError
 from ethereum.state import Address
 
-from ..fork_types import Authorization
+from ..fork_types import Authorization, ExecutionGas
 from ..state_tracker import (
     TransactionState,
     account_exists,
@@ -154,7 +154,7 @@ def recover_authority(authorization: Authorization) -> Address:
 
 def calculate_delegation_cost(
     evm: Evm, address: Address
-) -> Tuple[bool, Address, Uint]:
+) -> Tuple[bool, Address, ExecutionGas]:
     """
     Get the delegation address and the cost of access from the address.
 
@@ -167,7 +167,7 @@ def calculate_delegation_cost(
 
     Returns
     -------
-    delegation : `Tuple[bool, Address, Uint]`
+    delegation : `Tuple[bool, Address, ExecutionGas]`
         The delegation address and access gas cost.
 
     """
@@ -176,7 +176,7 @@ def calculate_delegation_cost(
     code = get_code(tx_state, get_account(tx_state, address).code_hash)
 
     if not is_valid_delegation(code):
-        return False, address, Uint(0)
+        return False, address, GasCosts.ZERO
 
     delegated_address = Address(code[EOA_DELEGATION_MARKER_LENGTH:])
 

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -26,7 +26,12 @@ from ..exceptions import (
     BlobGasLimitExceededError,
     InsufficientMaxFeePerBlobGasError,
 )
-from ..fork_types import StateGas, StateGasPerByte, VersionedHash
+from ..fork_types import (
+    ExecutionGas,
+    StateGas,
+    StateGasPerByte,
+    VersionedHash,
+)
 from ..transactions import (
     TX_MAX_GAS_LIMIT,
     BlobTransaction,
@@ -71,34 +76,35 @@ class GasCosts:
     """
 
     # Tiers
-    BASE: Final[Uint] = Uint(2)
-    VERY_LOW: Final[Uint] = Uint(3)
-    LOW: Final[Uint] = Uint(5)
-    MID: Final[Uint] = Uint(8)
-    HIGH: Final[Uint] = Uint(10)
+    BASE: Final[ExecutionGas] = ExecutionGas(Uint(2))
+    VERY_LOW: Final[ExecutionGas] = ExecutionGas(Uint(3))
+    LOW: Final[ExecutionGas] = ExecutionGas(Uint(5))
+    MID: Final[ExecutionGas] = ExecutionGas(Uint(8))
+    HIGH: Final[ExecutionGas] = ExecutionGas(Uint(10))
 
     # Access
-    WARM_ACCESS: Final[Uint] = Uint(100)
-    COLD_ACCOUNT_ACCESS: Final[Uint] = Uint(3000)
-    COLD_STORAGE_ACCESS: Final[Uint] = Uint(2100)
+    WARM_ACCESS: Final[ExecutionGas] = ExecutionGas(Uint(100))
+    COLD_ACCOUNT_ACCESS: Final[ExecutionGas] = ExecutionGas(Uint(3000))
+    COLD_STORAGE_ACCESS: Final[ExecutionGas] = ExecutionGas(Uint(2100))
 
     # Storage
-    STORAGE_WRITE: Final[Uint] = Uint(10000)
+    STORAGE_WRITE: Final[ExecutionGas] = ExecutionGas(Uint(10000))
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(11300)  # ACCOUNT_WRITE + CALL_STIPEND
-    CALL_STIPEND: Final[Uint] = Uint(2300)
-    ACCOUNT_WRITE: Final[Uint] = Uint(9000)
+    # ACCOUNT_WRITE + CALL_STIPEND
+    CALL_VALUE: Final[ExecutionGas] = ExecutionGas(Uint(11300))
+    CALL_STIPEND: Final[ExecutionGas] = ExecutionGas(Uint(2300))
+    ACCOUNT_WRITE: Final[ExecutionGas] = ExecutionGas(Uint(9000))
 
     # Contract Creation
-    CODE_DEPOSIT_PER_BYTE: Final[Uint] = Uint(200)
-    CODE_INIT_PER_WORD: Final[Uint] = Uint(2)
-    CREATE_ACCESS: Final[Uint] = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS
+    CODE_DEPOSIT_PER_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(200))
+    CODE_INIT_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(2))
+    CREATE_ACCESS: Final[ExecutionGas] = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS
 
     # Utility
-    ZERO: Final[Uint] = Uint(0)
-    MEMORY_PER_WORD: Final[Uint] = Uint(3)
-    FAST_STEP: Final[Uint] = Uint(5)
+    ZERO: Final[ExecutionGas] = ExecutionGas(Uint(0))
+    MEMORY_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(3))
+    FAST_STEP: Final[ExecutionGas] = ExecutionGas(Uint(5))
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = int(
@@ -106,26 +112,32 @@ class GasCosts:
     )
 
     # Precompiles
-    PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
-    PRECOMPILE_P256VERIFY: Final[Uint] = Uint(6900)
-    PRECOMPILE_SHA256_BASE: Final[Uint] = Uint(60)
-    PRECOMPILE_SHA256_PER_WORD: Final[Uint] = Uint(12)
-    PRECOMPILE_RIPEMD160_BASE: Final[Uint] = Uint(600)
-    PRECOMPILE_RIPEMD160_PER_WORD: Final[Uint] = Uint(120)
-    PRECOMPILE_IDENTITY_BASE: Final[Uint] = Uint(15)
-    PRECOMPILE_IDENTITY_PER_WORD: Final[Uint] = Uint(3)
-    PRECOMPILE_BLAKE2F_PER_ROUND: Final[Uint] = Uint(1)
-    PRECOMPILE_POINT_EVALUATION: Final[Uint] = Uint(50000)
-    PRECOMPILE_BLS_G1ADD: Final[Uint] = Uint(375)
-    PRECOMPILE_BLS_G1MUL: Final[Uint] = Uint(12000)
-    PRECOMPILE_BLS_G1MAP: Final[Uint] = Uint(5500)
-    PRECOMPILE_BLS_G2ADD: Final[Uint] = Uint(600)
-    PRECOMPILE_BLS_G2MUL: Final[Uint] = Uint(22500)
-    PRECOMPILE_BLS_G2MAP: Final[Uint] = Uint(23800)
-    PRECOMPILE_ECADD: Final[Uint] = Uint(150)
-    PRECOMPILE_ECMUL: Final[Uint] = Uint(6000)
-    PRECOMPILE_ECPAIRING_BASE: Final[Uint] = Uint(45000)
-    PRECOMPILE_ECPAIRING_PER_POINT: Final[Uint] = Uint(34000)
+    PRECOMPILE_ECRECOVER: Final[ExecutionGas] = ExecutionGas(Uint(3000))
+    PRECOMPILE_P256VERIFY: Final[ExecutionGas] = ExecutionGas(Uint(6900))
+    PRECOMPILE_SHA256_BASE: Final[ExecutionGas] = ExecutionGas(Uint(60))
+    PRECOMPILE_SHA256_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(12))
+    PRECOMPILE_RIPEMD160_BASE: Final[ExecutionGas] = ExecutionGas(Uint(600))
+    PRECOMPILE_RIPEMD160_PER_WORD: Final[ExecutionGas] = ExecutionGas(
+        Uint(120)
+    )
+    PRECOMPILE_IDENTITY_BASE: Final[ExecutionGas] = ExecutionGas(Uint(15))
+    PRECOMPILE_IDENTITY_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(3))
+    PRECOMPILE_BLAKE2F_PER_ROUND: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    PRECOMPILE_POINT_EVALUATION: Final[ExecutionGas] = ExecutionGas(
+        Uint(50000)
+    )
+    PRECOMPILE_BLS_G1ADD: Final[ExecutionGas] = ExecutionGas(Uint(375))
+    PRECOMPILE_BLS_G1MUL: Final[ExecutionGas] = ExecutionGas(Uint(12000))
+    PRECOMPILE_BLS_G1MAP: Final[ExecutionGas] = ExecutionGas(Uint(5500))
+    PRECOMPILE_BLS_G2ADD: Final[ExecutionGas] = ExecutionGas(Uint(600))
+    PRECOMPILE_BLS_G2MUL: Final[ExecutionGas] = ExecutionGas(Uint(22500))
+    PRECOMPILE_BLS_G2MAP: Final[ExecutionGas] = ExecutionGas(Uint(23800))
+    PRECOMPILE_ECADD: Final[ExecutionGas] = ExecutionGas(Uint(150))
+    PRECOMPILE_ECMUL: Final[ExecutionGas] = ExecutionGas(Uint(6000))
+    PRECOMPILE_ECPAIRING_BASE: Final[ExecutionGas] = ExecutionGas(Uint(45000))
+    PRECOMPILE_ECPAIRING_PER_POINT: Final[ExecutionGas] = ExecutionGas(
+        Uint(34000)
+    )
 
     # Blobs
     PER_BLOB: Final[U64] = U64(2**17)
@@ -137,20 +149,24 @@ class GasCosts:
     BLOB_BASE_FEE_UPDATE_FRACTION: Final[Uint] = Uint(11684671)
 
     # Block Access Lists
-    BLOCK_ACCESS_LIST_ITEM: Final[Uint] = Uint(2000)
+    BLOCK_ACCESS_LIST_ITEM: Final[ExecutionGas] = ExecutionGas(Uint(2000))
 
     # Transactions
-    TX_BASE: Final[Uint] = Uint(12000)
-    TX_CREATE: Final[Uint] = Uint(32000)
-    TX_VALUE_COST: Final[Uint] = Uint(6000)
-    TX_DATA_TOKEN_STANDARD: Final[Uint] = Uint(4)
-    TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(16)
-    TX_ACCESS_LIST_ADDRESS: Final[Uint] = COLD_ACCOUNT_ACCESS - WARM_ACCESS
-    TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = COLD_STORAGE_ACCESS - WARM_ACCESS
+    TX_BASE: Final[ExecutionGas] = ExecutionGas(Uint(12000))
+    TX_CREATE: Final[ExecutionGas] = ExecutionGas(Uint(32000))
+    TX_VALUE_COST: Final[ExecutionGas] = ExecutionGas(Uint(6000))
+    TX_DATA_TOKEN_STANDARD: Final[ExecutionGas] = ExecutionGas(Uint(4))
+    TX_DATA_TOKEN_FLOOR: Final[ExecutionGas] = ExecutionGas(Uint(16))
+    TX_ACCESS_LIST_ADDRESS: Final[ExecutionGas] = (
+        COLD_ACCOUNT_ACCESS - WARM_ACCESS
+    )
+    TX_ACCESS_LIST_STORAGE_KEY: Final[ExecutionGas] = (
+        COLD_STORAGE_ACCESS - WARM_ACCESS
+    )
 
     # Authorization
     AUTH_TUPLE_BYTES: Final[Uint] = Uint(101)
-    EXECUTION_PER_AUTH_BASE_COST: Final[Uint] = (
+    EXECUTION_PER_AUTH_BASE_COST: Final[ExecutionGas] = ExecutionGas(
         AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
         + PRECOMPILE_ECRECOVER
         + COLD_ACCOUNT_ACCESS
@@ -162,86 +178,86 @@ class GasCosts:
     LIMIT_MINIMUM: Final[Uint] = Uint(5000)
 
     # Static Opcodes
-    OPCODE_ADD: Final[Uint] = VERY_LOW
-    OPCODE_SUB: Final[Uint] = VERY_LOW
-    OPCODE_MUL: Final[Uint] = LOW
-    OPCODE_DIV: Final[Uint] = LOW
-    OPCODE_SDIV: Final[Uint] = LOW
-    OPCODE_MOD: Final[Uint] = LOW
-    OPCODE_SMOD: Final[Uint] = LOW
-    OPCODE_ADDMOD: Final[Uint] = MID
-    OPCODE_MULMOD: Final[Uint] = MID
-    OPCODE_SIGNEXTEND: Final[Uint] = LOW
-    OPCODE_LT: Final[Uint] = VERY_LOW
-    OPCODE_GT: Final[Uint] = VERY_LOW
-    OPCODE_SLT: Final[Uint] = VERY_LOW
-    OPCODE_SGT: Final[Uint] = VERY_LOW
-    OPCODE_EQ: Final[Uint] = VERY_LOW
-    OPCODE_ISZERO: Final[Uint] = VERY_LOW
-    OPCODE_AND: Final[Uint] = VERY_LOW
-    OPCODE_OR: Final[Uint] = VERY_LOW
-    OPCODE_XOR: Final[Uint] = VERY_LOW
-    OPCODE_NOT: Final[Uint] = VERY_LOW
-    OPCODE_BYTE: Final[Uint] = VERY_LOW
-    OPCODE_SHL: Final[Uint] = VERY_LOW
-    OPCODE_SHR: Final[Uint] = VERY_LOW
-    OPCODE_SAR: Final[Uint] = VERY_LOW
-    OPCODE_CLZ: Final[Uint] = LOW
-    OPCODE_JUMP: Final[Uint] = MID
-    OPCODE_JUMPI: Final[Uint] = HIGH
-    OPCODE_JUMPDEST: Final[Uint] = Uint(1)
-    OPCODE_CALLDATALOAD: Final[Uint] = VERY_LOW
-    OPCODE_BLOCKHASH: Final[Uint] = Uint(20)
-    OPCODE_COINBASE: Final[Uint] = BASE
-    OPCODE_POP: Final[Uint] = BASE
-    OPCODE_MSIZE: Final[Uint] = BASE
-    OPCODE_PC: Final[Uint] = BASE
-    OPCODE_GAS: Final[Uint] = BASE
-    OPCODE_ADDRESS: Final[Uint] = BASE
-    OPCODE_ORIGIN: Final[Uint] = BASE
-    OPCODE_CALLER: Final[Uint] = BASE
-    OPCODE_CALLVALUE: Final[Uint] = BASE
-    OPCODE_CALLDATASIZE: Final[Uint] = BASE
-    OPCODE_CODESIZE: Final[Uint] = BASE
-    OPCODE_GASPRICE: Final[Uint] = BASE
-    OPCODE_TIMESTAMP: Final[Uint] = BASE
-    OPCODE_NUMBER: Final[Uint] = BASE
-    OPCODE_GASLIMIT: Final[Uint] = BASE
-    OPCODE_PREVRANDAO: Final[Uint] = BASE
-    OPCODE_RETURNDATASIZE: Final[Uint] = BASE
-    OPCODE_CHAINID: Final[Uint] = BASE
-    OPCODE_BASEFEE: Final[Uint] = BASE
-    OPCODE_BLOBBASEFEE: Final[Uint] = BASE
-    OPCODE_SLOTNUM: Final[Uint] = BASE
-    OPCODE_BLOBHASH: Final[Uint] = Uint(3)
-    OPCODE_PUSH: Final[Uint] = VERY_LOW
-    OPCODE_PUSH0: Final[Uint] = BASE
-    OPCODE_DUP: Final[Uint] = VERY_LOW
-    OPCODE_SWAP: Final[Uint] = VERY_LOW
-    OPCODE_DUPN: Final[Uint] = VERY_LOW
-    OPCODE_SWAPN: Final[Uint] = VERY_LOW
-    OPCODE_EXCHANGE: Final[Uint] = VERY_LOW
-    OPCODE_TLOAD: Final[Uint] = Uint(100)
-    OPCODE_TSTORE: Final[Uint] = Uint(100)
+    OPCODE_ADD: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SUB: Final[ExecutionGas] = VERY_LOW
+    OPCODE_MUL: Final[ExecutionGas] = LOW
+    OPCODE_DIV: Final[ExecutionGas] = LOW
+    OPCODE_SDIV: Final[ExecutionGas] = LOW
+    OPCODE_MOD: Final[ExecutionGas] = LOW
+    OPCODE_SMOD: Final[ExecutionGas] = LOW
+    OPCODE_ADDMOD: Final[ExecutionGas] = MID
+    OPCODE_MULMOD: Final[ExecutionGas] = MID
+    OPCODE_SIGNEXTEND: Final[ExecutionGas] = LOW
+    OPCODE_LT: Final[ExecutionGas] = VERY_LOW
+    OPCODE_GT: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SLT: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SGT: Final[ExecutionGas] = VERY_LOW
+    OPCODE_EQ: Final[ExecutionGas] = VERY_LOW
+    OPCODE_ISZERO: Final[ExecutionGas] = VERY_LOW
+    OPCODE_AND: Final[ExecutionGas] = VERY_LOW
+    OPCODE_OR: Final[ExecutionGas] = VERY_LOW
+    OPCODE_XOR: Final[ExecutionGas] = VERY_LOW
+    OPCODE_NOT: Final[ExecutionGas] = VERY_LOW
+    OPCODE_BYTE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SHL: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SHR: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SAR: Final[ExecutionGas] = VERY_LOW
+    OPCODE_CLZ: Final[ExecutionGas] = LOW
+    OPCODE_JUMP: Final[ExecutionGas] = MID
+    OPCODE_JUMPI: Final[ExecutionGas] = HIGH
+    OPCODE_JUMPDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    OPCODE_CALLDATALOAD: Final[ExecutionGas] = VERY_LOW
+    OPCODE_BLOCKHASH: Final[ExecutionGas] = ExecutionGas(Uint(20))
+    OPCODE_COINBASE: Final[ExecutionGas] = BASE
+    OPCODE_POP: Final[ExecutionGas] = BASE
+    OPCODE_MSIZE: Final[ExecutionGas] = BASE
+    OPCODE_PC: Final[ExecutionGas] = BASE
+    OPCODE_GAS: Final[ExecutionGas] = BASE
+    OPCODE_ADDRESS: Final[ExecutionGas] = BASE
+    OPCODE_ORIGIN: Final[ExecutionGas] = BASE
+    OPCODE_CALLER: Final[ExecutionGas] = BASE
+    OPCODE_CALLVALUE: Final[ExecutionGas] = BASE
+    OPCODE_CALLDATASIZE: Final[ExecutionGas] = BASE
+    OPCODE_CODESIZE: Final[ExecutionGas] = BASE
+    OPCODE_GASPRICE: Final[ExecutionGas] = BASE
+    OPCODE_TIMESTAMP: Final[ExecutionGas] = BASE
+    OPCODE_NUMBER: Final[ExecutionGas] = BASE
+    OPCODE_GASLIMIT: Final[ExecutionGas] = BASE
+    OPCODE_PREVRANDAO: Final[ExecutionGas] = BASE
+    OPCODE_RETURNDATASIZE: Final[ExecutionGas] = BASE
+    OPCODE_CHAINID: Final[ExecutionGas] = BASE
+    OPCODE_BASEFEE: Final[ExecutionGas] = BASE
+    OPCODE_BLOBBASEFEE: Final[ExecutionGas] = BASE
+    OPCODE_SLOTNUM: Final[ExecutionGas] = BASE
+    OPCODE_BLOBHASH: Final[ExecutionGas] = ExecutionGas(Uint(3))
+    OPCODE_PUSH: Final[ExecutionGas] = VERY_LOW
+    OPCODE_PUSH0: Final[ExecutionGas] = BASE
+    OPCODE_DUP: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SWAP: Final[ExecutionGas] = VERY_LOW
+    OPCODE_DUPN: Final[ExecutionGas] = VERY_LOW
+    OPCODE_SWAPN: Final[ExecutionGas] = VERY_LOW
+    OPCODE_EXCHANGE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_TLOAD: Final[ExecutionGas] = ExecutionGas(Uint(100))
+    OPCODE_TSTORE: Final[ExecutionGas] = ExecutionGas(Uint(100))
 
     # Dynamic Opcode Components
-    OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW
-    OPCODE_RETURNDATACOPY_PER_WORD: Final[Uint] = Uint(3)
-    OPCODE_CALLDATACOPY_BASE: Final[Uint] = VERY_LOW
-    OPCODE_CODECOPY_BASE: Final[Uint] = VERY_LOW
-    OPCODE_MCOPY_BASE: Final[Uint] = VERY_LOW
-    OPCODE_MLOAD_BASE: Final[Uint] = VERY_LOW
-    OPCODE_MSTORE_BASE: Final[Uint] = VERY_LOW
-    OPCODE_MSTORE8_BASE: Final[Uint] = VERY_LOW
-    OPCODE_COPY_PER_WORD: Final[Uint] = Uint(3)
-    OPCODE_EXP_BASE: Final[Uint] = Uint(10)
-    OPCODE_EXP_PER_BYTE: Final[Uint] = Uint(50)
-    OPCODE_KECCAK256_BASE: Final[Uint] = Uint(30)
-    OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)
-    OPCODE_LOG_BASE: Final[Uint] = Uint(375)
-    OPCODE_LOG_DATA_PER_BYTE: Final[Uint] = Uint(8)
-    OPCODE_LOG_TOPIC: Final[Uint] = Uint(375)
-    OPCODE_SELFDESTRUCT_BASE: Final[Uint] = Uint(5000)
+    OPCODE_RETURNDATACOPY_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_RETURNDATACOPY_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(3))
+    OPCODE_CALLDATACOPY_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_CODECOPY_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_MCOPY_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_MLOAD_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_MSTORE_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_MSTORE8_BASE: Final[ExecutionGas] = VERY_LOW
+    OPCODE_COPY_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(3))
+    OPCODE_EXP_BASE: Final[ExecutionGas] = ExecutionGas(Uint(10))
+    OPCODE_EXP_PER_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(50))
+    OPCODE_KECCAK256_BASE: Final[ExecutionGas] = ExecutionGas(Uint(30))
+    OPCODE_KECCAK256_PER_WORD: Final[ExecutionGas] = ExecutionGas(Uint(6))
+    OPCODE_LOG_BASE: Final[ExecutionGas] = ExecutionGas(Uint(375))
+    OPCODE_LOG_DATA_PER_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(8))
+    OPCODE_LOG_TOPIC: Final[ExecutionGas] = ExecutionGas(Uint(375))
+    OPCODE_SELFDESTRUCT_BASE: Final[ExecutionGas] = ExecutionGas(Uint(5000))
 
 
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
@@ -262,7 +278,7 @@ class GasMeter:
     [`Evm`]: ref:ethereum.forks.amsterdam.vm.Evm
     """
 
-    gas_left: Uint
+    gas_left: ExecutionGas
     """
     Gas still available from the frame's execution-gas grant. Pays
     execution-gas charges, and state charges as [spill] once the
@@ -271,13 +287,13 @@ class GasMeter:
     [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
     """
 
-    state_gas_left: Uint
+    state_gas_left: StateGas
     """
     State gas still available in the frame's reservoir. Charges draw
     from here first and spill into `gas_left` once it is empty.
     """
 
-    state_gas_baseline: Uint
+    state_gas_baseline: StateGas
     """
     Reservoir level a rollback refills to: the frame's grant at entry,
     moved down by [`commit_state_gas`][commit] when charges become
@@ -289,7 +305,7 @@ class GasMeter:
     refund_counter: int = 0
     """Gas eligible for refund at the end of the transaction."""
 
-    state_gas_spilled: Uint = Uint(0)
+    state_gas_spilled: StateGas = StateGas(Uint(0))
     """
     Execution gas spent covering state charges after the reservoir
     emptied. Credited back to `gas_left` first, in LIFO order, on a
@@ -299,7 +315,7 @@ class GasMeter:
     [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
     """
 
-    state_gas_committed_spill: Uint = Uint(0)
+    state_gas_committed_spill: StateGas = StateGas(Uint(0))
     """
     [Spill] that [`commit_state_gas`][commit] marked non-refillable.
     It outlives the rollbacks [`restore_state_gas`][restore] performs;
@@ -321,13 +337,13 @@ class ExtendMemory:
     """
     Define the parameters for memory extension in opcodes.
 
-    `cost`: `ethereum.base_types.Uint`
+    `cost`: `ExecutionGas`
         The gas required to perform the extension
     `expand_by`: `ethereum.base_types.Uint`
         The size by which the memory will be extended
     """
 
-    cost: Uint
+    cost: ExecutionGas
     expand_by: Uint
 
 
@@ -338,19 +354,19 @@ class MessageCallGas:
     Define the gas cost and gas given to the sub-call for executing the call
     opcodes.
 
-    `cost`: `ethereum.base_types.Uint`
+    `cost`: `ExecutionGas`
         The gas required to execute the call opcode, excludes
         memory expansion costs.
-    `sub_call`: `ethereum.base_types.Uint`
+    `sub_call`: `ExecutionGas`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
     """
 
-    cost: Uint
-    sub_call: Uint
+    cost: ExecutionGas
+    sub_call: ExecutionGas
 
 
-def check_gas(evm: "Evm", amount: Uint) -> None:
+def check_gas(evm: "Evm", amount: ExecutionGas) -> None:
     """
     Checks if `amount` gas is available without charging it.
     Raises OutOfGasError if insufficient gas.
@@ -360,14 +376,14 @@ def check_gas(evm: "Evm", amount: Uint) -> None:
     evm :
         The current EVM.
     amount :
-        The amount of gas to check.
+        The amount of execution gas to check.
 
     """
     if evm.gas_meter.gas_left < amount:
         raise OutOfGasError
 
 
-def charge_gas_from_meter(gas_meter: GasMeter, amount: Uint) -> None:
+def charge_gas_from_meter(gas_meter: GasMeter, amount: ExecutionGas) -> None:
     """
     Subtracts `amount` from `gas_left` (execution gas).
 
@@ -384,7 +400,7 @@ def charge_gas_from_meter(gas_meter: GasMeter, amount: Uint) -> None:
     gas_meter.gas_left -= amount
 
 
-def charge_gas(evm: "Evm", amount: Uint) -> None:
+def charge_gas(evm: "Evm", amount: ExecutionGas) -> None:
     """
     Subtracts `amount` from `gas_left` (execution gas).
 
@@ -418,10 +434,10 @@ def charge_state_gas_from_meter(gas_meter: GasMeter, amount: StateGas) -> None:
     """
     if gas_meter.state_gas_left >= amount:
         gas_meter.state_gas_left -= amount
-    elif gas_meter.state_gas_left + gas_meter.gas_left >= amount:
+    elif Uint(gas_meter.state_gas_left) + Uint(gas_meter.gas_left) >= amount:
         remainder = amount - gas_meter.state_gas_left
-        gas_meter.state_gas_left = Uint(0)
-        gas_meter.gas_left -= remainder
+        gas_meter.state_gas_left = StateGas(Uint(0))
+        gas_meter.gas_left = ExecutionGas(gas_meter.gas_left - Uint(remainder))
         gas_meter.state_gas_spilled += remainder
     else:
         raise OutOfGasError
@@ -478,7 +494,7 @@ def commit_state_gas(gas_meter: GasMeter) -> None:
     assert gas_meter.state_gas_left <= gas_meter.state_gas_baseline
     gas_meter.state_gas_committed_spill += gas_meter.state_gas_spilled
     gas_meter.state_gas_baseline = gas_meter.state_gas_left
-    gas_meter.state_gas_spilled = Uint(0)
+    gas_meter.state_gas_spilled = StateGas(Uint(0))
 
 
 def restore_state_gas(gas_meter: GasMeter) -> None:
@@ -500,14 +516,16 @@ def restore_state_gas(gas_meter: GasMeter) -> None:
     [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
 
     """  # noqa: E501
-    gas_meter.gas_left += gas_meter.state_gas_spilled
-    gas_meter.state_gas_spilled = Uint(0)
+    gas_meter.gas_left = ExecutionGas(
+        gas_meter.gas_left + Uint(gas_meter.state_gas_spilled)
+    )
+    gas_meter.state_gas_spilled = StateGas(Uint(0))
     gas_meter.state_gas_left = gas_meter.state_gas_baseline
     gas_meter.refund_counter = 0
 
 
 def restore_state_gas_to_entry(
-    gas_meter: GasMeter, state_gas_reservoir: Uint
+    gas_meter: GasMeter, state_gas_reservoir: StateGas
 ) -> None:
     """
     Roll the frame's state gas back to frame entry, undoing any commit.
@@ -533,16 +551,20 @@ def restore_state_gas_to_entry(
     # Only pre-dispatch failures roll back to entry, and no refund
     # accrues before dispatch.
     assert gas_meter.refund_counter == 0
-    gas_meter.gas_left += (
-        gas_meter.state_gas_spilled + gas_meter.state_gas_committed_spill
+    gas_meter.gas_left = ExecutionGas(
+        gas_meter.gas_left
+        + Uint(gas_meter.state_gas_spilled)
+        + Uint(gas_meter.state_gas_committed_spill)
     )
-    gas_meter.state_gas_spilled = Uint(0)
-    gas_meter.state_gas_committed_spill = Uint(0)
+    gas_meter.state_gas_spilled = StateGas(Uint(0))
+    gas_meter.state_gas_committed_spill = StateGas(Uint(0))
     gas_meter.state_gas_left = state_gas_reservoir
     gas_meter.state_gas_baseline = state_gas_reservoir
 
 
-def tx_state_gas_used(gas_meter: GasMeter, state_gas_reservoir: Uint) -> int:
+def tx_state_gas_used(
+    gas_meter: GasMeter, state_gas_reservoir: StateGas
+) -> int:
     """
     Return the net state gas a transaction's execution consumed.
 
@@ -596,7 +618,7 @@ def credit_state_gas_refund(gas_meter: GasMeter, amount: StateGas) -> None:
 
     """
     from_gas_left = min(amount, gas_meter.state_gas_spilled)
-    gas_meter.gas_left += from_gas_left
+    gas_meter.gas_left = ExecutionGas(gas_meter.gas_left + Uint(from_gas_left))
     gas_meter.state_gas_spilled -= from_gas_left
     gas_meter.state_gas_left += amount - from_gas_left
 
@@ -614,10 +636,10 @@ def forfeit_remaining_gas(gas_meter: GasMeter) -> None:
     # A rollback owes any outstanding spill back to `gas_left`; it
     # must be restored before the remainder burns.
     assert gas_meter.state_gas_spilled == Uint(0)
-    gas_meter.gas_left = Uint(0)
+    gas_meter.gas_left = ExecutionGas(Uint(0))
 
 
-def withhold_create_gas(gas_meter: GasMeter) -> Uint:
+def withhold_create_gas(gas_meter: GasMeter) -> ExecutionGas:
     """
     Withhold and return the gas made available to a `CREATE*` child.
 
@@ -631,7 +653,7 @@ def withhold_create_gas(gas_meter: GasMeter) -> Uint:
 
     Returns
     -------
-    child_gas : `ethereum.base_types.Uint`
+    child_gas : `ExecutionGas`
         The execution gas granted to the child frame.
 
     """
@@ -640,7 +662,7 @@ def withhold_create_gas(gas_meter: GasMeter) -> Uint:
     return child_gas
 
 
-def drain_state_gas_reservoir(gas_meter: GasMeter) -> Uint:
+def drain_state_gas_reservoir(gas_meter: GasMeter) -> StateGas:
     """
     Empty the frame's state gas reservoir for a child frame.
 
@@ -655,17 +677,17 @@ def drain_state_gas_reservoir(gas_meter: GasMeter) -> Uint:
 
     Returns
     -------
-    reservoir : `ethereum.base_types.Uint`
+    reservoir : `StateGas`
         The state gas granted to the child frame.
 
     """
     reservoir = gas_meter.state_gas_left
-    gas_meter.state_gas_left = Uint(0)
+    gas_meter.state_gas_left = StateGas(Uint(0))
     return reservoir
 
 
 def restore_child_gas(
-    gas_meter: GasMeter, gas: Uint, state_gas_reservoir: Uint
+    gas_meter: GasMeter, gas: ExecutionGas, state_gas_reservoir: StateGas
 ) -> None:
     """
     Return a child frame's unused gas grant to the parent.
@@ -688,7 +710,7 @@ def restore_child_gas(
     gas_meter.state_gas_left += state_gas_reservoir
 
 
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> ExecutionGas:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -701,7 +723,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.Uint`
+    total_gas_cost : `ExecutionGas`
         The gas cost for storing data in memory.
 
     """
@@ -710,7 +732,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words ** Uint(2) // Uint(512)
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return total_gas_cost
+        return ExecutionGas(total_gas_cost)
     except ValueError as e:
         raise OutOfGasError from e
 
@@ -735,7 +757,7 @@ def calculate_gas_extend_memory(
 
     """
     size_to_extend = Uint(0)
-    to_be_paid = Uint(0)
+    to_be_paid = GasCosts.ZERO
     current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
@@ -757,11 +779,11 @@ def calculate_gas_extend_memory(
 
 def calculate_message_call_gas(
     value: U256,
-    gas: Uint,
-    gas_left: Uint,
-    memory_cost: Uint,
-    extra_gas: Uint,
-    call_stipend: Uint = GasCosts.CALL_STIPEND,
+    gas: ExecutionGas,
+    gas_left: ExecutionGas,
+    memory_cost: ExecutionGas,
+    extra_gas: ExecutionGas,
+    call_stipend: ExecutionGas = GasCosts.CALL_STIPEND,
 ) -> MessageCallGas:
     """
     Calculates the MessageCallGas (cost and gas made available to the sub-call)
@@ -789,7 +811,7 @@ def calculate_message_call_gas(
     message_call_gas: `MessageCallGas`
 
     """
-    call_stipend = Uint(0) if value == 0 else call_stipend
+    call_stipend = GasCosts.ZERO if value == 0 else call_stipend
     if gas_left < extra_gas + memory_cost:
         return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
@@ -798,7 +820,7 @@ def calculate_message_call_gas(
     return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
-def max_message_call_gas(gas: Uint) -> Uint:
+def max_message_call_gas(gas: ExecutionGas) -> ExecutionGas:
     """
     Calculates the maximum gas that is allowed for making a message call.
 
@@ -809,14 +831,14 @@ def max_message_call_gas(gas: Uint) -> Uint:
 
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.Uint`
+    max_allowed_message_call_gas: `ExecutionGas`
         The maximum gas allowed for making the message-call.
 
     """
-    return gas - (gas // Uint(64))
+    return ExecutionGas(gas - (gas // Uint(64)))
 
 
-def init_code_cost(init_code_length: Uint) -> Uint:
+def init_code_cost(init_code_length: Uint) -> ExecutionGas:
     """
     Calculates the gas to be charged for the init code in CREATE*
     opcodes as well as create transactions.
@@ -829,11 +851,13 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
     Returns
     -------
-    init_code_gas: `ethereum.base_types.Uint`
+    init_code_gas: `ExecutionGas`
         The gas to be charged for the init code.
 
     """
-    return GasCosts.CODE_INIT_PER_WORD * ceil32(init_code_length) // Uint(32)
+    return ExecutionGas(
+        GasCosts.CODE_INIT_PER_WORD * ceil32(init_code_length) // Uint(32)
+    )
 
 
 def calculate_excess_blob_gas(
@@ -1047,10 +1071,10 @@ class EvmGasAllocation:
     Split of a transaction's EVM gas across the two dimensions.
     """
 
-    execution_gas: Uint
+    execution_gas: ExecutionGas
     """Execution gas granted to the top frame, capped by the budget."""
 
-    state_gas_reservoir: Uint
+    state_gas_reservoir: StateGas
     """State gas set aside for the top frame's reservoir."""
 
 
@@ -1084,8 +1108,8 @@ def allocate_evm_gas(
     """
     evm_gas = tx_gas - Uint(intrinsic.execution)
     execution_gas_budget = TX_MAX_GAS_LIMIT - intrinsic.execution
-    execution_gas = min(execution_gas_budget, evm_gas)
-    state_gas_reservoir = Uint(evm_gas - execution_gas)
+    execution_gas = ExecutionGas(min(execution_gas_budget, evm_gas))
+    state_gas_reservoir = StateGas(evm_gas - execution_gas)
     return EvmGasAllocation(execution_gas, state_gas_reservoir)
 
 
@@ -1105,18 +1129,18 @@ class TransactionGasSettlement:
     gas_left: Uint
     """Gas returned to the sender, priced at the effective gas price."""
 
-    execution_gas_used: Uint
+    execution_gas_used: ExecutionGas
     """Execution gas the transaction contributes to the block total."""
 
-    state_gas_used: Uint
+    state_gas_used: StateGas
     """State gas the transaction contributes to the block total."""
 
 
 def settle_transaction_gas(
     tx_gas: Uint,
     calldata_floor: Uint,
-    gas_left: Uint,
-    state_gas_left: Uint,
+    gas_left: ExecutionGas,
+    state_gas_left: StateGas,
     refund_counter: U256,
     state_gas_used: int,
 ) -> TransactionGasSettlement:
@@ -1165,10 +1189,12 @@ def settle_transaction_gas(
     gas_used_after_refund = gas_used_before_refund - gas_refund
     gas_used = max(gas_used_after_refund, calldata_floor)
 
-    settled_state_gas_used = Uint(max(0, state_gas_used))
-    execution_gas_used = max(
-        gas_used_before_refund - settled_state_gas_used,
-        calldata_floor,
+    settled_state_gas_used = StateGas(Uint(max(0, state_gas_used)))
+    execution_gas_used = ExecutionGas(
+        max(
+            gas_used_before_refund - settled_state_gas_used,
+            calldata_floor,
+        )
     )
     return TransactionGasSettlement(
         gas_used=gas_used,

--- a/src/ethereum/forks/amsterdam/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/arithmetic.py
@@ -16,6 +16,7 @@ from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
 
+from ...fork_types import ExecutionGas
 from .. import Evm
 from ..gas import (
     GasCosts,
@@ -315,8 +316,10 @@ def exp(evm: Evm) -> None:
     exponent_bytes = (exponent_bits + Uint(7)) // Uint(8)
     charge_gas(
         evm,
-        GasCosts.OPCODE_EXP_BASE
-        + GasCosts.OPCODE_EXP_PER_BYTE * exponent_bytes,
+        ExecutionGas(
+            GasCosts.OPCODE_EXP_BASE
+            + GasCosts.OPCODE_EXP_PER_BYTE * exponent_bytes
+        ),
     )
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -17,6 +17,7 @@ from ethereum_types.numeric import U256, Uint, ulen
 from ethereum.state import EMPTY_ACCOUNT
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import ExecutionGas
 from ...state_tracker import get_account, get_code
 from ...utils.address import to_address_masked
 from ...vm.memory import buffer_read, memory_write
@@ -224,7 +225,7 @@ def calldatacopy(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    copy_gas_cost = GasCosts.OPCODE_COPY_PER_WORD * words
+    copy_gas_cost = ExecutionGas(GasCosts.OPCODE_COPY_PER_WORD * words)
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )
@@ -285,7 +286,7 @@ def codecopy(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    copy_gas_cost = GasCosts.OPCODE_COPY_PER_WORD * words
+    copy_gas_cost = ExecutionGas(GasCosts.OPCODE_COPY_PER_WORD * words)
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )
@@ -378,7 +379,7 @@ def extcodecopy(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    copy_gas_cost = GasCosts.OPCODE_COPY_PER_WORD * words
+    copy_gas_cost = ExecutionGas(GasCosts.OPCODE_COPY_PER_WORD * words)
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )
@@ -447,7 +448,9 @@ def returndatacopy(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    copy_gas_cost = GasCosts.OPCODE_RETURNDATACOPY_PER_WORD * words
+    copy_gas_cost = ExecutionGas(
+        GasCosts.OPCODE_RETURNDATACOPY_PER_WORD * words
+    )
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/amsterdam/vm/instructions/keccak.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/keccak.py
@@ -16,6 +16,7 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import ExecutionGas
 from .. import Evm
 from ..gas import (
     GasCosts,
@@ -45,7 +46,7 @@ def keccak(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(size)) // Uint(32)
-    word_gas_cost = GasCosts.OPCODE_KECCAK256_PER_WORD * words
+    word_gas_cost = ExecutionGas(GasCosts.OPCODE_KECCAK256_PER_WORD * words)
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )

--- a/src/ethereum/forks/amsterdam/vm/instructions/log.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/log.py
@@ -17,6 +17,7 @@ from typing import Callable
 from ethereum_types.numeric import Uint
 
 from ...blocks import Log
+from ...fork_types import ExecutionGas
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (
@@ -58,10 +59,12 @@ def log_n(evm: Evm, num_topics: int) -> None:
     )
     charge_gas(
         evm,
-        GasCosts.OPCODE_LOG_BASE
-        + GasCosts.OPCODE_LOG_DATA_PER_BYTE * Uint(size)
-        + GasCosts.OPCODE_LOG_TOPIC * Uint(num_topics)
-        + extend_memory.cost,
+        ExecutionGas(
+            GasCosts.OPCODE_LOG_BASE
+            + GasCosts.OPCODE_LOG_DATA_PER_BYTE * Uint(size)
+            + GasCosts.OPCODE_LOG_TOPIC * Uint(num_topics)
+            + extend_memory.cost
+        ),
     )
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/instructions/memory.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/memory.py
@@ -16,6 +16,7 @@ from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import ExecutionGas
 from .. import Evm
 from ..gas import (
     GasCosts,
@@ -159,7 +160,7 @@ def mcopy(evm: Evm) -> None:
 
     # GAS
     words = ceil32(Uint(length)) // Uint(32)
-    copy_gas_cost = GasCosts.OPCODE_COPY_PER_WORD * words
+    copy_gas_cost = ExecutionGas(GasCosts.OPCODE_COPY_PER_WORD * words)
 
     extend_memory = calculate_gas_extend_memory(
         evm.memory, [(source, length), (destination, length)]

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -13,7 +13,7 @@ Implementations of the EVM storage related instructions.
 
 from ethereum_types.numeric import Uint
 
-from ...fork_types import StateGas
+from ...fork_types import ExecutionGas, StateGas
 from ...state_tracker import (
     get_storage,
     get_storage_original,
@@ -85,7 +85,7 @@ def sstore(evm: Evm) -> None:
     # GAS (STATE-INDEPENDENT)
     # Price what is computable without touching state, and check it is
     # affordable before any state access is performed.
-    gas_cost = Uint(0)
+    gas_cost = GasCosts.ZERO
 
     # Access cost: cold or warm, always charged.
     is_cold_access = (
@@ -101,7 +101,9 @@ def sstore(evm: Evm) -> None:
     # records the slot read in the Block Access List. Post-repricing the
     # access cost can exceed the stipend, so the EIP-2200 stipend sentry
     # (`gas_left > CALL_STIPEND`) is no longer sufficient on its own.
-    check_gas(evm, max(gas_cost, GasCosts.CALL_STIPEND + Uint(1)))
+    check_gas(
+        evm, max(gas_cost, ExecutionGas(GasCosts.CALL_STIPEND + Uint(1)))
+    )
 
     # STATE ACCESS (STATE-DEPENDENT GAS)
     # Perform the access and complete the state-dependent pricing from

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -20,7 +20,7 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
-from ...fork_types import StateGas
+from ...fork_types import ExecutionGas, StateGas
 from ...state_tracker import (
     account_deployable,
     get_account,
@@ -282,10 +282,12 @@ def create2(evm: Evm) -> None:
     init_code_gas = init_code_cost(Uint(memory_size))
     charge_gas(
         evm,
-        GasCosts.CREATE_ACCESS
-        + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
-        + extend_memory.cost
-        + init_code_gas,
+        ExecutionGas(
+            GasCosts.CREATE_ACCESS
+            + GasCosts.OPCODE_KECCAK256_PER_WORD * call_data_words
+            + extend_memory.cost
+            + init_code_gas
+        ),
     )
 
     if memory_size > U256(MAX_INIT_CODE_SIZE):
@@ -351,8 +353,8 @@ class GenericCall:
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
 
-    gas: Uint
-    state_gas_reservoir: Uint
+    gas: ExecutionGas
+    state_gas_reservoir: StateGas
     value: U256
     caller: Address
     to: Address
@@ -480,7 +482,7 @@ def call(evm: Evm) -> None:
 
     """
     # STACK
-    gas = Uint(pop(evm.stack))
+    gas = ExecutionGas(Uint(pop(evm.stack)))
     to = to_address_masked(pop(evm.stack))
     value = pop(evm.stack)
     memory_input_start_position = pop(evm.stack)
@@ -508,7 +510,7 @@ def call(evm: Evm) -> None:
     else:
         access_gas_cost = GasCosts.WARM_ACCESS
 
-    transfer_gas_cost = Uint(0) if value == 0 else GasCosts.CALL_VALUE
+    transfer_gas_cost = GasCosts.ZERO if value == 0 else GasCosts.CALL_VALUE
 
     check_gas(
         evm,
@@ -558,9 +560,9 @@ def call(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
-        Uint(evm.gas_meter.gas_left),
-        memory_cost=Uint(0),
-        extra_gas=Uint(0),
+        evm.gas_meter.gas_left,
+        memory_cost=GasCosts.ZERO,
+        extra_gas=GasCosts.ZERO,
     )
     charge_gas(evm, message_call_gas.cost)
     call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
@@ -607,7 +609,7 @@ def callcode(evm: Evm) -> None:
 
     """
     # STACK
-    gas = Uint(pop(evm.stack))
+    gas = ExecutionGas(Uint(pop(evm.stack)))
     code_address = to_address_masked(pop(evm.stack))
     value = pop(evm.stack)
     memory_input_start_position = pop(evm.stack)
@@ -634,7 +636,7 @@ def callcode(evm: Evm) -> None:
     else:
         access_gas_cost = GasCosts.WARM_ACCESS
 
-    transfer_gas_cost = Uint(0) if value == 0 else GasCosts.CALL_VALUE
+    transfer_gas_cost = GasCosts.ZERO if value == 0 else GasCosts.CALL_VALUE
 
     check_gas(
         evm,
@@ -673,7 +675,7 @@ def callcode(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
-        Uint(evm.gas_meter.gas_left),
+        evm.gas_meter.gas_left,
         extend_memory.cost,
         extra_gas,
     )
@@ -749,7 +751,7 @@ def selfdestruct(evm: Evm) -> None:
     # and the creation, charged by the frame whose opcode causes it;
     # it refills only through the frame's own rollback.
     state_gas = StateGas(Uint(0))
-    account_write_gas = Uint(0)
+    account_write_gas = GasCosts.ZERO
     if (
         not is_account_alive(tx_state, beneficiary)
         and get_account(tx_state, evm.current_target).balance != 0
@@ -796,7 +798,7 @@ def delegatecall(evm: Evm) -> None:
 
     """
     # STACK
-    gas = Uint(pop(evm.stack))
+    gas = ExecutionGas(Uint(pop(evm.stack)))
     code_address = to_address_masked(pop(evm.stack))
     memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
@@ -854,7 +856,7 @@ def delegatecall(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
-        Uint(evm.gas_meter.gas_left),
+        evm.gas_meter.gas_left,
         extend_memory.cost,
         extra_gas,
     )
@@ -899,7 +901,7 @@ def staticcall(evm: Evm) -> None:
 
     """
     # STACK
-    gas = Uint(pop(evm.stack))
+    gas = ExecutionGas(Uint(pop(evm.stack)))
     to = to_address_masked(pop(evm.stack))
     memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
@@ -957,7 +959,7 @@ def staticcall(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
-        Uint(evm.gas_meter.gas_left),
+        evm.gas_meter.gas_left,
         extend_memory.cost,
         extra_gas,
     )

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -32,6 +32,7 @@ from ethereum.trace import (
 from ethereum.utils.numeric import ceil32
 
 from ..blocks import Log
+from ..fork_types import ExecutionGas, StateGas
 from ..state_tracker import (
     TransactionState,
     account_deployable,
@@ -95,7 +96,7 @@ class TransactionOutput:
     frame itself never leaves the interpreter.
     """
 
-    gas_left: Uint
+    gas_left: ExecutionGas
     """Execution gas remaining after execution."""
 
     refund_counter: U256
@@ -113,7 +114,7 @@ class TransactionOutput:
     return_data: Bytes
     """The output of the execution."""
 
-    state_gas_left: Uint
+    state_gas_left: StateGas
     """State gas remaining in the reservoir after execution."""
 
     state_gas_used: int
@@ -371,7 +372,7 @@ def process_create(evm: Evm) -> Evm:
             if len(contract_code) > MAX_CODE_SIZE:
                 raise OutOfGasError
             # Hash cost for computing keccak256 of deployed bytecode
-            code_hash_gas = (
+            code_hash_gas = ExecutionGas(
                 GasCosts.OPCODE_KECCAK256_PER_WORD
                 * ceil32(ulen(contract_code))
                 // Uint(32)

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/alt_bn128.py
@@ -30,6 +30,7 @@ from py_ecc.optimized_bn128.optimized_curve import (
 from py_ecc.optimized_bn128.optimized_pairing import pairing
 from py_ecc.typing import Optimized_Point3D as Point3D
 
+from ...fork_types import ExecutionGas
 from ...vm import Evm
 from ...vm.gas import GasCosts, charge_gas
 from ...vm.memory import buffer_read
@@ -207,8 +208,10 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
-        + GasCosts.PRECOMPILE_ECPAIRING_BASE,
+        ExecutionGas(
+            GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
+            + GasCosts.PRECOMPILE_ECPAIRING_BASE
+        ),
     )
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/bls12_381_g1.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/bls12_381_g1.py
@@ -19,6 +19,7 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     multiply as bls12_multiply,
 )
 
+from ....fork_types import ExecutionGas
 from ....vm import Evm
 from ....vm.gas import (
     GasCosts,
@@ -99,7 +100,9 @@ def bls12_g1_msm(evm: Evm) -> None:
     else:
         discount = Uint(G1_MAX_DISCOUNT)
 
-    gas_cost = Uint(k) * GasCosts.PRECOMPILE_BLS_G1MUL * discount // MULTIPLIER
+    gas_cost = ExecutionGas(
+        Uint(k) * GasCosts.PRECOMPILE_BLS_G1MUL * discount // MULTIPLIER
+    )
     charge_gas(evm, gas_cost)
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/bls12_381_g2.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/bls12_381_g2.py
@@ -19,6 +19,7 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     multiply as bls12_multiply,
 )
 
+from ....fork_types import ExecutionGas
 from ....vm import Evm
 from ....vm.gas import (
     GasCosts,
@@ -100,7 +101,9 @@ def bls12_g2_msm(evm: Evm) -> None:
     else:
         discount = Uint(G2_MAX_DISCOUNT)
 
-    gas_cost = Uint(k) * GasCosts.PRECOMPILE_BLS_G2MUL * discount // MULTIPLIER
+    gas_cost = ExecutionGas(
+        Uint(k) * GasCosts.PRECOMPILE_BLS_G2MUL * discount // MULTIPLIER
+    )
     charge_gas(evm, gas_cost)
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/bls12_381_pairing.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/bls12_381/bls12_381_pairing.py
@@ -15,6 +15,7 @@ from ethereum_types.numeric import Uint
 from py_ecc.optimized_bls12_381 import FQ12, curve_order, is_inf, pairing
 from py_ecc.optimized_bls12_381 import multiply as bls12_multiply
 
+from ....fork_types import ExecutionGas
 from ....vm import Evm
 from ....vm.gas import charge_gas
 from ...exceptions import InvalidParameter
@@ -42,7 +43,7 @@ def bls12_pairing(evm: Evm) -> None:
 
     # GAS
     k = len(data) // 384
-    gas_cost = Uint(32600 * k + 37700)
+    gas_cost = ExecutionGas(Uint(32600 * k + 37700))
     charge_gas(evm, gas_cost)
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/identity.py
@@ -15,6 +15,7 @@ from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import ExecutionGas
 from ...vm import Evm
 from ...vm.gas import (
     GasCosts,
@@ -38,8 +39,10 @@ def identity(evm: Evm) -> None:
     word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_IDENTITY_BASE
-        + GasCosts.PRECOMPILE_IDENTITY_PER_WORD * word_count,
+        ExecutionGas(
+            GasCosts.PRECOMPILE_IDENTITY_BASE
+            + GasCosts.PRECOMPILE_IDENTITY_PER_WORD * word_count
+        ),
     )
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/modexp.py
@@ -14,6 +14,7 @@ Implementation of the `MODEXP` precompiled contract.
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
+from ...fork_types import ExecutionGas
 from ...vm import Evm
 from ...vm.exceptions import ExceptionalHalt
 from ...vm.gas import charge_gas
@@ -144,7 +145,7 @@ def gas_cost(
     modulus_length: U256,
     exponent_length: U256,
     exponent_head: U256,
-) -> Uint:
+) -> ExecutionGas:
     """
     Calculate the gas cost of performing a modular exponentiation.
 
@@ -165,11 +166,11 @@ def gas_cost(
 
     Returns
     -------
-    gas_cost : `Uint`
+    gas_cost : `ExecutionGas`
         Gas required for performing the operation.
 
     """
     multiplication_complexity = complexity(base_length, modulus_length)
     iteration_count = iterations(exponent_length, exponent_head)
     cost = multiplication_complexity * iteration_count
-    return max(Uint(500), cost)
+    return ExecutionGas(max(Uint(500), cost))

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/ripemd160.py
@@ -18,6 +18,7 @@ from ethereum_types.numeric import Uint, ulen
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import ExecutionGas
 from ...vm import Evm
 from ...vm.gas import (
     GasCosts,
@@ -41,8 +42,10 @@ def ripemd160(evm: Evm) -> None:
     word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_RIPEMD160_BASE
-        + GasCosts.PRECOMPILE_RIPEMD160_PER_WORD * word_count,
+        ExecutionGas(
+            GasCosts.PRECOMPILE_RIPEMD160_BASE
+            + GasCosts.PRECOMPILE_RIPEMD160_PER_WORD * word_count
+        ),
     )
 
     # OPERATION

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/sha256.py
@@ -17,6 +17,7 @@ from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
+from ...fork_types import ExecutionGas
 from ...vm import Evm
 from ...vm.gas import (
     GasCosts,
@@ -40,8 +41,10 @@ def sha256(evm: Evm) -> None:
     word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_SHA256_BASE
-        + GasCosts.PRECOMPILE_SHA256_PER_WORD * word_count,
+        ExecutionGas(
+            GasCosts.PRECOMPILE_SHA256_BASE
+            + GasCosts.PRECOMPILE_SHA256_PER_WORD * word_count
+        ),
     )
 
     # OPERATION


### PR DESCRIPTION
### Description

Applies the `ExecutionGas` and `StateGas` `NewType` wrappers (introduced in
`fork_types.py` by #3037) to all EVM gas fields and constants across the
amsterdam fork, preventing accidental mixing of state gas with execution gas
at the type level.

Changes:
- All `GasCosts` constants typed as `ExecutionGas` (blob-fee, byte-count and
  block-limit constants stay `Uint`); `StateGasCosts` already typed as
  `StateGas`
- `GasMeter` fields typed: `gas_left`, `state_gas_left`,
  `state_gas_baseline`, `state_gas_spilled`, `state_gas_committed_spill`
- `Message`, `TransactionEnvironment`, `MessageCallOutput`, `GenericCall`,
  `MessageCallGas` and `ExtendMemory` gas fields typed
- `EvmGasAllocation` and the per-dimension `TransactionGasSettlement` fields
  typed
- Signatures updated: the gas-meter helpers (`charge_state_gas`, spill
  commit/restore, `withhold_create_gas`, `drain_state_gas_reservoir`,
  `restore_child_gas`, `tx_state_gas_used`), `max_message_call_gas`,
  `calculate_delegation_cost` and `settle_transaction_gas`

Rebased onto `forks/amsterdam` after the regular→execution gas rename
(#3238, #3263) and the `GasMeter` refactor, so the wrapper is now named
`ExecutionGas` and the typing covers the meter and settlement helpers.

### Related Issues or PRs

Closes #3015. Follows on from #3037.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Typing cat](https://cataas.com/cat/gif)
