### PR TITLE
fix(test-consume): accept bad-block-cache errors for resubmitted blocks

### DIFF
--- a/docs/running_tests/running.md
+++ b/docs/running_tests/running.md
@@ -107,7 +107,7 @@ Every test after the first in a pre-allocation group consequently exercises the 
 
 ### Bad-Block Cache Handling
 
-Clients cache the blocks they reject. Because a client is reused across a pre-allocation group, its bad-block cache persists between tests: if two tests in a group contain an identical invalid block, the client validates the first submission for real and returns the specific validation error, but answers the resubmission from its cache with a generic error (e.g. reth's "links to previously rejected block") that maps to no known exception.
+Clients typically cache the blocks they reject. Because a client is reused across a pre-allocation group, its bad-block cache persists between tests: if two tests in a group contain an identical invalid block, the client validates the first submission for real and returns the specific validation error, but may answer the resubmission from its cache with a generic error (e.g. geth's and reth's "links to previously rejected block" or Nethermind's "is known to be a part of an invalid chain") that maps to no known exception.
 
 The simulator therefore remembers the first validation error each client returns per invalid block. When a rejection does not match the test's expected exception, it is verified against the client's first rejection of the same block: it is accepted and logged ("Accepting mismatched validation error") if that first rejection matched the expected exception, and fails the test as before otherwise. This is sound because an identical block hash implies an identical block built on an identical parent chain, so the real validation outcome is deterministic. `consume engine` starts a fresh client per test and is unaffected.
 

--- a/docs/running_tests/running.md
+++ b/docs/running_tests/running.md
@@ -105,6 +105,12 @@ Every test after the first in a pre-allocation group consequently exercises the 
 
     It does mean, however, that a test which fails under `consume enginex` but passes under `consume engine` is more likely to indicate a bug in the client's reorg, head state rollback or block caching logic than in its EVM or block validation logic.
 
+### Bad-Block Cache Handling
+
+Clients cache the blocks they reject. Because a client is reused across a pre-allocation group, its bad-block cache persists between tests: if two tests in a group contain an identical invalid block, the client validates the first submission for real and returns the specific validation error, but answers the resubmission from its cache with a generic error (e.g. reth's "links to previously rejected block") that maps to no known exception.
+
+The simulator therefore remembers the first validation error each client returns per invalid block. When a rejection does not match the test's expected exception, it is verified against the client's first rejection of the same block: it is accepted and logged ("Accepting mismatched validation error") if that first rejection matched the expected exception, and fails the test as before otherwise. This is sound because an identical block hash implies an identical block built on an identical parent chain, so the real validation outcome is deterministic. `consume engine` starts a fresh client per test and is unaffected.
+
 ### Engine vs EngineX
 
 |                         | `consume engine`                                                     | `consume enginex`                                                                          |
@@ -116,6 +122,7 @@ Every test after the first in a pre-allocation group consequently exercises the 
 | **Execution speed**     | Slower (client startup overhead)                                     | Faster (amortized startup cost)                                                                |
 | **Test isolation**      | Full isolation                                                       | Shared client and genesis state within group; the chain head is reset to genesis for each test |
 | **Chain reorgs**        | Not exercised; each client executes one test's payloads only         | [Implicitly exercised](#implicit-chain-reorg-coverage) by every test after the first in a group |
+| **Exception matching**  | Response validated directly against the expected exception           | Identical, except a mismatched rejection is [accepted](#bad-block-cache-handling) if the client's first rejection of the identical block matched |
 
 EngineX achieves faster execution by:
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
@@ -17,6 +17,7 @@ from execution_testing.fixtures.file import Fixtures
 from execution_testing.rpc import EthRPC
 
 from ..consume import FixturesSource
+from .helpers.rejected_blocks import BlockRejectionTracker
 
 
 @pytest.fixture(scope="function")
@@ -36,6 +37,20 @@ def genesis_verified_clients() -> set[str]:
     pre-alloc group, letting later tests skip the redundant check.
     """
     return set()
+
+
+@pytest.fixture(scope="session")
+def block_rejection_tracker() -> BlockRejectionTracker:
+    """
+    Return the tracker of invalid blocks rejected by each client.
+
+    In enginex mode a client is reused across a pre-alloc group, so a later
+    test can resubmit a block that the client already rejected for an earlier
+    test and receive a generic bad-block-cache error instead of the specific
+    validation error. The tracker remembers each client's first rejection so
+    the expected exception can be verified against it in that case.
+    """
+    return BlockRejectionTracker()
 
 
 @pytest.fixture(scope="function")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/rejected_blocks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/rejected_blocks.py
@@ -1,0 +1,77 @@
+"""Track invalid blocks previously rejected by a client instance."""
+
+from execution_testing.base_types import Hash
+from execution_testing.exceptions import (
+    ExceptionInstanceOrList,
+    UndefinedException,
+)
+from execution_testing.rpc.rpc_types import (
+    BlockTransactionExceptionWithMessage,
+)
+
+ClientValidationError = (
+    BlockTransactionExceptionWithMessage | UndefinedException
+)
+
+
+class BlockRejectionTracker:
+    """
+    Track the first validation error a client returns per invalid block.
+
+    Clients keep a bad-block cache: resubmitting an already-rejected block
+    is answered from the cache with a generic error (e.g. reth's "links to
+    previously rejected block") instead of being re-validated and
+    rejected with the specific error again. In enginex mode a client
+    instance is reused across all tests of a pre-allocation group, so two
+    tests containing an identical invalid block trigger this cache: the
+    first submission is validated for real, the resubmission
+    short-circuits.
+
+    Remember the first (real) validation error per client and block so
+    that the simulator can verify the expected exception against it when
+    the response to a resubmission does not match.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the tracker with no recorded rejections."""
+        self._first_errors: dict[tuple[str, Hash], ClientValidationError] = {}
+
+    def track(
+        self,
+        client_id: str,
+        block_hash: Hash,
+        error: ClientValidationError,
+    ) -> ClientValidationError | None:
+        """
+        Track a block rejection and return the earlier error, if any.
+
+        Record `error` as the client's canonical validation error for the
+        block if this is the first time the client rejects it; later
+        rejections of the same block by the same client do not overwrite
+        it. Return the error recorded for the client's earlier rejection
+        of the block, or `None` if this is the first one.
+        """
+        key = (client_id, block_hash)
+        earlier_error = self._first_errors.get(key)
+        if earlier_error is None:
+            self._first_errors[key] = error
+        return earlier_error
+
+
+def matches_expected_exception(
+    earlier_rejection: ClientValidationError | None,
+    expected_exception: ExceptionInstanceOrList | None,
+) -> bool:
+    """
+    Return whether an earlier rejection matched the expected exception.
+
+    Return `False` if there was no earlier rejection, if its error could
+    not be mapped to any exception (`UndefinedException`), or if there is
+    no expected exception to match against.
+    """
+    if expected_exception is None:
+        return False
+    return (
+        isinstance(earlier_rejection, BlockTransactionExceptionWithMessage)
+        and expected_exception in earlier_rejection
+    )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/rejected_blocks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/rejected_blocks.py
@@ -1,17 +1,19 @@
-"""Track invalid blocks previously rejected by a client instance."""
+"""Track and verify invalid blocks rejected by a client instance."""
 
 from execution_testing.base_types import Hash
 from execution_testing.exceptions import (
     ExceptionInstanceOrList,
     UndefinedException,
 )
+from execution_testing.logging import get_logger
 from execution_testing.rpc.rpc_types import (
     BlockTransactionExceptionWithMessage,
+    ClientValidationError,
 )
 
-ClientValidationError = (
-    BlockTransactionExceptionWithMessage | UndefinedException
-)
+from .exceptions import LoggedError
+
+logger = get_logger(__name__)
 
 
 class BlockRejectionTracker:
@@ -41,37 +43,84 @@ class BlockRejectionTracker:
         client_id: str,
         block_hash: Hash,
         error: ClientValidationError,
-    ) -> ClientValidationError | None:
+    ) -> ClientValidationError:
         """
-        Track a block rejection and return the earlier error, if any.
+        Track a block rejection and return the client's first error for it.
 
         Record `error` as the client's canonical validation error for the
         block if this is the first time the client rejects it; later
         rejections of the same block by the same client do not overwrite
-        it. Return the error recorded for the client's earlier rejection
-        of the block, or `None` if this is the first one.
+        it. Return the recorded first error, which is `error` itself when
+        this is the first rejection.
         """
-        key = (client_id, block_hash)
-        earlier_error = self._first_errors.get(key)
-        if earlier_error is None:
-            self._first_errors[key] = error
-        return earlier_error
+        return self._first_errors.setdefault((client_id, block_hash), error)
 
 
 def matches_expected_exception(
-    earlier_rejection: ClientValidationError | None,
+    first_rejection: ClientValidationError,
     expected_exception: ExceptionInstanceOrList | None,
 ) -> bool:
     """
-    Return whether an earlier rejection matched the expected exception.
+    Return whether a tracked rejection matched the expected exception.
 
-    Return `False` if there was no earlier rejection, if its error could
-    not be mapped to any exception (`UndefinedException`), or if there is
-    no expected exception to match against.
+    Return `False` if the rejection's error could not be mapped to any
+    exception (`UndefinedException`) or if there is no expected exception
+    to match against.
     """
     if expected_exception is None:
         return False
     return (
-        isinstance(earlier_rejection, BlockTransactionExceptionWithMessage)
-        and expected_exception in earlier_rejection
+        isinstance(first_rejection, BlockTransactionExceptionWithMessage)
+        and expected_exception in first_rejection
     )
+
+
+def verify_block_rejection(
+    expected_exception: ExceptionInstanceOrList | None,
+    returned_error: ClientValidationError,
+    first_rejection: ClientValidationError,
+    block_hash: Hash,
+    strict_exception_matching: bool,
+) -> None:
+    """
+    Verify a client's block rejection against the expected exception.
+
+    Raise `LoggedError` if `returned_error` does not match
+    `expected_exception` (or could not be mapped to any exception at all)
+    and strict exception matching is enabled; without strict matching only
+    log a warning.
+
+    Accept and log a mismatched `returned_error` when `first_rejection`,
+    the client's first rejection of the same block, matched the expected
+    exception: the client has answered a resubmission of the block from
+    its bad-block cache with a generic error instead of re-validating it.
+    A mismatched or unmappable error can never match itself, so a block's
+    first rejection is always verified strictly.
+    """
+    if isinstance(returned_error, UndefinedException):
+        message = (
+            "Undefined exception message: "
+            f'expected exception: "{expected_exception}", '
+            f'returned exception: "{returned_error}" '
+            f'(mapper: "{returned_error.mapper_name}")'
+        )
+    elif expected_exception not in returned_error:
+        message = (
+            "Client returned unexpected validation error: "
+            f'got: "{returned_error}" '
+            f'expected: "{expected_exception}"'
+        )
+    else:
+        return
+    if matches_expected_exception(first_rejection, expected_exception):
+        logger.info(
+            f"Accepting mismatched validation error for block {block_hash}: "
+            "this client already rejected the same block with an error "
+            f'matching the expected exception ("{first_rejection}") and '
+            "has rejected the resubmission from its bad-block cache. "
+            f"{message}"
+        )
+    elif strict_exception_matching:
+        raise LoggedError(message)
+    else:
+        logger.warning(message)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -17,7 +17,6 @@ from typing import Union
 
 from hive.client import Client
 
-from execution_testing.exceptions import UndefinedException
 from execution_testing.fixtures import (
     BlockchainEngineFixture,
     BlockchainEngineXFixture,
@@ -41,7 +40,7 @@ from ..helpers.exceptions import (
 )
 from ..helpers.rejected_blocks import (
     BlockRejectionTracker,
-    matches_expected_exception,
+    verify_block_rejection,
 )
 from ..helpers.timing import TimingData
 
@@ -175,58 +174,19 @@ def test_blockchain_via_engine(
                                     "Client returned INVALID but no "
                                     "validation error was provided."
                                 )
-                            earlier_rejection = block_rejection_tracker.track(
+                            block_hash = payload.params[0].block_hash
+                            first_rejection = block_rejection_tracker.track(
                                 client.id,
-                                payload.params[0].block_hash,
+                                block_hash,
                                 payload_response.validation_error,
                             )
-                            if isinstance(
+                            verify_block_rejection(
+                                payload.validation_error,
                                 payload_response.validation_error,
-                                UndefinedException,
-                            ):
-                                message = (
-                                    "Undefined exception message: "
-                                    f"expected exception: "
-                                    f'"{payload.validation_error}", '
-                                    f"returned exception: "
-                                    f'"{payload_response.validation_error}" '
-                                    f"(mapper: "
-                                    f'"{payload_response.validation_error.mapper_name}")'  # noqa: E501
-                                )
-                            elif (
-                                payload.validation_error
-                                not in payload_response.validation_error
-                            ):
-                                message = (
-                                    "Client returned unexpected "
-                                    "validation error: "
-                                    f"got: "
-                                    f'"{payload_response.validation_error}" '
-                                    f"expected: "
-                                    f'"{payload.validation_error}"'
-                                )
-                            else:
-                                message = None
-                            if message is not None:
-                                if matches_expected_exception(
-                                    earlier_rejection,
-                                    payload.validation_error,
-                                ):
-                                    logger.info(
-                                        "Accepting mismatched validation "
-                                        "error for block "
-                                        f"{payload.params[0].block_hash}: "
-                                        "this client already rejected the "
-                                        "same block with an error matching "
-                                        "the expected exception "
-                                        f'("{earlier_rejection}") and has '
-                                        "rejected the resubmission from "
-                                        f"its bad-block cache. {message}"
-                                    )
-                                elif strict_exception_matching:
-                                    raise LoggedError(message)
-                                else:
-                                    logger.warning(message)
+                                first_rejection,
+                                block_hash,
+                                strict_exception_matching,
+                            )
 
                     except JSONRPCError as e:
                         logger.info(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -39,6 +39,10 @@ from ..helpers.exceptions import (
     GenesisBlockMismatchExceptionError,
     LoggedError,
 )
+from ..helpers.rejected_blocks import (
+    BlockRejectionTracker,
+    matches_expected_exception,
+)
 from ..helpers.timing import TimingData
 
 logger = get_logger(__name__)
@@ -50,6 +54,7 @@ def test_blockchain_via_engine(
     engine_rpc: EngineRPC,
     client: Client,
     genesis_verified_clients: set[str],
+    block_rejection_tracker: BlockRejectionTracker,
     fixture: Union[BlockchainEngineFixture, BlockchainEngineXFixture],
     strict_exception_matching: bool,
     genesis_header: FixtureHeader,
@@ -69,6 +74,14 @@ def test_blockchain_via_engine(
        done once per client and skipped for later tests in the group.
     3. Execute test fixture blocks using engine_newPayloadVX.
     4. For valid payloads, send FCU to advance the chain head.
+
+    A client's bad-block cache persists across the tests of a pre-alloc
+    group in enginex mode: a block that an earlier test already got
+    rejected may be rejected again with a generic cache error (e.g. reth's
+    "links to previously rejected block") instead of being re-validated.
+    When the returned error does not match the expected exception, it is
+    therefore verified against the error from the client's first rejection
+    of the same block before failing the test.
     """
     with timing_data.time("Initial forkchoice update"):
         logger.info("Sending initial forkchoice update to genesis block...")
@@ -162,6 +175,11 @@ def test_blockchain_via_engine(
                                     "Client returned INVALID but no "
                                     "validation error was provided."
                                 )
+                            earlier_rejection = block_rejection_tracker.track(
+                                client.id,
+                                payload.params[0].block_hash,
+                                payload_response.validation_error,
+                            )
                             if isinstance(
                                 payload_response.validation_error,
                                 UndefinedException,
@@ -175,27 +193,40 @@ def test_blockchain_via_engine(
                                     f"(mapper: "
                                     f'"{payload_response.validation_error.mapper_name}")'  # noqa: E501
                                 )
-                                if strict_exception_matching:
+                            elif (
+                                payload.validation_error
+                                not in payload_response.validation_error
+                            ):
+                                message = (
+                                    "Client returned unexpected "
+                                    "validation error: "
+                                    f"got: "
+                                    f'"{payload_response.validation_error}" '
+                                    f"expected: "
+                                    f'"{payload.validation_error}"'
+                                )
+                            else:
+                                message = None
+                            if message is not None:
+                                if matches_expected_exception(
+                                    earlier_rejection,
+                                    payload.validation_error,
+                                ):
+                                    logger.info(
+                                        "Accepting mismatched validation "
+                                        "error for block "
+                                        f"{payload.params[0].block_hash}: "
+                                        "this client already rejected the "
+                                        "same block with an error matching "
+                                        "the expected exception "
+                                        f'("{earlier_rejection}") and has '
+                                        "rejected the resubmission from "
+                                        f"its bad-block cache. {message}"
+                                    )
+                                elif strict_exception_matching:
                                     raise LoggedError(message)
                                 else:
                                     logger.warning(message)
-                            else:
-                                if (
-                                    payload.validation_error
-                                    not in payload_response.validation_error
-                                ):
-                                    message = (
-                                        "Client returned unexpected "
-                                        "validation error: "
-                                        f"got: "
-                                        f'"{payload_response.validation_error}" '  # noqa: E501
-                                        f"expected: "
-                                        f'"{payload.validation_error}"'
-                                    )
-                                    if strict_exception_matching:
-                                        raise LoggedError(message)
-                                    else:
-                                        logger.warning(message)
 
                     except JSONRPCError as e:
                         logger.info(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_rejected_blocks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_rejected_blocks.py
@@ -1,0 +1,109 @@
+"""Tests for the block rejection tracker used by the engine simulators."""
+
+from execution_testing.base_types import Hash
+from execution_testing.exceptions import (
+    BlockException,
+    UndefinedException,
+)
+from execution_testing.rpc.rpc_types import (
+    BlockTransactionExceptionWithMessage,
+)
+
+from ..simulators.helpers.rejected_blocks import (
+    BlockRejectionTracker,
+    matches_expected_exception,
+)
+
+CLIENT_A = "client-a"
+CLIENT_B = "client-b"
+BLOCK_1 = Hash(1)
+BLOCK_2 = Hash(2)
+
+EXCESS_BLOB_GAS_ERROR = BlockTransactionExceptionWithMessage(
+    exceptions=[BlockException.INCORRECT_EXCESS_BLOB_GAS],
+    message="invalid excess blob gas: got 1179648, expected 1048576",
+)
+CACHED_REJECTION_ERROR = UndefinedException(
+    "links to previously rejected block",
+    mapper_name="RethExceptionMapper",
+)
+
+
+def test_first_rejection_returns_no_earlier_error() -> None:
+    """The first rejection of a block has no earlier error."""
+    tracker = BlockRejectionTracker()
+    assert tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR) is None
+
+
+def test_resubmission_returns_first_error() -> None:
+    """Rejections after the first return the first recorded error."""
+    tracker = BlockRejectionTracker()
+    tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR)
+    assert (
+        tracker.track(CLIENT_A, BLOCK_1, CACHED_REJECTION_ERROR)
+        is EXCESS_BLOB_GAS_ERROR
+    )
+    # The first error is not overwritten by later rejections.
+    assert (
+        tracker.track(CLIENT_A, BLOCK_1, CACHED_REJECTION_ERROR)
+        is EXCESS_BLOB_GAS_ERROR
+    )
+
+
+def test_rejections_are_tracked_per_client() -> None:
+    """A rejection by one client is not an earlier error for another."""
+    tracker = BlockRejectionTracker()
+    tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR)
+    assert tracker.track(CLIENT_B, BLOCK_1, CACHED_REJECTION_ERROR) is None
+
+
+def test_rejections_are_tracked_per_block() -> None:
+    """A rejection of one block is not an earlier error for another."""
+    tracker = BlockRejectionTracker()
+    tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR)
+    assert tracker.track(CLIENT_A, BLOCK_2, CACHED_REJECTION_ERROR) is None
+
+
+def test_matching_earlier_rejection() -> None:
+    """An earlier rejection matches its mapped exception."""
+    assert matches_expected_exception(
+        EXCESS_BLOB_GAS_ERROR, BlockException.INCORRECT_EXCESS_BLOB_GAS
+    )
+
+
+def test_matching_earlier_rejection_with_exception_list() -> None:
+    """An earlier rejection matches a list containing its exception."""
+    assert matches_expected_exception(
+        EXCESS_BLOB_GAS_ERROR,
+        [
+            BlockException.INCORRECT_BLOB_GAS_USED,
+            BlockException.INCORRECT_EXCESS_BLOB_GAS,
+        ],
+    )
+
+
+def test_mismatching_earlier_rejection() -> None:
+    """An earlier rejection does not match a different exception."""
+    assert not matches_expected_exception(
+        EXCESS_BLOB_GAS_ERROR, BlockException.INCORRECT_BLOB_GAS_USED
+    )
+
+
+def test_no_earlier_rejection_never_matches() -> None:
+    """A block that was never rejected before cannot match."""
+    assert not matches_expected_exception(
+        None, BlockException.INCORRECT_EXCESS_BLOB_GAS
+    )
+
+
+def test_undefined_earlier_rejection_never_matches() -> None:
+    """An unmappable earlier rejection cannot be verified as a match."""
+    assert not matches_expected_exception(
+        CACHED_REJECTION_ERROR,
+        BlockException.INCORRECT_EXCESS_BLOB_GAS,
+    )
+
+
+def test_no_expected_exception_never_matches() -> None:
+    """Without an expected exception there is nothing to match."""
+    assert not matches_expected_exception(EXCESS_BLOB_GAS_ERROR, None)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_rejected_blocks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_rejected_blocks.py
@@ -1,5 +1,7 @@
 """Tests for the block rejection tracker used by the engine simulators."""
 
+import pytest
+
 from execution_testing.base_types import Hash
 from execution_testing.exceptions import (
     BlockException,
@@ -9,9 +11,11 @@ from execution_testing.rpc.rpc_types import (
     BlockTransactionExceptionWithMessage,
 )
 
+from ..simulators.helpers.exceptions import LoggedError
 from ..simulators.helpers.rejected_blocks import (
     BlockRejectionTracker,
     matches_expected_exception,
+    verify_block_rejection,
 )
 
 CLIENT_A = "client-a"
@@ -29,10 +33,13 @@ CACHED_REJECTION_ERROR = UndefinedException(
 )
 
 
-def test_first_rejection_returns_no_earlier_error() -> None:
-    """The first rejection of a block has no earlier error."""
+def test_first_rejection_returns_the_error_itself() -> None:
+    """The first rejection of a block records and returns its own error."""
     tracker = BlockRejectionTracker()
-    assert tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR) is None
+    assert (
+        tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR)
+        is EXCESS_BLOB_GAS_ERROR
+    )
 
 
 def test_resubmission_returns_first_error() -> None:
@@ -51,28 +58,34 @@ def test_resubmission_returns_first_error() -> None:
 
 
 def test_rejections_are_tracked_per_client() -> None:
-    """A rejection by one client is not an earlier error for another."""
+    """A rejection by one client is not the first error for another."""
     tracker = BlockRejectionTracker()
     tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR)
-    assert tracker.track(CLIENT_B, BLOCK_1, CACHED_REJECTION_ERROR) is None
+    assert (
+        tracker.track(CLIENT_B, BLOCK_1, CACHED_REJECTION_ERROR)
+        is CACHED_REJECTION_ERROR
+    )
 
 
 def test_rejections_are_tracked_per_block() -> None:
-    """A rejection of one block is not an earlier error for another."""
+    """A rejection of one block is not the first error for another."""
     tracker = BlockRejectionTracker()
     tracker.track(CLIENT_A, BLOCK_1, EXCESS_BLOB_GAS_ERROR)
-    assert tracker.track(CLIENT_A, BLOCK_2, CACHED_REJECTION_ERROR) is None
+    assert (
+        tracker.track(CLIENT_A, BLOCK_2, CACHED_REJECTION_ERROR)
+        is CACHED_REJECTION_ERROR
+    )
 
 
-def test_matching_earlier_rejection() -> None:
-    """An earlier rejection matches its mapped exception."""
+def test_matching_first_rejection() -> None:
+    """A tracked rejection matches its mapped exception."""
     assert matches_expected_exception(
         EXCESS_BLOB_GAS_ERROR, BlockException.INCORRECT_EXCESS_BLOB_GAS
     )
 
 
-def test_matching_earlier_rejection_with_exception_list() -> None:
-    """An earlier rejection matches a list containing its exception."""
+def test_matching_first_rejection_with_exception_list() -> None:
+    """A tracked rejection matches a list containing its exception."""
     assert matches_expected_exception(
         EXCESS_BLOB_GAS_ERROR,
         [
@@ -82,22 +95,15 @@ def test_matching_earlier_rejection_with_exception_list() -> None:
     )
 
 
-def test_mismatching_earlier_rejection() -> None:
-    """An earlier rejection does not match a different exception."""
+def test_mismatching_first_rejection() -> None:
+    """A tracked rejection does not match a different exception."""
     assert not matches_expected_exception(
         EXCESS_BLOB_GAS_ERROR, BlockException.INCORRECT_BLOB_GAS_USED
     )
 
 
-def test_no_earlier_rejection_never_matches() -> None:
-    """A block that was never rejected before cannot match."""
-    assert not matches_expected_exception(
-        None, BlockException.INCORRECT_EXCESS_BLOB_GAS
-    )
-
-
-def test_undefined_earlier_rejection_never_matches() -> None:
-    """An unmappable earlier rejection cannot be verified as a match."""
+def test_undefined_first_rejection_never_matches() -> None:
+    """An unmappable tracked rejection cannot be verified as a match."""
     assert not matches_expected_exception(
         CACHED_REJECTION_ERROR,
         BlockException.INCORRECT_EXCESS_BLOB_GAS,
@@ -107,3 +113,60 @@ def test_undefined_earlier_rejection_never_matches() -> None:
 def test_no_expected_exception_never_matches() -> None:
     """Without an expected exception there is nothing to match."""
     assert not matches_expected_exception(EXCESS_BLOB_GAS_ERROR, None)
+
+
+def test_verify_matching_error_passes() -> None:
+    """A rejection with the expected exception verifies silently."""
+    verify_block_rejection(
+        BlockException.INCORRECT_EXCESS_BLOB_GAS,
+        EXCESS_BLOB_GAS_ERROR,
+        EXCESS_BLOB_GAS_ERROR,
+        BLOCK_1,
+        strict_exception_matching=True,
+    )
+
+
+def test_verify_first_rejection_mismatch_raises() -> None:
+    """A block's first rejection is verified strictly."""
+    with pytest.raises(LoggedError, match="Undefined exception message"):
+        verify_block_rejection(
+            BlockException.INCORRECT_EXCESS_BLOB_GAS,
+            CACHED_REJECTION_ERROR,
+            CACHED_REJECTION_ERROR,
+            BLOCK_1,
+            strict_exception_matching=True,
+        )
+
+
+def test_verify_unexpected_error_raises() -> None:
+    """A mapped but unexpected error fails strict verification."""
+    with pytest.raises(LoggedError, match="unexpected validation error"):
+        verify_block_rejection(
+            BlockException.INCORRECT_BLOB_GAS_USED,
+            EXCESS_BLOB_GAS_ERROR,
+            EXCESS_BLOB_GAS_ERROR,
+            BLOCK_1,
+            strict_exception_matching=True,
+        )
+
+
+def test_verify_accepts_cached_resubmission_rejection() -> None:
+    """A cache error is accepted if the first rejection matched."""
+    verify_block_rejection(
+        BlockException.INCORRECT_EXCESS_BLOB_GAS,
+        CACHED_REJECTION_ERROR,
+        EXCESS_BLOB_GAS_ERROR,
+        BLOCK_1,
+        strict_exception_matching=True,
+    )
+
+
+def test_verify_mismatch_only_warns_without_strict_matching() -> None:
+    """A mismatched rejection does not fail without strict matching."""
+    verify_block_rejection(
+        BlockException.INCORRECT_EXCESS_BLOB_GAS,
+        CACHED_REJECTION_ERROR,
+        CACHED_REJECTION_ERROR,
+        BLOCK_1,
+        strict_exception_matching=False,
+    )

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -182,6 +182,16 @@ class BlockTransactionExceptionWithMessage(
     pass
 
 
+ClientValidationError = (
+    BlockTransactionExceptionWithMessage | UndefinedException
+)
+"""
+A client's validation error for a rejected block: the mapped exceptions
+with the verbatim message, or `UndefinedException` if the message could
+not be mapped.
+"""
+
+
 class PayloadStatus(CamelModel):
     """Represents the status of a payload after execution."""
 
@@ -189,7 +199,7 @@ class PayloadStatus(CamelModel):
     latest_valid_hash: Hash | None
     validation_error: (
         Annotated[
-            BlockTransactionExceptionWithMessage | UndefinedException,
+            ClientValidationError,
             ExceptionMapperValidator,
         ]
         | None


### PR DESCRIPTION
### Description

In enginex mode a client is reused across all tests of a pre-allocation group, so its bad-block cache persists between tests. When two tests in a group contain an identical invalid block, the client validates the first submission for real and returns the specific validation error, but answers the resubmission from its cache with a generic one: reth returns "links to previously rejected block", which maps to no known exception and fails the test under strict exception matching, even though the client correctly returns `INVALID` both times. This causes 18 systematic enginex-only failures on `tests@v20.0.0` and is the entire `consume-engine` vs `consume-enginex` diff for reth.

Fix: A new `BlockRejectionTracker` records the first validation error each client returns per invalid block hash. When a rejection does not match the expected exception, it is verified against the client's first (real) rejection of the same block: accepted and logged if that one matched, failed as before otherwise. This is sound because an identical block hash implies an identical block on an identical parent chain, so the validation outcome is deterministic. It is also xdist-safe: entries are scoped by client id, mirroring the per-process bad-block cache they model, and `--dist loadgroup` pins each group's client to one worker. Classic `consume engine` (fresh client per test) is unaffected.

#### Reproducing the Issue

Reproduction against reth via hive `--dev`: without this PR 18 of 342 tests fail; with it all pass, and the acceptance path logs "Accepting mismatched validation error" exactly 18 times.

```console
./hive --dev --client reth --client-file ../execution-specs/.github/configs/hive/master.yaml --docker.buildoutput --sim.loglevel 5 --dev.addr 127.0.0.1:3020
```

```console
export HIVE_SIMULATOR=http://127.0.0.1:3020
uv run consume enginex --input=tests@v20.0.0 -n 4 -v --sim.limit ".*(test_invalid_excess_blob_gas_(above_target_)?change|test_invalid_zero_excess_blob_gas_in_header).*"
```

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![208 Already Reported](https://http.dog/208.jpg)
