### PR TITLE
chore(tests, test-client-clis): map invalid transaction signature exceptions

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/besu.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/besu.py
@@ -452,6 +452,11 @@ class BesuExceptionMapper(ExceptionMapper):
             r"transaction invalid Transaction gas limit "
             r"must be at most \d+"
         ),
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            r"Failed to decode transactions from block parameter|"
+            r"transaction invalid Signature s value should be less "
+            r"than \d+, but got \d+"
+        ),
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"Blob transaction 0x[0-9a-f]+ exceeds "
             r"block blob gas limit: \d+ > \d+"

--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -55,6 +55,9 @@ class GethExceptionMapper(ExceptionMapper):
             "max priority fee per gas higher than max fee per gas"
         ),
         TransactionException.INVALID_CHAINID: "invalid chain id for signer",
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            "invalid transaction v, r, s values"
+        ),
         TransactionException.TYPE_1_TX_PRE_FORK: (
             "transaction type not supported"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -328,6 +328,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
         ),
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            "InvalidTxSignature: Signature is invalid."
+        ),
         TransactionException.TYPE_1_TX_PRE_FORK: (
             "InvalidTxType: Transaction type in Custom is not supported"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -28,6 +28,9 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
         TransactionException.INVALID_CHAINID: "invalid chain ID",
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            "invalid bool value, must be 0 or 1"
+        ),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             "blob version not supported"
         ),

--- a/tests/frontier/validation/test_transaction.py
+++ b/tests/frontier/validation/test_transaction.py
@@ -11,7 +11,10 @@ from execution_testing import (
     add_kzg_version,
 )
 from execution_testing.base_types.base_types import ZeroPaddedHexNumber
-from execution_testing.exceptions.exceptions import TransactionException
+from execution_testing.exceptions.exceptions import (
+    TransactionException,
+    TransactionExceptionInstanceOrList,
+)
 from execution_testing.forks.base_fork import BaseFork
 from execution_testing.specs.blockchain import (
     Block,
@@ -252,11 +255,23 @@ def test_bad_v_r_s(
     """
     to = pre.fund_eoa(0xDEADBEEE)
 
+    error: TransactionExceptionInstanceOrList = (
+        TransactionException.INVALID_SIGNATURE_VRS
+    )
+    if tx_type == 0 and v not in (27, 28):
+        # A legacy transaction encodes its chain id within v, so a client that
+        # derives the chain id from an out-of-range v rejects the transaction
+        # with a chain id mismatch instead of an invalid signature.
+        error = [
+            TransactionException.INVALID_SIGNATURE_VRS,
+            TransactionException.INVALID_CHAINID,
+        ]
+
     blob_versioned_hashes = add_kzg_version([0], 1) if tx_type == 3 else None
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=to,
-        error=TransactionException.INVALID_SIGNATURE_VRS,
+        error=error,
         ty=tx_type,
         blob_versioned_hashes=blob_versioned_hashes,
         value=1,


### PR DESCRIPTION
### Description

Maps `TransactionException.INVALID_SIGNATURE_VRS` in the besu, geth, nethermind and reth exception mappers, mirroring the fix already applied to ethrex (#3104) and erigon (#3105), so that `tests/frontier/validation/test_transaction.py::test_bad_v_r_s` reports meaningful failures under `consume engine|enginex` instead of undefined exception messages.

Two clients need more than a single message. Besu rejects typed transactions while decoding the block body but rejects legacy transactions in its signature malleability check, which produces two unrelated strings, so its mapping uses a regex alternation. Nethermind returns `InvalidTxSignature: Signature is invalid.`, which also matches the existing `INVALID_CHAINID` pattern; that is harmless, because a message resolves to a list of exceptions and a test passes when the expected one is a member.

`test_bad_v_r_s` is also relaxed for legacy transactions whose `v` is neither 27 nor 28. A legacy transaction encodes its chain id within `v`, so a client that derives the chain id from an out-of-range `v` rejects the transaction with a chain id mismatch rather than an invalid signature: geth, for instance, treats any `v` outside `{0, 1, 27, 28}` as EIP-155 protected and reports `invalid chain id for signer` before it ever reaches its `v`, `r`, `s` sanity check. The transaction is correctly rejected either way, only the reason differs, so the test now accepts either `INVALID_SIGNATURE_VRS` or `INVALID_CHAINID` for those cases, as sanctioned by `docs/writing_tests/exception_tests.md` for exceptions that depend on client implementation. The widening is surgical: only the legacy `v=34` parametrization is affected, and every typed transaction case still expects `INVALID_SIGNATURE_VRS` alone.

#### Remaining Fails For `test_bad_v_r_s` After This PR

##### Reth

Reth's legacy transactions are deliberately left unmapped, because both of its remaining failures are client side bugs rather than gaps in the mapper:

- Signer recovery failures, when `r` or `s` is at or above `secp256k1n`, return a JSON-RPC `-32603` internal error instead of `{status: INVALID, validationError: ...}`. The exception mapper never sees this, and the Engine API reserves an error object for failures unrelated to the normal processing flow of `engine_newPayload`.
- An out-of-range legacy `v` is reported as `Unexpected type flag`, an error that describes an unknown EIP-2718 type byte. The real error, `invalid parity value`, is discarded by the `TransactionEnvelope` derive in `alloy-tx-macros`.

Both are being reported upstream, to `paradigmxyz/reth` and `alloy-rs/alloy` respectively. Once fixed, reth's messages can be added to its mapper.

##### Besu

Reported/fix submitted via:
- https://github.com/besu-eth/besu/pull/10784

Besu passes every case here except the legacy `v=34` parametrization, which fails on all five forks with `HTTPError: 400 Client Error: Bad Request` rather than an exception mismatch, because besu answers `engine_newPayload` with a `-32600 Invalid Request` JSON-RPC error instead of an `INVALID` payload status. The exception mapper never sees the message, so this cannot be fixed here.

The cause is that `FrontierTransactionDecoder.decode` throws a bare `RuntimeException("An unsupported encoded `v` value of 34 was found")`, which escapes the `RLPException` and `IllegalArgumentException` handling that `AbstractEngineNewPayload` wraps around transaction decoding. Throwing `RLPException` instead, as the other transaction decoders do for malformed content, makes besu return `INVALID` with `Failed to decode transactions from block parameter`, which this PR's mapping already resolves to `INVALID_SIGNATURE_VRS`. A fix along those lines is being submitted upstream to `hyperledger/besu`.

Note that besu's `Failed to decode transactions from block parameter` is a catch-all: it is the same string besu returns for `TYPE_3_TX_WITH_FULL_BLOBS`, `TYPE_3_TX_ZERO_BLOBS` and `RLP_STRUCTURES_ENCODING`, so the mapper resolves it to all four exceptions and cannot distinguish them. That is pre-existing and does not fail any test, but a per-cause decode error would let us tighten the mapping.



### Related Issues or PRs

- #3104
- #3105

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture
<img width="771" height="873" alt="image" src="https://github.com/user-attachments/assets/c5e41ec0-1fe9-40f9-babe-af1535091695" />
