### PR TITLE
fix(spec-specs): load the recipient after authorization processing

### DIFF
--- a/src/ethereum/forks/amsterdam/utils/message.py
+++ b/src/ethereum/forks/amsterdam/utils/message.py
@@ -17,7 +17,7 @@ from ethereum_types.numeric import Uint
 
 from ethereum.state import Address
 
-from ..state_tracker import get_account, get_code
+from ..state_tracker import get_account
 from ..transactions import Transaction
 from ..vm import BlockEnvironment, Message, TransactionEnvironment
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
@@ -63,9 +63,7 @@ def prepare_message(
     elif isinstance(tx.to, Address):
         current_target = tx.to
         msg_data = tx.data
-        code = get_code(
-            tx_env.state, get_account(tx_env.state, tx.to).code_hash
-        )
+        code = Bytes(b"")
         code_address = tx.to
     else:
         raise AssertionError("Target must be address or empty bytes")

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -157,6 +157,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
             auth_state_refund, auth_regular_refund = set_delegation(message)
             state_refund += auth_state_refund
             refund_counter += U256(auth_regular_refund)
+        else:
+            message.code = get_code(
+                tx_state,
+                get_account(tx_state, message.current_target).code_hash,
+            )
 
         delegated_address = get_delegated_code_address(message.code)
         if delegated_address is not None:


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Per [EIPs#11902](https://github.com/ethereum/EIPs/pull/11902), the recipient must not enter the block access list when a halt during EIP-7702 authorization processing precedes its load. Defer the recipient code load from `prepare_message` to after `set_delegation`; behavior-neutral today (authorization costs are intrinsic, so no halt can intervene), it keeps the recipient unread once EIP-2780 charges them at runtime (#3126).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Implements [EIPs#11902](https://github.com/ethereum/EIPs/pull/11902); ordering becomes observable with #3126.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/640px-Cat03.jpg)
