### PR TITLE
fix(zkevm): support EIP-8282 requests in stateless validation

### DIFF
--- a/src/ethereum/forks/amsterdam/execution_engine/requests.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/requests.py
@@ -3,7 +3,7 @@ Typed execution-layer requests and engine-API wire-form codecs.
 
 The consensus layer defines ``ExecutionRequests`` as a typed Container
 holding deposit, withdrawal, consolidation, builder deposit, and builder exit
-lists. 
+lists.
 """
 
 from dataclasses import dataclass

--- a/src/ethereum/forks/amsterdam/execution_engine/requests.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/requests.py
@@ -2,11 +2,8 @@
 Typed execution-layer requests and engine-API wire-form codecs.
 
 The consensus layer defines ``ExecutionRequests`` as a typed Container
-holding ``deposits``, ``withdrawals``, and ``consolidations`` lists. At
-the engine-API boundary, that Container is flattened to a tuple of
-opaque blobs of the form ``TYPE_BYTE || concat(serialize(item))``,
-ordered ascending by type. This module exposes the typed Container and
-the boundary codecs (mirrors CL's ``get_execution_requests_list()``).
+holding deposit, withdrawal, consolidation, builder deposit, and builder exit
+lists. 
 """
 
 from dataclasses import dataclass
@@ -20,6 +17,8 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.state import Address
 
 from ..requests import (
+    BUILDER_DEPOSIT_REQUEST_TYPE,
+    BUILDER_EXIT_REQUEST_TYPE,
     CONSOLIDATION_REQUEST_TYPE,
     DEPOSIT_REQUEST_TYPE,
     WITHDRAWAL_REQUEST_TYPE,
@@ -28,6 +27,8 @@ from ..requests import (
 DEPOSIT_REQUEST_SIZE = 48 + 32 + 8 + 96 + 8
 WITHDRAWAL_REQUEST_SIZE = 20 + 48 + 8
 CONSOLIDATION_REQUEST_SIZE = 20 + 48 + 48
+BUILDER_DEPOSIT_REQUEST_SIZE = 184
+BUILDER_EXIT_REQUEST_SIZE = 68
 
 
 @final
@@ -68,6 +69,28 @@ class ConsolidationRequest:
 @final
 @slotted_freezable
 @dataclass
+class BuilderDepositRequest:
+    """A single EIP-8282 builder deposit request."""
+
+    pubkey: Bytes48
+    withdrawal_credentials: Bytes32
+    amount: U64
+    signature: Bytes96
+
+
+@final
+@slotted_freezable
+@dataclass
+class BuilderExitRequest:
+    """A single EIP-8282 builder exit request."""
+
+    source_address: Address
+    pubkey: Bytes48
+
+
+@final
+@slotted_freezable
+@dataclass
 class ExecutionRequests:
     """
     Typed engine-API container of execution-layer triggered requests.
@@ -78,6 +101,8 @@ class ExecutionRequests:
     deposits: Tuple[DepositRequest, ...]
     withdrawals: Tuple[WithdrawalRequest, ...]
     consolidations: Tuple[ConsolidationRequest, ...]
+    builder_deposits: Tuple[BuilderDepositRequest, ...]
+    builder_exits: Tuple[BuilderExitRequest, ...]
 
 
 def _encode_deposit(d: DepositRequest) -> Bytes:
@@ -106,6 +131,19 @@ def _encode_consolidation(c: ConsolidationRequest) -> Bytes:
     )
 
 
+def _encode_builder_deposit(b: BuilderDepositRequest) -> Bytes:
+    return Bytes(
+        bytes(b.pubkey)
+        + bytes(b.withdrawal_credentials)
+        + bytes(b.amount.to_le_bytes8())
+        + bytes(b.signature)
+    )
+
+
+def _encode_builder_exit(b: BuilderExitRequest) -> Bytes:
+    return Bytes(bytes(b.source_address) + bytes(b.pubkey))
+
+
 def _decode_deposit(payload: Bytes) -> DepositRequest:
     return DepositRequest(
         pubkey=Bytes48(payload[0:48]),
@@ -132,6 +170,22 @@ def _decode_consolidation(payload: Bytes) -> ConsolidationRequest:
     )
 
 
+def _decode_builder_deposit(payload: Bytes) -> BuilderDepositRequest:
+    return BuilderDepositRequest(
+        pubkey=Bytes48(payload[0:48]),
+        withdrawal_credentials=Bytes32(payload[48:80]),
+        amount=U64.from_le_bytes(payload[80:88]),
+        signature=Bytes96(payload[88:184]),
+    )
+
+
+def _decode_builder_exit(payload: Bytes) -> BuilderExitRequest:
+    return BuilderExitRequest(
+        source_address=Address(payload[0:20]),
+        pubkey=Bytes48(payload[20:68]),
+    )
+
+
 def encode_execution_requests(
     requests: ExecutionRequests,
 ) -> Tuple[Bytes, ...]:
@@ -155,6 +209,16 @@ def encode_execution_requests(
             _encode_consolidation(c) for c in requests.consolidations
         )
         output.append(Bytes(CONSOLIDATION_REQUEST_TYPE + body))
+    if requests.builder_deposits:
+        body = b"".join(
+            _encode_builder_deposit(b) for b in requests.builder_deposits
+        )
+        output.append(Bytes(BUILDER_DEPOSIT_REQUEST_TYPE + body))
+    if requests.builder_exits:
+        body = b"".join(
+            _encode_builder_exit(b) for b in requests.builder_exits
+        )
+        output.append(Bytes(BUILDER_EXIT_REQUEST_TYPE + body))
     return tuple(output)
 
 
@@ -171,6 +235,8 @@ def decode_execution_requests(
     deposits: Tuple[DepositRequest, ...] = ()
     withdrawals: Tuple[WithdrawalRequest, ...] = ()
     consolidations: Tuple[ConsolidationRequest, ...] = ()
+    builder_deposits: Tuple[BuilderDepositRequest, ...] = ()
+    builder_exits: Tuple[BuilderExitRequest, ...] = ()
 
     last_type = -1
     for blob in wire:
@@ -212,6 +278,28 @@ def decode_execution_requests(
                 )
                 for i in range(0, len(body), CONSOLIDATION_REQUEST_SIZE)
             )
+        elif type_byte == BUILDER_DEPOSIT_REQUEST_TYPE:
+            if len(body) % BUILDER_DEPOSIT_REQUEST_SIZE != 0:
+                raise InvalidBlock(
+                    "Invalid builder deposit request payload length"
+                )
+            builder_deposits = tuple(
+                _decode_builder_deposit(
+                    Bytes(body[i : i + BUILDER_DEPOSIT_REQUEST_SIZE])
+                )
+                for i in range(0, len(body), BUILDER_DEPOSIT_REQUEST_SIZE)
+            )
+        elif type_byte == BUILDER_EXIT_REQUEST_TYPE:
+            if len(body) % BUILDER_EXIT_REQUEST_SIZE != 0:
+                raise InvalidBlock(
+                    "Invalid builder exit request payload length"
+                )
+            builder_exits = tuple(
+                _decode_builder_exit(
+                    Bytes(body[i : i + BUILDER_EXIT_REQUEST_SIZE])
+                )
+                for i in range(0, len(body), BUILDER_EXIT_REQUEST_SIZE)
+            )
         else:
             raise InvalidBlock(
                 f"Unknown execution request type byte {type_byte!r}"
@@ -221,4 +309,6 @@ def decode_execution_requests(
         deposits=deposits,
         withdrawals=withdrawals,
         consolidations=consolidations,
+        builder_deposits=builder_deposits,
+        builder_exits=builder_exits,
     )

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -20,6 +20,8 @@ from ethereum.state import Address, Root
 
 from .blocks import Withdrawal
 from .execution_engine.requests import (
+    BuilderDepositRequest,
+    BuilderExitRequest,
     ConsolidationRequest,
     DepositRequest,
     ExecutionRequests,
@@ -50,6 +52,8 @@ MAX_BLOB_COMMITMENTS_PER_BLOCK = 4096
 MAX_DEPOSIT_REQUESTS_PER_PAYLOAD = 2**13
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD = 2**4
 MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD = 2**1
+MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD = 2**6
+MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD = 2**4
 
 # Stateless witness resource bounds.  These are local limits chosen for this
 # schema, not consensus-spec SSZ constants.
@@ -167,6 +171,22 @@ class SszConsolidationRequest(Container):
     target_pubkey: ByteVector[48]
 
 
+class SszBuilderDepositRequest(Container):
+    """SSZ container mirroring ``BuilderDepositRequest``."""
+
+    pubkey: ByteVector[48]
+    withdrawal_credentials: Bytes32
+    amount: uint64
+    signature: ByteVector[96]
+
+
+class SszBuilderExitRequest(Container):
+    """SSZ container mirroring ``BuilderExitRequest``."""
+
+    source_address: ByteVector[20]
+    pubkey: ByteVector[48]
+
+
 class SszExecutionRequests(Container):
     """SSZ container mirroring ``ExecutionRequests``."""
 
@@ -176,6 +196,12 @@ class SszExecutionRequests(Container):
     ]
     consolidations: SszList[
         SszConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
+    ]
+    builder_deposits: SszList[
+        SszBuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD
+    ]
+    builder_exits: SszList[
+        SszBuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
     ]
 
 
@@ -386,6 +412,50 @@ def _ssz_to_consolidation_request(
     )
 
 
+def _builder_deposit_request_to_ssz(
+    b: BuilderDepositRequest,
+) -> SszBuilderDepositRequest:
+    """Convert a BuilderDepositRequest to its SSZ form."""
+    return SszBuilderDepositRequest(
+        pubkey=ByteVector[48](bytes(b.pubkey)),
+        withdrawal_credentials=Bytes32(bytes(b.withdrawal_credentials)),
+        amount=uint64(int(b.amount)),
+        signature=ByteVector[96](bytes(b.signature)),
+    )
+
+
+def _ssz_to_builder_deposit_request(
+    sb: SszBuilderDepositRequest,
+) -> BuilderDepositRequest:
+    """Convert an SSZ builder deposit request back."""
+    return BuilderDepositRequest(
+        pubkey=Bytes48(bytes(sb.pubkey)),
+        withdrawal_credentials=Bytes32(bytes(sb.withdrawal_credentials)),
+        amount=U64(sb.amount),
+        signature=Bytes96(bytes(sb.signature)),
+    )
+
+
+def _builder_exit_request_to_ssz(
+    b: BuilderExitRequest,
+) -> SszBuilderExitRequest:
+    """Convert a BuilderExitRequest to its SSZ form."""
+    return SszBuilderExitRequest(
+        source_address=ByteVector[20](bytes(b.source_address)),
+        pubkey=ByteVector[48](bytes(b.pubkey)),
+    )
+
+
+def _ssz_to_builder_exit_request(
+    sb: SszBuilderExitRequest,
+) -> BuilderExitRequest:
+    """Convert an SSZ builder exit request back."""
+    return BuilderExitRequest(
+        source_address=Address(bytes(sb.source_address)),
+        pubkey=Bytes48(bytes(sb.pubkey)),
+    )
+
+
 def _execution_requests_to_ssz(
     er: ExecutionRequests,
 ) -> SszExecutionRequests:
@@ -400,6 +470,13 @@ def _execution_requests_to_ssz(
         consolidations=SszList[
             SszConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
         ](_consolidation_request_to_ssz(c) for c in er.consolidations),
+        builder_deposits=SszList[
+            SszBuilderDepositRequest,
+            MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD,
+        ](_builder_deposit_request_to_ssz(b) for b in er.builder_deposits),
+        builder_exits=SszList[
+            SszBuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
+        ](_builder_exit_request_to_ssz(b) for b in er.builder_exits),
     )
 
 
@@ -414,6 +491,12 @@ def _ssz_to_execution_requests(
         ),
         consolidations=tuple(
             _ssz_to_consolidation_request(sc) for sc in ser.consolidations
+        ),
+        builder_deposits=tuple(
+            _ssz_to_builder_deposit_request(sb) for sb in ser.builder_deposits
+        ),
+        builder_exits=tuple(
+            _ssz_to_builder_exit_request(sb) for sb in ser.builder_exits
         ),
     )
 

--- a/tests/amsterdam/eip8282_builder_execution_requests/test_modified_builder_contract.py
+++ b/tests/amsterdam/eip8282_builder_execution_requests/test_modified_builder_contract.py
@@ -121,12 +121,14 @@ def run_modified_requests_test(
                 Spec.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 1
             ),
             id="max_plus_1_builder_deposit_requests",
+            marks=pytest.mark.skip_stateless_validation,
         ),
         pytest.param(
             builder_deposit_list_with_custom_fee(
                 Spec.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 2
             ),
             id="max_plus_2_builder_deposit_requests",
+            marks=pytest.mark.skip_stateless_validation,
         ),
     ],
 )
@@ -172,12 +174,14 @@ def test_extra_builder_deposits(
                 Spec.MAX_EXIT_REQUESTS_PER_BLOCK + 1
             ),
             id="max_plus_1_builder_exit_requests",
+            marks=pytest.mark.skip_stateless_validation,
         ),
         pytest.param(
             builder_exit_list_with_custom_fee(
                 Spec.MAX_EXIT_REQUESTS_PER_BLOCK + 2
             ),
             id="max_plus_2_builder_exit_requests",
+            marks=pytest.mark.skip_stateless_validation,
         ),
     ],
 )

--- a/tests/json_loader/test_execution_requests.py
+++ b/tests/json_loader/test_execution_requests.py
@@ -1,0 +1,145 @@
+"""Tests for Amsterdam typed execution request codecs."""
+
+import pytest
+from ethereum_types.bytes import Bytes, Bytes32, Bytes48, Bytes96
+from ethereum_types.numeric import U64
+
+from ethereum.exceptions import InvalidBlock
+from ethereum.forks.amsterdam.execution_engine.requests import (
+    BuilderDepositRequest,
+    BuilderExitRequest,
+    ConsolidationRequest,
+    DepositRequest,
+    ExecutionRequests,
+    WithdrawalRequest,
+    decode_execution_requests,
+    encode_execution_requests,
+)
+from ethereum.state import Address
+
+
+def _builder_deposit() -> BuilderDepositRequest:
+    return BuilderDepositRequest(
+        pubkey=Bytes48(b"\x11" * 48),
+        withdrawal_credentials=Bytes32(b"\x22" * 32),
+        amount=U64(0x0102030405060708),
+        signature=Bytes96(b"\x33" * 96),
+    )
+
+
+def _builder_exit() -> BuilderExitRequest:
+    return BuilderExitRequest(
+        source_address=Address(b"\x44" * 20),
+        pubkey=Bytes48(b"\x55" * 48),
+    )
+
+
+def _all_execution_requests() -> ExecutionRequests:
+    return ExecutionRequests(
+        deposits=(
+            DepositRequest(
+                pubkey=Bytes48(b"\x01" * 48),
+                withdrawal_credentials=Bytes32(b"\x02" * 32),
+                amount=U64(3),
+                signature=Bytes96(b"\x04" * 96),
+                index=U64(5),
+            ),
+        ),
+        withdrawals=(
+            WithdrawalRequest(
+                source_address=Address(b"\x06" * 20),
+                validator_pubkey=Bytes48(b"\x07" * 48),
+                amount=U64(8),
+            ),
+        ),
+        consolidations=(
+            ConsolidationRequest(
+                source_address=Address(b"\x09" * 20),
+                source_pubkey=Bytes48(b"\x0a" * 48),
+                target_pubkey=Bytes48(b"\x0b" * 48),
+            ),
+        ),
+        builder_deposits=(_builder_deposit(),),
+        builder_exits=(_builder_exit(),),
+    )
+
+
+def test_builder_deposit_encode_decode() -> None:
+    """Builder deposit amounts use little-endian wire encoding."""
+    request = _builder_deposit()
+    requests = ExecutionRequests(
+        deposits=(),
+        withdrawals=(),
+        consolidations=(),
+        builder_deposits=(request,),
+        builder_exits=(),
+    )
+
+    wire = encode_execution_requests(requests)
+
+    assert wire == (
+        Bytes(
+            b"\x03"
+            + bytes(request.pubkey)
+            + bytes(request.withdrawal_credentials)
+            + b"\x08\x07\x06\x05\x04\x03\x02\x01"
+            + bytes(request.signature)
+        ),
+    )
+    assert decode_execution_requests(wire) == requests
+
+
+def test_builder_exit_encode_decode() -> None:
+    """Builder exits encode the source address followed by the pubkey."""
+    request = _builder_exit()
+    requests = ExecutionRequests(
+        deposits=(),
+        withdrawals=(),
+        consolidations=(),
+        builder_deposits=(),
+        builder_exits=(request,),
+    )
+
+    wire = encode_execution_requests(requests)
+
+    assert wire == (
+        Bytes(b"\x04" + bytes(request.source_address) + bytes(request.pubkey)),
+    )
+    assert decode_execution_requests(wire) == requests
+
+
+def test_all_execution_request_types_roundtrip_in_order() -> None:
+    """All five request types round trip in strict ascending order."""
+    requests = _all_execution_requests()
+
+    wire = encode_execution_requests(requests)
+
+    assert tuple(blob[0] for blob in wire) == (0, 1, 2, 3, 4)
+    assert decode_execution_requests(wire) == requests
+
+
+@pytest.mark.parametrize(
+    ("type_byte", "invalid_payload_size", "message"),
+    [
+        pytest.param(b"\x03", 183, "builder deposit", id="builder-deposit"),
+        pytest.param(b"\x04", 67, "builder exit", id="builder-exit"),
+    ],
+)
+def test_decode_rejects_invalid_builder_request_payload_length(
+    type_byte: bytes,
+    invalid_payload_size: int,
+    message: str,
+) -> None:
+    """Builder request payloads must contain whole wire records."""
+    wire = (Bytes(type_byte + b"\x00" * invalid_payload_size),)
+
+    with pytest.raises(InvalidBlock, match=message):
+        decode_execution_requests(wire)
+
+
+def test_decode_rejects_non_ascending_builder_request_types() -> None:
+    """Builder request types cannot be duplicated or misordered."""
+    wire = encode_execution_requests(_all_execution_requests())
+
+    with pytest.raises(InvalidBlock, match="strict ascending type order"):
+        decode_execution_requests((*wire[:3], wire[4], wire[3]))

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -12,6 +12,8 @@ from ethereum.crypto.hash import Hash32
 from ethereum.forks.amsterdam.block_access_lists import BlockAccessList
 from ethereum.forks.amsterdam.blocks import Block, Header
 from ethereum.forks.amsterdam.execution_engine.requests import (
+    BuilderDepositRequest,
+    BuilderExitRequest,
     DepositRequest,
     ExecutionRequests,
 )
@@ -152,6 +154,22 @@ def _make_deposit_request() -> DepositRequest:
     )
 
 
+def _make_builder_deposit_request() -> BuilderDepositRequest:
+    return BuilderDepositRequest(
+        pubkey=Bytes48(_rb(48)),
+        withdrawal_credentials=Bytes32(_rb(32)),
+        amount=U64(_RNG.randint(0, 2**64 - 1)),
+        signature=Bytes96(_rb(96)),
+    )
+
+
+def _make_builder_exit_request() -> BuilderExitRequest:
+    return BuilderExitRequest(
+        source_address=Address(_rb(20)),
+        pubkey=Bytes48(_rb(48)),
+    )
+
+
 def _make_stateless_input() -> StatelessInput:
     versioned_hashes: Tuple[Hash32, ...] = (Hash32(_rb(32)), Hash32(_rb(32)))
     return StatelessInput(
@@ -166,6 +184,8 @@ def _make_stateless_input() -> StatelessInput:
                 ),
                 withdrawals=(),
                 consolidations=(),
+                builder_deposits=(_make_builder_deposit_request(),),
+                builder_exits=(_make_builder_exit_request(),),
             ),
         ),
         witness=ExecutionWitness(
@@ -213,6 +233,8 @@ class TestBuildStatelessInput:
                 deposits=(),
                 withdrawals=(),
                 consolidations=(),
+                builder_deposits=(),
+                builder_exits=(),
             ),
             block_access_list=block_access_list,
             chain_id=U64(123),
@@ -258,6 +280,8 @@ class TestBuildStatelessInput:
                 deposits=(),
                 withdrawals=(),
                 consolidations=(),
+                builder_deposits=(),
+                builder_exits=(),
             ),
             block_access_list=[],
             chain_id=U64(1),
@@ -290,6 +314,8 @@ class TestSerializeStatelessInput:
                     deposits=(),
                     withdrawals=(),
                     consolidations=(),
+                    builder_deposits=(),
+                    builder_exits=(),
                 ),
             ),
             witness=ExecutionWitness(state=(), codes=(), headers=()),
@@ -336,6 +362,8 @@ class TestDeserializeStatelessInput:
                     deposits=(),
                     withdrawals=(),
                     consolidations=(),
+                    builder_deposits=(),
+                    builder_exits=(),
                 ),
             ),
             witness=ExecutionWitness(state=(), codes=(), headers=()),


### PR DESCRIPTION
### Description
Add EIP-8282 builder deposit and builder exit requests to the Amsterdam stateless execution path.

Since EIP-8282 implied new system contracts and in EIP-8025 in eest we had to add the EngineAPI layer, this means we were missing identifying these new execution requests and properly detecting them, causing `statelessOutputBytes` to not be correctly constructed.

Additionally, some new tests violate (intentionally) the max limit of these new execution request types, so we mark them as skipped only for guest programs (this is the correct way to handle these situations, since not doing so means having to modify the CL define SSZ list limits which is not correct). This situation isn't surprising, the marker to skip the tests was already created months ago for the same situation with other execution request length violations.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
