### PR TITLE
feat(test-fill): pack Engine X pre-alloc groups

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1000,6 +1000,16 @@ def pytest_terminal_summary(
                 yellow=True,
             )
 
+    engine_x_warning = getattr(config, "engine_x_check_warning", None)
+    if engine_x_warning is not None:
+        terminalreporter.write_sep(
+            "=",
+            " WARNING: Engine X execution consistency check skipped ",
+            bold=True,
+            yellow=True,
+        )
+        terminalreporter.write_line(engine_x_warning, yellow=True)
+
 
 def _aggregate_cache_stats(node: Any) -> None:
     """Aggregate t8n cache stats from an xdist worker."""
@@ -2221,19 +2231,32 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     # test's execution (raises on drift, like a pre-alloc collision).
     _log_timing("verify_engine_x_execution: starting...")
     t0 = time.time()
-    engine_x_check_summary = verify_engine_x_execution(
-        fixture_output.directory
-    )
-    if engine_x_check_summary is not None:
-        logger.info(engine_x_check_summary)
+    engine_x_check = verify_engine_x_execution(fixture_output.directory)
+    engine_x_warning: str | None = None
+    if engine_x_check is not None:
+        if engine_x_check.compared > 0:
+            logger.info(engine_x_check.summary)
+        elif engine_x_check.skipped > 0:
+            engine_x_warning = (
+                "Engine X execution consistency check skipped: none of "
+                f"the {engine_x_check.skipped} Engine X fixtures have a "
+                "blockchain_tests_engine sibling fixture to compare "
+                "against. Leaks from pre-alloc group packing are not "
+                "verified for this output."
+            )
     elif (fixture_output.directory / ENGINE_X_FIXTURES_DIR).is_dir():
