### PR TITLE
fix(test-tests): skip Constantinople for evmone in t8n support test

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tools_support.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tools_support.py
@@ -13,6 +13,7 @@ from execution_testing.base_types import (
     TestPrivateKey,
 )
 from execution_testing.client_clis import (
+    EvmOneTransitionTool,
     ExecutionSpecsTransitionTool,
     TransitionTool,
 )
@@ -74,9 +75,9 @@ def test_t8n_support(fork: Fork, installed_t8n: TransitionTool) -> None:
     """Stress test that sends all possible t8n interactions."""
     if fork in [MuirGlacier, ArrowGlacier, GrayGlacier]:
         return
-    if isinstance(installed_t8n, ExecutionSpecsTransitionTool) and fork in [
-        Constantinople
-    ]:
+    if isinstance(
+        installed_t8n, (ExecutionSpecsTransitionTool, EvmOneTransitionTool)
+    ) and fork in [Constantinople]:
         return
     env = Environment()
     sender = TestAddress


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
evmone removed the `Constantinople` revision, so `test_t8n_support[EvmOneTransitionTool-Constantinople]` fails with `unknown revision: Constantinople`. Extend the existing `ExecutionSpecsTransitionTool` Constantinople skip to `EvmOneTransitionTool`.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/pFz1Q12_hXEAAAAM/cat-holding-head-cat.gif)
