### PR TITLE
feat(fill-stateful): make the per-test chain rewind optional (add debug_resetHead)

### DIFF
--- a/docs/filling_tests/fill_stateful.md
+++ b/docs/filling_tests/fill_stateful.md
@@ -13,7 +13,7 @@ The target client must expose:
 
 - `testing` (`testing_buildBlockV1`) — block construction with explicit transaction ordering.
 - `engine` — `engine_newPayloadVX`, `engine_forkchoiceUpdatedVX`.
-- `eth`, `debug` — chain queries and `debug_setHead` for between-test rewind.
+- `eth`, `debug` — chain queries and `debug_setHead` (or `debug_resetHead` on clients like Nethermind that lack `debug_setHead`) for between-test rewind.
 - `web3` (optional) — `web3_clientVersion` is recorded into the fixture's `_info.filling-transition-tool` for traceability.
 
 The production-ready filler is `ethpandaops/geth:master`.
@@ -213,7 +213,7 @@ Both backends satisfy `FillerBackend` (`client_clis/filler_backend.py`). `Client
     2. `_split_blocks_by_phase` splits any mixed-phase blocks (e.g. EIP-7702 SETUP + benchmark TEST).
     3. For each block, `ClientBackend.evaluate` builds + finalises it; payload partitioned by `Block.phase` into `setupEngineNewPayloads` vs `engineNewPayloads`.
     4. Write `<test>.json` (a `BlockchainEngineStatefulFixture`).
-3. **Per-test reset** (`_reset_chain_between_tests`): `debug_setHead(start_block.number)`, re-fetch `latest`, abort if hash drifted.
+3. **Per-test reset** (`_reset_chain_between_tests`): `debug_setHead(start_block.number)` — or `debug_resetHead(start_block.hash)` on clients without `debug_setHead`, e.g. Nethermind — re-fetch `latest`, abort if hash drifted.
 
 ### Fixture types
 
@@ -239,7 +239,7 @@ pristine snapshot ───copy──▶ datadir ───▶ geth ───▶ 
                                                        └── for each test fixture:
                                                             ├── replay setupEngineNewPayloads
                                                             ├── replay engineNewPayloads (timed)
-                                                            ├── debug_setHead → start_block
+                                                            ├── debug_setHead/resetHead → start_block
                                                             └── re-fetch latest, verify hash
 ```
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -271,7 +271,24 @@ def _compute_deploy_gas_limit(
         new_bytes=len(bytes(initcode))
     )
     regular_gas += storage_slots * sstore_regular_gas
-    regular_gas *= 2
+
+    # Double as a safety buffer since gas estimation is approximate. The buffer
+    # must not, by itself, push a contract that genuinely deploys within the
+    # EIP-7825 regular-gas cap over it: when the unbuffered estimate still fits
+    # the cap, clamp the limit to the cap instead. The deploy then runs with a
+    # cap-sized regular limit and consumes only its (smaller) actual gas.
+    # Only a contract whose unbuffered estimate exceeds the cap is truly
+    # undeployable (the caller raises on that).
+    buffered_regular_gas = regular_gas * 2
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
+    if (
+        tx_gas_limit_cap is not None
+        and buffered_regular_gas > tx_gas_limit_cap
+        and regular_gas <= tx_gas_limit_cap
+    ):
+        regular_gas = tx_gas_limit_cap
+    else:
+        regular_gas = buffered_regular_gas
 
     # State portion, from the block reservoir.
     state_gas = intrinsic_state_gas

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -395,9 +395,26 @@ def session_worker_key(seed_key: EOA) -> EOA:
 
 
 @pytest.fixture(scope="function")
-def worker_key(eth_rpc: EthRPC, session_worker_key: EOA) -> EOA:
+def worker_key(
+    eth_rpc: EthRPC,
+    session_worker_key: EOA,
+    client_backend: ClientBackend,
+) -> EOA:
     """Sync seed key nonce before each test."""
-    account = eth_rpc.get_account(session_worker_key, skip_code=True)
+    # Read the nonce at the reset head (start_block), not "latest": a client
+    # whose rewind restores the build state but leaves the `latest` pointer at
+    # the previous test's tip (e.g. nethermind's debug_resetHead) would
+    # otherwise report a stale, too-high nonce and get every funding tx
+    # rejected ("Invalid nonce - expected 0").
+    start = client_backend.start_block
+    if start is None:
+        account = eth_rpc.get_account(session_worker_key, skip_code=True)
+    else:
+        account = eth_rpc.get_account(
+            session_worker_key,
+            block_number=int(start["number"], 16),
+            skip_code=True,
+        )
     session_worker_key.nonce = Number(account.nonce)
     return session_worker_key
 