-        logger.warning(
+        engine_x_warning = (
             "Engine X execution consistency check skipped: this fill "
             "generated no blockchain_tests_engine fixtures to compare "
             "against (e.g. filling with `-m blockchain_test_engine_x`). "
             "Leaks from pre-alloc group packing are not verified for this "
             "output."
         )
+    if engine_x_warning is not None:
+        logger.warning(engine_x_warning)
+        # Repeated in the terminal summary; a log line alone is easy to
+        # miss.
+        session.config.engine_x_check_warning = engine_x_warning  # type: ignore[attr-defined] # noqa: E501
     _log_timing(f"verify_engine_x_execution: done in {time.time() - t0:.1f}s")
 
     # Verify fixtures after merge if verification is enabled

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1678,6 +1678,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                         chain_id=ChainConfigDefaults.chain_id,
                         environment=genesis_environment,
                         pre=pre,
+                        group_salt=group_salt,
                     )
                     return  # Skip fixture generation in phase 1
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -63,6 +63,7 @@ from execution_testing.fixtures import (
 from execution_testing.fixtures.pre_alloc_groups import (
     _get_worker_id,
     merge_partial_group_files,
+    pack_pre_alloc_groups,
 )
 from execution_testing.forks import (
     Fork,
@@ -159,6 +160,11 @@ class FillingSession:
     filling_phase: FixtureFillingPhase
     pre_alloc_groups: PreAllocGroups | None = None
     pre_alloc_group_builders: PreAllocGroupBuilders | None = None
+    # Phase 2 reverse index: test id -> packed pre-alloc group hash. Packing
+    # (see pack_pre_alloc_groups) makes a group's hash depend on the whole set
+    # of tests it holds, so it can no longer be recomputed per-test; a test
+    # finds its group through the authoritative `testIds` lists instead.
+    _test_group_index: Dict[str, str] | None = field(default=None, repr=False)
 
     @classmethod
     def from_config(
@@ -287,6 +293,34 @@ class FillingSession:
             )
 
         return self.pre_alloc_groups[hash_key]
+
+    def group_hash_for_test(self, test_id: str) -> str:
+        """
+        Return the packed pre-alloc group hash that owns ``test_id``.
+
+        Built once (per worker) by inverting the ``testIds`` lists of the
+        packed group files written at the end of phase 1.
+        """
+        if self._test_group_index is None:
+            self._test_group_index = self._build_test_group_index()
+        try:
+            return self._test_group_index[test_id]
+        except KeyError:
+            raise ValueError(
+                f"Test {test_id!r} was not assigned to any pre-allocation "
+                "group. Ensure phase 1 (--generate-pre-alloc-groups) ran over "
+                "the same test selection as phase 2."
+            ) from None
+
+    def _build_test_group_index(self) -> Dict[str, str]:
+        """Map every test id to the hash of the group file that contains it."""
+        folder = self.fixture_output.pre_alloc_groups_folder_path
+        index: Dict[str, str] = {}
+        for file in folder.glob("*.json"):
+            data = json.loads(file.read_text())
+            for test_id in data.get("testIds", []):
+                index[test_id] = file.stem
+        return index
 
     def save_pre_alloc_groups(self) -> None:
         """Save pre-allocation groups to disk as partial files."""
@@ -1653,11 +1687,11 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     FixtureFillingPhase.PRE_ALLOC_GENERATION
                     in fixture_format.format_phases
                 ):
-                    pre_alloc_hash = pre.compute_pre_alloc_group_hash(
-                        fork=fork,
-                        genesis_environment=self.get_genesis_environment(),
-                        group_salt=group_salt,
-                    )
+                    # Groups are packed after phase 1, so a test's group hash
+                    # can no longer be recomputed from its own pre; look it up
+                    # by test id instead.
+                    test_id = _strip_xdist_group_suffix(request.node.nodeid)
+                    pre_alloc_hash = session.group_hash_for_test(test_id)
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
                 fill_result: FillResult | None = None
@@ -2103,6 +2137,13 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             merge_partial_group_files(pre_alloc_folder)
             _log_timing(
                 f"Phase 1 (master): merge done in {time.time() - t0:.1f}s"
+            )
+            # Pack the fine-grained groups into fewer, larger ones so Engine X
+            # boots one client for many tests instead of one per test.
+            t0 = time.time()
+            pack_pre_alloc_groups(pre_alloc_folder)
+            _log_timing(
+                f"Phase 1 (master): pack done in {time.time() - t0:.1f}s"
             )
         else:
             # Workers: clear in-memory state to reduce memory pressure while

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -65,9 +65,11 @@ from execution_testing.fixtures.engine_x_checks import (
     verify_engine_x_execution,
 )
 from execution_testing.fixtures.pre_alloc_groups import (
+    GroupIndexEntry,
     _get_worker_id,
     merge_partial_group_files,
     pack_pre_alloc_groups,
+    packed_group_hash_for_test,
     read_test_group_index,
 )
 from execution_testing.forks import (
@@ -165,12 +167,14 @@ class FillingSession:
     filling_phase: FixtureFillingPhase
     pre_alloc_groups: PreAllocGroups | None = None
     pre_alloc_group_builders: PreAllocGroupBuilders | None = None
-    # Phase 2 reverse index: test id -> packed pre-alloc group hash. Packing
+    # Phase 2 reverse index: test id -> packed pre-alloc group. Packing
     # (see pack_pre_alloc_groups) makes a group's hash depend on the whole set
     # of tests it holds, so it can no longer be recomputed per-test; a test
     # finds its group through the packed index file instead (see
     # read_test_group_index).
-    _test_group_index: Dict[str, str] | None = field(default=None, repr=False)
+    _test_group_index: Dict[str, GroupIndexEntry] | None = field(
+        default=None, repr=False
+    )
 
     @classmethod
     def from_config(
@@ -300,25 +304,23 @@ class FillingSession:
 
         return self.pre_alloc_groups[hash_key]
 
-    def group_hash_for_test(self, test_id: str) -> str:
+    def group_hash_for_test(self, test_id: str, phase1_hash: str) -> str:
         """
         Return the packed pre-alloc group hash that owns ``test_id``.
 
         Loaded once (per worker) from the index file written by
-        `pack_pre_alloc_groups` at the end of phase 1.
+        `pack_pre_alloc_groups` at the end of phase 1. ``phase1_hash`` is
+        the test's fine-grained group hash recomputed from its current
+        content, so a stale pre-alloc folder fails loudly (see
+        `packed_group_hash_for_test`).
         """
         if self._test_group_index is None:
             self._test_group_index = read_test_group_index(
                 self.fixture_output.pre_alloc_groups_folder_path
             )
-        try:
-            return self._test_group_index[test_id]
-        except KeyError:
-            raise ValueError(
-                f"Test {test_id!r} was not assigned to any pre-allocation "
-                "group. Ensure phase 1 (--generate-pre-alloc-groups) ran over "
-                "the same test selection as phase 2."
-            ) from None
+        return packed_group_hash_for_test(
+            self._test_group_index, test_id, phase1_hash
+        )
 
     def save_pre_alloc_groups(self) -> None:
         """Save pre-allocation groups to disk as partial files."""
@@ -1688,9 +1690,19 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                 ):
                     # Groups are packed after phase 1, so a test's group hash
                     # can no longer be recomputed from its own pre; look it up
-                    # by test id instead.
+                    # by test id instead, fingerprinted by the recomputed
+                    # phase 1 hash so a stale group folder fails loudly.
                     test_id = _strip_xdist_group_suffix(request.node.nodeid)
-                    pre_alloc_hash = session.group_hash_for_test(test_id)
+                    pre_alloc_hash = session.group_hash_for_test(
+                        test_id,
+                        phase1_hash=pre.compute_pre_alloc_group_hash(
+                            fork=fork,
+                            genesis_environment=(
+                                self.get_genesis_environment()
+                            ),
+                            group_salt=group_salt,
+                        ),
+                    )
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
                 fill_result: FillResult | None = None

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -60,6 +60,10 @@ from execution_testing.fixtures import (
     merge_partial_fixture_files,
     strip_fixture_format_from_node,
 )
+from execution_testing.fixtures.engine_x_checks import (
+    ENGINE_X_FIXTURES_DIR,
+    verify_engine_x_execution,
+)
 from execution_testing.fixtures.pre_alloc_groups import (
     _get_worker_id,
     merge_partial_group_files,
@@ -2200,6 +2204,25 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         for file in lock_files:
             file.unlink()
         _log_timing(f"Lock files removed in {time.time() - t0:.1f}s")
+
+    # Loudly fail the fill if pre-alloc group packing changed any Engine X
+    # test's execution (raises on drift, like a pre-alloc collision).
+    _log_timing("verify_engine_x_execution: starting...")
+    t0 = time.time()
+    engine_x_check_summary = verify_engine_x_execution(
+        fixture_output.directory
+    )
+    if engine_x_check_summary is not None:
+        logger.info(engine_x_check_summary)
+    elif (fixture_output.directory / ENGINE_X_FIXTURES_DIR).is_dir():
+        logger.warning(
+            "Engine X execution consistency check skipped: this fill "
+            "generated no blockchain_tests_engine fixtures to compare "
+            "against (e.g. filling with `-m blockchain_test_engine_x`). "
+            "Leaks from pre-alloc group packing are not verified for this "
+            "output."
+        )
+    _log_timing(f"verify_engine_x_execution: done in {time.time() - t0:.1f}s")
 
     # Verify fixtures after merge if verification is enabled
     if session.config.getoption("verify_fixtures"):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -64,6 +64,7 @@ from execution_testing.fixtures.pre_alloc_groups import (
     _get_worker_id,
     merge_partial_group_files,
     pack_pre_alloc_groups,
+    read_test_group_index,
 )
 from execution_testing.forks import (
     Fork,
@@ -163,7 +164,8 @@ class FillingSession:
     # Phase 2 reverse index: test id -> packed pre-alloc group hash. Packing
     # (see pack_pre_alloc_groups) makes a group's hash depend on the whole set
     # of tests it holds, so it can no longer be recomputed per-test; a test
-    # finds its group through the authoritative `testIds` lists instead.
+    # finds its group through the packed index file instead (see
+    # read_test_group_index).
     _test_group_index: Dict[str, str] | None = field(default=None, repr=False)
 
     @classmethod
@@ -298,11 +300,13 @@ class FillingSession:
         """
         Return the packed pre-alloc group hash that owns ``test_id``.
 
-        Built once (per worker) by inverting the ``testIds`` lists of the
-        packed group files written at the end of phase 1.
+        Loaded once (per worker) from the index file written by
+        `pack_pre_alloc_groups` at the end of phase 1.
         """
         if self._test_group_index is None:
-            self._test_group_index = self._build_test_group_index()
+            self._test_group_index = read_test_group_index(
+                self.fixture_output.pre_alloc_groups_folder_path
+            )
         try:
             return self._test_group_index[test_id]
         except KeyError:
@@ -311,16 +315,6 @@ class FillingSession:
                 "group. Ensure phase 1 (--generate-pre-alloc-groups) ran over "
                 "the same test selection as phase 2."
             ) from None
-
-    def _build_test_group_index(self) -> Dict[str, str]:
-        """Map every test id to the hash of the group file that contains it."""
-        folder = self.fixture_output.pre_alloc_groups_folder_path
-        index: Dict[str, str] = {}
-        for file in folder.glob("*.json"):
-            data = json.loads(file.read_text())
-            for test_id in data.get("testIds", []):
-                index[test_id] = file.stem
-        return index
 
     def save_pre_alloc_groups(self) -> None:
         """Save pre-allocation groups to disk as partial files."""

--- a/packages/testing/src/execution_testing/fixtures/__init__.py
+++ b/packages/testing/src/execution_testing/fixtures/__init__.py
@@ -28,6 +28,7 @@ from .pre_alloc_groups import (
     PreAllocGroupBuilder,
     PreAllocGroupBuilders,
     PreAllocGroups,
+    pack_pre_alloc_groups,
 )
 from .state import StateFixture
 from .transaction import TransactionFixture
@@ -57,4 +58,5 @@ __all__ = [
     "TestInfo",
     "TransactionFixture",
     "merge_partial_fixture_files",
+    "pack_pre_alloc_groups",
 ]

--- a/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
@@ -1,0 +1,142 @@
+"""Fill-time execution-consistency check for Engine X fixtures."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+ENGINE_X_FIXTURES_DIR = "blockchain_tests_engine_x"
+SIBLING_FIXTURES_DIR = "blockchain_tests_engine"
+
+# Every state-root-derived field of an execution payload. These are the only
+# fields a packed (merged) genesis is allowed to change; everything else in a
+# payload is a pure function of the test's execution.
+_STATE_ROOT_DERIVED_FIELDS = ("stateRoot", "blockHash", "parentHash")
+
+
+class EngineXExecutionDriftError(Exception):
+    """
+    A packed pre-allocation group changed a test's execution.
+
+    An Engine X fixture is filled against its group's merged genesis, while
+    the test's `blockchain_test_engine` sibling is filled against the test's
+    own pre-allocation. Their per-payload execution outputs (gas used,
+    receipts root, logs bloom, ...) must be identical; a difference means an
+    account introduced by pre-alloc group packing leaked into the test's
+    execution (see `pack_pre_alloc_groups`).
+    """
+
+    def __init__(self, mismatches: List[Tuple[str, str]], compared: int):
+        """Initialize with the mismatched test ids and the compared count."""
+        self.mismatches = mismatches
+        self.compared = compared
+        details = "\n".join(
+            f"  {test_id}: {what}" for test_id, what in mismatches[:10]
+        )
+        if len(mismatches) > 10:
+            details += f"\n  ... and {len(mismatches) - 10} more"
+        super().__init__(
+            f"{len(mismatches)} of {compared} Engine X fixtures execute "
+            "differently against their packed pre-allocation group's genesis "
+            "than against their own pre-allocation:\n"
+            f"{details}\n"
+            "An account introduced by pre-alloc group packing leaked into "
+            "these tests' execution. Isolate the affected tests with "
+            "@pytest.mark.pre_alloc_group and re-fill."
+        )
+
+
+def _scrubbed_payloads(fixture: Dict[str, Any]) -> List[Any]:
+    """Return the fixture's payload entries minus state-root-derived fields."""
+    payloads = []
+    for entry in fixture.get("engineNewPayloads", []):
+        entry = json.loads(json.dumps(entry))
+        params = entry.get("params")
+        if params and isinstance(params[0], dict):
+            for field in _STATE_ROOT_DERIVED_FIELDS:
+                params[0].pop(field, None)
+        payloads.append(entry)
+    return payloads
+
+
+def _describe_mismatch(base: List[Any], packed: List[Any]) -> str:
+    """Return a short description of the first difference between payloads."""
+    if len(base) != len(packed):
+        return f"payload count: {len(base)} != {len(packed)}"
+    for i, (base_entry, packed_entry) in enumerate(
+        zip(base, packed, strict=False)
+    ):
+        if base_entry == packed_entry:
+            continue
+        base_payload = base_entry.get("params", [{}])[0]
+        packed_payload = packed_entry.get("params", [{}])[0]
+        if isinstance(base_payload, dict) and isinstance(packed_payload, dict):
+            fields = sorted(
+                field
+                for field in set(base_payload) | set(packed_payload)
+                if base_payload.get(field) != packed_payload.get(field)
+            )
+            if fields:
+                return f"payload {i} differs in: {', '.join(fields)}"
+        return f"payload {i} differs"
+    return "payloads differ"
+
+
+def verify_engine_x_execution(output_dir: Path) -> Optional[str]:
+    """
+    Verify that pre-alloc group packing did not change any test's execution.
+
+    For every Engine X fixture (filled against its packed group's merged
+    genesis), compare its `engineNewPayloads` against the test's
+    `blockchain_test_engine` sibling fixture (filled against the test's own
+    pre-allocation in the same session, with an independent `t8n` execution:
+    Engine X fixtures never share the transition tool output cache). All
+    payload fields except the state-root-derived ones must match exactly.
+
+    Return a summary string, or ``None`` when the check cannot run (no
+    Engine X fixtures, or no sibling fixtures to compare against, e.g. when
+    filling with ``-m blockchain_test_engine_x``).
+
+    Raise `EngineXExecutionDriftError` if any test executed differently.
+    """
+    engine_x_dir = output_dir / ENGINE_X_FIXTURES_DIR
+    sibling_dir = output_dir / SIBLING_FIXTURES_DIR
+    if not engine_x_dir.is_dir() or not sibling_dir.is_dir():
+        return None
+
+    compared = 0
+    skipped = 0
+    mismatches: List[Tuple[str, str]] = []
+    for engine_x_file in engine_x_dir.rglob("*.json"):
+        if "pre_alloc" in engine_x_file.parts:
+            continue
+        sibling_file = sibling_dir / engine_x_file.relative_to(engine_x_dir)
+        sibling_fixtures = (
+            json.loads(sibling_file.read_text())
+            if sibling_file.exists()
+            else {}
+        )
+        for test_id, fixture in json.loads(engine_x_file.read_text()).items():
+            sibling_id = test_id.replace(
+                "blockchain_test_engine_x", "blockchain_test_engine"
+            )
+            sibling = sibling_fixtures.get(sibling_id)
+            if sibling is None:
+                skipped += 1
+                continue
+            compared += 1
+            base = _scrubbed_payloads(sibling)
+            packed = _scrubbed_payloads(fixture)
+            if base != packed:
+                mismatches.append((test_id, _describe_mismatch(base, packed)))
+
+    if mismatches:
+        raise EngineXExecutionDriftError(mismatches, compared)
+    if compared == 0:
+        return None
+    summary = (
+        f"{compared} Engine X fixtures execute identically against their "
+        "packed group's genesis"
+    )
+    if skipped:
+        summary += f" ({skipped} skipped: no sibling engine fixture)"
+    return summary

--- a/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
@@ -110,6 +110,14 @@ def verify_engine_x_execution(output_dir: Path) -> Optional[str]:
         if "pre_alloc" in engine_x_file.parts:
             continue
         sibling_file = sibling_dir / engine_x_file.relative_to(engine_x_dir)
+        if not sibling_file.exists():
+            # A --single-fixture-per-file fill embeds the fixture format
+            # name in every file name, so the sibling's basename differs.
+            sibling_file = sibling_file.with_name(
+                sibling_file.name.replace(
+                    "blockchain_test_engine_x", "blockchain_test_engine"
+                )
+            )
         sibling_fixtures = (
             json.loads(sibling_file.read_text())
             if sibling_file.exists()

--- a/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 ENGINE_X_FIXTURES_DIR = "blockchain_tests_engine_x"
 SIBLING_FIXTURES_DIR = "blockchain_tests_engine"
@@ -45,6 +45,24 @@ class EngineXExecutionDriftError(Exception):
         )
 
 
+class EngineXCheckResult(NamedTuple):
+    """Comparison counts from a completed Engine X execution check."""
+
+    compared: int
+    skipped: int
+
+    @property
+    def summary(self) -> str:
+        """Return a one-line summary of the check for the fill log."""
+        summary = (
+            f"{self.compared} Engine X fixtures execute identically "
+            "against their packed group's genesis"
+        )
+        if self.skipped:
+            summary += f" ({self.skipped} skipped: no sibling engine fixture)"
+        return summary
+
+
 def _scrubbed_payloads(fixture: Dict[str, Any]) -> List[Any]:
     """Return the fixture's payload entries minus state-root-derived fields."""
     payloads = []
@@ -81,7 +99,9 @@ def _describe_mismatch(base: List[Any], packed: List[Any]) -> str:
     return "payloads differ"
 
 
-def verify_engine_x_execution(output_dir: Path) -> Optional[str]:
+def verify_engine_x_execution(
+    output_dir: Path,
+) -> Optional[EngineXCheckResult]:
     """
     Verify that pre-alloc group packing did not change any test's execution.
 
@@ -92,9 +112,9 @@ def verify_engine_x_execution(output_dir: Path) -> Optional[str]:
     Engine X fixtures never share the transition tool output cache). All
     payload fields except the state-root-derived ones must match exactly.
 
-    Return a summary string, or ``None`` when the check cannot run (no
-    Engine X fixtures, or no sibling fixtures to compare against, e.g. when
-    filling with ``-m blockchain_test_engine_x``).
+    Return the comparison counts, or ``None`` when one of the two fixture
+    format trees was not generated at all (e.g. when filling with
+    ``-m blockchain_test_engine_x``, which produces no siblings).
 
     Raise `EngineXExecutionDriftError` if any test executed differently.
     """
@@ -139,12 +159,4 @@ def verify_engine_x_execution(output_dir: Path) -> Optional[str]:
 
     if mismatches:
         raise EngineXExecutionDriftError(mismatches, compared)
-    if compared == 0:
-        return None
-    summary = (
-        f"{compared} Engine X fixtures execute identically against their "
-        "packed group's genesis"
-    )
-    if skipped:
-        summary += f" ({skipped} skipped: no sibling engine fixture)"
-    return summary
+    return EngineXCheckResult(compared=compared, skipped=skipped)

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -290,10 +290,11 @@ def packed_group_hash_for_test(
     return entry.group_hash
 
 
-# Addresses below this value are precompiles / the reserved range. A ported
-# state test can call them without ever declaring them in its pre, so an
-# account introduced there by another test in the group silently changes its
-# execution.
+# Blanket-reserved low address range. A ported state test can blindly call
+# a low address without ever declaring it in its pre, so an account
+# introduced there by another test in the group silently changes its
+# execution. Precompiles at or above this range (EIP-7951 puts P256VERIFY
+# at 0x100) are reserved via the bucket fork's precompile list instead.
 _RESERVED_ADDRESS_CEILING = 0x100
 
 
@@ -305,15 +306,22 @@ def _reserved_addresses(builders: List["PreAllocGroupBuilder"]) -> Set[str]:
     A ported state test only declares the accounts it sets and assumes all
     other addresses are empty, so introducing an account at an address it
     quietly depends on (a precompile, a canonical scratch contract, ...)
-    changes its result. Two kinds of address are therefore reserved: the low
-    precompile range, and any address more than one group allocates (i.e. a
-    shared/canonical address rather than one private to a single test).
+    changes its result. Three kinds of address are therefore reserved: the
+    blanket low range, the fork's precompile addresses (which extend beyond
+    that range from EIP-7951's P256VERIFY at ``0x100`` on), and any address
+    more than one group allocates (i.e. a shared/canonical address rather
+    than one private to a single test).
     """
+    # Packing buckets by fork, so every builder shares this one; a
+    # transition fork reserves the post-transition precompiles, matching
+    # the genesis built by `PreAllocGroupBuilders.add_test_pre`.
+    fork = builders[0].fork.transitions_to()
+    reserved = {str(address) for address in fork.precompiles()}
     frequency: Dict[str, int] = defaultdict(int)
     for builder in builders:
         for address in builder.pre.root:
             frequency[str(address)] += 1
-    return {
+    return reserved | {
         address
         for address, count in frequency.items()
         if count > 1 or int(address, 16) < _RESERVED_ADDRESS_CEILING

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -43,6 +43,13 @@ class PreAllocGroupBuilder(CamelModel):
     )
     fork: Fork | TransitionFork = Field(..., alias="network")
     chain_id: int = DEFAULT_CHAIN_ID
+    group_salt: str | None = Field(
+        None,
+        description=(
+            "Explicit isolation salt from the `pre_alloc_group` marker; "
+            "groups only pack with groups carrying the same salt."
+        ),
+    )
     pre: Alloc
 
     def get_pre_account_count(self) -> int:
@@ -77,6 +84,7 @@ class PreAllocGroupBuilder(CamelModel):
             environment=self.environment,
             fork=self.fork,
             chain_id=self.chain_id,
+            group_salt=self.group_salt,
             pre=self.pre.model_dump(),
             pre_account_count=self.get_pre_account_count(),
             test_count=self.get_test_count(),
@@ -270,14 +278,15 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     genuine address conflicts require. `groupstats` shows this dominates the
     group count, with most groups a single test.
 
-    This pass reclaims that while preserving each test's isolation. Groups are
-    bucketed by everything a shared genesis requires (fork, chain id, and
-    environment) and then by their reserved-address footprint (see
-    `_reserved_addresses`), so two tests only share a genesis when they agree
-    on every precompile and shared address. Within a bucket the reserved
-    accounts are identical and the remaining (test-private) addresses are
-    unique to one group, so the union is always conflict-free and the whole
-    bucket collapses to a single group.
+    This pass reclaims that while preserving each test's isolation. Groups
+    are bucketed by everything a shared genesis requires (fork, chain id, and
+    environment), by the explicit `pre_alloc_group` marker salt (so a test
+    that demands its own genesis keeps it), and then by their
+    reserved-address footprint (see `_reserved_addresses`), so two tests only
+    share a genesis when they agree on every precompile and shared address.
+    Within a bucket the reserved accounts are identical and the remaining
+    (test-private) addresses are unique to one group, so the union is always
+    conflict-free and the whole bucket collapses to a single group.
 
     The packing is deterministic: buckets are processed in sorted order and
     each group's id is derived from its sorted test ids, so a re-fill of the
@@ -295,14 +304,15 @@ def pack_pre_alloc_groups(folder: Path) -> None:
         for file in files
     ]
 
-    genesis_buckets: Dict[Tuple[str, int, str], List[PreAllocGroupBuilder]] = (
-        defaultdict(list)
-    )
+    genesis_buckets: Dict[
+        Tuple[str, int, str, str], List[PreAllocGroupBuilder]
+    ] = defaultdict(list)
     for builder in builders:
         genesis_buckets[
             (
                 builder.fork.name(),
                 builder.chain_id,
+                builder.group_salt or "",
                 _environment_group_key(builder.environment),
             )
         ].append(builder)
@@ -368,6 +378,7 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
         chain_id: int,
         environment: Environment,
         pre: Alloc,
+        group_salt: str | None = None,
     ) -> None:
         """Adds a single test to the appropriate group based on the hash."""
         if pre_alloc_hash in self.root:
@@ -379,6 +390,9 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
             assert group.chain_id == chain_id, (
                 f"Incompatible chain id: {group.chain_id}!={chain_id}"
             )
+            assert group.group_salt == group_salt, (
+                f"Incompatible group salt: {group.group_salt}!={group_salt}"
+            )
             group.add_test_alloc(test_id, pre)
         else:
             # Create new group - use Environment instead of expensive genesis
@@ -388,6 +402,7 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
                 fork=fork,
                 chain_id=chain_id,
                 environment=environment,
+                group_salt=group_salt,
                 pre=Alloc.merge(
                     Alloc.model_validate(
                         fork.transitions_to().pre_allocation_blockchain()

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -212,6 +212,31 @@ def _packed_group_hash(test_ids: List[str]) -> str:
     return f"0x{int.from_bytes(digest[:8], byteorder='big'):016x}"
 
 
+# The test id -> group hash index written next to the group files by
+# `pack_pre_alloc_groups`. Deliberately not a `*.json` name: every consumer
+# of the folder (including this module) discovers group files by that glob.
+TEST_GROUP_INDEX_FILE = "test_group_index"
+
+
+def read_test_group_index(folder: Path) -> Dict[str, str]:
+    """
+    Map every test id to the hash of the pre-alloc group that contains it.
+
+    Prefer the index file written by `pack_pre_alloc_groups`; fall back to
+    scanning every group file's ``testIds`` for folders produced without a
+    packing pass (e.g. by an older framework version).
+    """
+    index_file = folder / TEST_GROUP_INDEX_FILE
+    if index_file.exists():
+        return json.loads(index_file.read_text())
+    index: Dict[str, str] = {}
+    for file in folder.glob("*.json"):
+        data = json.loads(file.read_text())
+        for test_id in data.get("testIds", []):
+            index[test_id] = file.stem
+    return index
+
+
 # Addresses below this value are precompiles / the reserved range. A ported
 # state test can call them without ever declaring them in its pre, so an
 # account introduced there by another test in the group silently changes its
@@ -293,7 +318,9 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     same tests reproduces the same groups.
 
     Called on the master process after `merge_partial_group_files`, replacing
-    the fine-grained files in `folder` with the packed ones.
+    the fine-grained files in `folder` with the packed ones. Also writes a
+    test id -> group hash index file (see `read_test_group_index`), so phase
+    2 workers can find a test's group without scanning every group file.
     """
     files = sorted(folder.glob("*.json"))
     if not files:
@@ -322,6 +349,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     for file in files:
         file.unlink()
 
+    test_group_index: Dict[str, str] = {}
     for genesis_key in sorted(genesis_buckets):
         bucket = genesis_buckets[genesis_key]
         reserved = _reserved_addresses(bucket)
@@ -344,6 +372,12 @@ def pack_pre_alloc_groups(folder: Path) -> None:
                     by_alias=True, exclude_none=True, indent=2
                 )
             )
+            for test_id in merged.test_ids:
+                test_group_index[test_id] = packed_hash
+
+    (folder / TEST_GROUP_INDEX_FILE).write_text(
+        json.dumps(test_group_index, sort_keys=True, indent=2)
+    )
 
 
 class PreAllocGroupBuilders(EthereumTestRootModel):

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     Optional,
     Self,
+    Set,
     Tuple,
 )
 
@@ -203,6 +204,61 @@ def _packed_group_hash(test_ids: List[str]) -> str:
     return f"0x{int.from_bytes(digest[:8], byteorder='big'):016x}"
 
 
+# Addresses below this value are precompiles / the reserved range. A ported
+# state test can call them without ever declaring them in its pre, so an
+# account introduced there by another test in the group silently changes its
+# execution.
+_RESERVED_ADDRESS_CEILING = 0x100
+
+
+def _reserved_addresses(builders: List["PreAllocGroupBuilder"]) -> Set[str]:
+    """
+    Return the addresses that are unsafe to introduce via a merge.
+
+    A shared genesis leaks every account it holds to every test in the group.
+    A ported state test only declares the accounts it sets and assumes all
+    other addresses are empty, so introducing an account at an address it
+    quietly depends on (a precompile, a canonical scratch contract, ...)
+    changes its result. Two kinds of address are therefore reserved: the low
+    precompile range, and any address more than one group allocates (i.e. a
+    shared/canonical address rather than one private to a single test).
+    """
+    frequency: Dict[str, int] = defaultdict(int)
+    for builder in builders:
+        for address in builder.pre.root:
+            frequency[str(address)] += 1
+    return {
+        address
+        for address, count in frequency.items()
+        if count > 1 or int(address, 16) < _RESERVED_ADDRESS_CEILING
+    }
+
+
+def _reserved_signature(
+    builder: "PreAllocGroupBuilder", reserved: Set[str]
+) -> Tuple[Tuple[str, str], ...]:
+    """
+    Return a group's reserved-address footprint as a hashable signature.
+
+    Groups may only merge when this matches exactly, so every test in a packed
+    group sees identical reserved accounts (and identically absent ones).
+    """
+    return tuple(
+        sorted(
+            (
+                str(address),
+                "null"
+                if account is None
+                else json.dumps(
+                    account.model_dump(mode="json"), sort_keys=True
+                ),
+            )
+            for address, account in builder.pre.root.items()
+            if str(address) in reserved
+        )
+    )
+
+
 def pack_pre_alloc_groups(folder: Path) -> None:
     """
     Merge fine-grained pre-allocation groups into fewer, larger ones.
@@ -214,15 +270,18 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     genuine address conflicts require. `groupstats` shows this dominates the
     group count, with most groups a single test.
 
-    This pass reclaims that. It buckets the already-merged Phase 1 groups by
-    everything that must match for a shared genesis (fork, chain id, and
-    environment) and greedily packs each bucket's groups into as few
-    super-groups as possible, only keeping two apart when their pre-allocations
-    genuinely conflict (the same address needing two different accounts).
+    This pass reclaims that while preserving each test's isolation. Groups are
+    bucketed by everything a shared genesis requires (fork, chain id, and
+    environment) and then by their reserved-address footprint (see
+    `_reserved_addresses`), so two tests only share a genesis when they agree
+    on every precompile and shared address. Within a bucket the reserved
+    accounts are identical and the remaining (test-private) addresses are
+    unique to one group, so the union is always conflict-free and the whole
+    bucket collapses to a single group.
 
-    The packing is deterministic: buckets and their members are processed in
-    sorted order and each super-group's id is derived from its sorted test ids,
-    so a re-fill of the same tests reproduces the same groups.
+    The packing is deterministic: buckets are processed in sorted order and
+    each group's id is derived from its sorted test ids, so a re-fill of the
+    same tests reproduces the same groups.
 
     Called on the master process after `merge_partial_group_files`, replacing
     the fine-grained files in `folder` with the packed ones.
@@ -231,52 +290,47 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     if not files:
         return
 
-    builders: List[Tuple[str, PreAllocGroupBuilder]] = [
-        (file.stem, PreAllocGroupBuilder.model_validate_json(file.read_text()))
+    builders = [
+        PreAllocGroupBuilder.model_validate_json(file.read_text())
         for file in files
     ]
 
-    buckets: Dict[
-        Tuple[str, int, str], List[Tuple[str, PreAllocGroupBuilder]]
-    ] = defaultdict(list)
-    for stem, builder in builders:
-        bucket_key = (
-            builder.fork.name(),
-            builder.chain_id,
-            _environment_group_key(builder.environment),
-        )
-        buckets[bucket_key].append((stem, builder))
+    genesis_buckets: Dict[Tuple[str, int, str], List[PreAllocGroupBuilder]] = (
+        defaultdict(list)
+    )
+    for builder in builders:
+        genesis_buckets[
+            (
+                builder.fork.name(),
+                builder.chain_id,
+                _environment_group_key(builder.environment),
+            )
+        ].append(builder)
 
     # Drop the fine-grained files up front; the packed files written below are
     # named by content hash and never clash with the (now stale) originals.
     for file in files:
         file.unlink()
 
-    for bucket_key in sorted(buckets):
-        # Sort members by their (deterministic) Phase 1 hash for a stable
-        # first-fit order.
-        members = sorted(buckets[bucket_key], key=lambda item: item[0])
-        super_groups: List[PreAllocGroupBuilder] = []
-        for _stem, builder in members:
-            candidate = builder.pre.root
-            for super_group in super_groups:
-                accounts = super_group.pre.root
-                if any(
-                    address in accounts and accounts[address] != account
-                    for address, account in candidate.items()
-                ):
-                    continue  # Real conflict: try the next super-group.
-                accounts.update(candidate)
-                super_group.test_ids.extend(builder.test_ids)
-                break
-            else:
-                super_groups.append(builder)
+    for genesis_key in sorted(genesis_buckets):
+        bucket = genesis_buckets[genesis_key]
+        reserved = _reserved_addresses(bucket)
 
-        for super_group in super_groups:
-            super_group.test_ids.sort()
-            packed_hash = _packed_group_hash(super_group.test_ids)
+        packed: Dict[Tuple[Tuple[str, str], ...], PreAllocGroupBuilder] = {}
+        for builder in bucket:
+            signature = _reserved_signature(builder, reserved)
+            if signature in packed:
+                merged = packed[signature]
+                merged.pre.root.update(builder.pre.root)
+                merged.test_ids.extend(builder.test_ids)
+            else:
+                packed[signature] = builder
+
+        for merged in packed.values():
+            merged.test_ids.sort()
+            packed_hash = _packed_group_hash(merged.test_ids)
             (folder / f"{packed_hash}.json").write_text(
-                super_group.model_dump_json(
+                merged.model_dump_json(
                     by_alias=True, exclude_none=True, indent=2
                 )
             )

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -14,6 +14,7 @@ from typing import (
     KeysView,
     List,
     Literal,
+    NamedTuple,
     Optional,
     Self,
     Set,
@@ -218,23 +219,75 @@ def _packed_group_hash(test_ids: List[str]) -> str:
 TEST_GROUP_INDEX_FILE = "test_group_index"
 
 
-def read_test_group_index(folder: Path) -> Dict[str, str]:
+class GroupIndexEntry(NamedTuple):
     """
-    Map every test id to the hash of the pre-alloc group that contains it.
+    A test's entry in the test id -> pre-alloc group index.
+
+    ``group_hash`` names the (packed) group that holds the test.
+    ``phase1_hash`` is the test's fine-grained phase 1 group hash, which
+    phase 2 recomputes from the test's own fork, genesis environment, and
+    pre-allocation to detect a stale group folder (see
+    `packed_group_hash_for_test`); it is ``None`` when the index was
+    reconstructed by scanning group files.
+    """
+
+    group_hash: str
+    phase1_hash: str | None
+
+
+def read_test_group_index(folder: Path) -> Dict[str, GroupIndexEntry]:
+    """
+    Map every test id to the pre-alloc group that contains it.
 
     Prefer the index file written by `pack_pre_alloc_groups`; fall back to
     scanning every group file's ``testIds`` for folders produced without a
-    packing pass (e.g. by an older framework version).
+    packing pass (e.g. by an older framework version). Scanned entries
+    carry no phase 1 fingerprint.
     """
     index_file = folder / TEST_GROUP_INDEX_FILE
     if index_file.exists():
-        return json.loads(index_file.read_text())
-    index: Dict[str, str] = {}
+        return {
+            test_id: GroupIndexEntry(entry["group"], entry["phase1"])
+            for test_id, entry in json.loads(index_file.read_text()).items()
+        }
+    index: Dict[str, GroupIndexEntry] = {}
     for file in folder.glob("*.json"):
         data = json.loads(file.read_text())
         for test_id in data.get("testIds", []):
-            index[test_id] = file.stem
+            index[test_id] = GroupIndexEntry(file.stem, None)
     return index
+
+
+def packed_group_hash_for_test(
+    index: Dict[str, GroupIndexEntry],
+    test_id: str,
+    phase1_hash: str,
+) -> str:
+    """
+    Return the packed group hash owning ``test_id``, verifying freshness.
+
+    ``phase1_hash`` is the test's fine-grained phase 1 group hash,
+    recomputed by phase 2 from the test's current fork, genesis
+    environment, and pre-allocation. A mismatch with the fingerprint
+    recorded by `pack_pre_alloc_groups` means the groups on disk were
+    built from a different version of the test, so phase 2 would fill it
+    against the wrong genesis.
+    """
+    entry = index.get(test_id)
+    if entry is None:
+        raise ValueError(
+            f"Test {test_id!r} was not assigned to any pre-allocation "
+            "group. Ensure phase 1 (--generate-pre-alloc-groups) ran over "
+            "the same test selection as phase 2."
+        )
+    if entry.phase1_hash is not None and entry.phase1_hash != phase1_hash:
+        raise ValueError(
+            f"The pre-allocation groups are stale for test {test_id!r}: "
+            "its pre-allocation or genesis environment changed after they "
+            "were generated. Re-run phase 1 (--generate-pre-alloc-groups) "
+            "to regenerate them."
+        )
+    return entry.group_hash
 
 
 # Addresses below this value are precompiles / the reserved range. A ported
@@ -319,17 +372,22 @@ def pack_pre_alloc_groups(folder: Path) -> None:
 
     Called on the master process after `merge_partial_group_files`, replacing
     the fine-grained files in `folder` with the packed ones. Also writes a
-    test id -> group hash index file (see `read_test_group_index`), so phase
-    2 workers can find a test's group without scanning every group file.
+    test id -> group index file (see `read_test_group_index`), so phase 2
+    workers can find a test's group without scanning every group file; each
+    entry records the test's fine-grained phase 1 hash as a fingerprint so a
+    stale folder is detected (see `packed_group_hash_for_test`).
     """
     files = sorted(folder.glob("*.json"))
     if not files:
         return
 
-    builders = [
-        PreAllocGroupBuilder.model_validate_json(file.read_text())
-        for file in files
-    ]
+    builders = []
+    phase1_hash_by_test: Dict[str, str] = {}
+    for file in files:
+        builder = PreAllocGroupBuilder.model_validate_json(file.read_text())
+        for test_id in builder.test_ids:
+            phase1_hash_by_test[test_id] = file.stem
+        builders.append(builder)
 
     genesis_buckets: Dict[
         Tuple[str, int, str, str], List[PreAllocGroupBuilder]
@@ -349,7 +407,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     for file in files:
         file.unlink()
 
-    test_group_index: Dict[str, str] = {}
+    test_group_index: Dict[str, GroupIndexEntry] = {}
     for genesis_key in sorted(genesis_buckets):
         bucket = genesis_buckets[genesis_key]
         reserved = _reserved_addresses(bucket)
@@ -373,10 +431,22 @@ def pack_pre_alloc_groups(folder: Path) -> None:
                 )
             )
             for test_id in merged.test_ids:
