### PR TITLE
fix(test-benchmark): make audited compute benchmarks measure real work

### DIFF
--- a/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
+++ b/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
@@ -100,19 +100,26 @@ class ExtCallGenerator(BenchmarkCodeGenerator):
 
         # Create caller contract that repeatedly calls the target contract
         # attack = POP(
-        #             STATICCALL(GAS, target_contract_address, 0, 0, 0, 0)
+        #             (STATIC)CALL(GAS, target_contract_address, ...)
         #          )
         #
         # setup + JUMPDEST + attack + attack + ... + attack +
         # JUMP(setup_length)
+        #
+        # The target must be entered via CALL when it contains
+        # state-changing opcodes: a STATICCALL'd frame faults on the
+        # first one and the target executes nothing.
+        call_opcode = (
+            Op.CALL if self.uses_state_changing_opcode() else Op.STATICCALL
+        )
         code_sequence = Op.POP(
-            Op.STATICCALL(
-                Op.GAS,
-                self._target_contract_address,
-                Op.PUSH0,
-                Op.CALLDATASIZE,
-                Op.PUSH0,
-                Op.PUSH0,
+            call_opcode(
+                gas=Op.GAS,
+                address=self._target_contract_address,
+                args_offset=Op.PUSH0,
+                args_size=Op.CALLDATASIZE,
+                ret_offset=Op.PUSH0,
+                ret_size=Op.PUSH0,
             )
         )
 

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -64,6 +64,23 @@ class OpcodeTarget:
         return self.name
 
 
+STATE_CHANGING_OPCODES = (
+    Op.SSTORE,
+    Op.TSTORE,
+    Op.CREATE,
+    Op.CREATE2,
+    Op.CALL,
+    Op.CALLCODE,
+    Op.SELFDESTRUCT,
+    Op.LOG0,
+    Op.LOG1,
+    Op.LOG2,
+    Op.LOG3,
+    Op.LOG4,
+)
+"""Opcodes that are illegal inside a static context (EIP-214)."""
+
+
 @dataclass(kw_only=True)
 class BenchmarkCodeGenerator(ABC):
     """Abstract base class for generating benchmark bytecode."""
@@ -81,6 +98,18 @@ class BenchmarkCodeGenerator(ABC):
     def deploy_contracts(self, *, pre: Alloc, fork: Fork) -> Address:
         """Deploy any contracts needed for the benchmark."""
         ...
+
+    def uses_state_changing_opcode(self) -> bool:
+        """
+        Return whether the setup or attack block contains an opcode that
+        is illegal in a static context, in which case the target contract
+        must be entered via CALL instead of STATICCALL (a STATICCALL'd
+        frame faults on the first such opcode and executes nothing).
+        """
+        target_code = bytes(self.setup) + bytes(self.attack_block)
+        return any(
+            bytes(opcode) in target_code for opcode in STATE_CHANGING_OPCODES
+        )
 
     def deploy_fix_count_contracts(self, *, pre: Alloc, fork: Fork) -> Address:
         """Deploy the contract with a fixed opcode count."""
@@ -107,27 +136,10 @@ class BenchmarkCodeGenerator(ABC):
             Op.PUSH0, Op.PUSH0, Op.CALLDATASIZE
         ) + Op.PUSH4(iterations)
 
-        is_state_changing_set = [
-            Op.SSTORE,
-            Op.TSTORE,
-            Op.CREATE,
-            Op.CREATE2,
-            Op.CALL,
-            Op.CALLCODE,
-            Op.SELFDESTRUCT,
-            Op.LOG0,
-            Op.LOG1,
-            Op.LOG2,
-            Op.LOG3,
-            Op.LOG4,
-        ]
-
         # Select CALL for state-changing opcodes, STATICCALL otherwise
