### PR TITLE
feat(tests): add dynamic-destination JUMP/JUMPI invalid-target tests

### DIFF
--- a/tests/frontier/opcodes/test_dynamic_jump.py
+++ b/tests/frontier/opcodes/test_dynamic_jump.py
@@ -1,0 +1,150 @@
+"""Tests for JUMP and JUMPI with runtime-computed destinations."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Fork,
+    Hash,
+    Op,
+    StateTestFiller,
+    Storage,
+    Transaction,
+)
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+GAS_LIMIT = 100_000
+
+LEGACY_VM_TESTS = (
+    "https://github.com/ethereum/legacytests/blob/master/"
+    "src/LegacyTests/Constantinople/VMTestsFiller/vmIOandFlowOperations"
+)
+
+
+@pytest.mark.ported_from(
+    [
+        f"{LEGACY_VM_TESTS}/DynamicJumpInsidePushWithJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpInsidePushWithoutJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpifInsidePushWithJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpifInsidePushWithoutJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpiOutsideBoundaryFiller.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpJD_DependsOnJumps0Filler.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpPathologicalTest1Filler.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpPathologicalTest2Filler.json",
+        f"{LEGACY_VM_TESTS}/DynamicJumpPathologicalTest3Filler.json",
+        f"{LEGACY_VM_TESTS}/BlockNumberDynamicJumpInsidePushWithJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/BlockNumberDynamicJumpInsidePushWithoutJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/BlockNumberDynamicJumpifInsidePushWithJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/BlockNumberDynamicJumpifInsidePushWithoutJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/BlockNumberDynamicJumpiOutsideBoundaryFiller.json",
+        f"{LEGACY_VM_TESTS}/JDfromStorageDynamicJumpInsidePushWithJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/JDfromStorageDynamicJumpInsidePushWithoutJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/JDfromStorageDynamicJumpifInsidePushWithJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/JDfromStorageDynamicJumpifInsidePushWithoutJumpDestFiller.json",
+        f"{LEGACY_VM_TESTS}/JDfromStorageDynamicJumpiOutsideBoundaryFiller.json",
+        f"{LEGACY_VM_TESTS}/bad_indirect_jump2Filler.json",
+    ],
+)
+@pytest.mark.valid_from("Frontier")
+@pytest.mark.parametrize("opcode", [Op.JUMP, Op.JUMPI])
+@pytest.mark.parametrize(
+    "dest_kind",
+    ["push_data_jumpdest", "push_data_non_jumpdest", "beyond_code"],
+)
+def test_dynamic_jump_invalid_destination(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    opcode: Op,
+    dest_kind: str,
+) -> None:
+    """
+    Jump to an invalid destination taken from calldata and verify the
+    exceptional halt: storage stays empty and all gas is consumed.
+
+    The destination comes from calldata, so implementations that
+    pre-analyze static PUSH+JUMP pairs must still validate it at
+    execution time. Covers landing inside PUSH immediate data (on a 0x5B
+    byte and on a non-0x5B byte) and landing far beyond the code size at
+    a destination whose 64-bit truncation is a valid JUMPDEST.
+    """
+    storage = Storage()
+    if opcode == Op.JUMP:
+        dispatch = Op.JUMP(Op.CALLDATALOAD(0))
+    else:
+        dispatch = Op.JUMPI(Op.CALLDATALOAD(0), 1)
+    fallthrough = (
+        Op.SSTORE(storage.store_next(0, "jump not halted"), 1) + Op.STOP
+    )
+    # PUSH2 data holds a 0x5B byte that must not count as a JUMPDEST.
+    island = Op.PUSH2(0x5B00) + Op.POP
+    code = (
+        dispatch
+        + fallthrough
+        + island
+        + Op.JUMPDEST
+        + Op.SSTORE(storage.store_next(0, "invalid destination taken"), 2)
+        + Op.STOP
+    )
+    push_data = len(dispatch + fallthrough) + 1
+    jumpdest = len(dispatch + fallthrough + island)
+    assert bytes(code)[jumpdest] == Op.JUMPDEST.int()
+    dest = {
+        "push_data_jumpdest": push_data,
+        "push_data_non_jumpdest": push_data + 1,
+        # An implementation truncating the destination to 64 bits would
+        # land on the valid JUMPDEST and store 2 instead of halting.
+        "beyond_code": 2**64 + jumpdest,
+    }[dest_kind]
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract,
+        data=Hash(dest),
+        gas_limit=GAS_LIMIT,
+        expected_receipt={"cumulative_gas_used": GAS_LIMIT},
+        protected=fork.supports_protected_txs(),
+    )
+
+    state_test(pre=pre, post={contract: Account(storage=storage)}, tx=tx)
+
+
+@pytest.mark.ported_from(
+    [
+        f"{LEGACY_VM_TESTS}/jumpi1Filler.json",
+    ],
+)
+@pytest.mark.valid_from("Frontier")
+def test_jumpi_not_taken_invalid_destination(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify that a false-condition JUMPI whose static destination is
+    invalid does not fail and falls through.
+
+    The condition comes from calldata, so implementations that
+    eagerly validate a static JUMPI destination must still skip the
+    validation when the branch is not taken.
+    """
+    storage = Storage()
+    fallthrough = Op.SSTORE(storage.store_next(1, "fell through"), 1) + Op.STOP
+    dispatch = Op.JUMPI(0, Op.CALLDATALOAD(0))
+    stop_offset = len(dispatch + fallthrough) - 1
+    dispatch = Op.JUMPI(stop_offset, Op.CALLDATALOAD(0))
+    code = dispatch + fallthrough
+    assert bytes(code)[stop_offset] == Op.STOP.int()
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract,
+        data=Hash(0),
+        protected=fork.supports_protected_txs(),
+    )
+
+    state_test(pre=pre, post={contract: Account(storage=storage)}, tx=tx)