@@ -454,7 +471,7 @@ def max_gas_limit_per_test(
 
 @pytest.fixture(scope="session")
 def debug_rpc(eth_rpc: EthRPC) -> DebugRPC:
-    """DebugRPC on the same endpoint as eth_rpc (for debug_setHead)."""
+    """DebugRPC on eth_rpc's endpoint (debug_setHead/resetHead rewind)."""
     return DebugRPC(eth_rpc.url)
 
 
@@ -600,14 +617,27 @@ def _session_pre_run(
         f"hash={snapshot_block['hash'][:20]}..."
     )
 
-    # 2. Fund seed key via CL withdrawal; helper returns the built payload.
+    # 2. Fund seed key via CL withdrawal, unless it is already funded (e.g.
+    #    pre-funded in the snapshot state). Skipping the withdrawal keeps the
+    #    pre-run empty so start_block == the snapshot block, whose persistent
+    #    state debug_setHead can always rewind to between tests. Otherwise
+    #    start_block sits one diff-layer above the snapshot and a test that
+    #    builds many blocks (e.g. test_blockhash) can prune its state, making
+    #    the per-test rewind collapse to the snapshot block and abort the run.
     captured: List[EnginePayloadMetadata] = []
-    fund_payload = eth_rpc.fund_via_withdrawals(
-        [(Address(session_worker_key), SEED_FUNDING_WEI)]
-    )
-    if fund_payload is not None:
-        captured.append(fund_payload)
-    logger.info(f"Funded {Address(session_worker_key)} via withdrawal")
+    seed_address = Address(session_worker_key)
+    if eth_rpc.get_balance(seed_address) >= SEED_FUNDING_WEI:
+        logger.info(
+            f"Seed {seed_address} already funded "
+            f"(>= {SEED_FUNDING_WEI} wei); skipping withdrawal"
+        )
+    else:
+        fund_payload = eth_rpc.fund_via_withdrawals(
+            [(seed_address, SEED_FUNDING_WEI)]
+        )
+        if fund_payload is not None:
+            captured.append(fund_payload)
+        logger.info(f"Funded {seed_address} via withdrawal")
 
     # 3. Deploy deterministic factory if not already present.
     lock_file = session_temp_folder / "fill_stateful_setup.lock"
@@ -706,9 +736,12 @@ def _reset_chain_between_tests(
 ) -> Generator[None, None, None]:
     """
     Rewind to start_block after each test so the chain is identical for
-    every fill. ``debug_setHead`` only takes a number, so after the
-    rewind we re-fetch ``latest`` and fail loudly if the hash drifted
-    (e.g. live reorg of a same-numbered block).
+    every fill. Uses ``debug_setHead`` (by number) when available, else
+    ``debug_resetHead`` (by hash) for clients like Nethermind, else nothing
+    — each test's first block is built on its explicit start_block parent,
+    so the client reorgs onto it even without a debug rewind. Afterwards we
+    verify the block at the start_block number matches and fail loudly if it
+    drifted (e.g. a live reorg).
     """
     yield
     if client_backend.start_block is None:
@@ -720,14 +753,20 @@ def _reset_chain_between_tests(
     if current_head is not None and current_head["hash"] == expected_hash:
         return
     try:
-        debug_rpc.set_head(start_hex)
+        debug_rpc.rewind_head(block_number=start_hex, block_hash=expected_hash)
     except Exception as e:
-        pytest.exit(f"debug_setHead failed — subsequent fixtures invalid: {e}")
-    head = eth_rpc.get_block_by_number("latest")
+        pytest.exit(f"head rewind failed — subsequent fixtures invalid: {e}")
+    # Verify the rewind landed by querying the block at the expected
+    # start_block number, not "latest": nethermind's debug_resetHead restores
+    # the build head but leaves the `latest` pointer at the previous test's
+    # tip, so "latest" is unreliable there. The block at start_block's number
+    # is the start block on both geth (debug_setHead moves latest) and
+    # nethermind (resetHead leaves it stale).
+    head = eth_rpc.get_block_by_number(start_hex)
     if head is None or head["hash"] != expected_hash:
         observed = head["hash"] if head is not None else "<none>"
         pytest.exit(
-            f"debug_setHead landed on hash {observed} but expected "
+            f"head rewind landed on hash {observed} but expected "
             f"{expected_hash} (start_block at number {start_hex}). The "
             "live chain may have reorged out from under fill-stateful; "
             "rerun against a quiescent client or use --snapshot-block "

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -52,6 +52,7 @@ from .rpc_types import (
     ForkchoiceUpdateResponse,
     GetBlobsResponse,
     GetPayloadResponse,
+    JSONRPCError,
     JSONRPCRequest,
     JSONRPCResponse,
     PayloadAttributes,
@@ -1282,6 +1283,17 @@ class DebugRPC(EthRPC):
     used within EEST based hive simulators.
     """
 
+    # JSON-RPC "method not found" error code.
+    _METHOD_NOT_FOUND = -32601
+
+    # JSON-RPC "internal error" code. Nethermind registers debug_setHead
+    # but throws NotImplementedException, surfaced as this code.
+    _METHOD_NOT_IMPLEMENTED = -32603
+
+    # Which head-rewind method the client supports; resolved on first use
+    # so the fallback probe runs only once per session.
+    _rewind_method: str | None = None
+
     def trace_call(self, tr: dict[str, str], block_number: str) -> Any | None:
         """`debug_traceCall`: Returns pre state required for transaction."""
         params = [tr, block_number, {"tracer": "prestateTracer"}]
@@ -1290,10 +1302,63 @@ class DebugRPC(EthRPC):
         ).result_or_raise()
 
     def set_head(self, block_number: str) -> None:
-        """`debug_setHead`: Reset chain head to the given block."""
+        """`debug_setHead`: Reset chain head to the given block number."""
         self.post_request(
             request=RPCCall(method="setHead", params=[block_number])
         ).result_or_raise()
+
+    def reset_head(self, block_hash: str) -> None:
+        """`debug_resetHead`: Reset chain head to the given block hash."""
+        self.post_request(
+            request=RPCCall(method="resetHead", params=[block_hash])
+        ).result_or_raise()
+
+    def rewind_head(self, *, block_number: str, block_hash: str) -> None:
+        """
+        Rewind the chain head to a given block.
+
+        Prefer geth's ``debug_setHead`` (takes a block number); if the
+        client does not expose it (e.g. Nethermind, which returns a
+        "method not found"/"not implemented" error), fall back to
+        ``debug_resetHead`` (takes a block hash). If the client implements
+        neither, give up gracefully (``"none"``): each per-test block is
+        built on its explicit start_block parent, so the client reorgs onto
+        it without a debug rewind. The chosen method is cached after the
+        first call so the probe runs only once.
+
+        Note ``debug_setHead`` truncates the chain (geth), keeping the block
+        tree small, whereas ``debug_resetHead`` only repoints the head on
+        Nethermind — there per-test forks still accumulate as under
+        ``"none"``.
+        """
+        if self._rewind_method is None:
+            try:
+                self.set_head(block_number)
+                self._rewind_method = "setHead"
+                return
+            except JSONRPCError as e:
+                if e.code not in (
+                    self._METHOD_NOT_FOUND,
+                    self._METHOD_NOT_IMPLEMENTED,
+                ):
+                    raise
+            try:
+                self.reset_head(block_hash)
+                self._rewind_method = "resetHead"
+                return
+            except JSONRPCError as e:
+                if e.code not in (
+                    self._METHOD_NOT_FOUND,
+                    self._METHOD_NOT_IMPLEMENTED,
+                ):
+                    raise
+                self._rewind_method = "none"
+                return
+        if self._rewind_method == "setHead":
+            self.set_head(block_number)
+        elif self._rewind_method == "resetHead":
+            self.reset_head(block_hash)
+        # "none": no debug rewind available; the explicit-parent build reorgs.
 
 
 class EngineRPC(BaseJwtRPC):


### PR DESCRIPTION
## 🗒️ Description

Ports #3050 (merged into `devnets/bal/7-bench`) to `forks/amsterdam`.

The per-test chain rewind (`_reset_chain_between_tests`) hard-required geth's `debug_setHead`. This makes it optional and client-agnostic:

- **adds `debug_resetHead`** (by block hash) as an alternative — for clients like Nethermind that don't implement `debug_setHead`;
- **makes the debug rewind optional**: if a client implements neither, fill-stateful keeps going instead of aborting — each test's first block is built on its explicit `start_block` parent, so the client reorgs onto it without any debug call.

So fill-stateful is no longer tied to the geth `debug` namespace. Nethermind is the concrete client this was validated against (on the original PR), and it now works as a filler.

## Details

- **Three-tier per-test rewind** in `rewind_head`, probed once and cached:
  1. `debug_setHead` (by number) — geth; **truncates** the chain, keeping the block tree small;
  2. else `debug_resetHead` (by hash) — e.g. Nethermind;
  3. else **nothing** — rely on the explicit `start_block` parent; the client reorgs onto it.
- **Read per-test state at `start_block`, not `"latest"`** (the seed-nonce sync and the post-rewind check). A `debug_resetHead`-style rewind (or no rewind) restores the build state but leaves `latest` at the previous test's tip, so reading `"latest"` there returns a stale nonce and every funding tx is rejected (`Invalid nonce - expected 0`). Identical to `"latest"` on clients (geth) whose `debug_setHead` moves it.
- Two small base fill fixes (deploy gas safety-buffer cap; skip redundant seed withdrawal funding).

## Validation

The behavior was validated on the original PR (#3050) against the bloatnet stateful repricing prestate (Amsterdam) with `nethermindeth/nethermind:master`: 225/225 fills via both the `debug_resetHead` and the no-debug (`"none"`) path, replaying clean on geth and Nethermind. This port is the same net diff applied onto `forks/amsterdam` (applied cleanly with no conflicts); geth filling is unaffected (it takes the `debug_setHead` tier, and `latest` already tracks the rewind).

## 🔗 Related Issues or PRs

Ports #3050.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cute cat](https://cataas.com/cat/gif?3127)
