### PR TITLE
feat(zkevm): simplify ChainConfig and provide more structure to SCHEMA_ID

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -1053,7 +1053,6 @@ def is_invalid_stateless_input_sentinel(stateless_output: Any) -> bool:
     """
     Return whether output is the invalid stateless input sentinel.
     """
-    from ethereum.forks.amsterdam.stateless import ProtocolFork
     from ethereum_types.numeric import U64
 
     chain_config = stateless_output.chain_config
@@ -1063,7 +1062,6 @@ def is_invalid_stateless_input_sentinel(stateless_output: Any) -> bool:
         not stateless_output.successful_validation
         and bytes(stateless_output.new_payload_request_root) == b"\0" * 32
         and chain_config.chain_id == U64(0)
-        and active_fork.fork == ProtocolFork.Frontier
         and activation.block_number is None
         and activation.timestamp is None
     )

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -1066,7 +1066,6 @@ def is_invalid_stateless_input_sentinel(stateless_output: Any) -> bool:
         and active_fork.fork == ProtocolFork.Frontier
         and activation.block_number is None
         and activation.timestamp is None
-        and active_fork.blob_schedule is None
     )
 
 

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -21,11 +21,6 @@ from .execution_engine.requests import ExecutionRequests
 from .execution_engine.types import ExecutionPayload, NewPayloadRequest
 from .fork import ChainContext
 from .fork_types import VersionedHash
-from .vm.gas import (
-    BLOB_BASE_FEE_UPDATE_FRACTION,
-    BLOB_SCHEDULE_MAX,
-    BLOB_SCHEDULE_TARGET,
-)
 from .witness_state import WitnessState, build_code_db, build_node_db
 
 
@@ -150,19 +145,6 @@ class ForkActivation:
 @final
 @slotted_freezable
 @dataclass
-class BlobSchedule:
-    """
-    Effective blob parameters for a protocol fork.
-    """
-
-    target: U64
-    max: U64
-    base_fee_update_fraction: U64
-
-
-@final
-@slotted_freezable
-@dataclass
 class ForkConfig:
     """
     Per-fork configuration needed to interpret stateless inputs.
@@ -170,7 +152,6 @@ class ForkConfig:
 
     fork: ProtocolFork
     activation: ForkActivation
-    blob_schedule: BlobSchedule | None
 
 
 @final
@@ -326,17 +307,6 @@ def _is_activation_active(
     return True
 
 
-def _expected_amsterdam_blob_schedule() -> BlobSchedule:
-    """
-    Return the blob schedule currently compiled into the Amsterdam guest.
-    """
-    return BlobSchedule(
-        target=BLOB_SCHEDULE_TARGET,
-        max=BLOB_SCHEDULE_MAX,
-        base_fee_update_fraction=U64(BLOB_BASE_FEE_UPDATE_FRACTION),
-    )
-
-
 def validate_chain_config(
     chain_config: ChainConfig,
     new_payload_request: NewPayloadRequest,
@@ -355,11 +325,6 @@ def validate_chain_config(
     if active_fork.fork != ProtocolFork.Amsterdam:
         raise UnsupportedForkConfigError(
             f"Amsterdam stateless guest cannot execute {active_fork.fork}"
-        )
-
-    if active_fork.blob_schedule != _expected_amsterdam_blob_schedule():
-        raise UnsupportedForkConfigError(
-            "ChainConfig active_fork blob_schedule does not match Amsterdam"
         )
 
     return active_fork

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -3,7 +3,7 @@ Stateless validation interfaces.
 """
 
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import IntEnum
 from typing import List, Sequence, Tuple, final
 
 from ethereum_rlp import rlp
@@ -78,32 +78,32 @@ class NewPayloadRequestHeader:
     execution_requests: ExecutionRequests
 
 
-class ProtocolFork(StrEnum):
+class ProtocolFork(IntEnum):
     """
-    Semantic execution-layer fork names understood by stateless inputs.
+    Stable execution-layer fork identifiers used by stateless schemas.
     """
 