--- a/tests/frontier/opcodes/test_dynamic_jump.py
+++ b/tests/frontier/opcodes/test_dynamic_jump.py
@@ -1,4 +1,6 @@
-"""Tests for JUMP and JUMPI with runtime-computed destinations."""
+"""
+Tests for JUMP and JUMPI with runtime-computed destinations or conditions.
+"""
 
 from typing import Tuple
 

--- a/tests/frontier/opcodes/test_dynamic_jump.py
+++ b/tests/frontier/opcodes/test_dynamic_jump.py
@@ -73,8 +73,11 @@ LEGACY_VM_TESTS = (
 )
 @pytest.mark.parametrize(
     "dest_source,dest_kind",
-    [("calldata", kind) for kind in DESTINATION_KINDS]
-    + [(source, "push_data_jumpdest") for source in ("storage", "number")],
+    [
+        (source, kind)
+        for source in ("calldata", "storage", "number")
+        for kind in DESTINATION_KINDS
+    ],
 )
 def test_dynamic_jump_invalid_destination(
     state_test: StateTestFiller,

--- a/tests/frontier/opcodes/test_dynamic_jump.py
+++ b/tests/frontier/opcodes/test_dynamic_jump.py
@@ -1,21 +1,35 @@
 """Tests for JUMP and JUMPI with runtime-computed destinations."""
 
+from typing import Tuple
+
 import pytest
 from execution_testing import (
     Account,
     Alloc,
+    Environment,
     Fork,
     Hash,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionReceipt,
 )
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
 
 GAS_LIMIT = 100_000
+
+DESTINATION_SLOT = 0xDE
+
+DESTINATION_KINDS = [
+    "push_data_jumpdest",
+    "push_data_non_jumpdest",
+    "one_past_code",
+    "jumpdest_alias_2_64",
+    "max_u256",
+]
 
 LEGACY_VM_TESTS = (
     "https://github.com/ethereum/legacytests/blob/master/"
@@ -48,37 +62,49 @@ LEGACY_VM_TESTS = (
     ],
 )
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.parametrize("opcode", [Op.JUMP, Op.JUMPI])
 @pytest.mark.parametrize(
-    "dest_kind",
-    ["push_data_jumpdest", "push_data_non_jumpdest", "beyond_code"],
+    "opcode,condition",
+    [
+        pytest.param(Op.JUMP, (), id="jump"),
+        pytest.param(Op.JUMPI, (1,), id="jumpi"),
+    ],
+)
+@pytest.mark.parametrize(
+    "dest_source,dest_kind",
+    [("calldata", kind) for kind in DESTINATION_KINDS]
+    + [(source, "push_data_jumpdest") for source in ("storage", "number")],
 )
 def test_dynamic_jump_invalid_destination(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
     opcode: Op,
+    condition: Tuple[int, ...],
+    dest_source: str,
     dest_kind: str,
 ) -> None:
     """
-    Jump to an invalid destination taken from calldata and verify the
+    Jump to an invalid destination computed at run time and verify the
     exceptional halt: storage stays empty and all gas is consumed.
 
-    The destination comes from calldata, so implementations that
-    pre-analyze static PUSH+JUMP pairs must still validate it at
-    execution time. Covers landing inside PUSH immediate data (on a 0x5B
-    byte and on a non-0x5B byte) and landing far beyond the code size at
-    a destination whose 64-bit truncation is a valid JUMPDEST.
+    The destination is never a static PUSH, so implementations that
+    pre-analyze PUSH+JUMP pairs must still validate it at execution time.
+    It is read from calldata, read from storage, or derived from the
+    block number, and it lands inside PUSH immediate data (on a 0x5B byte
+    and on a non-0x5B byte), one byte past the code, at an offset whose
+    truncation to 64 bits is a valid JUMPDEST, or at the maximum word.
     """
+    env = Environment()
     storage = Storage()
-    if opcode == Op.JUMP:
-        dispatch = Op.JUMP(Op.CALLDATALOAD(0))
-    else:
-        dispatch = Op.JUMPI(Op.CALLDATALOAD(0), 1)
+    dest_expression = {
+        "calldata": Op.CALLDATALOAD(0),
+        "storage": Op.SLOAD(DESTINATION_SLOT),
+        "number": Op.ADD(Op.NUMBER, Op.CALLDATALOAD(0)),
+    }[dest_source]
+    dispatch = opcode(dest_expression, *condition)
     fallthrough = (
         Op.SSTORE(storage.store_next(0, "jump not halted"), 1) + Op.STOP
     )
-    # PUSH2 data holds a 0x5B byte that must not count as a JUMPDEST.
     island = Op.PUSH2(0x5B00) + Op.POP
     code = (
         dispatch
@@ -90,26 +116,38 @@ def test_dynamic_jump_invalid_destination(
     )
     push_data = len(dispatch + fallthrough) + 1
     jumpdest = len(dispatch + fallthrough + island)
+    assert bytes(code)[push_data] == Op.JUMPDEST.int()
+    assert bytes(code)[push_data + 1] != Op.JUMPDEST.int()
     assert bytes(code)[jumpdest] == Op.JUMPDEST.int()
     dest = {
         "push_data_jumpdest": push_data,
         "push_data_non_jumpdest": push_data + 1,
-        # An implementation truncating the destination to 64 bits would
-        # land on the valid JUMPDEST and store 2 instead of halting.
-        "beyond_code": 2**64 + jumpdest,
+        "one_past_code": len(code),
+        "jumpdest_alias_2_64": 2**64 + jumpdest,
+        "max_u256": 2**256 - 1,
     }[dest_kind]
 
-    contract = pre.deploy_contract(code)
+    initial_storage = Storage()
+    if dest_source == "storage":
+        initial_storage[DESTINATION_SLOT] = dest
+        storage[DESTINATION_SLOT] = dest
+    contract = pre.deploy_contract(code, storage=initial_storage)
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=contract,
-        data=Hash(dest),
+        data={
+            "calldata": Hash(dest),
+            "storage": b"",
+            "number": Hash(dest - env.number),
+        }[dest_source],
         gas_limit=GAS_LIMIT,
-        expected_receipt={"cumulative_gas_used": GAS_LIMIT},
+        expected_receipt=TransactionReceipt(cumulative_gas_used=GAS_LIMIT),
         protected=fork.supports_protected_txs(),
     )
 
-    state_test(pre=pre, post={contract: Account(storage=storage)}, tx=tx)
+    state_test(
+        env=env, pre=pre, post={contract: Account(storage=storage)}, tx=tx
+    )
 
 
 @pytest.mark.ported_from(
@@ -118,26 +156,33 @@ def test_dynamic_jump_invalid_destination(
     ],
 )
 @pytest.mark.valid_from("Frontier")
+@pytest.mark.parametrize(
+    "dest",
+    [pytest.param(1, id="push_data"), pytest.param(2**256 - 1, id="max_u256")],
+)
 def test_jumpi_not_taken_invalid_destination(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    dest: int,
 ) -> None:
     """
-    Verify that a false-condition JUMPI whose static destination is
-    invalid does not fail and falls through.
+    Verify that a false-condition JUMPI whose destination is invalid does
+    not fail and falls through.
 
-    The condition comes from calldata, so implementations that
-    eagerly validate a static JUMPI destination must still skip the
-    validation when the branch is not taken.
+    The condition comes from calldata, so implementations that eagerly
+    validate a static JUMPI destination must still skip the validation
+    when the branch is not taken. The code holds no JUMPDEST at all, so
+    both an in-code destination inside PUSH immediate data and one past
+    the maximum code size are invalid.
     """
     storage = Storage()
-    fallthrough = Op.SSTORE(storage.store_next(1, "fell through"), 1) + Op.STOP
-    dispatch = Op.JUMPI(0, Op.CALLDATALOAD(0))
-    stop_offset = len(dispatch + fallthrough) - 1
-    dispatch = Op.JUMPI(stop_offset, Op.CALLDATALOAD(0))
-    code = dispatch + fallthrough
-    assert bytes(code)[stop_offset] == Op.STOP.int()
+    code = (
+        Op.JUMPI(dest, Op.CALLDATALOAD(0))
+        + Op.SSTORE(storage.store_next(1, "fell through"), 1)
+        + Op.STOP
+    )
+    assert Op.JUMPDEST.int() not in bytes(code)
 
     contract = pre.deploy_contract(code)
     tx = Transaction(


### PR DESCRIPTION
### Description

Port the behaviors of the legacy VMTests dynamic-jump family (DynamicJump*, BlockNumberDynamicJump*, JDfromStorageDynamicJump*, bad_indirect_jump2, jumpi1) that had no EEST equivalent: jumps with runtime-computed destinations landing inside PUSH immediate data (on 0x5B and non-0x5B bytes) or far beyond code size, and a not-taken JUMPI with an invalid static destination.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
