### PR TITLE
fix(test-fixtures): emit chainId in state test fixture transaction

### DIFF
--- a/docs/running_tests/test_formats/state_test.md
+++ b/docs/running_tests/test_formats/state_test.md
@@ -108,6 +108,10 @@ Excess blob gas of the block where the transaction is executed.
 
 ### `FixtureTransaction`
 
+#### - `chainId`: [`ZeroPaddedHexNumber`](./common_types.md#zeropaddedhexnumber)
+
+Chain id of the transaction; omitted for unprotected (non-EIP-155) type-0 transactions
+
 #### - `nonce`: [`ZeroPaddedHexNumber`](./common_types.md#zeropaddedhexnumber)
 
 Nonce of the account that sends the transaction

--- a/packages/testing/src/execution_testing/fixtures/state.py
+++ b/packages/testing/src/execution_testing/fixtures/state.py
@@ -46,6 +46,7 @@ class FixtureTransaction(TransactionFixtureConverter):
     # via model_dump(), which includes many fields not in this model.
     model_config = CamelModel.model_config | {"extra": "ignore"}
 
+    chain_id: ZeroPaddedHexNumber | None = None
     nonce: ZeroPaddedHexNumber
     gas_price: ZeroPaddedHexNumber | None = None
     max_priority_fee_per_gas: ZeroPaddedHexNumber | None = None
@@ -69,6 +70,9 @@ class FixtureTransaction(TransactionFixtureConverter):
             exclude={"gas_limit", "value", "data", "access_list"},
             exclude_none=True,
         )
+        if tx.ty == 0 and not tx.protected:
+            # Unprotected legacy transactions encode no chain id.
+            model_as_dict.pop("chain_id", None)
         model_as_dict["gas_limit"] = [tx.gas_limit]
         model_as_dict["value"] = [tx.value]
         model_as_dict["data"] = [tx.data]

--- a/packages/testing/src/execution_testing/specs/tests/fixtures/chainid_cancun_state_test_tx_type_1.json
+++ b/packages/testing/src/execution_testing/specs/tests/fixtures/chainid_cancun_state_test_tx_type_1.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Cancun/tx_type_1": {
         "_info": {
-            "hash": "0x49130f37343fa73f364ed83e2a2e7146c4effa64cdb6b371f5f2bf3f2004fade",
+            "hash": "0x0c9cdd9849022dfb46f20fc00a646394a58e0fc8847f6e3cf578dff67378e6bc",
             "fixture_format": "state_test"
         },
         "env": {
@@ -39,6 +39,7 @@
             }
         },
         "transaction": {
+            "chainId": "0x01",
             "accessLists": [
                 [
                     {


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
The state test fixture `transaction` object carries no chain id, so the wrong-chain-id fixtures shipped in `tests-glamsterdam-devnet@v6.1.1` (#3000) can only be detected by decoding `txbytes`.

Emit `chainId` in the state fixture transaction so JSON field consumers can see it, omitting it for unprotected type 0 transactions which encode no chain id.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to #3000.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/pFz1Q12_hXEAAAAM/cat-holding-head-cat.gif)