-                test_group_index[test_id] = packed_hash
+                test_group_index[test_id] = GroupIndexEntry(
+                    packed_hash, phase1_hash_by_test[test_id]
+                )
 
     (folder / TEST_GROUP_INDEX_FILE).write_text(
-        json.dumps(test_group_index, sort_keys=True, indent=2)
+        json.dumps(
+            {
+                test_id: {
+                    "group": entry.group_hash,
+                    "phase1": entry.phase1_hash,
+                }
+                for test_id, entry in test_group_index.items()
+            },
+            sort_keys=True,
+            indent=2,
+        )
     )
 
 

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -1,7 +1,9 @@
 """Pre-allocation group models for test fixture generation."""
 
+import hashlib
 import json
 import os
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -175,6 +177,106 @@ def merge_partial_group_files(folder: Path) -> None:
         if merged_builder is not None:
             target_path.write_text(
                 merged_builder.model_dump_json(
+                    by_alias=True, exclude_none=True, indent=2
+                )
+            )
+
+
+def _environment_group_key(environment: Environment) -> str:
+    """
+    Return a stable string identifying a genesis environment.
+
+    Two groups can only share a client if they share a genesis block, so the
+    environment is part of every packing bucket. The canonical JSON dump
+    matches the equality semantics of `Environment` (which compares the
+    alias-keyed, none-excluded dump).
+    """
+    return json.dumps(
+        environment.model_dump(mode="json", by_alias=True, exclude_none=True),
+        sort_keys=True,
+    )
+
+
+def _packed_group_hash(test_ids: List[str]) -> str:
+    """Return a deterministic ``0x``-prefixed id for a packed group."""
+    digest = hashlib.sha256("\n".join(test_ids).encode("utf-8")).digest()
+    return f"0x{int.from_bytes(digest[:8], byteorder='big'):016x}"
+
+
+def pack_pre_alloc_groups(folder: Path) -> None:
+    """
+    Merge fine-grained pre-allocation groups into fewer, larger ones.
+
+    Phase 1 keys every test's group on the exact content of any hard-coded
+    accounts it sets (`modified_accounts_salt`), so a test that pins accounts
+    to fixed addresses lands in its own group even when it could safely share a
+    genesis with others. This is conservative: it splits far more than the
+    genuine address conflicts require. `groupstats` shows this dominates the
+    group count, with most groups a single test.
+
+    This pass reclaims that. It buckets the already-merged Phase 1 groups by
+    everything that must match for a shared genesis (fork, chain id, and
+    environment) and greedily packs each bucket's groups into as few
+    super-groups as possible, only keeping two apart when their pre-allocations
+    genuinely conflict (the same address needing two different accounts).
+
+    The packing is deterministic: buckets and their members are processed in
+    sorted order and each super-group's id is derived from its sorted test ids,
+    so a re-fill of the same tests reproduces the same groups.
+
+    Called on the master process after `merge_partial_group_files`, replacing
+    the fine-grained files in `folder` with the packed ones.
+    """
+    files = sorted(folder.glob("*.json"))
+    if not files:
+        return
+
+    builders: List[Tuple[str, PreAllocGroupBuilder]] = [
+        (file.stem, PreAllocGroupBuilder.model_validate_json(file.read_text()))
+        for file in files
+    ]
+
+    buckets: Dict[
+        Tuple[str, int, str], List[Tuple[str, PreAllocGroupBuilder]]
+    ] = defaultdict(list)
+    for stem, builder in builders:
+        bucket_key = (
+            builder.fork.name(),
+            builder.chain_id,
+            _environment_group_key(builder.environment),
+        )
+        buckets[bucket_key].append((stem, builder))
+
+    # Drop the fine-grained files up front; the packed files written below are
+    # named by content hash and never clash with the (now stale) originals.
+    for file in files:
+        file.unlink()
+
+    for bucket_key in sorted(buckets):
+        # Sort members by their (deterministic) Phase 1 hash for a stable
+        # first-fit order.
+        members = sorted(buckets[bucket_key], key=lambda item: item[0])
+        super_groups: List[PreAllocGroupBuilder] = []
+        for _stem, builder in members:
+            candidate = builder.pre.root
+            for super_group in super_groups:
+                accounts = super_group.pre.root
+                if any(
+                    address in accounts and accounts[address] != account
+                    for address, account in candidate.items()
+                ):
+                    continue  # Real conflict: try the next super-group.
+                accounts.update(candidate)
+                super_group.test_ids.extend(builder.test_ids)
+                break
+            else:
+                super_groups.append(builder)
+
+        for super_group in super_groups:
+            super_group.test_ids.sort()
+            packed_hash = _packed_group_hash(super_group.test_ids)
+            (folder / f"{packed_hash}.json").write_text(
+                super_group.model_dump_json(
                     by_alias=True, exclude_none=True, indent=2
                 )
             )

