### PR TITLE
feat(tests): restore sstore_combinations as a hand-written test

### DIFF
--- a/scripts/filler_to_python/__main__.py
+++ b/scripts/filler_to_python/__main__.py
@@ -18,6 +18,25 @@ logger = logging.getLogger(__name__)
 
 MANUALLY_ENHANCED_TAG = "@manually-enhanced"
 
+# Fillers consolidated into hand-written tests outside
+# ``tests/ported_static``; never regenerate them.
+# sstore_combinations_*:
+#   tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
+CONSOLIDATED_FILLERS = {
+    "sstore_combinations_initial00_ParisFiller",
+    "sstore_combinations_initial00_2_ParisFiller",
+    "sstore_combinations_initial01_ParisFiller",
+    "sstore_combinations_initial01_2_ParisFiller",
+    "sstore_combinations_initial10_ParisFiller",
+    "sstore_combinations_initial10_2_ParisFiller",
+    "sstore_combinations_initial11_ParisFiller",
+    "sstore_combinations_initial11_2_ParisFiller",
+    "sstore_combinations_initial20_ParisFiller",
+    "sstore_combinations_initial20_2_ParisFiller",
+    "sstore_combinations_initial21_ParisFiller",
+    "sstore_combinations_initial21_2_ParisFiller",
+}
+
 
 def _has_manually_enhanced_tag(file_path: Path) -> bool:
     """Check if a file has @manually-enhanced in its module docstring."""
