### PR TITLE
chore(test-client-clis): update Nethermind exception mappings

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -414,6 +414,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             r"max fee per gas less than block base fee"
         ),
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            r"max fee per blob gas less than block blob gas fee"
+        ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: (r"nonce too low"),
         TransactionException.NONCE_MISMATCH_TOO_HIGH: (r"nonce too high"),
         TransactionException.INVALID_CHAINID: (
@@ -442,10 +445,12 @@ class NethermindExceptionMapper(ExceptionMapper):
             r"calculated hash 0x[0-9a-f]+"
         ),
         BlockException.SYSTEM_CONTRACT_EMPTY: (
-            r"(Withdrawals|Consolidations)Empty: Contract is not deployed\."
+            r"(Withdrawals|Consolidations|BuilderDeposits|BuilderExits)"
+            r"Empty: Contract is not deployed\."
         ),
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
-            r"(Withdrawals|Consolidations)Failed: Contract execution failed\."
+            r"(Withdrawals|Consolidations|BuilderDeposits|BuilderExits)"
+            r"Failed: Contract execution failed\."
         ),
         # BAL Exceptions — specific exceptions have unique patterns, but
         # INVALID_BLOCK_ACCESS_LIST and INCORRECT_BLOCK_FORMAT intentionally


### PR DESCRIPTION
### Description

Maps Nethermind's Glamsterdam errors and backports the evmone Constantinople CI skip.
Requires #3130 in the branch

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Cat](https://placecats.com/300/200)