--- a/packages/testing/src/execution_testing/fixtures/tests/test_engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_engine_x_checks.py
@@ -1,0 +1,157 @@
+"""Tests for the Engine X execution-consistency check."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from execution_testing.fixtures.engine_x_checks import (
+    ENGINE_X_FIXTURES_DIR,
+    SIBLING_FIXTURES_DIR,
+    EngineXExecutionDriftError,
+    verify_engine_x_execution,
+)
+
+ENGINE_X_ID = (
+    "tests/a.py::test_a[fork_Prague-blockchain_test_engine_x_from_state_test]"
+)
+SIBLING_ID = (
+    "tests/a.py::test_a[fork_Prague-blockchain_test_engine_from_state_test]"
+)
+
+
+def _payload(
+    *, gas_used: str, state_root: str, block_hash: str
+) -> Dict[str, Any]:
+    """Build a single newPayload entry."""
+    return {
+        "newPayloadVersion": "4",
+        "forkchoiceUpdatedVersion": "3",
+        "params": [
+            {
+                "parentHash": f"0x{'00' * 31}aa",
+                "stateRoot": state_root,
+                "blockHash": block_hash,
+                "gasUsed": gas_used,
+                "receiptsRoot": f"0x{'11' * 32}",
+                "logsBloom": f"0x{'00' * 256}",
+                "transactions": ["0xf86b..."],
+            },
+            [],
+            f"0x{'00' * 32}",
+        ],
+    }
+
+
+def _write_fixture(
+    folder: Path,
+    fixture_dir: str,
+    test_id: str,
+    payloads: List[Dict[str, Any]],
+) -> None:
+    """Write a single-fixture file into a format tree."""
+    file = folder / fixture_dir / "prague" / "module" / "test_a.json"
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(json.dumps({test_id: {"engineNewPayloads": payloads}}))
+
+
+def test_identical_execution_passes(tmp_path: Path) -> None:
+    """State-root-derived differences alone do not trip the check."""
+    _write_fixture(
+        tmp_path,
+        SIBLING_FIXTURES_DIR,
+        SIBLING_ID,
+        [_payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")],
+    )
+    _write_fixture(
+        tmp_path,
+        ENGINE_X_FIXTURES_DIR,
+        ENGINE_X_ID,
+        [_payload(gas_used="0x5208", state_root="0xaa", block_hash="0xbb")],
+    )
+
+    summary = verify_engine_x_execution(tmp_path)
+
+    assert summary is not None
+    assert "1 Engine X fixtures execute identically" in summary
+
+
+def test_execution_drift_raises(tmp_path: Path) -> None:
+    """A gas difference (a leaked account changed execution) fails loudly."""
+    _write_fixture(
+        tmp_path,
+        SIBLING_FIXTURES_DIR,
+        SIBLING_ID,
+        [_payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")],
+    )
+    _write_fixture(
+        tmp_path,
+        ENGINE_X_FIXTURES_DIR,
+        ENGINE_X_ID,
+        [_payload(gas_used="0xbeef", state_root="0xaa", block_hash="0xbb")],
+    )
+
+    with pytest.raises(EngineXExecutionDriftError) as exc_info:
+        verify_engine_x_execution(tmp_path)
+
+    message = str(exc_info.value)
+    assert ENGINE_X_ID in message
+    assert "gasUsed" in message
+
+
+def test_payload_count_drift_raises(tmp_path: Path) -> None:
+    """A different number of payloads fails loudly."""
+    payload = _payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")
+    _write_fixture(tmp_path, SIBLING_FIXTURES_DIR, SIBLING_ID, [payload])
+    _write_fixture(
+        tmp_path, ENGINE_X_FIXTURES_DIR, ENGINE_X_ID, [payload, payload]
+    )
+
+    with pytest.raises(EngineXExecutionDriftError) as exc_info:
+        verify_engine_x_execution(tmp_path)
+
+    assert "payload count" in str(exc_info.value)
+
+
+def test_no_sibling_fixtures_skips_check(tmp_path: Path) -> None:
+    """An Engine X only fill (no sibling format tree) skips the check."""
+    _write_fixture(
+        tmp_path,
+        ENGINE_X_FIXTURES_DIR,
+        ENGINE_X_ID,
+        [_payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")],
+    )
+
+    assert verify_engine_x_execution(tmp_path) is None
+
+
+def test_no_engine_x_fixtures_skips_check(tmp_path: Path) -> None:
+    """A fill without Engine X fixtures skips the check."""
+    _write_fixture(
+        tmp_path,
+        SIBLING_FIXTURES_DIR,
+        SIBLING_ID,
+        [_payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")],
+    )
+
+    assert verify_engine_x_execution(tmp_path) is None
+
+
+def test_missing_sibling_fixture_is_skipped(tmp_path: Path) -> None:
+    """A test filtered from the sibling format is skipped, not failed."""
+    payload = _payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")
+    _write_fixture(tmp_path, SIBLING_FIXTURES_DIR, SIBLING_ID, [payload])
+    other_engine_x_id = ENGINE_X_ID.replace("test_a[", "test_b[")
+    _write_fixture(tmp_path, ENGINE_X_FIXTURES_DIR, ENGINE_X_ID, [payload])
+    file = (
+        tmp_path / ENGINE_X_FIXTURES_DIR / "prague" / "module" / "test_b.json"
+    )
+    file.write_text(
+        json.dumps({other_engine_x_id: {"engineNewPayloads": [payload]}})
+    )
+
+    summary = verify_engine_x_execution(tmp_path)
+
+    assert summary is not None
+    assert "1 skipped" in summary

--- a/packages/testing/src/execution_testing/fixtures/tests/test_engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_engine_x_checks.py
@@ -71,10 +71,11 @@ def test_identical_execution_passes(tmp_path: Path) -> None:
         [_payload(gas_used="0x5208", state_root="0xaa", block_hash="0xbb")],
     )
 
-    summary = verify_engine_x_execution(tmp_path)
+    result = verify_engine_x_execution(tmp_path)
 
-    assert summary is not None
-    assert "1 Engine X fixtures execute identically" in summary
+    assert result is not None
+    assert result.compared == 1
+    assert "1 Engine X fixtures execute identically" in result.summary
 
 
 def test_execution_drift_raises(tmp_path: Path) -> None:
@@ -167,10 +168,11 @@ def test_single_fixture_per_file_sibling_lookup(tmp_path: Path) -> None:
         json.dumps({ENGINE_X_ID: {"engineNewPayloads": [payload]}})
     )
 
-    summary = verify_engine_x_execution(tmp_path)
+    result = verify_engine_x_execution(tmp_path)
 
-    assert summary is not None
-    assert "1 Engine X fixtures execute identically" in summary
+    assert result is not None
+    assert result.compared == 1
+    assert result.skipped == 0
 
 
 def test_missing_sibling_fixture_is_skipped(tmp_path: Path) -> None:
@@ -186,7 +188,26 @@ def test_missing_sibling_fixture_is_skipped(tmp_path: Path) -> None:
         json.dumps({other_engine_x_id: {"engineNewPayloads": [payload]}})
     )
 
-    summary = verify_engine_x_execution(tmp_path)
+    result = verify_engine_x_execution(tmp_path)
 
-    assert summary is not None
-    assert "1 skipped" in summary
+    assert result is not None
+    assert result.compared == 1
+    assert result.skipped == 1
+    assert "1 skipped" in result.summary
+
+
+def test_no_matching_siblings_reports_skip_count(tmp_path: Path) -> None:
+    """
+    Sibling fixtures exist but none match: The check reports the skip
+    count instead of pretending no siblings were generated.
+    """
+    payload = _payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")
+    other_sibling_id = SIBLING_ID.replace("test_a[", "test_b[")
+    _write_fixture(tmp_path, SIBLING_FIXTURES_DIR, other_sibling_id, [payload])
+    _write_fixture(tmp_path, ENGINE_X_FIXTURES_DIR, ENGINE_X_ID, [payload])
+
+    result = verify_engine_x_execution(tmp_path)
+
+    assert result is not None
+    assert result.compared == 0
+    assert result.skipped == 1

--- a/packages/testing/src/execution_testing/fixtures/tests/test_engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_engine_x_checks.py
@@ -138,6 +138,41 @@ def test_no_engine_x_fixtures_skips_check(tmp_path: Path) -> None:
     assert verify_engine_x_execution(tmp_path) is None
 
 
+def test_single_fixture_per_file_sibling_lookup(tmp_path: Path) -> None:
+    """
+    A `--single-fixture-per-file` fill embeds the fixture format name in
+    every file name; the sibling is still found under its own basename.
+    """
+    payload = _payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")
+    sibling_file = (
+        tmp_path
+        / SIBLING_FIXTURES_DIR
+        / "prague"
+        / "module"
+        / "a__fork_Prague_blockchain_test_engine_from_state_test.json"
+    )
+    sibling_file.parent.mkdir(parents=True, exist_ok=True)
+    sibling_file.write_text(
+        json.dumps({SIBLING_ID: {"engineNewPayloads": [payload]}})
+    )
+    engine_x_file = (
+        tmp_path
+        / ENGINE_X_FIXTURES_DIR
+        / "prague"
+        / "module"
+        / "a__fork_Prague_blockchain_test_engine_x_from_state_test.json"
+    )
+    engine_x_file.parent.mkdir(parents=True, exist_ok=True)
+    engine_x_file.write_text(
+        json.dumps({ENGINE_X_ID: {"engineNewPayloads": [payload]}})
+    )
+
+    summary = verify_engine_x_execution(tmp_path)
+
+    assert summary is not None
+    assert "1 Engine X fixtures execute identically" in summary
+
+
 def test_missing_sibling_fixture_is_skipped(tmp_path: Path) -> None:
     """A test filtered from the sibling format is skipped, not failed."""
     payload = _payload(gas_used="0x5208", state_root="0x01", block_hash="0x02")

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -178,3 +178,105 @@ def test_pack_is_deterministic(tmp_path: Path) -> None:
     pack_pre_alloc_groups(second)
 
     assert set(_packed(first)) == set(_packed(second))
+
+
+def test_pack_isolates_funded_precompile(tmp_path: Path) -> None:
+    """
+    A precompile funded by one test is never merged into a test that
+    assumes it empty (precompiles are in the reserved range).
+    """
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x02: Account(balance=1), 0x9000: Account(balance=1)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x9001: Account(balance=2)},
+        environment=env,
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    packed = _packed(tmp_path)
+    assert len(packed) == 2
+    with_precompile = [
+        g
+        for g in packed.values()
+        if "0x0000000000000000000000000000000000000002" in g["pre"]
+    ]
+    assert len(with_precompile) == 1
+    assert with_precompile[0]["testIds"] == ["tests/a.py::test_a"]
+
+
+def test_pack_merges_when_shared_address_agrees(tmp_path: Path) -> None:
+    """
+    Groups that agree on a shared (canonical) address and differ only in
+    test-private addresses still merge into one.
+    """
+    env = Environment()
+    shared = Account(balance=1, nonce=1)
+    for stem, test_id, private in [
+        ("0x01", "tests/a.py::test_a", 0xA000),
+        ("0x02", "tests/b.py::test_b", 0xB000),
+        ("0x03", "tests/c.py::test_c", 0xC000),
+    ]:
+        _write_group(
+            tmp_path,
+            stem,
+            test_id,
+            {0x9000: shared, private: Account(balance=2)},
+            environment=env,
+        )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    assert len(_packed(tmp_path)) == 1
+
+
+def test_pack_isolates_disagreeing_shared_address(tmp_path: Path) -> None:
+    """
+    A shared address present in some groups but absent from others keeps
+    them apart, so it is never leaked into a test that omits it.
+    """
+    env = Environment()
+    shared = Account(balance=1, nonce=1)
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x9000: shared, 0xA000: Account(balance=2)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x9000: shared, 0xB000: Account(balance=2)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x03",
+        "tests/c.py::test_c",
+        {0xC000: Account(balance=2)},
+        environment=env,
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    packed = _packed(tmp_path)
+    assert len(packed) == 2
+    all_ids = sorted(
+        tid for group in packed.values() for tid in group["testIds"]
+    )
+    assert all_ids == [
+        "tests/a.py::test_a",
+        "tests/b.py::test_b",
+        "tests/c.py::test_c",
+    ]

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -6,8 +6,10 @@ from typing import Dict
 
 from execution_testing.base_types import Account, Address
 from execution_testing.fixtures.pre_alloc_groups import (
+    TEST_GROUP_INDEX_FILE,
     PreAllocGroupBuilder,
     pack_pre_alloc_groups,
+    read_test_group_index,
 )
 from execution_testing.forks import Prague
 from execution_testing.test_types import Alloc, Environment
@@ -228,6 +230,76 @@ def test_pack_merges_groups_with_matching_salt(tmp_path: Path) -> None:
     assert len(packed) == 1
     (group,) = packed.values()
     assert group["groupSalt"] == "shared"
+
+
+def test_pack_writes_test_group_index(tmp_path: Path) -> None:
+    """
+    Packing writes a test id -> group hash index that matches the packed
+    files' ``testIds`` and is not picked up as a group file itself.
+    """
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x2000: Account(balance=2)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x03",
+        "tests/c.py::test_c",
+        {0x1000: Account(balance=3)},
+        environment=env,
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    assert (tmp_path / TEST_GROUP_INDEX_FILE).exists()
+    packed = _packed(tmp_path)
+    assert TEST_GROUP_INDEX_FILE not in packed
+    index = read_test_group_index(tmp_path)
+    assert sorted(index) == [
+        "tests/a.py::test_a",
+        "tests/b.py::test_b",
+        "tests/c.py::test_c",
+    ]
+    for test_id, group_hash in index.items():
+        assert test_id in packed[group_hash]["testIds"]
+
+
+def test_read_test_group_index_falls_back_to_scanning(
+    tmp_path: Path,
+) -> None:
+    """A folder without an index file (unpacked/legacy) is scanned."""
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x2000: Account(balance=2)},
+        environment=env,
+    )
+
+    assert not (tmp_path / TEST_GROUP_INDEX_FILE).exists()
+    assert read_test_group_index(tmp_path) == {
+        "tests/a.py::test_a": "0x01",
+        "tests/b.py::test_b": "0x02",
+    }
 
 
 def test_pack_is_deterministic(tmp_path: Path) -> None:

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -15,7 +15,7 @@ from execution_testing.fixtures.pre_alloc_groups import (
     packed_group_hash_for_test,
     read_test_group_index,
 )
-from execution_testing.forks import Prague
+from execution_testing.forks import Fork, Osaka, Prague
 from execution_testing.test_types import Alloc, Environment
 
 
@@ -27,12 +27,13 @@ def _write_group(
     *,
     environment: Environment,
     group_salt: str | None = None,
+    fork: Fork = Prague,
 ) -> None:
     """Write a single fine-grained group file, as Phase 1 would."""
     builder = PreAllocGroupBuilder(
         test_ids=[test_id],
         environment=environment,
-        fork=Prague,
+        fork=fork,
         group_salt=group_salt,
         pre=Alloc(
             {Address(address): account for address, account in pre.items()}
@@ -422,6 +423,41 @@ def test_pack_isolates_funded_precompile(tmp_path: Path) -> None:
     ]
     assert len(with_precompile) == 1
     assert with_precompile[0]["testIds"] == ["tests/a.py::test_a"]
+
+
+def test_pack_isolates_fork_precompile_above_blanket_range(
+    tmp_path: Path,
+) -> None:
+    """
+    An account pinned at a fork precompile address above the blanket
+    reserved range (P256VERIFY at ``0x100``, EIP-7951) keeps its group
+    isolated on a fork that has the precompile; on an earlier fork the
+    same address is plain scratch space and the groups merge.
+    """
+    env = Environment()
+    for fork, expected_group_count in ((Prague, 1), (Osaka, 2)):
+        folder = tmp_path / fork.name()
+        folder.mkdir()
+        _write_group(
+            folder,
+            "0x01",
+            "tests/a.py::test_a",
+            {0x100: Account(balance=1)},
+            environment=env,
+            fork=fork,
+        )
+        _write_group(
+            folder,
+            "0x02",
+            "tests/b.py::test_b",
+            {0x2000: Account(balance=2)},
+            environment=env,
+            fork=fork,
+        )
+
+        pack_pre_alloc_groups(folder)
+
+        assert len(_packed(folder)) == expected_group_count, fork.name()
 
 
 def test_pack_merges_when_shared_address_agrees(tmp_path: Path) -> None:

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -1,0 +1,180 @@
+"""Tests for conflict-aware packing of pre-allocation groups."""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from execution_testing.base_types import Account, Address
+from execution_testing.fixtures.pre_alloc_groups import (
+    PreAllocGroupBuilder,
+    pack_pre_alloc_groups,
+)
+from execution_testing.forks import Prague
+from execution_testing.test_types import Alloc, Environment
+
+
+def _write_group(
+    folder: Path,
+    stem: str,
+    test_id: str,
+    pre: Dict[int, Account],
+    *,
+    environment: Environment,
+) -> None:
+    """Write a single fine-grained group file, as Phase 1 would."""
+    builder = PreAllocGroupBuilder(
+        test_ids=[test_id],
+        environment=environment,
+        fork=Prague,
+        pre=Alloc(
+            {Address(address): account for address, account in pre.items()}
+        ),
+    )
+    (folder / f"{stem}.json").write_text(
+        builder.model_dump_json(by_alias=True, exclude_none=True, indent=2)
+    )
+
+
+def _packed(folder: Path) -> Dict[str, dict]:
+    """Load the packed group files by stem."""
+    return {
+        file.stem: json.loads(file.read_text())
+        for file in folder.glob("*.json")
+    }
+
+
+def test_pack_merges_non_conflicting_groups(tmp_path: Path) -> None:
+    """Two groups sharing a genesis but no address merge into one."""
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x2000: Account(balance=2)},
+        environment=env,
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    packed = _packed(tmp_path)
+    assert len(packed) == 1
+    (group,) = packed.values()
+    assert sorted(group["testIds"]) == [
+        "tests/a.py::test_a",
+        "tests/b.py::test_b",
+    ]
+    assert set(group["pre"]) == {
+        "0x0000000000000000000000000000000000001000",
+        "0x0000000000000000000000000000000000002000",
+    }
+
+
+def test_pack_keeps_conflicting_groups_apart(tmp_path: Path) -> None:
+    """The same address with different accounts cannot be merged."""
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x1000: Account(balance=2)},
+        environment=env,
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    packed = _packed(tmp_path)
+    assert len(packed) == 2
+    # Every test is still represented exactly once.
+    all_ids = sorted(
+        tid for group in packed.values() for tid in group["testIds"]
+    )
+    assert all_ids == ["tests/a.py::test_a", "tests/b.py::test_b"]
+
+
+def test_pack_merges_identical_account_at_shared_address(
+    tmp_path: Path,
+) -> None:
+    """
+    A shared address with the *same* account (e.g. a system contract) is
+    not a conflict.
+    """
+    env = Environment()
+    shared = Account(balance=1, nonce=1)
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: shared, 0x2000: Account(balance=5)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x1000: shared, 0x3000: Account(balance=6)},
+        environment=env,
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    assert len(_packed(tmp_path)) == 1
+
+
+def test_pack_separates_distinct_environments(tmp_path: Path) -> None:
+    """Groups with different genesis environments never merge."""
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=Environment(),
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x2000: Account(balance=2)},
+        environment=Environment(gas_limit=0x1000000),
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    assert len(_packed(tmp_path)) == 2
+
+
+def test_pack_is_deterministic(tmp_path: Path) -> None:
+    """Packing the same inputs twice yields the same group ids."""
+
+    def build(folder: Path) -> None:
+        folder.mkdir()
+        env = Environment()
+        for i in range(6):
+            _write_group(
+                folder,
+                f"0x0{i}",
+                f"tests/t{i}.py::test_{i}",
+                {0x1000 + i: Account(balance=i)},
+                environment=env,
+            )
+
+    first, second = tmp_path / "first", tmp_path / "second"
+    build(first)
+    build(second)
+    pack_pre_alloc_groups(first)
+    pack_pre_alloc_groups(second)
+
+    assert set(_packed(first)) == set(_packed(second))

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -20,12 +20,14 @@ def _write_group(
     pre: Dict[int, Account],
     *,
     environment: Environment,
+    group_salt: str | None = None,
 ) -> None:
     """Write a single fine-grained group file, as Phase 1 would."""
     builder = PreAllocGroupBuilder(
         test_ids=[test_id],
         environment=environment,
         fork=Prague,
+        group_salt=group_salt,
         pre=Alloc(
             {Address(address): account for address, account in pre.items()}
         ),
@@ -154,6 +156,78 @@ def test_pack_separates_distinct_environments(tmp_path: Path) -> None:
     pack_pre_alloc_groups(tmp_path)
 
     assert len(_packed(tmp_path)) == 2
+
+
+def test_pack_respects_group_salt(tmp_path: Path) -> None:
+    """
+    A group salted via the `pre_alloc_group` marker never merges with an
+    unsalted group or a group carrying a different salt.
+    """
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x2000: Account(balance=2)},
+        environment=env,
+        group_salt="isolated",
+    )
+    _write_group(
+        tmp_path,
+        "0x03",
+        "tests/c.py::test_c",
+        {0x3000: Account(balance=3)},
+        environment=env,
+        group_salt="other",
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    packed = _packed(tmp_path)
+    assert len(packed) == 3
+    all_ids = sorted(
+        tid for group in packed.values() for tid in group["testIds"]
+    )
+    assert all_ids == [
+        "tests/a.py::test_a",
+        "tests/b.py::test_b",
+        "tests/c.py::test_c",
+    ]
+
+
+def test_pack_merges_groups_with_matching_salt(tmp_path: Path) -> None:
+    """Groups sharing the same explicit salt still pack together."""
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+        group_salt="shared",
+    )
+    _write_group(
+        tmp_path,
+        "0x02",
+        "tests/b.py::test_b",
+        {0x2000: Account(balance=2)},
+        environment=env,
+        group_salt="shared",
+    )
+
+    pack_pre_alloc_groups(tmp_path)
+
+    packed = _packed(tmp_path)
+    assert len(packed) == 1
+    (group,) = packed.values()
+    assert group["groupSalt"] == "shared"
 
 
 def test_pack_is_deterministic(tmp_path: Path) -> None:

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -4,11 +4,15 @@ import json
 from pathlib import Path
 from typing import Dict
 
+import pytest
+
 from execution_testing.base_types import Account, Address
 from execution_testing.fixtures.pre_alloc_groups import (
     TEST_GROUP_INDEX_FILE,
+    GroupIndexEntry,
     PreAllocGroupBuilder,
     pack_pre_alloc_groups,
+    packed_group_hash_for_test,
     read_test_group_index,
 )
 from execution_testing.forks import Prague
@@ -271,8 +275,12 @@ def test_pack_writes_test_group_index(tmp_path: Path) -> None:
         "tests/b.py::test_b",
         "tests/c.py::test_c",
     ]
-    for test_id, group_hash in index.items():
-        assert test_id in packed[group_hash]["testIds"]
+    for test_id, entry in index.items():
+        assert test_id in packed[entry.group_hash]["testIds"]
+    # Every entry records the test's fine-grained phase 1 hash.
+    assert index["tests/a.py::test_a"].phase1_hash == "0x01"
+    assert index["tests/b.py::test_b"].phase1_hash == "0x02"
+    assert index["tests/c.py::test_c"].phase1_hash == "0x03"
 
 
 def test_read_test_group_index_falls_back_to_scanning(
@@ -297,9 +305,65 @@ def test_read_test_group_index_falls_back_to_scanning(
 
     assert not (tmp_path / TEST_GROUP_INDEX_FILE).exists()
     assert read_test_group_index(tmp_path) == {
-        "tests/a.py::test_a": "0x01",
-        "tests/b.py::test_b": "0x02",
+        "tests/a.py::test_a": GroupIndexEntry("0x01", None),
+        "tests/b.py::test_b": GroupIndexEntry("0x02", None),
     }
+
+
+def test_packed_group_hash_lookup_validates_phase1_hash(
+    tmp_path: Path,
+) -> None:
+    """
+    A phase 2 lookup verifies the recomputed phase 1 hash against the
+    index fingerprint, so a stale pre-alloc folder fails loudly instead
+    of silently filling a changed test against its old genesis.
+    """
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+    pack_pre_alloc_groups(tmp_path)
+    index = read_test_group_index(tmp_path)
+
+    packed_hash = packed_group_hash_for_test(
+        index, "tests/a.py::test_a", phase1_hash="0x01"
+    )
+    assert packed_hash == index["tests/a.py::test_a"].group_hash
+
+    with pytest.raises(ValueError, match="stale"):
+        packed_group_hash_for_test(
+            index, "tests/a.py::test_a", phase1_hash="0xff"
+        )
+    with pytest.raises(ValueError, match="not assigned"):
+        packed_group_hash_for_test(
+            index, "tests/b.py::test_b", phase1_hash="0x02"
+        )
+
+
+def test_packed_group_hash_lookup_without_fingerprint(
+    tmp_path: Path,
+) -> None:
+    """A scanned (legacy) index has no fingerprints to validate against."""
+    env = Environment()
+    _write_group(
+        tmp_path,
+        "0x01",
+        "tests/a.py::test_a",
+        {0x1000: Account(balance=1)},
+        environment=env,
+    )
+
+    index = read_test_group_index(tmp_path)
+    assert (
+        packed_group_hash_for_test(
+            index, "tests/a.py::test_a", phase1_hash="0xff"
+        )
+        == "0x01"
+    )
 
 
 def test_pack_is_deterministic(tmp_path: Path) -> None:


### PR DESCRIPTION
## 🗒️ Description

### Impact

This PR will help speed-up `consume enginex` by removing 2179 pre-alloc groups (5458 -> 3279). Besu's pure startup time is ~6.7 s, Nethermind's is 5 s (ignoring docker overhead), this would lead to the following approx savings per test run:

| Client     | Startup time per group | Churn saved per consume run (x 2,179) | With `--sim.parallelism=4` |
| ---------- | ---------------------- | ------------------------------------- | -------------------------- |
| Nethermind | ~5.0 s                 | ~3.0 h                                | ~45 min                    |
| Besu       | ~6.8 s                 | ~4.1 h                                | ~1.0 h                     |
| geth       | ~0.8 s                 | ~29 min                               | ~7 min  

### Background

`consume enginex` boots one execution client per pre-allocation group and amortizes that boot across the group's tests via repeated `engine_newPayload` calls, so the tail of a run is dominated by the fixed per-group container-startup cost and the main lever on runtime is the group count. Phase 1 keys a test's group on the exact content of any hard-coded accounts it sets, which is a conservative proxy for genuine address conflicts: it leaves 65% of Engine X groups holding a single test, most of them in `tests/ported_static`, where nearly every test pins accounts to canonical addresses.

### Approach in this PR

Please check this HTML doc that provides an overview:

[prealloc-packing.html](https://github.com/user-attachments/files/29977886/prealloc-packing.html)


This PR adds a `pack_pre_alloc_groups` pass that runs on the master process at the end of phase 1 and merges the fine-grained groups into fewer, larger ones without changing what any test executes:

- Groups are bucketed by everything a shared genesis requires (fork, chain id, and genesis environment) and by the explicit `pre_alloc_group` marker salt, so a test that demands its own genesis keeps it.
- Within a bucket, an address is *reserved* if it is a precompile (`< 0x100`, implicitly callable by any test) or is allocated by more than one group (a shared or canonical address rather than one private to a single test).
- Two groups merge only when their reserved accounts match exactly, so a funded precompile or scratch contract is never introduced into a test that assumes that address is empty. Test-private addresses merge freely, which is where most of the reduction comes from; within a bucket a non-reserved address has exactly one allocator and reserved accounts are byte-identical, so the merged pre-allocation cannot collide by construction.
- Packing is deterministic (a packed group's id derives from its sorted test ids) and writes a test id to group hash index file, which phase 2 uses to look up each test's group (the packed hash can no longer be recomputed per test).
- Any leak the reserved-address rule might miss fails the fill loudly: After phase 2, every Engine X fixture's payloads are compared against the test's `blockchain_test_engine` sibling, which is filled against the test's own pre-allocation with an independent `t8n` execution (Engine X fixtures never share the transition tool output cache). A difference in any payload field other than the state-root-derived ones (`stateRoot`, `blockHash`, `parentHash`) aborts the fill naming the offending tests, so a leaked account cannot change a test's behavior without failing the fill. Fills that generate no sibling fixtures (e.g. `-m blockchain_test_engine_x`) log a warning that the check was skipped; release fills generate all formats and always verify. The check adds well under a minute even to a full fill (measured: `0.8s` for 6126 fixtures).

### Results

Full fill across all forks:

```console
uv run fill --until=Amsterdam --output=fixtures-prealloc-all --generate-pre-alloc-groups -m blockchain_test_engine_x -n 6 --clean
```

| Metric | `forks/amsterdam` | This PR | Change |
| --- | ---: | ---: | ---: |
| Pre-alloc groups (one client boot each) | 5458 | 3279 | -40% |
| Single-test groups | 3564 (65.3%) | 1690 (51.5%) | -53% |
| Total genesis accounts | 137622 | 123908 | -10% |
| Tests | 74673 | 74673 | unchanged |

On the heavily fragmented forks the packing roughly doubles the boot amortization (average tests per group: Cancun 9.8 to 17.8, Prague 12.2 to 21.4, Osaka 12.7 to 21.1, Amsterdam 16.4 to 25.9).

The reduction comes almost entirely (98%) from `tests/ported_static`; the remainder comes for free from EIP test directories whose tests pin distinct fixed addresses and can now share a genesis (`paris/eip7610_create_collision`, `constantinople/eip1052_extcodehash`, and several `amsterdam` EIP tests):

| Groups by source directory | `forks/amsterdam` | This PR | Change |
| --- | ---: | ---: | ---: |
| `ported_static` | 4436 | 2309 | -2127 |
| `paris` | 154 | 132 | -22 |
| `amsterdam` | 94 | 76 | -18 |
| `constantinople` | 60 | 48 | -12 |
| `cancun` | 209 | 203 | -6 |
| Groups spanning multiple directories | 58 | 64 | +6 |
| All other directories | 447 | 447 | unchanged |

### Verification

All A/B comparisons below are against a base-branch fill at the same commit (`80cc337bf36`).

- Packing strictly merges whole phase-1 groups: Mapping all 74673 tests from their phase-1 group to their packed group shows that no phase-1 group is ever split or reassigned.
- Two-phase fills pass on both the ported and the non-ported merge paths: `tests/ported_static` at Osaka (`-m "blockchain_test_engine_x and (not slow)"`, 6126 passed, 0 failed) and `tests/paris/eip7610_create_collision` plus `tests/constantinople/eip1052_extcodehash` at Paris (125 passed, 0 failed).
- Execution is provably unchanged: Comparing every Engine X fixture between the two fills shows all payload fields equal except `stateRoot`, `blockHash`, and `parentHash` (which change with the genesis) for all 6126 Osaka tests (2282 of which received a different genesis from packing) and all 125 Paris tests.
- The `state_test`, `blockchain_test`, and `blockchain_test_engine` formats are untouched by construction (they are generated from a test's own pre-allocation, and packing runs entirely inside the Engine X pre-alloc pipeline): Re-filling `tests/ported_static` at Osaka on both branches yields identical fixture hashes for all 18378 fixtures of these formats, with byte differences only in `_info` metadata (the framework version string differs across branches).

### Reviewer notes

- The reserved-address rule is sound-leaning rather than proven (it cannot see an address a test reads but never allocates), but a leak cannot ship silently: The post-fill execution check above turns any behavioral change into a hard fill error, and an affected test can then be isolated with `@pytest.mark.pre_alloc_group` (whose salt the packing respects) and re-filled.
- The remaining single-test groups are the deliberate price of the exact-match rule, not unfinished work: A group whose reserved-address footprint matches no other group's stays alone, and a genuinely irreducible set remains (e.g. tests that overwrite a system contract at its canonical address, where no two variants can share a genesis). Packing on direct conflicts only, with an automatic split-and-retry for any test the execution check flags, is the natural follow-up to cut the count further.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="1024" alt="iA well-packed pre-allocation group sharing a single genesis at Salisbury Plain, South Georgia" src="https://github.com/user-attachments/assets/628fdb0d-22e7-4251-ae7f-d216d842b54d" />
