### PR TITLE
docs(test-consume): fix and augment enginex docs

### DIFF
--- a/docs/running_tests/running.md
+++ b/docs/running_tests/running.md
@@ -59,10 +59,12 @@ The `consume engine` command:
 
 1. **Initializes the execution client** with genesis state.
 2. **Connects via Engine API** (port 8551), primitively mocking a consensus client.
-3. **Sends a forkchoice update** to establish the chain head.
-4. **Submits payloads** using `engine_newPayload` calls.
-5. **Validates responses** against expected results.
-6. **Tests error conditions** and exception handling.
+3. **Sends a forkchoice update** to the genesis block to establish the chain head.
+4. **Verifies the client's genesis block hash** via `eth_getBlockByNumber(0)`.
+5. **Submits payloads** using `engine_newPayload` calls.
+6. **Validates responses** against expected results.
+7. **Sends a forkchoice update** after each valid payload to advance the chain head.
+8. **Tests error conditions** and exception handling.
 
 ## EngineX
 
@@ -78,29 +80,33 @@ The `consume enginex` command, for each pre-allocation group:
 
 1. **Initializes the execution client** with the group's shared genesis state.
 2. **Connects via Engine API** (port 8551).
-3. **Executes all tests in the group** against the same client:
+3. **Executes all tests in the group** against the same client. Each test:
 
-    - Submits payloads from each test using `engine_newPayload` calls.
+    - Sends a forkchoice update to the genesis block, resetting the chain head.
+    - Verifies the client's genesis block hash via `eth_getBlockByNumber(0)`; this is only done for the first test executed against the client, as genesis is immutable.
+    - Submits payloads from the test using `engine_newPayload` calls.
     - Validates responses against expected results.
+    - Sends a forkchoice update after each valid payload to advance the chain head.
     - Tests error conditions and exception handling.
 
 4. **Stops the client** when all tests in the group complete.
 
 ### Engine vs EngineX
 
-|                      | `consume engine`                                                       | `consume enginex`                                                        |
-| -------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| **Fixture format**     | [`blockchain_test_engine`](./test_formats/blockchain_test_engine.md) | [`blockchain_test_engine_x`](./test_formats/blockchain_test_engine_x.md)                                       |
-| **Client lifecycle**   | New client per test                                                    | Client reused across tests with same pre-alloc                                                                 |
-| **Fork choice update** | FCU called for genesis and final payload                               | FCU for genesis and final payload skipped |
-| **Execution speed**    | Slower (client startup overhead)                                       | Faster (amortized startup cost)                                                                                |
-| **Test isolation**     | Full isolation                                                         | Shared genesis state within group                                                                              |
+|                         | `consume engine`                                                     | `consume enginex`                                                                          |
+| ----------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Fixture format**      | [`blockchain_test_engine`](./test_formats/blockchain_test_engine.md) | [`blockchain_test_engine_x`](./test_formats/blockchain_test_engine_x.md)                       |
+| **Client lifecycle**    | New client per test                                                  | Client reused across tests with same pre-alloc                                                 |
+| **Engine API flow**     | FCU to genesis, then an `engine_newPayload` and FCU per valid payload | Identical, to keep both methods equivalent                                                    |
+| **Genesis block check** | `eth_getBlockByNumber(0)` per test                                    | `eth_getBlockByNumber(0)` once per client; genesis is immutable                                |
+| **Execution speed**     | Slower (client startup overhead)                                     | Faster (amortized startup cost)                                                                |
+| **Test isolation**      | Full isolation                                                       | Shared client and genesis state within group; the chain head is reset to genesis for each test |
 
 EngineX achieves faster execution by:
 
 1. **Grouping tests** by their pre-allocation state (genesis configuration).
 2. **Reusing clients** across all tests in a group, avoiding repeated client startup.
-3. **Skipping redundant initialization** since the client is already at the expected genesis state.
+3. **Skipping the redundant genesis block check** for reused clients: the client's genesis block hash is verified once per client, instead of once per test.
 
 !!! note "When to use EngineX vs Engine"
 