@@ -136,6 +155,13 @@ def process_single_filler(
     Return "ok", "fail", "warn", or "skip".
     """
     try:
+        if filler_path.stem in CONSOLIDATED_FILLERS:
+            logger.info(
+                "SKIP: %s (consolidated into a hand-written test)",
+                filler_path,
+            )
+            return "skip"
+
         # Relative path for the generated test's ported_from marker
         try:
             rel_path = filler_path.relative_to(fillers_base.parent)

--- a/tests/istanbul/eip2200_net_gas_metering/__init__.py
+++ b/tests/istanbul/eip2200_net_gas_metering/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests [EIP-2200: Structured Definitions for Net Gas Metering](https://eips.ethereum.org/EIPS/eip-2200).
+"""

--- a/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
+++ b/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
@@ -90,7 +90,7 @@ MIDDLE_ACTIONS = [
 
 @pytest.mark.parametrize("initial", range(3))
 @pytest.mark.parametrize("call_4, call_4_target", MIDDLE_ACTIONS)
-@pytest.mark.parametrize("call_3", [Op.STATICCALL, Op.CALL, Op.DELEGATECALL])
+@pytest.mark.parametrize("call_3", [Op.CALL, Op.DELEGATECALL])
 @pytest.mark.parametrize("call_2, call_2_target", MIDDLE_ACTIONS)
 @pytest.mark.parametrize("call_1", [Op.CALL, Op.DELEGATECALL])
 def test_sstore_combinations_initial(
@@ -182,15 +182,21 @@ def test_sstore_combinations_initial(
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize("dirty", [False, True])
 @pytest.mark.parametrize("initial", range(3))
 def test_sstore_combinations_initial_staticcall_only(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
     initial: int,
+    dirty: bool,
 ) -> None:
     """
-    Test the base case of a single STATICCALL to the update contract.
+    Test a STATICCALL to the update contract, whose SSTORE must fault.
+
+    With dirty=True a plain CALL to the update contract runs first, so
+    the faulting SSTORE observes a slot whose current value already
+    differs from its original value.
     """
     sender = pre.fund_eoa()
 
@@ -203,8 +209,14 @@ def test_sstore_combinations_initial_staticcall_only(
     )
     sstore_toggle = pre.deploy_contract(code=SSTORE_TOGGLE_CODE)
 
+    dirtying_call = (
+        Op.POP(Op.CALL(gas=CALL_GAS, address=update_contract, args_size=0x20))
+        if dirty
+        else Bytecode()
+    )
     initcode = (
         Op.MSTORE(offset=0x64, value=0x0)
+        + dirtying_call
         + Op.POP(
             Op.STATICCALL(
                 gas=CALL_GAS,

--- a/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
+++ b/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
@@ -8,12 +8,12 @@ from execution_testing import (
     Address,
     Alloc,
     Bytecode,
+    Fork,
+    Op,
     StateTestFiller,
     Transaction,
     compute_create_address,
 )
-from execution_testing.forks import Fork
-from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2200.md"
 REFERENCE_SPEC_VERSION = "ad4eaaa1fe5c7aa394b2ab09e885b73b898f5da0"
@@ -54,8 +54,6 @@ SSTORE_TOGGLE_CODE = (
     + Op.SSTORE(key=0x1, value=0x1)
     + Op.STOP
 )
-
-CALL_GAS = 0x493E0
 
 
 class MidContractActions(StrEnum):
@@ -135,33 +133,32 @@ def test_sstore_combinations_initial(
     }
 
     update_contract = pre.deploy_contract(
-        code=Op.SSTORE(key=0x0, value=0x0)
-        + Op.SSTORE(key=0x1, value=0x1)
-        + Op.SSTORE(key=0x2, value=0x2)
-        + Op.STOP,
+        code=UPDATE_CONTRACT_CODE,
         storage={0: initial, 1: initial, 2: initial} if initial > 0 else {},
     )
     sstore_toggle = side[MidContractActions.SSTORE_TOGGLE]
+
+    call_gas = SSTORE_TOGGLE_CODE.gas_cost(fork)
 
     initcode = (
         Op.MSTORE(offset=0x64, value=0x0)
         + Op.POP(
             call_1(
-                gas=CALL_GAS,
+                gas=call_gas,
                 address=update_contract,
                 args_size=0x20,
             )
         )
-        + Op.POP(call_2(gas=CALL_GAS, address=side[call_2_target]))
+        + Op.POP(call_2(gas=call_gas, address=side[call_2_target]))
         + Op.POP(
             call_3(
-                gas=CALL_GAS,
+                gas=call_gas,
                 address=update_contract,
                 args_size=0x20,
             )
         )
-        + Op.POP(call_4(gas=CALL_GAS, address=side[call_4_target]))
-        + Op.CALL(gas=CALL_GAS * 2, address=sstore_toggle)
+        + Op.POP(call_4(gas=call_gas, address=side[call_4_target]))
+        + Op.CALL(gas=call_gas, address=sstore_toggle)
         + Op.STOP
     )
 
@@ -169,7 +166,6 @@ def test_sstore_combinations_initial(
         sender=sender,
         to=None,
         data=initcode,
-        gas_limit=2_000_000,
         value=1,
         protected=fork.supports_protected_txs(),
     )
@@ -201,16 +197,15 @@ def test_sstore_combinations_initial_staticcall_only(
     sender = pre.fund_eoa()
 
     update_contract = pre.deploy_contract(
-        code=Op.SSTORE(key=0x0, value=0x0)
-        + Op.SSTORE(key=0x1, value=0x1)
-        + Op.SSTORE(key=0x2, value=0x2)
-        + Op.STOP,
+        code=UPDATE_CONTRACT_CODE,
         storage={0: initial, 1: initial, 2: initial} if initial > 0 else {},
     )
     sstore_toggle = pre.deploy_contract(code=SSTORE_TOGGLE_CODE)
 
+    call_gas = SSTORE_TOGGLE_CODE.gas_cost(fork)
+
     dirtying_call = (
-        Op.POP(Op.CALL(gas=CALL_GAS, address=update_contract, args_size=0x20))
+        Op.POP(Op.CALL(gas=call_gas, address=update_contract, args_size=0x20))
         if dirty
         else Bytecode()
     )
@@ -219,12 +214,12 @@ def test_sstore_combinations_initial_staticcall_only(
         + dirtying_call
         + Op.POP(
             Op.STATICCALL(
-                gas=CALL_GAS,
+                gas=call_gas,
                 address=update_contract,
                 args_size=0x20,
             )
         )
-        + Op.CALL(gas=CALL_GAS * 2, address=sstore_toggle)
+        + Op.CALL(gas=call_gas, address=sstore_toggle)
         + Op.STOP
     )
 
@@ -232,7 +227,6 @@ def test_sstore_combinations_initial_staticcall_only(
         sender=sender,
         to=None,
         data=initcode,
-        gas_limit=2_000_000,
         value=1,
         protected=fork.supports_protected_txs(),
     )

--- a/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
+++ b/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
@@ -1,0 +1,239 @@
+"""Tests for SSTORE combinations across nested call types."""
+
+from enum import StrEnum
+
+import pytest
+from execution_testing import (
+    Account,
+    Address,
+    Alloc,
+    Bytecode,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+from execution_testing.forks import Fork
+from execution_testing.vm import Op
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2200.md"
+REFERENCE_SPEC_VERSION = "ad4eaaa1fe5c7aa394b2ab09e885b73b898f5da0"
+
+pytestmark = [
+    pytest.mark.ported_from(
+        "state_tests/stTimeConsuming/sstore_combinations_initial00_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial00_2_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial01_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial01_2_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial10_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial10_2_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial11_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial11_2_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial20_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial20_2_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial21_ParisFiller.json",
+        "state_tests/stTimeConsuming/sstore_combinations_initial21_2_ParisFiller.json",
+    ),
+    pytest.mark.valid_from("Byzantium"),
+]
+
+
+# Writes slots 0..2 of the executing frame's storage account.
+UPDATE_CONTRACT_CODE = (
+    Op.SSTORE(key=0x0, value=0x0)
+    + Op.SSTORE(key=0x1, value=0x1)
+    + Op.SSTORE(key=0x2, value=0x2)
+    + Op.STOP
+)
+
+# Flip slots 1..16 to accumulate net-metering refunds, then set slot 1.
+SSTORE_TOGGLE_CODE = (
+    sum(
+        Op.SSTORE(key=i, value=0x1) + Op.SSTORE(key=i, value=0x0)
+        for i in range(0x1, 0x10 + 1)
+    )
+    + Op.SSTORE(key=0x1, value=0x1)
+    + Op.STOP
+)
+
+CALL_GAS = 0x493E0
+
+
+class MidContractActions(StrEnum):
+    """List of actions the middle contracts can perform."""
+
+    NOOP = "noop"
+    SSTORE_TOGGLE = "sstore-toggle"
+    REVERT = "revert"
+
+
+# Middle-action combinations: (call_opcode, side_contract_kind).
+# The no-op contract has no code and the reverting contract performs no
+# SSTORE, so for those two targets the calling opcode is unobservable:
+# CALL and CALLCODE produce identical executions, as do DELEGATECALL and
+# STATICCALL (confirmed by tracing all combinations), and one opcode of
+# each pair is kept. The storage-toggling contract behaves differently
+# under each opcode, so all four are kept there.
+MIDDLE_ACTIONS = [
+    (op, MidContractActions.SSTORE_TOGGLE)
+    for op in [
+        Op.CALL,
+        Op.CALLCODE,
+        Op.DELEGATECALL,
+        Op.STATICCALL,
+    ]
+] + [
+    (op, t)
+    for op in [Op.CALL, Op.DELEGATECALL]
+    for t in [MidContractActions.NOOP, MidContractActions.REVERT]
+]
+
+
+@pytest.mark.parametrize("initial", range(3))
+@pytest.mark.parametrize("call_4, call_4_target", MIDDLE_ACTIONS)
+@pytest.mark.parametrize(
+    "call_3",
+    [Op.STATICCALL, Op.CALL, Op.CALLCODE, Op.DELEGATECALL],
+)
+@pytest.mark.parametrize("call_2, call_2_target", MIDDLE_ACTIONS)
+@pytest.mark.parametrize(
+    "call_1",
+    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL],
+)
+def test_sstore_combinations_initial(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    initial: int,
+    call_1: Op,
+    call_2: Op,
+    call_2_target: MidContractActions,
+    call_3: Op,
+    call_4: Op,
+    call_4_target: MidContractActions,
+) -> None:
+    """
+    Test SSTORE with four interleaved calls.
+
+    Exercises every combination of call types across four call slots,
+    varying the update-contract's initial storage state (0, 1, or 2).
+    Valid from Byzantium (REVERT and STATICCALL availability) so the
+    pre-EIP-2200 storage gas rules are covered as a baseline.
+    Consolidated replacement for the twelve legacy
+    ``sstore_combinations_initial*_ParisFiller.json`` fillers from
+    ``state_tests/stTimeConsuming/``.
+    """
+    sender = pre.fund_eoa()
+
+    def deploy_side(kind: MidContractActions) -> Address:
+        if kind == MidContractActions.NOOP:
+            return pre.deploy_contract(Bytecode())
+        if kind == MidContractActions.SSTORE_TOGGLE:
+            return pre.deploy_contract(code=SSTORE_TOGGLE_CODE)
+        return pre.deploy_contract(
+            code=Op.REVERT(offset=0x0, size=0x20) + Op.STOP,
+        )
+
+    side = {
+        kind: deploy_side(kind)
+        for kind in MidContractActions
+        if kind
+        in {call_2_target, call_4_target, MidContractActions.SSTORE_TOGGLE}
+    }
+
+    update_contract = pre.deploy_contract(
+        code=Op.SSTORE(key=0x0, value=0x0)
+        + Op.SSTORE(key=0x1, value=0x1)
+        + Op.SSTORE(key=0x2, value=0x2)
+        + Op.STOP,
+        storage={0: initial, 1: initial, 2: initial} if initial > 0 else {},
+    )
+    sstore_toggle = side[MidContractActions.SSTORE_TOGGLE]
+
+    initcode = (
+        Op.MSTORE(offset=0x64, value=0x0)
+        + Op.POP(
+            call_1(
+                gas=CALL_GAS,
+                address=update_contract,
+                args_size=0x20,
+            )
+        )
+        + Op.POP(call_2(gas=CALL_GAS, address=side[call_2_target]))
+        + Op.POP(
+            call_3(
+                gas=CALL_GAS,
+                address=update_contract,
+                args_size=0x20,
+            )
+        )
+        + Op.POP(call_4(gas=CALL_GAS, address=side[call_4_target]))
+        + Op.CALL(gas=CALL_GAS * 2, address=sstore_toggle)
+        + Op.STOP
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode,
+        gas_limit=2_000_000,
+        value=1,
+        protected=fork.supports_protected_txs(),
+    )
+
+    post = {
+        sstore_toggle: Account(storage={1: 1}),
+        compute_create_address(address=sender, nonce=0): Account(nonce=1),
+    }
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize("initial", range(3))
+def test_sstore_combinations_initial_staticcall_only(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    initial: int,
+) -> None:
+    """
+    Test the base case of a single STATICCALL to the update contract.
+    """
+    sender = pre.fund_eoa()
+
+    update_contract = pre.deploy_contract(
+        code=Op.SSTORE(key=0x0, value=0x0)
+        + Op.SSTORE(key=0x1, value=0x1)
+        + Op.SSTORE(key=0x2, value=0x2)
+        + Op.STOP,
+        storage={0: initial, 1: initial, 2: initial} if initial > 0 else {},
+    )
+    sstore_toggle = pre.deploy_contract(code=SSTORE_TOGGLE_CODE)
+
+    initcode = (
+        Op.MSTORE(offset=0x64, value=0x0)
+        + Op.POP(
+            Op.STATICCALL(
+                gas=CALL_GAS,
+                address=update_contract,
+                args_size=0x20,
+            )
+        )
+        + Op.CALL(gas=CALL_GAS * 2, address=sstore_toggle)
+        + Op.STOP
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode,
+        gas_limit=2_000_000,
+        value=1,
+        protected=fork.supports_protected_txs(),
+    )
+
+    post = {
+        sstore_toggle: Account(storage={1: 1}),
+        compute_create_address(address=sender, nonce=0): Account(nonce=1),
+    }
+
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
+++ b/tests/istanbul/eip2200_net_gas_metering/test_sstore_combinations.py
@@ -90,15 +90,9 @@ MIDDLE_ACTIONS = [
 
 @pytest.mark.parametrize("initial", range(3))
 @pytest.mark.parametrize("call_4, call_4_target", MIDDLE_ACTIONS)
-@pytest.mark.parametrize(
-    "call_3",
-    [Op.STATICCALL, Op.CALL, Op.CALLCODE, Op.DELEGATECALL],
-)
+@pytest.mark.parametrize("call_3", [Op.STATICCALL, Op.CALL, Op.DELEGATECALL])
 @pytest.mark.parametrize("call_2, call_2_target", MIDDLE_ACTIONS)
-@pytest.mark.parametrize(
-    "call_1",
-    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL],
-)
+@pytest.mark.parametrize("call_1", [Op.CALL, Op.DELEGATECALL])
 def test_sstore_combinations_initial(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/ported_static/stTimeConsuming/__init__.py
+++ b/tests/ported_static/stTimeConsuming/__init__.py
@@ -1,1 +1,0 @@
-"""Ported static tests: stTimeConsuming."""  # noqa: N999

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial00_2_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial00_2_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 0 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial00_2_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial00_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial00_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 0 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial00_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial01_2_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial01_2_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 0 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial01_2_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial01_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial01_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 0 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial01_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial10_2_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial10_2_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 1 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial10_2_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial10_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial10_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 1 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial10_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial11_2_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial11_2_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 1 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial11_2_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial11_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial11_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 1 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial11_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial20_2_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial20_2_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 2 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial20_2_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial20_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial20_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 2 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial20_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial21_2_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial21_2_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 2 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial21_2_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""

--- a/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial21_paris.py
+++ b/tests/ported_static/stTimeConsuming/test_sstore_combinations_initial21_paris.py
@@ -1,9 +1,0 @@
-"""
-Sstore 2 -> {calltype} -> change to {0, 1, 2} |-> {calltype} -> {non,...
-
-Ported from:
-state_tests/stTimeConsuming/sstore_combinations_initial21_ParisFiller.json
-
-@manually-enhanced: Do not overwrite. This test has been manually reviewed and
-enhanced.
-"""


### PR DESCRIPTION
### Description

test_sstore_combinations_initial.py, added in #2623 as the consolidated
replacement for the twelve legacy sstore_combinations fillers, was
deleted accidentally by the ported-static regeneration sweep in #2695:
the sweep only preserves generator outputs and files tagged
@manually-enhanced, and the slow-marked test was also absent from the
trace-verification baseline, so the deletion went unnoticed and the
twelve fillers were left with no coverage at all.

Restore it as tests/istanbul/eip2200_net_gas_metering/
test_sstore_combinations.py, where hand-written tests are never touched
by regeneration, keeping the ported_from lineage. Delete the twelve
docstring-only stub files: the regeneration guard they provided is now
a CONSOLIDATED_FILLERS skip set in the filler_to_python generator
itself.

Also shrink the matrix from 5187 to 774 cases per fork, with each
reduction step verified by tracing EELS before and after. The
middle-action parametrization drops from 12 to 8 combinations per
slot: for the no-op and reverting side contracts CALL and CALLCODE
produce identical executions, as do DELEGATECALL and STATICCALL, so
one opcode of each pair is kept. CALLCODE is dropped from the
update-contract slots (call_1, call_3) because it produces the same
storage transitions as the retained DELEGATECALL. STATICCALL leaves
those slots for a dedicated staticcall_only test: in the matrix it
contributed a single faulting behavior already covered extensively by
the stStaticCall and eip214_staticcall tests, and the variant unique
to this file, a faulting SSTORE that observes a dirty slot, is kept
via the new dirty parameter.

Each call forwards SSTORE_TOGGLE_CODE.gas_cost(fork), a worst-case
bound on any callee's consumption, instead of the legacy fixed
0x493E0 that made many variants run out of gas mid-call; traces of
the final test contain no OutOfGas, so every storage scenario
executes in full. The transaction gas_limit is left for the framework
to auto-fill. The slow marker is dropped so the test actually runs
in CI.


These tests should be important for Amsterdam where there is a lot of changes to storage prices.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