-    Frontier = "Frontier"
-    Homestead = "Homestead"
-    DAOFork = "DAOFork"
-    TangerineWhistle = "TangerineWhistle"
-    SpuriousDragon = "SpuriousDragon"
-    Byzantium = "Byzantium"
-    StPetersburg = "StPetersburg"
-    Istanbul = "Istanbul"
-    MuirGlacier = "MuirGlacier"
-    Berlin = "Berlin"
-    London = "London"
-    ArrowGlacier = "ArrowGlacier"
-    GrayGlacier = "GrayGlacier"
-    Paris = "Paris"
-    Shanghai = "Shanghai"
-    Cancun = "Cancun"
-    Prague = "Prague"
-    Osaka = "Osaka"
-    BPO1 = "BPO1"
-    BPO2 = "BPO2"
-    Amsterdam = "Amsterdam"
+    Frontier = 0x01
+    Homestead = 0x02
+    DAOFork = 0x03
+    TangerineWhistle = 0x04
+    SpuriousDragon = 0x05
+    Byzantium = 0x06
+    StPetersburg = 0x07
+    Istanbul = 0x08
+    MuirGlacier = 0x09
+    Berlin = 0x0A
+    London = 0x0B
+    ArrowGlacier = 0x0C
+    GrayGlacier = 0x0D
+    Paris = 0x0E
+    Shanghai = 0x0F
+    Cancun = 0x10
+    Prague = 0x11
+    Osaka = 0x12
+    BPO1 = 0x13
+    BPO2 = 0x14
+    Amsterdam = 0x15
 
 
 class ChainConfigValidationError(Exception):
@@ -121,12 +121,6 @@ class InactiveForkConfigError(ChainConfigValidationError):
 class InvalidForkActivationError(ChainConfigValidationError):
     """
     Raised when a fork entry has a malformed activation point.
-    """
-
-
-class UnsupportedForkConfigError(ChainConfigValidationError):
-    """
-    Raised when this guest cannot execute the configured active fork.
     """
 
 