--- a/docs/running_tests/running.md
+++ b/docs/running_tests/running.md
@@ -14,7 +14,7 @@ Both `consume` and `execute` provide sub-commands which correspond to different 
 | [`consume direct`](#direct)             | Client consume tests via a `statetest` interface                                        | EVM                                                          | None          | Module test                       |
 | [`consume direct`](#direct)             | Client consume tests via a `blocktest` interface                                        | EVM, block processing                                        | None          | Module test,</br>Integration test |
 | [`consume engine`](#engine)             | Client imports blocks via Engine API `EngineNewPayload` in Hive                         | EVM, block processing, Engine API                            | Staging, Hive | System test                       |
-| [`consume enginex`](#enginex)           | Client imports blocks via Engine API in Hive, optimized by client reuse            | EVM, block processing, Engine API                            | Staging, Hive | System test                       |
+| [`consume enginex`](#enginex)           | Client imports blocks via Engine API in Hive, optimized by client reuse            | EVM, block processing, Engine API, chain reorgs (implicit\*\*) | Staging, Hive | System test                       |
 | [`consume sync`](#sync)                 | Client syncs from another client using Engine API in Hive                               | EVM, block processing, Engine API, P2P sync                  | Staging, Hive | System test                       |
 | [`consume rlp`](#rlp)                   | Client imports RLP-encoded blocks upon start-up in Hive                                 | EVM, block processing, RLP import (sync\*)                   | Staging, Hive | System test                       |
 | [`build-block`](#block-building)        | Client builds blocks via `testing_buildBlockV1` in Hive, validated against fixture       | EVM, block production, Engine API (testing namespace)        | Staging, Hive | System test                       |
@@ -22,6 +22,8 @@ Both `consume` and `execute` provide sub-commands which correspond to different 
 | [`execute remote`](./execute/remote.md) | Tests executed against a client via JSON RPC `eth_sendRawTransaction` on a live network | EVM, JSON RPC, mempool, EL-EL/EL-CL interaction (indirectly) | Production    | System Test                       |
 
 \*sync: Depending on code paths used in the client implementation, see the [RLP vs Engine Simulator section below](#engine-vs-rlp-simulator).
+
+\*\*chain reorgs: A side-effect of client reuse, not something the test cases describe, see the [Implicit Chain Reorg Coverage section below](#implicit-chain-reorg-coverage).
 
 The following sections describe the different methods in more detail.
 
@@ -91,6 +93,18 @@ The `consume enginex` command, for each pre-allocation group:
 
 4. **Stops the client** when all tests in the group complete.
 
+### Implicit Chain Reorg Coverage
+
+Client reuse gives `consume enginex` coverage that `consume engine` does not have. The forkchoice update at the start of each test resets the client's head from the previous test's chain tip back to genesis. The payload that follows is therefore a sibling of a block the client already imported and considered canonical (the same parent and block number, but a different block hash), and the forkchoice update sent after it makes the new branch canonical.
+
+Every test after the first in a pre-allocation group consequently exercises the client's chain reorganization path: rolling the head state back to an ancestor, importing a competing block at an already-occupied height, and re-canonicalizing a new branch.
+
+!!! note "This coverage is implicit"
+
+    No `blockchain_test_engine_x` fixture describes a reorg; the reorgs are an artifact of how the simulator reuses clients. A test whose payloads are all invalid also leaves the head at genesis, so no rollback precedes the next test in the group.
+
+    It does mean, however, that a test which fails under `consume enginex` but passes under `consume engine` is more likely to indicate a bug in the client's reorg, head state rollback or block caching logic than in its EVM or block validation logic.
+
 ### Engine vs EngineX
 
 |                         | `consume engine`                                                     | `consume enginex`                                                                          |
@@ -101,6 +115,7 @@ The `consume enginex` command, for each pre-allocation group:
 | **Genesis block check** | `eth_getBlockByNumber(0)` per test                                    | `eth_getBlockByNumber(0)` once per client; genesis is immutable                                |
 | **Execution speed**     | Slower (client startup overhead)                                     | Faster (amortized startup cost)                                                                |
 | **Test isolation**      | Full isolation                                                       | Shared client and genesis state within group; the chain head is reset to genesis for each test |
+| **Chain reorgs**        | Not exercised; each client executes one test's payloads only         | [Implicitly exercised](#implicit-chain-reorg-coverage) by every test after the first in a group |
 
 EngineX achieves faster execution by:
 


### PR DESCRIPTION
### Description

Fixes and extends the `consume enginex` documentation in `docs/running_tests/running.md`, which still described the Engine API flow as it was before #3093.

- Correct the claim that enginex skips the forkchoice update (FCU) to genesis and the FCU after valid payloads. Since #3093 both `consume engine` and `consume enginex` send the identical Engine API sequence; the only step enginex skips is the `eth_getBlockByNumber(0)` genesis block hash check, which now runs once per client, instead of once per test, as genesis is immutable.
- Expand the `consume engine` and `consume enginex` step lists to include the initial FCU to genesis, the genesis block hash check and the FCU sent after each valid payload.
- Document enginex's implicit chain reorg coverage in a new section: the FCU at the start of each test rolls the client's head back from the previous test's chain tip to genesis, so the next payload arrives as a sibling of a block the client already considers canonical, and the FCU that follows it re-canonicalizes a new branch. Every test after the first in a pre-allocation group therefore exercises the client's reorg path, which `consume engine` never reaches. The section notes that this coverage is a side-effect of client reuse and not something the fixtures describe, and that an enginex-only failure points at the client's reorg, head state rollback or block caching logic.
- Add `chain reorgs (implicit)` to the components tested by `consume enginex` in the top-level comparison table, and add a `Chain reorgs` row to the "Engine vs EngineX" table.

### Related Issues or PRs

Fixes docs following:
- #3093.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![HTTP 200 OK dog](https://http.dog/200.jpg)
