### PR TITLE
feat(test-benchmark): validate post-state for stateful filler

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -10,13 +10,13 @@ import pytest
 from pytest_metadata.plugin import metadata_key
 
 from execution_testing.base_types import Account
-from execution_testing.base_types import Alloc as BaseAlloc
 from execution_testing.base_types.base_types import HexNumber
 from execution_testing.execution import BaseExecute
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EngineRPC, EthRPC
 from execution_testing.specs import BaseTest
+from execution_testing.test_types import Alloc as BaseAlloc
 from execution_testing.test_types import (
     Environment,
     EnvironmentDefaults,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -20,9 +20,6 @@ from execution_testing.base_types import (
     Storage,
     StorageRootType,
 )
-from execution_testing.base_types import (
-    Alloc as BaseAlloc,
-)
 from execution_testing.base_types.conversions import (
     BytesConvertible,
     NumberConvertible,
@@ -42,6 +39,7 @@ from execution_testing.test_types import (
     TransactionTestMetadata,
     compute_deterministic_create2_address,
 )
+from execution_testing.test_types import Alloc as BaseAlloc
 from execution_testing.tools import Initcode
 from execution_testing.vm import Bytecode, Op
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -9,11 +9,7 @@ import pytest
 from pytest import StashKey
 
 from execution_testing.base_types import Account, Number
-from execution_testing.base_types import Alloc as BaseAlloc
-from execution_testing.execution import (
-    BaseExecute,
-    LabeledExecuteFormat,
-)
+from execution_testing.execution import BaseExecute, LabeledExecuteFormat
 from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
@@ -65,7 +61,7 @@ def _validate_and_cache_address_stubs(
     eth_rpc = EthRPC(rpc_endpoint)
     labels = list(address_stubs.root.keys())
     addresses = [address_stubs.root[k].addr for k in labels]
-    query = BaseAlloc(root={addr: Account() for addr in addresses})
+    query = Alloc(root={addr: Account() for addr in addresses})
     alloc = eth_rpc.get_alloc(query)
     empty: list[str] = []
     accounts: Dict[str, Account] = {}

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -316,12 +316,7 @@ class ClientBackend:
         self, expected: Alloc, *, block_number: BlockNumberType = "latest"
     ) -> Alloc:
         """Fetch the post-state that ``expected`` constrains from client."""
-        got = self.eth_rpc.get_alloc(expected, block_number=block_number)
-        result = Alloc(root=got.root)
-        for address, account in expected.root.items():
-            if account is None and not result.root.get(address):
-                result.root[address] = None
-        return result
+        return self.eth_rpc.get_alloc(expected, block_number=block_number)
 
     def extract_block_opcode_count(
         self, block_hash: Hash

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -20,6 +20,7 @@ from execution_testing.exceptions import ExceptionBase, ExceptionMapper
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import (
+    BlockNumberType,
     DebugRPC,
     EngineRPC,
     EthRPC,
@@ -33,7 +34,12 @@ from execution_testing.rpc.rpc_types import (
     PayloadAttributes,
     PayloadStatusEnum,
 )
-from execution_testing.test_types import Requests, Transaction, Withdrawal
+from execution_testing.test_types import (
+    Alloc,
+    Requests,
+    Transaction,
+    Withdrawal,
+)
 from execution_testing.test_types.block_access_list import BlockAccessList
 from execution_testing.test_types.receipt_types import TransactionReceipt
 
@@ -305,6 +311,17 @@ class ClientBackend:
                 ),
             ),
         )
+
+    def get_post_state_alloc(
+        self, expected: Alloc, *, block_number: BlockNumberType = "latest"
+    ) -> Alloc:
+        """Fetch the post-state that ``expected`` constrains from client."""
+        got = self.eth_rpc.get_alloc(expected, block_number=block_number)
+        result = Alloc(root=got.root)
+        for address, account in expected.root.items():
+            if account is None and not result.root.get(address):
+                result.root[address] = None
+        return result
 
     def extract_block_opcode_count(
         self, block_hash: Hash

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Dict, List
 import pytest
 from pytest import FixtureRequest
 
-from execution_testing.base_types import Address, Alloc, Hash
+from execution_testing.base_types import Address, Hash
 from execution_testing.forks import Fork
 from execution_testing.logging import get_logger
 from execution_testing.rpc import (
@@ -14,6 +14,7 @@ from execution_testing.rpc import (
     SendTransactionExceptionError,
 )
 from execution_testing.test_types import (
+    Alloc,
     Environment,
     NetworkWrappedTransaction,
     TestPhase,

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -37,7 +37,6 @@ from tenacity import (
 from execution_testing.base_types import (
     Account,
     Address,
-    Alloc,
     Bytes,
     Hash,
     to_json,
@@ -45,6 +44,7 @@ from execution_testing.base_types import (
 from execution_testing.logging import (
     get_logger,
 )
+from execution_testing.test_types import Alloc
 
 from .rpc_types import (
     EthConfigResponse,

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1382,7 +1382,8 @@ class BlockchainTest(BaseTest):
         - Payloads are partitioned by ``FixtureEngineNewPayload.phase``
           into ``setup_payloads`` (setup-phase txs) and ``payloads``
           (execution-phase txs).
-        - ``verify_post_state`` is skipped: the client is the oracle.
+        - ``post`` is verified against the live client (the oracle) via
+          ``get_post_state_alloc``; there is no t8n post alloc to diff.
         """
         if not isinstance(t8n, ClientBackend):
             raise RuntimeError(
@@ -1546,6 +1547,10 @@ class BlockchainTest(BaseTest):
                 },
             )
             head_hash = client_hash
+
+        if self.post.root:
+            got_alloc = t8n.get_post_state_alloc(self.post)
+            self.post.verify_post_alloc(got_alloc)
 
         fixture = BlockchainEngineStatefulFixture(
             fork=self.fork,

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -324,6 +324,13 @@ class Alloc(BaseAlloc):
             address = Address(address)
         return address in self.root
 
+    def get(self, address: Address) -> Account | None:
+        """Get an account if it's present in the allocation, otherwise None."""
+        account = self.root.get(address)
+        if not account:
+            return None
+        return account
+
     def empty_accounts(self) -> List[Address]:
         """Return list of addresses of empty accounts."""
         return [
@@ -372,12 +379,10 @@ class Alloc(BaseAlloc):
         for address, account in self.root.items():
             if account is None:
                 # Account must not exist
-                if (
-                    address in got_alloc.root
-                    and got_alloc.root[address] is not None
-                ):
+                got_account = got_alloc.get(address)
+                if got_account:
                     raise Alloc.UnexpectedAccountError(
-                        address=address, account=got_alloc.root[address]
+                        address=address, account=got_account
                     )
             else:
                 if address in got_alloc.root:


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

EELS stateful filling didn't implement receipt validation and post-state verification. Even though these were configured in the benchmark test wrapper, validation was skipped. This PR implements these features.

```python
benchmark_test(
  pre=pre,
  post=post,
  blocks=blocks,
  expected_receipt_status=1,
)
```

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->


### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