@@ -150,7 +144,6 @@ class ForkConfig:
     Per-fork configuration needed to interpret stateless inputs.
     """
 
-    fork: ProtocolFork
     activation: ForkActivation
 
 
@@ -320,11 +313,6 @@ def validate_chain_config(
     if not _is_activation_active(active_fork.activation, execution_payload):
         raise InactiveForkConfigError(
             "ChainConfig active_fork is not active for the target payload"
-        )
-
-    if active_fork.fork != ProtocolFork.Amsterdam:
-        raise UnsupportedForkConfigError(
-            f"Amsterdam stateless guest cannot execute {active_fork.fork}"
         )
 
     return active_fork

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -11,7 +11,6 @@ from .stateless import (
     ChainConfig,
     ForkActivation,
     ForkConfig,
-    ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
     verify_stateless_new_payload,
@@ -61,7 +60,6 @@ def _default_failed_stateless_output() -> StatelessValidationResult:
         chain_config=ChainConfig(
             chain_id=U64(0),
             active_fork=ForkConfig(
-                fork=ProtocolFork.Frontier,
                 activation=ForkActivation(
                     block_number=None,
                     timestamp=None,

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -66,7 +66,6 @@ def _default_failed_stateless_output() -> StatelessValidationResult:
                     block_number=None,
                     timestamp=None,
                 ),
-                blob_schedule=None,
             ),
         ),
     )

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -20,7 +20,6 @@ from .stateless import (
     ExecutionWitness,
     ForkActivation,
     ForkConfig,
-    ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
 )
@@ -64,7 +63,6 @@ def build_chain_config(chain_id: U64) -> ChainConfig:
     return ChainConfig(
         chain_id=chain_id,
         active_fork=ForkConfig(
-            fork=ProtocolFork.Amsterdam,
             activation=ForkActivation(
                 block_number=None,
                 timestamp=U64(0),

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -16,7 +16,6 @@ from .execution_engine.requests import ExecutionRequests
 from .execution_engine.types import ExecutionPayload, NewPayloadRequest
 from .fork_types import VersionedHash
 from .stateless import (
-    BlobSchedule,
     ChainConfig,
     ExecutionWitness,
     ForkActivation,
@@ -37,11 +36,6 @@ from .transactions import (
     Transaction,
     decode_transaction,
     recover_transaction_public_key,
-)
-from .vm.gas import (
-    BLOB_BASE_FEE_UPDATE_FRACTION,
-    BLOB_SCHEDULE_MAX,
-    BLOB_SCHEDULE_TARGET,
 )
 
 
@@ -74,11 +68,6 @@ def build_chain_config(chain_id: U64) -> ChainConfig:
             activation=ForkActivation(
                 block_number=None,
                 timestamp=U64(0),
-            ),
-            blob_schedule=BlobSchedule(
-                target=BLOB_SCHEDULE_TARGET,
-                max=BLOB_SCHEDULE_MAX,
-                base_fee_update_fraction=U64(BLOB_BASE_FEE_UPDATE_FRACTION),
             ),
         ),
     )

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -84,11 +84,9 @@ PUBLIC_KEY_BYTES = 65
 
 # Stateless guest input bytes are schema-prefixed:
 #   schema_id || encoded_payload
-# schema_id is fork_index || schema_revision. fork_index is the 1-based
-# ProtocolFork order, with BPO forks counted. Amsterdam is fork 0x15, and
-# revision 0x01 uses SSZ encode(SszStatelessInput) for the payload. This
-# prefix selects byte decoding and is separate from SszForkConfig.fork.
-STATELESS_INPUT_SCHEMA_FORK_INDEX = 0x15
+# schema_id is fork_index || schema_revision. Amsterdam is fork 0x15, and
+# revision 0x01 uses SSZ encode(SszStatelessInput) for the payload.
+STATELESS_INPUT_SCHEMA_FORK_INDEX = ProtocolFork.Amsterdam
 STATELESS_INPUT_SCHEMA_REVISION = 0x01
 STATELESS_INPUT_SCHEMA_ID = (
     STATELESS_INPUT_SCHEMA_FORK_INDEX << 8
@@ -208,7 +206,6 @@ class SszForkActivation(Container):
 class SszForkConfig(Container):
     """SSZ container mirroring ``ForkConfig``."""
 
-    fork: uint64
     activation: SszForkActivation
 
 
@@ -237,23 +234,6 @@ class SszStatelessValidationResult(Container):
 
 
 # --- Conversion helpers ---
-
-
-PROTOCOL_FORKS = tuple(ProtocolFork)
-
-
-def _protocol_fork_to_ssz(fork: ProtocolFork) -> uint64:
-    """Convert a ProtocolFork to its SSZ enum value."""
-    protocol_fork = ProtocolFork(fork)
-    return uint64(PROTOCOL_FORKS.index(protocol_fork))
-
-
-def _ssz_to_protocol_fork(ssz_fork: uint64) -> ProtocolFork:
-    """Convert an SSZ enum value back to a ProtocolFork."""
-    try:
-        return PROTOCOL_FORKS[int(ssz_fork)]
-    except IndexError as error:
-        raise ValueError(f"Unknown protocol fork value: {ssz_fork}") from error
 
 
 def _withdrawal_to_ssz(w: Withdrawal) -> SszWithdrawal:
@@ -537,7 +517,6 @@ def _fork_config_to_ssz(
 ) -> SszForkConfig:
     """Convert a ForkConfig to its SSZ form."""
     return SszForkConfig(
-        fork=_protocol_fork_to_ssz(fork_config.fork),
         activation=_fork_activation_to_ssz(fork_config.activation),
     )
 
@@ -547,7 +526,6 @@ def _ssz_to_fork_config(
 ) -> ForkConfig:
     """Convert an SSZ fork config back."""
     return ForkConfig(
-        fork=_ssz_to_protocol_fork(ssz_fork_config.fork),
         activation=_ssz_to_fork_activation(ssz_fork_config.activation),
     )
 

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -28,7 +28,6 @@ from .execution_engine.requests import (
 from .execution_engine.types import ExecutionPayload, NewPayloadRequest
 from .fork_types import Bloom, VersionedHash
 from .stateless import (
-    BlobSchedule,
     ChainConfig,
     ExecutionWitness,
     ForkActivation,
@@ -77,7 +76,6 @@ MAX_BYTES_PER_HEADER = 2**10
 MAX_BYTES_PER_WITNESS_NODE = 2**10
 
 MAX_OPTIONAL_FORK_ACTIVATION_VALUES = 1
-MAX_BLOB_SCHEDULES_PER_FORK = 1
 # One public key is supplied per transaction. Every valid transaction consumes
 # at least 21_000 gas, so a 500M gas block can contain at most
 # 500_000_000 // 21_000 = 23_809 transactions, rounded up to next power of 2.
@@ -198,25 +196,11 @@ class SszForkActivation(Container):
     timestamp: SszOptionalForkActivationValue
 
 
-class SszBlobSchedule(Container):
-    """SSZ container mirroring ``BlobSchedule``."""
-
-    target: uint64
-    max: uint64
-    base_fee_update_fraction: uint64
-
-
-SszOptionalBlobSchedule: TypeAlias = SszList[
-    SszBlobSchedule, MAX_BLOB_SCHEDULES_PER_FORK
-]
-
-
 class SszForkConfig(Container):
     """SSZ container mirroring ``ForkConfig``."""
 
     fork: uint64
     activation: SszForkActivation
-    blob_schedule: SszOptionalBlobSchedule
 
 
 class SszChainConfig(Container):
@@ -539,50 +523,6 @@ def _ssz_to_fork_activation(
     )
 
 
-def _blob_schedule_to_ssz(
-    blob_schedule: BlobSchedule,
-) -> SszBlobSchedule:
-    """Convert a BlobSchedule to its SSZ form."""
-    return SszBlobSchedule(
-        target=uint64(int(blob_schedule.target)),
-        max=uint64(int(blob_schedule.max)),
-        base_fee_update_fraction=uint64(
-            int(blob_schedule.base_fee_update_fraction)
-        ),
-    )
-
-
-def _ssz_to_blob_schedule(
-    ssz_blob_schedule: SszBlobSchedule,
-) -> BlobSchedule:
-    """Convert an SSZ blob schedule back."""
-    return BlobSchedule(
-        target=U64(ssz_blob_schedule.target),
-        max=U64(ssz_blob_schedule.max),
-        base_fee_update_fraction=U64(
-            ssz_blob_schedule.base_fee_update_fraction
-        ),
-    )
-
-
-def _optional_blob_schedule_to_ssz(
-    blob_schedule: BlobSchedule | None,
-) -> SszOptionalBlobSchedule:
-    """Convert an optional BlobSchedule to a zero-or-one SSZ list."""
-    if blob_schedule is None:
-        return SszOptionalBlobSchedule()
-    return SszOptionalBlobSchedule(_blob_schedule_to_ssz(blob_schedule))
-
-
-def _ssz_to_optional_blob_schedule(
-    ssz_blob_schedule: SszOptionalBlobSchedule,
-) -> BlobSchedule | None:
-    """Convert a zero-or-one SSZ blob schedule list back."""
-    if ssz_blob_schedule.length() == 0:
-        return None
-    return _ssz_to_blob_schedule(ssz_blob_schedule.get(0))
-
-
 def _fork_config_to_ssz(
     fork_config: ForkConfig,
 ) -> SszForkConfig:
@@ -590,9 +530,6 @@ def _fork_config_to_ssz(
     return SszForkConfig(
         fork=_protocol_fork_to_ssz(fork_config.fork),
         activation=_fork_activation_to_ssz(fork_config.activation),
-        blob_schedule=_optional_blob_schedule_to_ssz(
-            fork_config.blob_schedule
-        ),
     )
 
 
@@ -603,9 +540,6 @@ def _ssz_to_fork_config(
     return ForkConfig(
         fork=_ssz_to_protocol_fork(ssz_fork_config.fork),
         activation=_ssz_to_fork_activation(ssz_fork_config.activation),
-        blob_schedule=_ssz_to_optional_blob_schedule(
-            ssz_fork_config.blob_schedule
-        ),
     )
 
 

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -82,8 +82,17 @@ MAX_OPTIONAL_FORK_ACTIVATION_VALUES = 1
 MAX_PUBLIC_KEYS = 2**15
 PUBLIC_KEY_BYTES = 65
 
-# Amsterdam SSZ stateless input schema identifier.
-STATELESS_INPUT_SCHEMA_ID = 0x0001
+# Stateless guest input bytes are schema-prefixed:
+#   schema_id || encoded_payload
+# schema_id is fork_index || schema_revision. fork_index is the 1-based
+# ProtocolFork order, with BPO forks counted. Amsterdam is fork 0x15, and
+# revision 0x01 uses SSZ encode(SszStatelessInput) for the payload. This
+# prefix selects byte decoding and is separate from SszForkConfig.fork.
+STATELESS_INPUT_SCHEMA_FORK_INDEX = 0x15
+STATELESS_INPUT_SCHEMA_REVISION = 0x01
+STATELESS_INPUT_SCHEMA_ID = (
+    STATELESS_INPUT_SCHEMA_FORK_INDEX << 8
+) | STATELESS_INPUT_SCHEMA_REVISION
 STATELESS_INPUT_SCHEMA_ID_SIZE = 2
 STATELESS_INPUT_SCHEMA_ID_BYTES = STATELESS_INPUT_SCHEMA_ID.to_bytes(
     STATELESS_INPUT_SCHEMA_ID_SIZE,

--- a/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
@@ -34,9 +34,14 @@ def incomplete_schema_id(input_bytes: Bytes) -> Bytes:
     return Bytes(input_bytes[:1])
 
 
-def unsupported_schema_id(input_bytes: Bytes) -> Bytes:
+def unsupported_schema_revision(input_bytes: Bytes) -> Bytes:
     """Replace the schema id with an unsupported Amsterdam revision."""
     return Bytes(b"\x15\x02" + input_bytes[2:])
+
+
+def unsupported_schema_fork(input_bytes: Bytes) -> Bytes:
+    """Replace the schema id with an unsupported fork."""
+    return Bytes(b"\x16\x01" + input_bytes[2:])
 
 
 def missing_ssz_body(input_bytes: Bytes) -> Bytes:
@@ -74,7 +79,11 @@ def invalid_first_ssz_offset(input_bytes: Bytes) -> Bytes:
     [
         pytest.param(empty_input_bytes, id="empty_input_bytes"),
         pytest.param(incomplete_schema_id, id="incomplete_schema_id"),
-        pytest.param(unsupported_schema_id, id="unsupported_schema_id"),
+        pytest.param(
+            unsupported_schema_revision,
+            id="unsupported_schema_revision",
+        ),
+        pytest.param(unsupported_schema_fork, id="unsupported_schema_fork"),
         pytest.param(missing_ssz_body, id="missing_ssz_body"),
         pytest.param(truncated_ssz_body, id="truncated_ssz_body"),
         pytest.param(trailing_garbage, id="trailing_garbage"),

--- a/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
@@ -35,8 +35,8 @@ def incomplete_schema_id(input_bytes: Bytes) -> Bytes:
 
 
 def unsupported_schema_id(input_bytes: Bytes) -> Bytes:
-    """Replace the schema id while keeping the SSZ body."""
-    return Bytes(b"\x00\x02" + input_bytes[2:])
+    """Replace the schema id with an unsupported Amsterdam revision."""
+    return Bytes(b"\x15\x02" + input_bytes[2:])
 
 
 def missing_ssz_body(input_bytes: Bytes) -> Bytes:
@@ -59,10 +59,12 @@ def invalid_first_ssz_offset(input_bytes: Bytes) -> Bytes:
     Corrupt the first SSZ container offset.
 
     The stateless input starts with a 2-byte schema id, followed by the
-    SSZ-encoded ``SszStatelessInput`` container. Its first four SSZ bytes
-    encode the offset to the first variable-size field. Setting that offset
-    to 1 makes it point inside the fixed-size section, so the SSZ decoder
-    must reject the input before stateless validation can run.
+    encoded payload selected by that schema. For Amsterdam schema 0x1501,
+    the payload is an SSZ-encoded ``SszStatelessInput`` container. Its
+    first four SSZ bytes encode the offset to the first variable-size field.
+    Setting that offset to 1 makes it point inside the fixed-size section,
+    so the SSZ decoder must reject the input before stateless validation
+    can run.
     """
     return Bytes(input_bytes[:2] + b"\x01\x00\x00\x00" + input_bytes[6:])
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_config.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_config.py
@@ -56,10 +56,7 @@ def future_timestamp_activation_chain_config(stateless_input: Any) -> Any:
     """Move Amsterdam activation one second after the payload timestamp."""
     from ethereum_types.numeric import U64
 
