### PR TITLE
fix(test-benchmark): correct compute benchmarks that ran below worst case

### DIFF
--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -98,18 +98,6 @@ from ..helpers import DEFAULT_BINOP_ARGS, make_dup, neg
             ),
         ),
         pytest.param(
-            # Not suitable for MOD, as values quickly become zero.
-            Op.MOD,
-            DEFAULT_BINOP_ARGS,
-            marks=pytest.mark.repricing,
-        ),
-        pytest.param(
-            # Not suitable for SMOD, as values quickly become zero.
-            Op.SMOD,
-            DEFAULT_BINOP_ARGS,
-            marks=pytest.mark.repricing,
-        ),
-        pytest.param(
             # This keeps the values unchanged
             # pow(2**256-1, 2**256-1, 2**256) == 2**256-1.
             Op.EXP,
@@ -125,24 +113,6 @@ from ..helpers import DEFAULT_BINOP_ARGS, make_dup, neg
             (
                 3,
                 0xFFDADADA,  # Negative to have more work.
-            ),
-            marks=pytest.mark.repricing,
-        ),
-        pytest.param(
-            Op.ADDMOD,
-            (
-                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
-                0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001,
-                0x100000000000000000000000000000033,
-            ),
-            marks=pytest.mark.repricing,
-        ),
-        pytest.param(
-            Op.MULMOD,
-            (
-                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
-                0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001,
-                0x100000000000000000000000000000033,
             ),
             marks=pytest.mark.repricing,
         ),

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -20,7 +20,12 @@ from execution_testing import (
 
 
 @pytest.mark.repricing(mem_size=1)
-@pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000, 1_000_000])
+# MSIZE is O(1), so its cost does not vary with memory size. mem_size only
+# controls the one-time expansion in setup; capping it at 100_000 keeps that
+# expansion a minority of the measured gas. A larger value (e.g. 1_000_000)
+# would make the quadratic expansion dwarf the MSIZE loop, benchmarking
+# expansion rather than MSIZE.
+@pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000])
 def test_msize(
     benchmark_test: BenchmarkTestFiller,
     mem_size: int,

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -11,33 +11,50 @@ Supported Opcodes:
 
 import pytest
 from execution_testing import (
+    BenchmarkCodeGenerator,
     BenchmarkTestFiller,
     Bytecode,
     ExtCallGenerator,
+    Fork,
     JumpLoopGenerator,
     Op,
 )
 
 
 @pytest.mark.repricing(mem_size=1)
-# MSIZE is O(1), so its cost does not vary with memory size. mem_size only
-# controls the one-time expansion in setup; capping it at 100_000 keeps that
-# expansion a minority of the measured gas. A larger value (e.g. 1_000_000)
-# would make the quadratic expansion dwarf the MSIZE loop, benchmarking
-# expansion rather than MSIZE.
-@pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000])
+# MSIZE should be O(1), but sweep mem_size so a size-dependent
+# implementation shows up as a regression. ExtCallGenerator re-expands
+# memory in every call frame, so once the expansion outweighs a frame's
+# MSIZE work (~16 KiB), loop in a single frame instead, paying one POP
+# per MSIZE but expanding only once.
+@pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000, 1_000_000])
 def test_msize(
     benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
     mem_size: int,
 ) -> None:
     """Benchmark MSIZE instruction."""
