### PR TITLE
feat(test-fill): collect per-test opcode counts in fill-stateful via `debug_traceBlockByNumber`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -61,6 +61,7 @@ from ..execute.rpc.hive import (
 )
 from ..shared.helpers import is_help_or_collectonly_mode
 from ..shared.live_client_flags import FEE_BUMP_MULTIPLIER
+from .opcode_tracing import write_opcode_trace_file
 
 # 1 billion ETH. Withdrawals are Gwei (u64-capped); much higher risks
 # overflow on some clients, this is plenty for any single fill session.
@@ -116,6 +117,28 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help=(
             "Private key for signing transactions. Optional — a random "
             "key is generated and funded via CL withdrawal if omitted."
+        ),
+    )
+    group.addoption(
+        "--trace-opcodes",
+        action="store_true",
+        dest="trace_opcodes",
+        default=False,
+        help=(
+            "Collect per-test opcode counts by tracing each built block "
+            "via debug_traceBlockByNumber (unigram tracer) and write them "
+            "to a JSON file mapping test names to opcode counts."
+        ),
+    )
+    group.addoption(
+        "--trace-opcodes-output",
+        action="store",
+        dest="trace_opcodes_output",
+        default=None,
+        type=str,
+        help=(
+            "Output path for the opcode trace JSON (default: "
+            "<output-dir>/opcodes_tracing.json)."
         ),
     )
     group.addoption(
@@ -477,7 +500,9 @@ def debug_rpc(eth_rpc: EthRPC) -> DebugRPC:
 
 @pytest.fixture(scope="session")
 def client_backend(
+    request: pytest.FixtureRequest,
     eth_rpc: ChainBuilderEthRPC,
+    debug_rpc: DebugRPC,
     session_fork: Fork | TransitionFork,
     default_gas_price: int | None,
     default_max_fee_per_gas: int | None,
@@ -502,6 +527,8 @@ def client_backend(
         eth_rpc=eth_rpc,
         fork=session_fork,
     )
+    if request.config.getoption("trace_opcodes"):
+        backend.opcode_tracer_rpc = debug_rpc
 
     priority_fee = default_max_priority_fee_per_gas
     if priority_fee is None:
@@ -703,6 +730,7 @@ def _session_pre_run(
 
 @pytest.fixture(autouse=True, scope="session")
 def session_t8n(
+    request: pytest.FixtureRequest,
     client_backend: ClientBackend,
     _session_pre_run: None,
 ) -> Generator[ClientBackend, None, None]:
@@ -712,6 +740,22 @@ def session_t8n(
     """
     del _session_pre_run
     yield client_backend
+    if request.config.getoption("trace_opcodes"):
+        output_arg = request.config.getoption("trace_opcodes_output")
+        trace_output = (
+            Path(output_arg)
+            if output_arg
+            else Path(request.config.getoption("output"))
+            / "opcodes_tracing.json"
+        )
+        write_opcode_trace_file(
+            trace_output, client_backend.collected_opcode_counts
+        )
+        logger.info(
+            f"Wrote opcode counts for "
+            f"{len(client_backend.collected_opcode_counts)} tests to "
+            f"{trace_output}"
+        )
     client_backend.shutdown()
 
 
@@ -721,6 +765,21 @@ def t8n(
 ) -> Generator[ClientBackend, None, None]:
     """Override: no per-test reset needed for ClientBackend."""
     yield session_t8n
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _current_test_id(
+    request: pytest.FixtureRequest,
+    client_backend: ClientBackend,
+) -> Generator[None, None, None]:
+    """
+    Tag the backend with the running test's node id so execution-phase
+    opcode counts recorded by ``make_stateful_fixture`` land under the
+    right test in the ``--trace-opcodes`` output.
+    """
+    client_backend.current_test_id = request.node.nodeid
+    yield
+    client_backend.current_test_id = None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/opcode_tracing.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/opcode_tracing.py
@@ -1,0 +1,68 @@
+"""
+Opcode-trace output for ``fill-stateful --trace-opcodes``.
+
+Serialise the per-test opcode counts collected by ``ClientBackend``
+(via ``debug_traceBlockByNumber`` with the unigram tracer) into a JSON
+file mapping test names to opcode counts, matching the format produced
+by gas-benchmarks' ``eest_stateful_generator.py --trace-json``::
+
+    {
+      "test_single_opcode.py__test_sload[fork_Amsterdam-...]": {
+        "PUSH1": 55674,
+        "SLOAD": 11132
+      }
+    }
+"""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from execution_testing.client_clis.cli_types import OpcodeCount
+
+# ``OpcodeCount`` canonicalizes client-reported opcode names through the
+# ``Opcodes`` enum (geth's ``KECCAK256`` becomes ``SHA3``); map back to
+# the geth-style name so the output matches gas-benchmarks' trace files.
+_OPCODE_OUTPUT_NAMES = {"SHA3": "KECCAK256"}
+
+
+def node_id_to_test_key(node_id: str) -> str:
+    """
+    Convert a pytest node id to a gas-benchmarks-compatible test key.
+
+    ``tests/benchmark/test_single_opcode.py::test_sload[params]`` becomes
+    ``test_single_opcode.py__test_sload[params]``: the module path is
+    reduced to its basename and ``::`` separators become ``__``, mirroring
+    the payload file names gas-benchmarks derives its keys from.
+    """
+    module_path, sep, test_part = node_id.partition("::")
+    if not sep:
+        return node_id
+    module_name = module_path.rpartition("/")[2]
+    return f"{module_name}__{test_part.replace('::', '__')}"
+
+
+def write_opcode_trace_file(
+    path: Path, collected: Dict[str, OpcodeCount]
+) -> None:
+    """
+    Write collected per-test opcode counts to ``path`` as JSON.
+
+    ``collected`` is keyed by pytest node id; keys are converted via
+    ``node_id_to_test_key``. Keys that collide after the module path is
+    flattened get an ``__<n>`` suffix, as in gas-benchmarks.
+    """
+    results: Dict[str, Dict[str, int]] = {}
+    for node_id, opcode_count in collected.items():
+        key = node_id_to_test_key(node_id)
+        if key in results:
+            duplicate_idx = 1
+            while f"{key}__{duplicate_idx}" in results:
+                duplicate_idx += 1
+            key = f"{key}__{duplicate_idx}"
+        results[key] = {
+            _OPCODE_OUTPUT_NAMES.get(str(opcode), str(opcode)): count
+            for opcode, count in opcode_count.root.items()
+        }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(results, indent=2), encoding="utf-8")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/tests/__init__.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the fill-stateful pytest plugin."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/tests/test_opcode_tracing.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/tests/test_opcode_tracing.py
@@ -1,0 +1,127 @@
+"""Tests for the --trace-opcodes output file (gas-benchmarks format)."""
+
+import json
+from pathlib import Path
+
+from execution_testing.cli.pytest_commands.plugins.fill_stateful.opcode_tracing import (  # noqa: E501
+    node_id_to_test_key,
+    write_opcode_trace_file,
+)
+from execution_testing.client_clis.cli_types import OpcodeCount
+
+# ---------------------------------------------------------------------------
+# node_id_to_test_key
+# ---------------------------------------------------------------------------
+
+
+def test_key_strips_module_directory() -> None:
+    """Reduce the module path to its basename."""
+    node_id = (
+        "tests/benchmark/stateful/bloatnet/test_single_opcode.py::"
+        "test_sload_erc20_generic[fork_Amsterdam-benchmark_300M]"
+    )
+    assert node_id_to_test_key(node_id) == (
+        "test_single_opcode.py__"
+        "test_sload_erc20_generic[fork_Amsterdam-benchmark_300M]"
+    )
+
+
+def test_key_without_parameters() -> None:
+    """Handle node ids without a parametrization suffix."""
+    assert (
+        node_id_to_test_key("tests/test_mod.py::test_case")
+        == "test_mod.py__test_case"
+    )
+
+
+def test_key_class_based_test() -> None:
+    """Flatten every ``::`` separator to ``__``."""
+    assert (
+        node_id_to_test_key("tests/test_mod.py::TestClass::test_case")
+        == "test_mod.py__TestClass__test_case"
+    )
+
+
+def test_key_without_separator() -> None:
+    """Pass through strings that are not node ids."""
+    assert node_id_to_test_key("not-a-node-id") == "not-a-node-id"
+
+
+# ---------------------------------------------------------------------------
+# write_opcode_trace_file
+# ---------------------------------------------------------------------------
+
+
+def test_write_matches_gas_benchmarks_format(tmp_path: Path) -> None:
+    """Produce the exact JSON layout of gas-benchmarks' trace output."""
+    output = tmp_path / "opcodes_tracing.json"
+    write_opcode_trace_file(
+        output,
+        {
+            "tests/benchmark/test_account_query.py::"
+            "test_account_access[fork_Amsterdam-opcode_BALANCE]": (
+                OpcodeCount.model_validate({"PUSH1": 55674, "BALANCE": 11132})
+            ),
+        },
+    )
+    expected = (
+        "{\n"
+        '  "test_account_query.py__'
+        'test_account_access[fork_Amsterdam-opcode_BALANCE]": {\n'
+        '    "PUSH1": 55674,\n'
+        '    "BALANCE": 11132\n'
+        "  }\n"
+        "}"
+    )
+    assert output.read_text(encoding="utf-8") == expected
+
+
+def test_write_restores_keccak256_name(tmp_path: Path) -> None:
+    """Serialise SHA3 back to KECCAK256, as clients report it."""
+    output = tmp_path / "opcodes_tracing.json"
+    write_opcode_trace_file(
+        output,
+        {
+            "tests/t.py::test_x": OpcodeCount.model_validate(
+                {"KECCAK256": 3, "ADD": 1}
+            )
+        },
+    )
+    counts = json.loads(output.read_text(encoding="utf-8"))["t.py__test_x"]
+    assert counts == {"KECCAK256": 3, "ADD": 1}
+
+
+def test_write_suffixes_colliding_keys(tmp_path: Path) -> None:
+    """Suffix keys that collide once module paths are flattened."""
+    output = tmp_path / "opcodes_tracing.json"
+    write_opcode_trace_file(
+        output,
+        {
+            f"tests/{subdir}/test_mod.py::test_case": (
+                OpcodeCount.model_validate({"ADD": count})
+            )
+            for subdir, count in [("a", 1), ("b", 2), ("c", 3)]
+        },
+    )
+    results = json.loads(output.read_text(encoding="utf-8"))
+    assert results == {
+        "test_mod.py__test_case": {"ADD": 1},
+        "test_mod.py__test_case__1": {"ADD": 2},
+        "test_mod.py__test_case__2": {"ADD": 3},
+    }
+
+
+def test_write_empty_collection(tmp_path: Path) -> None:
+    """Write an empty JSON object when nothing was collected."""
+    output = tmp_path / "opcodes_tracing.json"
+    write_opcode_trace_file(output, {})
+    assert json.loads(output.read_text(encoding="utf-8")) == {}
+
+
+def test_write_creates_parent_directories(tmp_path: Path) -> None:
+    """Create missing parent directories for the output path."""
+    output = tmp_path / "nested" / "dir" / "opcodes_tracing.json"
+    write_opcode_trace_file(
+        output, {"tests/t.py::test_x": OpcodeCount.model_validate({"STOP": 1})}
+    )
+    assert output.is_file()

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -17,7 +17,14 @@ from typing import Any, ClassVar, Dict, List, Optional
 from execution_testing.base_types import Bytes, Hash
 from execution_testing.exceptions import ExceptionBase, ExceptionMapper
 from execution_testing.forks import Fork, TransitionFork
-from execution_testing.rpc import EngineRPC, EthRPC, TestingRPC, Web3RPC
+from execution_testing.logging import get_logger
+from execution_testing.rpc import (
+    DebugRPC,
+    EngineRPC,
+    EthRPC,
+    TestingRPC,
+    Web3RPC,
+)
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
     GetPayloadResponse,
@@ -37,6 +44,8 @@ from .cli_types import (
     TransitionToolOutput,
 )
 from .transition_tool import TransitionTool
+
+logger = get_logger(__name__)
 
 
 class ClientBackendExceptionMapper(ExceptionMapper):
@@ -82,6 +91,16 @@ class ClientBackend:
     max_priority_fee_per_gas: int = 0
     max_fee_per_blob_gas: int = 0
 
+    # Opcode tracing (``--trace-opcodes``): when the fill-stateful plugin
+    # sets ``opcode_tracer_rpc``, each built block is traced via
+    # ``debug_traceBlockByNumber`` (unigram tracer) right after it is made
+    # canonical. ``current_test_id`` is set per test by the plugin;
+    # ``make_stateful_fixture`` records each test's execution-phase totals
+    # into ``collected_opcode_counts``.
+    opcode_tracer_rpc: DebugRPC | None = None
+    current_test_id: str | None = None
+    collected_opcode_counts: Dict[str, OpcodeCount]
+
     def __init__(
         self,
         *,
@@ -98,6 +117,9 @@ class ClientBackend:
         self.exception_mapper = ClientBackendExceptionMapper()
         self.snapshot_block = None
         self.start_block = None
+        self.opcode_tracer_rpc = None
+        self.current_test_id = None
+        self.collected_opcode_counts = {}
         self._info_metadata = {}
         self.gas_price = 0
         self.max_fee_per_gas = 0
@@ -195,6 +217,10 @@ class ClientBackend:
             withdrawals=env.withdrawals,
             block_fork=block_fork,
         )
+        if self.opcode_tracer_rpc is not None:
+            result.opcode_count = self._trace_block_opcode_count(
+                int(get_payload_response.execution_payload.number)
+            )
         alloc = LazyAllocJson(raw={}, _state_root=result.state_root)
         return TransitionToolOutput(
             alloc=alloc,
@@ -207,6 +233,51 @@ class ClientBackend:
                     payload_attributes.parent_beacon_block_root
                 ),
             ),
+        )
+
+    def _trace_block_opcode_count(
+        self, block_number: int
+    ) -> OpcodeCount | None:
+        """
+        Trace a just-canonicalized block and return its opcode counts.
+
+        Failures (unsupported client, trace error, unknown opcode names
+        in the response) are logged and yield ``None`` — tracing must
+        never fail the fill.
+        """
+        assert self.opcode_tracer_rpc is not None
+        try:
+            counts = self.opcode_tracer_rpc.trace_block_opcode_counts(
+                hex(block_number)
+            )
+        except Exception as e:
+            logger.warning(
+                f"Opcode trace failed for block {block_number}: {e}"
+            )
+            return None
+        if counts is None:
+            return None
+        try:
+            return OpcodeCount.model_validate(counts)
+        except Exception as e:
+            logger.warning(
+                f"Unparsable opcode trace for block {block_number}: {e}"
+            )
+            return None
+
+    def record_test_opcode_count(self, opcode_count: OpcodeCount) -> None:
+        """
+        Record a test's execution-phase opcode counts.
+
+        Keyed by ``current_test_id`` (set per test by the fill-stateful
+        plugin); repeated records for the same test are summed. No-op
+        when no test id is set.
+        """
+        if self.current_test_id is None:
+            return
+        existing = self.collected_opcode_counts.get(self.current_test_id)
+        self.collected_opcode_counts[self.current_test_id] = (
+            existing + opcode_count if existing is not None else opcode_count
         )
 
     def _payload_attributes(

--- a/packages/testing/src/execution_testing/client_clis/tests/test_client_backend_opcode_tracing.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_client_backend_opcode_tracing.py
@@ -1,0 +1,214 @@
+"""Tests for ClientBackend opcode-trace collection."""
+
+from typing import Any, Dict
+
+import pytest
+
+from execution_testing.base_types import (
+    Address,
+    Bloom,
+    Bytes,
+    Hash,
+    HexNumber,
+)
+from execution_testing.client_clis.cli_types import OpcodeCount
+from execution_testing.client_clis.client_backend import ClientBackend
+from execution_testing.client_clis.transition_tool import TransitionTool
+from execution_testing.fixtures.blockchain import FixtureExecutionPayload
+from execution_testing.forks import Prague
+from execution_testing.rpc.rpc_types import GetPayloadResponse
+from execution_testing.test_types import Alloc, Environment
+
+
+class TracerStub:
+    """Stand-in for DebugRPC.trace_block_opcode_counts."""
+
+    def __init__(self, counts: Dict[str, int] | None) -> None:
+        """Return the given counts for every traced block."""
+        self.counts = counts
+        self.traced_blocks: list[str] = []
+
+    def trace_block_opcode_counts(
+        self, block_number: str
+    ) -> Dict[str, int] | None:
+        """Record the request and return the configured counts."""
+        self.traced_blocks.append(block_number)
+        return self.counts
+
+
+class RaisingTracerStub:
+    """Tracer stand-in whose trace call always raises."""
+
+    def trace_block_opcode_counts(self, block_number: str) -> None:
+        """Raise to simulate a client-side trace failure."""
+        del block_number
+        raise RuntimeError("trace exploded")
+
+
+@pytest.fixture
+def backend(monkeypatch: pytest.MonkeyPatch) -> ClientBackend:
+    """ClientBackend with stubbed RPC dependencies (no network)."""
+
+    class Web3Stub:
+        def __init__(self, url: str) -> None:
+            pass
+
+        def client_version(self) -> str:
+            return "stub/v0.0.0"
+
+    monkeypatch.setattr(
+        "execution_testing.client_clis.client_backend.Web3RPC", Web3Stub
+    )
+
+    class EthRPCStub:
+        url = "http://localhost:8545"
+
+    return ClientBackend(
+        testing_rpc=None,  # type: ignore[arg-type]
+        engine_rpc=None,  # type: ignore[arg-type]
+        eth_rpc=EthRPCStub(),  # type: ignore[arg-type]
+        fork=Prague,
+    )
+
+
+def test_trace_disabled_by_default(backend: ClientBackend) -> None:
+    """No tracer RPC is attached unless the plugin sets one."""
+    assert backend.opcode_tracer_rpc is None
+
+
+def test_trace_block_opcode_count(backend: ClientBackend) -> None:
+    """Return validated OpcodeCount from the tracer's raw counts."""
+    tracer = TracerStub({"PUSH1": 2, "SLOAD": 1})
+    backend.opcode_tracer_rpc = tracer  # type: ignore[assignment]
+    opcode_count = backend._trace_block_opcode_count(5)
+    assert opcode_count is not None
+    assert opcode_count.model_dump() == {"PUSH1": 2, "SLOAD": 1}
+    assert tracer.traced_blocks == ["0x5"]
+
+
+def test_trace_block_unsupported_client(backend: ClientBackend) -> None:
+    """Propagate None when the tracer reports no support."""
+    backend.opcode_tracer_rpc = TracerStub(None)  # type: ignore[assignment]
+    assert backend._trace_block_opcode_count(5) is None
+
+
+def test_trace_block_failure_is_non_fatal(
+    backend: ClientBackend, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A trace error yields None with a warning; the fill continues."""
+    backend.opcode_tracer_rpc = RaisingTracerStub()  # type: ignore[assignment]
+    with caplog.at_level("WARNING"):
+        assert backend._trace_block_opcode_count(5) is None
+    assert any("trace" in r.message.lower() for r in caplog.records)
+
+
+def test_trace_block_unknown_opcode_name(
+    backend: ClientBackend, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unparsable opcode names yield None instead of failing the fill."""
+    backend.opcode_tracer_rpc = TracerStub(  # type: ignore[assignment]
+        {"NOT_AN_OPCODE": 1}
+    )
+    with caplog.at_level("WARNING"):
+        assert backend._trace_block_opcode_count(5) is None
+    assert any("opcode" in r.message.lower() for r in caplog.records)
+
+
+def test_record_requires_test_id(backend: ClientBackend) -> None:
+    """Recording without a current test id is a no-op."""
+    backend.record_test_opcode_count(OpcodeCount.model_validate({"PUSH1": 1}))
+    assert backend.collected_opcode_counts == {}
+
+
+def test_record_and_merge(backend: ClientBackend) -> None:
+    """Repeated records for the same test are summed."""
+    backend.current_test_id = "tests/test_mod.py::test_case[x]"
+    backend.record_test_opcode_count(
+        OpcodeCount.model_validate({"PUSH1": 1, "ADD": 2})
+    )
+    backend.record_test_opcode_count(OpcodeCount.model_validate({"PUSH1": 3}))
+    recorded = backend.collected_opcode_counts[
+        "tests/test_mod.py::test_case[x]"
+    ]
+    assert recorded.model_dump() == {"PUSH1": 4, "ADD": 2}
+
+
+def test_record_separate_tests(backend: ClientBackend) -> None:
+    """Counts land under the test id active at record time."""
+    backend.current_test_id = "tests/test_mod.py::test_one"
+    backend.record_test_opcode_count(OpcodeCount.model_validate({"PUSH1": 1}))
+    backend.current_test_id = "tests/test_mod.py::test_two"
+    backend.record_test_opcode_count(OpcodeCount.model_validate({"ADD": 1}))
+    assert set(backend.collected_opcode_counts) == {
+        "tests/test_mod.py::test_one",
+        "tests/test_mod.py::test_two",
+    }
+
+
+def _evaluate_with_stub_client(backend: ClientBackend) -> Any:
+    """
+    Run ``evaluate`` against a stubbed client.
+
+    ``build_block`` returns a canned empty payload and the engine
+    finalization is skipped; everything else (result assembly and the
+    opcode-trace hook) runs for real.
+    """
+    payload = FixtureExecutionPayload(
+        parent_hash=Hash(0),
+        fee_recipient=Address(0),
+        state_root=Hash(0),
+        receipts_root=Hash(0),
+        logs_bloom=Bloom(b"\x00" * 256),
+        number=HexNumber(7),
+        gas_limit=HexNumber(30_000_000),
+        gas_used=HexNumber(0),
+        timestamp=HexNumber(0),
+        extra_data=Bytes(b""),
+        prev_randao=Hash(0),
+        base_fee_per_gas=HexNumber(7),
+        blob_gas_used=HexNumber(0),
+        excess_blob_gas=HexNumber(0),
+        block_hash=Hash(1),
+        transactions=[],
+        withdrawals=[],
+    )
+
+    class TestingRPCStub:
+        @staticmethod
+        def build_block(**kwargs: Any) -> GetPayloadResponse:
+            del kwargs
+            return GetPayloadResponse(
+                execution_payload=payload, execution_requests=[]
+            )
+
+    def skip_finalize(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+
+    backend.testing_rpc = TestingRPCStub()  # type: ignore[assignment]
+    backend._finalize = skip_finalize  # type: ignore[method-assign]
+    transition_tool_data = TransitionTool.TransitionToolData(
+        alloc=Alloc(),
+        txs=[],
+        env=Environment(withdrawals=[]),
+        fork=Prague,
+        chain_id=1,
+        reward=0,
+        blob_schedule=None,
+    )
+    return backend.evaluate(transition_tool_data=transition_tool_data)
+
+
+def test_evaluate_without_tracing(backend: ClientBackend) -> None:
+    """Evaluate leaves opcode_count unset when tracing is disabled."""
+    output = _evaluate_with_stub_client(backend)
+    assert output.result.opcode_count is None
+
+
+def test_evaluate_with_tracing(backend: ClientBackend) -> None:
+    """Evaluate traces the built block when a tracer RPC is attached."""
+    tracer = TracerStub({"STOP": 1})
+    backend.opcode_tracer_rpc = tracer  # type: ignore[assignment]
+    output = _evaluate_with_stub_client(backend)
+    assert output.result.opcode_count is not None
+    assert output.result.opcode_count.model_dump() == {"STOP": 1}
+    assert tracer.traced_blocks == ["0x7"]

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -1277,6 +1277,31 @@ class EthRPC(BaseRPC):
         return results
 
 
+def sum_unigram_block_trace(block_trace: Any) -> Dict[str, int]:
+    """
+    Sum per-transaction unigram tracer results into per-block counts.
+
+    ``debug_traceBlockByNumber`` returns one entry per transaction, whose
+    shape varies across clients: ``{"txHash": ..., "result": {op: count}}``
+    (geth), ``{"result": {op: count}}`` (older geth/erigon), or the bare
+    ``{op: count}`` map. Entries carrying a per-transaction ``error`` (or
+    any non-integer values) are skipped.
+    """
+    counts: Dict[str, int] = {}
+    if not isinstance(block_trace, list):
+        return counts
+    for entry in block_trace:
+        if not isinstance(entry, dict):
+            continue
+        inner = entry.get("result") if "result" in entry else entry
+        if not isinstance(inner, dict):
+            continue
+        for opcode, occurrences in inner.items():
+            if isinstance(opcode, str) and isinstance(occurrences, int):
+                counts[opcode] = counts.get(opcode, 0) + occurrences
+    return counts
+
+
 class DebugRPC(EthRPC):
     """
     Represents an `debug_X` RPC class for every default ethereum RPC method
@@ -1294,12 +1319,84 @@ class DebugRPC(EthRPC):
     # so the fallback probe runs only once per session.
     _rewind_method: str | None = None
 
+    # Inline JS source equivalent to geth's embedded ``unigramTracer``.
+    # Fallback for clients that run geth-style JS tracers but do not
+    # resolve built-in tracer names (e.g. reth).
+    UNIGRAM_TRACER_JS: ClassVar[str] = (
+        "{counts: {}, "
+        "step: function(log) { "
+        "var op = log.op.toString(); "
+        "this.counts[op] = (this.counts[op] || 0) + 1; "
+        "}, "
+        "fault: function() {}, "
+        "result: function() { return this.counts; }}"
+    )
+
+    # Which opcode tracer the client accepts ("unigramTracer" by name,
+    # "js" for the inline source, or "none" when unsupported); resolved
+    # on first use so the fallback probe runs only once per session.
+    _opcode_tracer: str | None = None
+
     def trace_call(self, tr: dict[str, str], block_number: str) -> Any | None:
         """`debug_traceCall`: Returns pre state required for transaction."""
         params = [tr, block_number, {"tracer": "prestateTracer"}]
         return self.post_request(
             request=RPCCall(method="traceCall", params=params)
         ).result_or_raise()
+
+    def trace_block_by_number(self, block_number: str, tracer: str) -> Any:
+        """`debug_traceBlockByNumber` with the given tracer."""
+        return self.post_request(
+            request=RPCCall(
+                method="traceBlockByNumber",
+                params=[block_number, {"tracer": tracer}],
+            )
+        ).result_or_raise()
+
+    def trace_block_opcode_counts(
+        self, block_number: str
+    ) -> Dict[str, int] | None:
+        """
+        Collect per-opcode execution counts for the given block.
+
+        Try geth's built-in ``unigramTracer`` by name first (geth,
+        erigon and nethermind resolve it); if the client rejects it,
+        retry with the equivalent JS tracer source inlined (reth). When
+        neither works (e.g. besu, which has no JS tracer engine), warn
+        once and return ``None`` for this and all subsequent calls. The
+        working tracer is cached after the first call.
+        """
+        if self._opcode_tracer == "none":
+            return None
+        if self._opcode_tracer is not None:
+            tracer = (
+                self.UNIGRAM_TRACER_JS
+                if self._opcode_tracer == "js"
+                else self._opcode_tracer
+            )
+            return sum_unigram_block_trace(
+                self.trace_block_by_number(block_number, tracer)
+            )
+        for method, tracer in (
+            ("unigramTracer", "unigramTracer"),
+            ("js", self.UNIGRAM_TRACER_JS),
+        ):
+            try:
+                block_trace = self.trace_block_by_number(block_number, tracer)
+            except JSONRPCError as e:
+                logger.debug(
+                    f"Opcode tracer probe {method!r} rejected by client: {e}"
+                )
+                continue
+            self._opcode_tracer = method
+            return sum_unigram_block_trace(block_trace)
+        logger.warning(
+            "Client supports neither the built-in unigramTracer nor "
+            "inline JS tracers via debug_traceBlockByNumber; opcode "
+            "counts will not be collected."
+        )
+        self._opcode_tracer = "none"
+        return None
 
     def set_head(self, block_number: str) -> None:
         """`debug_setHead`: Reset chain head to the given block number."""

--- a/packages/testing/src/execution_testing/rpc/tests/test_opcode_tracing.py
+++ b/packages/testing/src/execution_testing/rpc/tests/test_opcode_tracing.py
@@ -1,0 +1,169 @@
+"""Tests for DebugRPC opcode tracing (unigram tracer + fallback)."""
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from execution_testing.rpc.rpc import DebugRPC, sum_unigram_block_trace
+from execution_testing.rpc.rpc_types import JSONRPCError
+
+# ---------------------------------------------------------------------------
+# sum_unigram_block_trace
+# ---------------------------------------------------------------------------
+
+
+def test_sum_geth_shape() -> None:
+    """Sum per-transaction entries with txHash + result (geth)."""
+    block_trace = [
+        {"txHash": "0x1", "result": {"PUSH1": 2, "ADD": 1}},
+        {"txHash": "0x2", "result": {"PUSH1": 3, "SLOAD": 4}},
+    ]
+    assert sum_unigram_block_trace(block_trace) == {
+        "PUSH1": 5,
+        "ADD": 1,
+        "SLOAD": 4,
+    }
+
+
+def test_sum_legacy_shape() -> None:
+    """Sum entries without txHash (older geth/erigon)."""
+    block_trace = [
+        {"result": {"PUSH1": 1}},
+        {"result": {"PUSH1": 1}},
+    ]
+    assert sum_unigram_block_trace(block_trace) == {"PUSH1": 2}
+
+
+def test_sum_bare_map_shape() -> None:
+    """Sum entries that are bare opcode maps."""
+    block_trace = [{"PUSH1": 1, "STOP": 1}]
+    assert sum_unigram_block_trace(block_trace) == {"PUSH1": 1, "STOP": 1}
+
+
+def test_sum_skips_error_entries() -> None:
+    """Skip per-transaction error entries and non-integer values."""
+    block_trace = [
+        {"txHash": "0x1", "error": "execution aborted"},
+        {"result": {"PUSH1": 1}},
+        {"result": "not a dict"},
+        "not a dict either",
+    ]
+    assert sum_unigram_block_trace(block_trace) == {"PUSH1": 1}
+
+
+def test_sum_empty_block() -> None:
+    """Return an empty count for a block with no transactions."""
+    assert sum_unigram_block_trace([]) == {}
+
+
+def test_sum_non_list_input() -> None:
+    """Return an empty count for unexpected response shapes."""
+    assert sum_unigram_block_trace(None) == {}
+    assert sum_unigram_block_trace({"PUSH1": 1}) == {}
+
+
+# ---------------------------------------------------------------------------
+# DebugRPC.trace_block_opcode_counts fallback behavior
+# ---------------------------------------------------------------------------
+
+
+class TracerRecorder:
+    """Patched trace_block_by_number recording calls per tracer."""
+
+    def __init__(self, rejected_tracers: set[str]) -> None:
+        """Reject the given tracers; accept all others."""
+        self.rejected_tracers = rejected_tracers
+        self.calls: List[Tuple[str, str]] = []
+
+    def __call__(self, block_number: str, tracer: str) -> Any:
+        """Simulate the client's tracer support."""
+        self.calls.append((block_number, tracer))
+        if tracer in self.rejected_tracers:
+            raise JSONRPCError(code=-32602, message="tracer not found")
+        return [{"txHash": "0x1", "result": {"PUSH1": 2, "ADD": 1}}]
+
+
+@pytest.fixture
+def debug_rpc() -> DebugRPC:
+    """DebugRPC instance; no requests are made (methods are patched)."""
+    return DebugRPC("http://localhost:8545")
+
+
+def test_tracer_by_name(
+    debug_rpc: DebugRPC, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Use the built-in unigramTracer name when the client accepts it."""
+    recorder = TracerRecorder(rejected_tracers=set())
+    monkeypatch.setattr(debug_rpc, "trace_block_by_number", recorder)
+
+    counts = debug_rpc.trace_block_opcode_counts("0x2")
+    assert counts == {"PUSH1": 2, "ADD": 1}
+    assert recorder.calls == [("0x2", "unigramTracer")]
+
+    # Cached: the second call goes straight to the name, no re-probe.
+    debug_rpc.trace_block_opcode_counts("0x3")
+    assert recorder.calls[1:] == [("0x3", "unigramTracer")]
+
+
+def test_tracer_js_fallback(
+    debug_rpc: DebugRPC, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fall back to the inline JS tracer when the name is rejected."""
+    recorder = TracerRecorder(rejected_tracers={"unigramTracer"})
+    monkeypatch.setattr(debug_rpc, "trace_block_by_number", recorder)
+
+    counts = debug_rpc.trace_block_opcode_counts("0x2")
+    assert counts == {"PUSH1": 2, "ADD": 1}
+    assert recorder.calls == [
+        ("0x2", "unigramTracer"),
+        ("0x2", DebugRPC.UNIGRAM_TRACER_JS),
+    ]
+
+    # Cached: no name re-probe on subsequent calls.
+    debug_rpc.trace_block_opcode_counts("0x3")
+    assert recorder.calls[2:] == [("0x3", DebugRPC.UNIGRAM_TRACER_JS)]
+
+
+def test_tracer_unsupported(
+    debug_rpc: DebugRPC,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Warn once and return None when the client supports no tracer."""
+    recorder = TracerRecorder(
+        rejected_tracers={"unigramTracer", DebugRPC.UNIGRAM_TRACER_JS}
+    )
+    monkeypatch.setattr(debug_rpc, "trace_block_by_number", recorder)
+
+    with caplog.at_level("WARNING"):
+        assert debug_rpc.trace_block_opcode_counts("0x2") is None
+    assert len(recorder.calls) == 2
+    assert any("opcode" in record.message.lower() for record in caplog.records)
+
+    # Cached: subsequent calls return None without any RPC traffic.
+    assert debug_rpc.trace_block_opcode_counts("0x3") is None
+    assert len(recorder.calls) == 2
+
+
+def test_trace_block_by_number_request_shape(
+    debug_rpc: DebugRPC, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Post debug_traceBlockByNumber with [block, {tracer}] params."""
+    captured: Dict[str, Any] = {}
+
+    def fake_post_request(*, request: Any, **kwargs: Any) -> Any:
+        del kwargs
+        captured["method"] = request.method
+        captured["params"] = request.params
+
+        class Response:
+            @staticmethod
+            def result_or_raise() -> Any:
+                return []
+
+        return Response()
+
+    monkeypatch.setattr(debug_rpc, "post_request", fake_post_request)
+    debug_rpc.trace_block_by_number("0x2", "unigramTracer")
+    assert captured["method"] == "traceBlockByNumber"
+    assert captured["params"] == ["0x2", {"tracer": "unigramTracer"}]

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1468,6 +1468,7 @@ class BlockchainTest(BaseTest):
         head_hash = start_block_hash
         benchmark_gas_used: int | None = None
         benchmark_opcode_count: OpcodeCount | None = None
+        execution_opcode_count: OpcodeCount | None = None
         # Alloc is not authoritative in stateful mode; pass self.pre as a
         # placeholder — ClientBackend ignores it.
         alloc: Alloc | LazyAlloc = self.pre
@@ -1489,9 +1490,15 @@ class BlockchainTest(BaseTest):
                 setup_payloads.append(payload)
             else:
                 execution_payloads.append(payload)
+                block_opcode_count = built_block.result.opcode_count
+                if block_opcode_count is not None:
+                    execution_opcode_count = (
+                        execution_opcode_count + block_opcode_count
+                        if execution_opcode_count is not None
+                        else block_opcode_count
+                    )
                 if self.operation_mode == OpMode.BENCHMARKING:
                     benchmark_gas_used = int(built_block.result.gas_used)
-                    benchmark_opcode_count = built_block.result.opcode_count
             # Overwrite the block_hash apply_new_parent just recorded —
             # it's the FixtureHeader-recomputed RLP hash, which diverges
             # from the client's authoritative hash (client picks fields
@@ -1508,6 +1515,14 @@ class BlockchainTest(BaseTest):
                 },
             )
             head_hash = client_hash
+
+        # Execution-phase opcode totals (``--trace-opcodes``): summed
+        # across the test's execution blocks, mirroring gas-benchmarks'
+        # per-test merge; setup blocks are excluded.
+        if execution_opcode_count is not None:
+            t8n.record_test_opcode_count(execution_opcode_count)
+            if self.operation_mode == OpMode.BENCHMARKING:
+                benchmark_opcode_count = execution_opcode_count
 
         fixture = BlockchainEngineStatefulFixture(
             fork=self.fork,

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1269,6 +1269,8 @@ uncomp
 underflow
 undersize
 unencoded
+unigram
+unigramTracer
 unixsocket
 unlink
 unoptimized


### PR DESCRIPTION
Made using Claude, Draft PR as I have not thoroughly checked this myself.

----

Ports the opcode-count collection feature from [gas-benchmarks](https://github.com/NethermindEth/gas-benchmarks) (its `eest_stateful_generator.py --trace-json` flag / `run.sh` `TRACE_BLOCKS` env var) to `fill-stateful`.

New flags (**disabled by default**):

- `--trace-opcodes` — after each block is built via `testing_buildBlockV1` and made canonical, trace it with `debug_traceBlockByNumber` using the unigram tracer (per-opcode execution counts) and, at session end, write a JSON file mapping each test to its summed opcode counts.
- `--trace-opcodes-output` — output path override (default: `<output-dir>/opcodes_tracing.json`).

The output file format is identical to gas-benchmarks' trace output:

```json
{
  "test_single_opcode.py__test_sload_erc20_generic[fork_Amsterdam-...]": {
    "PUSH1": 55674,
    "SLOAD": 11132
  }
}
```

Implementation notes:

- **Client compatibility**: geth, erigon and nethermind resolve the built-in `unigramTracer` tracer by name; reth does not, but runs the equivalent inline JS tracer source (its `js-tracer` feature is enabled in default builds). `DebugRPC.trace_block_opcode_counts` probes the name first, falls back to inline JS, and — for clients supporting neither (besu has no JS tracer engine) — warns once and continues filling without traces. The working tracer is cached per session, mirroring the existing `rewind_head` probe.
- **Phase scoping**: only execution-phase payloads count toward a test's totals; per-test setup blocks (funding, deploys) are excluded, matching gas-benchmarks, which derives counts from the `testing/` payloads only. Counts are summed across a test's execution blocks.
- **Name parity**: `OpcodeCount` canonicalizes `KECCAK256` to the `Opcodes` enum's `SHA3`; the writer maps it back to `KECCAK256` so the output matches what clients report and what gas-benchmarks files contain.
- Tracing failures are never fatal to the fill: trace errors and unparsable responses are logged and skipped.
- As a side effect, `benchmark_opcode_count` is now populated in stateful benchmarking fills, so `fixed_opcode_count` / `expected_opcode_count` verification works on the stateful path when tracing is enabled.

Usage:

```console
uv run fill-stateful --fork=Amsterdam \
  --rpc-endpoint http://localhost:8545 \
  --engine-endpoint http://localhost:8551 \
  --engine-jwt-secret-file ./jwt.hex \
  --trace-opcodes \
  --output fixtures/erc20_mixed \
  tests/benchmark/stateful/bloatnet/test_multi_opcode.py
# -> fixtures/erc20_mixed/opcodes_tracing.json
```

Includes unit tests for the trace-response parsing (per-tx shapes of all clients), the name→JS→warn-once fallback chain, key derivation from pytest node ids, the exact output file format, per-test merging, and `ClientBackend.evaluate` tracing off-by-default/on-when-enabled behavior.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Crow image](https://images.unsplash.com/photo-1609828435263-e9dc691d630b?q=80&w=1134&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
