### PR TITLE
fix(tests): EIP-8037: failing test

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2123,7 +2123,9 @@ def test_create_account_charge_reduces_child_gas(
 @pytest.mark.parametrize(
     "init_code",
     [
-        pytest.param(Op.REVERT(0, 0), id="revert"),
+        pytest.param(
+            Op.REVERT(0, 10_000, new_memory_size=10_000), id="revert"
+        ),
         pytest.param(Op.INVALID, id="halt"),
     ],
 )
@@ -2139,6 +2141,9 @@ def test_failed_create_tx_refunds_intrinsic_new_account(
     refunded on creation-tx revert/halt. Block state-gas excludes it
     so header gas_used reflects only the regular component, and the
     sender's receipt reflects the same refund via cumulative_gas_used.
+
+    Gas consumed must be above the floor for the test to work, hence
+    the increased memory consumption in some of the initcodes.
     """
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     create_state_gas = fork.create_state_gas(code_size=0)
@@ -2147,7 +2152,7 @@ def test_failed_create_tx_refunds_intrinsic_new_account(
         calldata=bytes(init_code), contract_creation=True
     )
     intrinsic_regular = intrinsic_total - create_state_gas
-    gas_limit = intrinsic_total + 1000
+    gas_limit = intrinsic_total + init_code.regular_cost(fork) + 1000
 
     if init_code == Op.INVALID:
         regular_consumed = gas_limit - intrinsic_total
@@ -2158,11 +2163,10 @@ def test_failed_create_tx_refunds_intrinsic_new_account(
     expected_cumulative = intrinsic_total + regular_consumed - create_state_gas
     # A tiny init code can leave the decomposed calldata floor above the
     # regular gas consumed, pinning gas_used to the floor.
-    floor = fork.transaction_data_floor_cost_calculator()(
-        data=bytes(init_code), contract_creation=True
-    )
-    expected_gas_used = max(expected_gas_used, floor)
-    expected_cumulative = max(expected_cumulative, floor)
+    data_floor_calc = fork.transaction_data_floor_cost_calculator()
+    floor = data_floor_calc(data=init_code, contract_creation=True)
+    assert expected_gas_used > floor
+    assert expected_cumulative > floor
 
     tx = Transaction(
         to=None,


### PR DESCRIPTION
### Description

Fixes test that broken during the spec changes of #3120:

Since the floor data cost increased due to the anchor change, the test was always consuming the data floor instead of the expected gas. 

Fix was to increase the regular used by the initcode via memory increment.

### Related Issues or PRs
N/A.

### Checklist
- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Nile_crocodile_head.jpg/250px-Nile_crocodile_head.jpg)
