### PR TITLE
feat(test-consume): set HIVE_EXPECT_DEEP_REORGS in the multi-test client environment

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/multi_test_client.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/multi_test_client.py
@@ -252,6 +252,11 @@ def environment(
         "HIVE_CHECK_LIVE_PORT": str(check_live_port),
         **{k: f"{v:d}" for k, v in ruleset[fork].items()},
         "HIVE_FORK": pre_alloc_group.fork.name(),
+        # Tell client wrapper scripts this workload performs deep reorgs:
+        # clients are reused across a group's tests with a rewind to genesis
+        # in between, so wrappers can raise client-specific limits that would
+        # otherwise reject them (e.g. geth's engine API max reorg depth).
+        "HIVE_EXPECT_DEEP_REORGS": "1",
     }
 
     environment_cache[pre_hash] = env


### PR DESCRIPTION
Multi-test client workloads (currently `consume enginex`) reuse one client across a pre-alloc group's tests and rewind the head to genesis between tests, which trips client-specific reorg depth limits — e.g. geth refuses rewinds deeper than 32 blocks since ethereum/go-ethereum#34767, permanently poisoning the shared client:

```
JSONRPCError(code=-38006, message=Too deep reorg, data={'err': 'reorg depth 37 exceeds limit 32'})
```

Setting `HIVE_EXPECT_DEEP_REORGS=1` in the multi-test client environment gives hive client wrapper scripts an intent-named, simulator-agnostic way to detect such workloads and raise those limits only where needed, e.g. `export GETH_ENGINE_MAXREORGDEPTH=512` in ethereum/hive#1572.

![416 Range Not Satisfiable](https://http.dog/416.jpg)