-    from ethereum.forks.amsterdam.stateless import (
-        ForkActivation,
-        ProtocolFork,
-    )
+    from ethereum.forks.amsterdam.stateless import ForkActivation
 
     payload = stateless_input.new_payload_request.execution_payload
     chain_config = stateless_input.chain_config
@@ -68,7 +65,6 @@ def future_timestamp_activation_chain_config(stateless_input: Any) -> Any:
         chain_config,
         active_fork=replace(
             active_fork,
-            fork=ProtocolFork.Amsterdam,
             activation=ForkActivation(
                 block_number=None,
                 timestamp=U64(int(payload.timestamp) + 1),

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -20,7 +20,6 @@ from ethereum.forks.amsterdam.execution_engine.types import (
 )
 from ethereum.forks.amsterdam.fork_types import Bloom
 from ethereum.forks.amsterdam.stateless import (
-    BlobSchedule,
     ChainConfig,
     ExecutionWitness,
     ForkActivation,
@@ -45,11 +44,6 @@ from ethereum.forks.amsterdam.stateless_host import (
 from ethereum.forks.amsterdam.stateless_ssz import (
     STATELESS_INPUT_SCHEMA_ID_BYTES,
     stateless_input_to_ssz,
-)
-from ethereum.forks.amsterdam.vm.gas import (
-    BLOB_BASE_FEE_UPDATE_FRACTION,
-    BLOB_SCHEDULE_MAX,
-    BLOB_SCHEDULE_TARGET,
 )
 from ethereum.state import Address, Root
 
@@ -130,11 +124,6 @@ def _expected_amsterdam_chain_config(chain_id: U64) -> ChainConfig:
             activation=ForkActivation(
                 block_number=None,
                 timestamp=U64(0),
-            ),
-            blob_schedule=BlobSchedule(
-                target=BLOB_SCHEDULE_TARGET,
-                max=BLOB_SCHEDULE_MAX,
-                base_fee_update_fraction=U64(BLOB_BASE_FEE_UPDATE_FRACTION),
             ),
         ),
     )
@@ -357,7 +346,6 @@ class TestRunStatelessGuest:
         assert result.chain_config.active_fork.fork == ProtocolFork.Frontier
         assert result.chain_config.active_fork.activation.block_number is None
         assert result.chain_config.active_fork.activation.timestamp is None
-        assert result.chain_config.active_fork.blob_schedule is None
 
 
 class TestComputeNewPayloadRequestRoot:

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -42,12 +42,24 @@ from ethereum.forks.amsterdam.stateless_host import (
     serialize_stateless_input,
 )
 from ethereum.forks.amsterdam.stateless_ssz import (
+    STATELESS_INPUT_SCHEMA_FORK_INDEX,
+    STATELESS_INPUT_SCHEMA_ID,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
+    STATELESS_INPUT_SCHEMA_REVISION,
     stateless_input_to_ssz,
 )
 from ethereum.state import Address, Root
 
 _RNG = random.Random(0xDEADBEEF)
+
+
+def test_stateless_input_schema_id_identifies_amsterdam_revision() -> None:
+    """Amsterdam stateless input schema id is fork_index || revision."""
+    assert tuple(ProtocolFork).index(ProtocolFork.Amsterdam) + 1 == 0x15
+    assert STATELESS_INPUT_SCHEMA_FORK_INDEX == 0x15
+    assert STATELESS_INPUT_SCHEMA_REVISION == 0x01
+    assert STATELESS_INPUT_SCHEMA_ID == 0x1501
+    assert STATELESS_INPUT_SCHEMA_ID_BYTES == b"\x15\x01"
 
 
 def _rb(n: int) -> bytes:
@@ -293,13 +305,19 @@ class TestDeserializeStatelessInput:
     def test_one_byte_input_rejected(self) -> None:
         """Reject input that does not contain a full schema id."""
         with pytest.raises(ValueError, match="missing schema id"):
-            deserialize_stateless_input(Bytes(b"\x01"))
+            deserialize_stateless_input(Bytes(b"\x15"))
 
-    def test_unknown_schema_id_rejected(self) -> None:
-        """Reject input with a schema id other than Amsterdam's."""
+    def test_unsupported_schema_revision_rejected(self) -> None:
+        """Reject an unsupported Amsterdam schema revision."""
         encoded = serialize_stateless_input(_make_stateless_input())
-        with pytest.raises(ValueError, match="Unsupported stateless input"):
-            deserialize_stateless_input(Bytes(b"\x00\x02" + encoded[2:]))
+        with pytest.raises(ValueError, match="0x1502"):
+            deserialize_stateless_input(Bytes(b"\x15\x02" + encoded[2:]))
+
+    def test_unsupported_schema_fork_rejected(self) -> None:
+        """Reject an unsupported stateless input schema fork."""
+        encoded = serialize_stateless_input(_make_stateless_input())
+        with pytest.raises(ValueError, match="0x1601"):
+            deserialize_stateless_input(Bytes(b"\x16\x01" + encoded[2:]))
 
     def test_legacy_raw_ssz_input_rejected(self) -> None:
         """Reject unprefixed SSZ input bytes."""

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -55,7 +55,7 @@ _RNG = random.Random(0xDEADBEEF)
 
 def test_stateless_input_schema_id_identifies_amsterdam_revision() -> None:
     """Amsterdam stateless input schema id is fork_index || revision."""
-    assert tuple(ProtocolFork).index(ProtocolFork.Amsterdam) + 1 == 0x15
+    assert STATELESS_INPUT_SCHEMA_FORK_INDEX is ProtocolFork.Amsterdam
     assert STATELESS_INPUT_SCHEMA_FORK_INDEX == 0x15
     assert STATELESS_INPUT_SCHEMA_REVISION == 0x01
     assert STATELESS_INPUT_SCHEMA_ID == 0x1501
@@ -132,7 +132,6 @@ def _expected_amsterdam_chain_config(chain_id: U64) -> ChainConfig:
     return ChainConfig(
         chain_id=chain_id,
         active_fork=ForkConfig(
-            fork=ProtocolFork.Amsterdam,
             activation=ForkActivation(
                 block_number=None,
                 timestamp=U64(0),
@@ -361,7 +360,6 @@ class TestRunStatelessGuest:
         assert result.new_payload_request_root == Hash32(b"\0" * 32)
         assert not result.successful_validation
         assert result.chain_config.chain_id == U64(0)
-        assert result.chain_config.active_fork.fork == ProtocolFork.Frontier
         assert result.chain_config.active_fork.activation.block_number is None
         assert result.chain_config.active_fork.activation.timestamp is None
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -237,6 +237,3 @@ ProtocolFork.Prague
 ProtocolFork.Osaka
 ProtocolFork.BPO1
 ProtocolFork.BPO2
-ProtocolFork.BPO3
-ProtocolFork.BPO4
-ProtocolFork.BPO5


### PR DESCRIPTION
### Description
This PR:

1. Simplifies the Amsterdam stateless chain configuration by removing the blob schedule and redundant fork identifier from `ForkConfig`.
2. Updates the stateless input schema prefix to explicitly identify both the protocol fork and the schema revision.

Regarding 1, consensus-layer clients act as public-input verifiers but do not configure execution-layer blob parameters such as the target, maximum, or base-fee update fraction. Including these values in `ChainConfig` added unnecessary friction because verifiers had to obtain and supply execution-layer constants.

Guest programs are now expected to own a fixed blob schedule for each `(chain_id, protocol_fork)` pair. The `chain_id` remains part of `ChainConfig`, while the protocol fork is identified by the stateless input schema prefix. Consequently, both `BlobSchedule` and the now-redundant `ForkConfig.fork` field are removed from the serialized public inputs. Fork activation data remains in `ChainConfig`.

Regarding 2, `SCHEMA_ID` is now a structured two-byte prefix:

- The first byte is a stable `ProtocolFork` identifier.
- The second byte is the schema revision for that fork.

For Amsterdam revision 1, the prefix is `0x1501`, where `0x15` identifies Amsterdam and `0x01` selects the current SSZ schema.

This gives guest programs explicit decoding logic along two dimensions: first selecting the fork-specific payload and execution rules, then selecting the input schema revision used by that fork. It also establishes a clear convention for defining stateless input schemas for forks before and after Amsterdam.


### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