-        uses_state_changing_opcode = any(
-            bytes(opcode) in bytes(self.attack_block)
-            for opcode in is_state_changing_set
+        call_opcode = (
+            Op.CALL if self.uses_state_changing_opcode() else Op.STATICCALL
         )
-        call_opcode = Op.CALL if uses_state_changing_opcode else Op.STATICCALL
 
         opcode = (
             prefix

--- a/tests/benchmark/compute/eip7928_block_level_access_lists/test_block_access_list.py
+++ b/tests/benchmark/compute/eip7928_block_level_access_lists/test_block_access_list.py
@@ -629,16 +629,6 @@ def test_deploy_then_interact(
 
     runtime_code, setup_gas, _, reserve_gas = _build_keccak_chain(fork)
 
-    creation_code = Initcode(
-        deploy_code=runtime_code,
-        initcode_prefix=Op.SSTORE(0, 1),
-    )
-
-    intrinsic_gas_create = intrinsic_gas_calculator(
-        calldata=bytes(creation_code),
-        contract_creation=True,
-    )
-
     initcode_sstore = Op.SSTORE(
         0,
         1,
@@ -647,12 +637,22 @@ def test_deploy_then_interact(
         current_value=0,
         new_value=1,
     )
-    initcode_exec_gas = initcode_sstore.gas_cost(fork)
-    code_deposit_gas = 200 * len(runtime_code)
+    creation_code = Initcode(
+        deploy_code=runtime_code,
+        initcode_prefix=initcode_sstore,
+    )
 
-    # Buffer for Initcode wrapper overhead (CODECOPY + RETURN + memory).
+    intrinsic_gas_create = intrinsic_gas_calculator(
+        calldata=bytes(creation_code),
+        contract_creation=True,
+    )
+
+    # Initcode.gas_cost covers the prefix SSTORE, the CODECOPY/RETURN
+    # wrapper, and the code deposit — which under EIP-8037 is state gas
+    # (1,530 per byte) that spills from the regular budget when the
+    # transaction has no reservoir. Small buffer for memory expansion.
     deploy_gas_limit = (
-        intrinsic_gas_create + initcode_exec_gas + code_deposit_gas + 10000
+        intrinsic_gas_create + creation_code.gas_cost(fork) + 10000
     )
 
     min_call_gas = intrinsic_gas + setup_gas + reserve_gas

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -251,17 +251,17 @@ from tests.byzantium.eip197_ec_pairing.spec import (
             )
             # Second pairing
             + PointG1(
-                x=0x0000000000000000000000000000000000000000000000000000000000000013,
-                y=0x0644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD451,
+                x=0x17072B2ED3BB8D759A5325F477629386CB6FC6ECB801BD76983A6B86ABFFE078,
+                y=0x168ADA6CD130DD52017BB54BFA19377AADFE3BF05D18F41B77809F7F60D4AF9E,
             )
             + PointG2(
                 x=(
-                    0x971FF0471B09FA93CAAF13CBF443C1AEDE09CC4328F5A62AAD45F40EC133EB40,
-                    0x91058A3141822985733CBDDDFED0FD8D6C104E9E9EFF40BF5ABFEF9AB163BC72,
+                    0x228B515A17F28B89920873207477F8C7FC05582DEBAF3184FEBF1CFDEDC5CE88,
+                    0x12BB1156A9F6B360FCB2614E15D8A3FF07F2C699DC69CA830B20D2DF91FE9CD3,
                 ),
                 y=(
-                    0xA23AF9A5CE2BA2796C1F4E453A370EB0AF8C212D9DC9ACD8FC02C2E907BAEA22,
-                    0x3A8EB0B0996252CB548A4487DA97B02422EBC0E834613F954DE6C7E0AFDC1FC0,
+                    0x2B15DC62A5C9E36597914DDBBFDE48806A8EABE45C8D3CCCF9578AD08E058F92,
+                    0x02A4FD764F52470E2FCFFF325FB9692F55D6B8B077EEFEAA04E07152B4D1FA94,
                 ),
             ),
             Precompile.BN128_PAIRING,
@@ -269,7 +269,20 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            b"",
+            PointG1(
+                x=0x0769BF9AC56BEA3FF40232BCB1B6BD159315D84715B8E679F2D355961915ABF0,
+                y=0x2AB799BEE0489429554FDB7C8D086475319E63B40B9C5B57CDF1FF3DD9FE2261,
+            )
+            + PointG2(
+                x=(
+                    0x0A09CCF561B55FD99D1C1208DEE1162457B57AC5AF3759D50671E510E428B2A1,
+                    0x2E539C423B302D13F4E5773C603948EAF5DB5DF8AE8A9A9113708390A06410D8,
+                ),
+                y=(
+                    0x19B763513924A736E4EEBD0D78C91C1BC1D657FEE4214057D21414011CFCC763,
+                    0x2F8D9F9AB83727C77A2FEC063CB7B6E5EB23044CCF535AD49D46D394FB6F6BF6,
+                ),
+            ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_1_pair",
         ),
@@ -302,23 +315,50 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         pytest.param(
             EIP197Spec.ECPAIRING,
             # First pairing
-            PointG1(x=0, y=0)
+            PointG1(
+                x=0x030644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD3,
+                y=0x15ED738C0E0A7C92E7845F96B2AE9C0A68A6A449E3538FC7FF3EBF7A5A18A2C4,
+            )
             + PointG2(
                 x=(
-                    0x0EF4AAC9B7954D5FC6EAFAE7F4F4C2A732AB05B45F8D50D102CEE4973F36EB2C,
-                    0x23DB7D30C99E0A2A7F3BB5CD1F04635AAEA58732B58887DF93D9239C28230D28,
+                    0x1014772F57BB9742735191CD5DCFE4EBBC04156B6878A0A7C9824F32FFB66E85,
+                    0x06064E784DB10E9051E52826E192715E8D7E478CB09A5E0012DEFA0694FBC7F5,
                 ),
                 y=(
-                    0x2BD99D31A5054F2556D226F2E5EF0E075423D8604178B2E2C08006311CAEE54F,
-                    0x0F11AFB0C6073D12D21B13F4F78210E8CA9A66729206D3FCC2C1B04824C425F2,
+                    0x021E2335F3354BB7922FFCC2F38D3323DD9453AC49B55441452AEACA147711B2,
+                    0x058E1D5681B5B9E0074B0F9C8D2C68A069B920D74521E79765036D57666C5597,
                 ),
             )
-            # Second pairing (32 zero + G2 generator = 160 bytes)
-            + bytes(32)
-            + EIP197Spec.G2
-            # Third pairing (same structure as second)
-            + bytes(32)
-            + EIP197Spec.G2,
+            # Second pairing
+            + PointG1(
+                x=0x17C139DF0EFEE0F766BC0204762B774362E4DED88953A39CE849A8A7FA163FA9,
+                y=0x01E0559BACB160664764A357AF8A9FE70BAA9258E0B959273FFC5718C6D4CC7C,
+            )
+            + PointG2(
+                x=(
+                    0x2903BA015A9ABDE26A5D081E84551E63BE0FD4516E46EE6D593EDEBA46362455,
+                    0x224BDC5D4327FCF8ED702E01DE1C2F1657A253BA75E32A89C390142AAA28B308,
+                ),
+                y=(
+                    0x03C8B7CDA6B2DEDB7AEEAF5FDA464AD17036BEA1C4E6F7ADBAED1EBE0335E0D8,
+                    0x1D92FFF52A265017EECCB372E37D7A7BD431800ECA28DFD82E21E8054114233F,
+                ),
+            )
+            # Third pairing
+            + PointG1(
+                x=0x2A14705537B009189DA8808651EECDB82482477FE92AC12CA8B71F80FC3D49EF,
+                y=0x2DF7EE7F243EA8B38E1DDF14029258877A618C779FD4717DB6177E19EA67EC38,
+            )
+            + PointG2(
+                x=(
+                    0x009EDAF0698A8C56F51139588ACC094CEE3C37D427BB6D2EAB830AAE529097D1,
+                    0x23AD66F3A7CCA9DC75049635FAEBD124316244B91DE5FB2764CD151572A905F7,
+                ),
+                y=(
+                    0x2700E8A29B7BB45F3022A18A07BDC66D0254559E17CCE64E3B4AD21578FCF410,
+                    0x1AD4F87D3B4375A39988AC099B042B1E7C0C715678E4C2BEA8905F607CF950F8,
+                ),
+            ),
             Precompile.BN128_PAIRING,
             id="ec_pairing_3_pair",
         ),
@@ -464,7 +504,10 @@ from tests.byzantium.eip197_ec_pairing.spec import (
         ),
         pytest.param(
             EIP197Spec.ECPAIRING,
-            bytes(32),
+            # One correctly sized (192-byte) pair of infinity points: the
+            # minimal input the precompile still accepts and charges a full
+            # pair for. bytes(32) would be rejected as a bad length.
+            bytes(192),
             Precompile.BN128_PAIRING,
             id="ec_pairing_1_pair_empty",
         ),

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -299,19 +299,26 @@ def _g2add_calldata(seed: int) -> Bytes:
     return Bytes(_generate_bls12_g2_point(seed) + bls12381_spec.Spec.P2)
 
 
+# Full-width scalar just below the subgroup order. Using Q itself would be
+# congruent to 0 mod the subgroup order, so Q * P == O and the output fed
+# back into the next call would multiply the point at infinity forever. Q - 2
+# keeps every call a real scalar multiplication over a long, non-repeating
+# sequence of distinct points (its order mod Q exceeds any per-block
+# iteration count), preserving both the workload and the anti-caching intent.
+_MSM_SCALAR = bls12381_spec.Spec.Q - 2
+
+
 def _g1msm_calldata(seed: int) -> Bytes:
     """Generate G1MSM calldata with unique point."""
     return Bytes(
-        _generate_bls12_g1_point(seed)
-        + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
+        _generate_bls12_g1_point(seed) + bls12381_spec.Scalar(_MSM_SCALAR)
     )
 
 
 def _g2msm_calldata(seed: int) -> Bytes:
     """Generate G2MSM calldata with unique point."""
     return Bytes(
-        _generate_bls12_g2_point(seed)
-        + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
+        _generate_bls12_g2_point(seed) + bls12381_spec.Scalar(_MSM_SCALAR)
     )
 
 

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -277,6 +277,24 @@ def test_ether_transfers(
     )
 
 
+EMPTY_INPUT_PRECOMPILE_GAS: dict[int, int] = {
+    0x01: 3_000,  # ECRECOVER charges fully, recovers nothing.
+    0x02: 60,  # SHA2-256 base cost.
+    0x03: 600,  # RIPEMD-160 base cost.
+    0x04: 15,  # IDENTITY base cost.
+    0x05: 500,  # MODEXP minimum (EIP-7883).
+    0x06: 150,  # BN128ADD (zero-padded input adds two infinities).
+    0x07: 6_000,  # BN128MUL.
+    0x08: 45_000,  # BN128PAIRING base (zero pairs).
+    0x100: 6_900,  # P256VERIFY charges fully, verifies nothing.
+}
+"""
+Gas each precompile consumes for empty calldata. Precompiles absent from
+this map (BLAKE2F, POINT_EVALUATION, the BLS12-381 family) reject empty
+input outright, so a plain transfer to them reverts by construction.
+"""
+
+
 @pytest.mark.with_all_precompiles
 @pytest.mark.parametrize("transfer_amount", [0, 1])
 def test_ether_transfers_to_precompile(
@@ -288,11 +306,28 @@ def test_ether_transfers_to_precompile(
     transfer_amount: int,
 ) -> None:
     """Test a block full of ether transfers to a precompile address."""
-    # A precompile already exists, so a value transfer pays the EIP-2780
-    # value-transfer charge but never the new-account state gas.
-    iteration_cost = fork.transaction_intrinsic_cost_calculator()(
-        sends_value=transfer_amount > 0,
-        recipient_type=RecipientType.PRECOMPILE,
+    precompile_id = int.from_bytes(bytes(Address(precompile)), "big")
+    if precompile_id not in EMPTY_INPUT_PRECOMPILE_GAS:
+        pytest.skip(
+            "precompile rejects empty input, so the transfer cannot succeed"
+        )
+    sends_value = transfer_amount > 0
+    if sends_value:
+        # Pre-fund the precompile so its account already exists. Otherwise
+        # the first transfer would bring an empty account to life and pay
+        # the one-time EIP-8037 new-account state gas (183,600), which has
+        # no reservoir below the state-gas cap and OOGs the transaction.
+        # Funding it up front keeps every transfer the same uniform cost.
+        pre.fund_address(Address(precompile), 1)
+    # The precompile still executes with empty calldata, so each
+    # transaction must also budget (and is billed) its empty-input cost on
+    # top of the intrinsic value-transfer charge.
+    iteration_cost = (
+        fork.transaction_intrinsic_cost_calculator()(
+            sends_value=sends_value,
+            recipient_type=RecipientType.PRECOMPILE,
+        )
+        + EMPTY_INPUT_PRECOMPILE_GAS[precompile_id]
     )
     iteration_count = gas_benchmark_value // iteration_cost
     txs = []


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Fixes benchmarks in #3098 that filled green but silently measured nothing, their target operations were faulting, running out of gas, or being rejected before doing any real work.

- **`test_storage_access_cold_benchmark` / `test_storage_access_warm_benchmark` (SSTORE cases) and `test_tload` (`fixed_value=False`)**. The `ExtCallGenerator` wrapped every target in `STATICCALL`, so the SSTORE/TSTORE faulted on the first op and the benchmark did zero work, the caller now uses `CALL` when the target contains a state changing opcode. The fix is at the generator, so it also covers any future state changing `ExtCallGenerator` benchmark.
- **`test_deploy_then_interact`**. The deploy budget used the pre-8037 200/byte code-deposit cost, so every deploy ran out of gas and the interact txs hit empty accounts. It now budgets the creation code's actual gas cost.
- **`test_ether_transfers_to_precompile`**. The `gas_limit` was intrinsic only, leaving zero budget so every precompile call OOG'd, adds each precompiles empty input cost and pre funds the precompile so value transfers don't pay the one time new account state gas.
- **`test_alt_bn128`, the `ec_pairing_2_sets`, `ec_pairing_3_pair`, `ec_pairing_1_pair` and `ec_pairing_1_pair_empty` cases**. These used off curve points, wrong length input, or empty calldata and were rejected before any pairing ran. Replaced with valid on curve, correctly sized pairs so each does real Miller loop work.
- **`test_bls12_381_uncachable`, the `bls12_g1msm` / `bls12_g2msm` cases**. The MSM scalar was exactly the subgroup order `r`, so `r·P = O` and the output fed back loop multiplied infinity forever, uses `r - 2` to keep every call a real scalar multiplication over a non-repeating sequence.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to #3098, related to #3128.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/KEzW7ALwfUAAAAAM/cat-what.gif)