-    benchmark_test(
-        target_opcode=Op.MSIZE,
-        code_generator=ExtCallGenerator(
-            setup=Op.POP(Op.MLOAD(Op.SELFBALANCE)),
+    setup = Op.POP(Op.MLOAD(Op.SELFBALANCE))
+    expansion_gas = fork.memory_expansion_gas_calculator()(new_bytes=mem_size)
+    frame_msize_gas = fork.max_stack_height() * fork.gas_costs().BASE
+
+    code_generator: BenchmarkCodeGenerator
+    if expansion_gas <= frame_msize_gas:
+        code_generator = ExtCallGenerator(
+            setup=setup,
             attack_block=Op.MSIZE,
             contract_balance=mem_size,
-        ),
+        )
+    else:
+        code_generator = JumpLoopGenerator(
+            setup=setup,
+            attack_block=Op.POP(Op.MSIZE),
+            contract_balance=mem_size,
+        )
+
+    benchmark_test(
+        target_opcode=Op.MSIZE,
+        code_generator=code_generator,
     )
 
 

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -39,35 +39,11 @@ from tests.prague.eip2537_bls_12_381_precompiles.spec import (
             marks=pytest.mark.repricing,
         ),
         pytest.param(
-            bls12381_spec.Spec.G1MSM,
-            (
-                bls12381_spec.Spec.P1
-                + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
-            )
-            * (len(bls12381_spec.Spec.G1MSM_DISCOUNT_TABLE) - 1),
-            Precompile.BLS12_G1MSM,
-            id="bls12_g1msm",
-        ),
-        pytest.param(
             bls12381_spec.Spec.G2ADD,
             bls12381_spec.Spec.G2 + bls12381_spec.Spec.P2,
             Precompile.BLS12_G2ADD,
             id="bls12_g2add",
             marks=pytest.mark.repricing,
-        ),
-        pytest.param(
-            bls12381_spec.Spec.G2MSM,
-            # TODO: the //2 is required due to a limitation of the max
-            # contract size limit. In a further iteration we can insert
-            # inputs as calldata or storage and avoid doing PUSHes which
-            # has this limitation. This also applies to G1MSM.
-            (
-                bls12381_spec.Spec.P2
-                + bls12381_spec.Scalar(bls12381_spec.Spec.Q)
-            )
-            * (len(bls12381_spec.Spec.G2MSM_DISCOUNT_TABLE) // 2),
-            Precompile.BLS12_G2MSM,
-            id="bls12_g2msm",
         ),
         pytest.param(
             bls12381_spec.Spec.PAIRING,
@@ -140,11 +116,7 @@ def test_bls12_g1_msm(
     if precompile_address not in fork.precompiles():
         pytest.skip("BLS12_G1_MSM precompile not enabled")
 
-    # Generate k pairs of (point, scalar)
-    calldata = Bytes(
-        (bls12381_spec.Spec.P1 + bls12381_spec.Scalar(bls12381_spec.Spec.Q))
-        * k
-    )
+    calldata = _g1msm_worstcase_calldata(k)
 
     intrinsic_gas_cost = fork.transaction_intrinsic_cost_calculator()(
         calldata=calldata
@@ -190,11 +162,7 @@ def test_bls12_g2_msm(
     if precompile_address not in fork.precompiles():
         pytest.skip("BLS12_G2_MSM precompile not enabled")
 
-    # Generate k pairs of (point, scalar)
-    calldata = Bytes(
-        (bls12381_spec.Spec.P2 + bls12381_spec.Scalar(bls12381_spec.Spec.Q))
-        * k
-    )
+    calldata = _g2msm_worstcase_calldata(k)
 
     intrinsic_gas_cost = fork.transaction_intrinsic_cost_calculator()(
         calldata=calldata
@@ -277,6 +245,40 @@ def _generate_bls12_g2_point(seed: int) -> Bytes:
         + y_im.to_bytes(64, "big")
         + y_re.to_bytes(64, "big")
     )
+
+
+def _g1msm_worstcase_calldata(k: int) -> Bytes:
+    """
+    Build a k-pair G1MSM input that resists MSM shortcuts.
+
+    Identical points would let the precompile factor out (sum sᵢ)·P, and
+    identical scalars would let Pippenger bucket every term together. Pairing
+    distinct points with distinct full-width scalars below the subgroup order
+    (so no term collapses to the point at infinity) forces the full k-term
+    computation.
+    """
+    rng = random.Random(0)
+    parts = [
+        bytes(_generate_bls12_g1_point(i))
+        + bytes(
+            bls12381_spec.Scalar(rng.randint(2**254, bls12381_spec.Spec.Q - 1))
+        )
+        for i in range(k)
+    ]
+    return Bytes(b"".join(parts))
+
+
+def _g2msm_worstcase_calldata(k: int) -> Bytes:
+    """G2MSM counterpart of `_g1msm_worstcase_calldata`."""
+    rng = random.Random(0)
+    parts = [
+        bytes(_generate_bls12_g2_point(i))
+        + bytes(
+            bls12381_spec.Scalar(rng.randint(2**254, bls12381_spec.Spec.Q - 1))
+        )
+        for i in range(k)
+    ]
+    return Bytes(b"".join(parts))
 
 
 def _generate_bls12_pairs(n: int, seed: int = 0) -> Bytes:


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Follow-up to #3135. Where #3135 fixes benchmarks that measured *nothing*, this fixes three that measured the "wrong thing" where the gas is exact, but the work is below worst case.

- **`test_arithmetic`, drop the MOD/SMOD/ADDMOD/MULMOD cases.** Their operand chain collapses to `x mod 0` after ~150 iterations, so >99.99% of the loop is trivial (the params are even commented "not suitable ... values quickly become zero"). The dedicated `test_mod` / `test_mod_arithmetic` already benchmark these at worst case and carry the `repricing` marker, so these cases are redundant duplicates.
- **`test_bls12_g1_msm` / `test_bls12_g2_msm`, use distinct points and scalars.** The input was a single point `P1` repeated with scalar = the subgroup order `r`, so every term was `r·P1 = O` and an MSM can bucket the identical scalars / factor out the shared point. Distinct points paired with distinct full width scalars below `r` force the full k term computation. The exactly redundant k=128/k=64 cases in the `test_bls12_381` sweep (which carry no `repricing` marker) are removed.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to #3135, related to #3128.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/pFz1Q12_hXEAAAAM/cat-holding-head-cat.gif)
