### PR TITLE
refactor(spec-specs): organize gas logic in amsterdam EIP-8037/8038/2780

### DIFF
--- a/.claude/commands/implement-eip.md
+++ b/.claude/commands/implement-eip.md
@@ -28,9 +28,21 @@ Each fork lives at `src/ethereum/forks/<fork_name>/`. Explore the latest fork di
 ## Adding a New Opcode
 
 1. Add to `Ops` enum in `vm/instructions/__init__.py` with hex value
-2. Implement function in appropriate `vm/instructions/<category>.py` — follows pattern: STACK → GAS (`charge_gas`) → OPERATION → PROGRAM COUNTER
+2. Implement function in appropriate `vm/instructions/<category>.py` — follows pattern: STACK → GAS (`charge_gas`) → OPERATION → PROGRAM COUNTER. Opcodes that touch state use the staged gas labels — see "Gas Handling" below.
 3. Register in `op_implementation` dict in `vm/instructions/__init__.py`
 4. Add gas constant in `vm/gas.py` if needed
+
+## Gas Handling
+
+Recent forks meter two gas dimensions: regular gas and state gas (for durable state growth). Key rules:
+
+1. Gas constants and calculations go in `vm/gas.py`; a frame's mutable gas state lives on `Evm.gas_meter`.
+2. Extend the named helper vocabulary (`charge_*`, `credit_*`, `restore_*`, `withhold_*`, ...) instead of doing gas arithmetic by hand at call sites; encode each helper's invariant as an assert.
+3. State gas is charged by the frame whose opcode causes the creation, before the child's regular-gas share is withheld; the whole reservoir passes to the child.
+4. A failing frame settles its own meter before returning, so parents incorporate children unconditionally.
+5. Opcodes that touch state use labeled stages, with all charging before the operation: `GAS (STATE-INDEPENDENT)` → `STATE ACCESS (STATE-DEPENDENT GAS)` → `STATE GAS` → `CHILD GRANT` → `OPERATION`. Simple opcodes keep the bare `GAS` marker. `generic_call`/`generic_create` contain no pricing; they run the child lifecycle: `PREFLIGHT` → `DESTINATION ACCESS` → `CHILD GRANT` → `DISPATCH` → `OUTCOME`.
+6. Avoid "frame" in gas identifiers (a future EIP claims the term); when a name diverges from the spec's variable name, cross-reference the spec name in the docstring.
+7. A gas change is behavior-preserving only if the relative order of every charge, check, and trace event is unchanged; verify with the gas-related fill tests under `tests/<fork>/`.
 
 ## Adding a New Precompile
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -103,10 +103,12 @@ from .vm.eoa_delegation import is_valid_delegation
 from .vm.gas import (
     GasCosts,
     StateGasCosts,
+    allocate_execution_gas,
     calculate_blob_gas_price,
     calculate_data_fee,
     calculate_excess_blob_gas,
     calculate_total_blob_gas,
+    settle_transaction_gas,
 )
 from .vm.interpreter import MessageCallOutput, process_message_call
 
@@ -1032,8 +1034,6 @@ def process_transaction(
     sender = recover_sender(tx)
     intrinsic = validate_transaction(tx, sender)
 
-    intrinsic_gas = Uint(intrinsic.regular)
-
     (
         effective_gas_price,
         blob_versioned_hashes,
@@ -1055,12 +1055,9 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    # Split execution gas into gas_left (capped by remaining regular gas
-    # budget) and state_gas_reservoir.
-    execution_gas = tx.gas - intrinsic_gas
-    regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic.regular
-    gas = min(regular_gas_budget, execution_gas)
-    state_gas_reservoir = Uint(execution_gas - gas)
+    # Split execution gas into a regular grant (capped by the remaining
+    # regular-gas budget) and a state gas reservoir.
+    allocation = allocate_execution_gas(tx.gas, intrinsic)
 
     increment_nonce(tx_state, sender)
 
@@ -1087,8 +1084,8 @@ def process_transaction(
         recipient=tx.to,
         value=tx.value,
         gas_price=effective_gas_price,
-        gas=gas,
-        state_gas_reservoir=state_gas_reservoir,
+        gas=allocation.regular_gas,
+        state_gas_reservoir=allocation.state_gas_reservoir,
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
         state=tx_state,
@@ -1102,24 +1099,20 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    tx_gas_used_before_refund = (
-        tx.gas - tx_output.gas_left - tx_output.state_gas_left
+    settlement = settle_transaction_gas(
+        tx.gas,
+        intrinsic,
+        tx_output.gas_left,
+        tx_output.state_gas_left,
+        tx_output.refund_counter,
+        tx_output.state_gas_used,
     )
-    tx_gas_refund = min(
-        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
-    )
-    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
 
-    # Transactions with less execution_gas_used than the floor pay at the
-    # floor cost.
-    tx_gas_used = max(tx_gas_used_after_refund, intrinsic.calldata_floor)
-
-    tx_gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_gas_left * effective_gas_price
+    gas_refund_amount = settlement.gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = settlement.gas_used * priority_fee_per_gas
 
     # refund gas
     create_ether(tx_state, sender, U256(gas_refund_amount))
@@ -1127,18 +1120,11 @@ def process_transaction(
     # transfer miner fees
     create_ether(tx_state, block_env.coinbase, U256(transaction_fee))
 
-    tx_state_gas = tx_output.state_gas_used
-    # The calldata floor binds the regular-gas dimension: subtract state gas
-    # first so the floor is not discounted by a transaction's state spending.
-    tx_regular_gas = max(
-        tx_gas_used_before_refund - Uint(max(0, tx_state_gas)),
-        intrinsic.calldata_floor,
-    )
-    block_output.block_gas_used += tx_regular_gas
-    block_output.block_state_gas_used += Uint(max(0, tx_state_gas))
+    block_output.block_gas_used += settlement.regular_gas_used
+    block_output.block_state_gas_used += settlement.state_gas_used
     block_output.blob_gas_used += tx_blob_gas_used
 
-    block_output.cumulative_gas_used += tx_gas_used
+    block_output.cumulative_gas_used += settlement.gas_used
     receipt = make_receipt(
         tx, tx_output.error, block_output.cumulative_gas_used, tx_output.logs
     )

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -26,9 +26,14 @@ from ethereum.utils.byte import left_pad_zero_bytes
 
 from ..block_access_lists import BlockAccessList, BlockAccessListBuilder
 from ..blocks import Log, Receipt, Withdrawal
-from ..fork_types import Authorization, StateGas, VersionedHash
+from ..fork_types import Authorization, VersionedHash
 from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
+from .gas import (
+    GasMeter,
+    absorb_child_gas_on_error,
+    absorb_child_gas_on_success,
+)
 
 __all__ = ("Environment", "Evm", "Message")
 TRANSFER_TOPIC = keccak256(b"Transfer(address,address,uint256)")
@@ -170,11 +175,9 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: Uint
-    state_gas_left: Uint
+    gas_meter: GasMeter
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]
-    refund_counter: int
     running: bool
     message: Message
     output: Bytes
@@ -183,38 +186,6 @@ class Evm:
     error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
-    regular_gas_used: Uint = Uint(0)
-    state_gas_spilled: Uint = Uint(0)
-    committed_state_gas: int = 0
-    """
-    State gas locked in by [`commit_frame_state_gas`] because the state
-    it paid for outlives a later failure in the frame.
-
-    [`commit_frame_state_gas`]: ref:ethereum.forks.amsterdam.vm.commit_frame_state_gas
-    """  # noqa: E501
-
-
-def credit_state_gas_refund(evm: Evm, amount: StateGas) -> None:
-    """
-    Credit a state gas refund to the local frame, in LIFO order.
-
-    State-gas charges draw from the reservoir first and from `gas_left`
-    last, so refills credit the pool charged last first: `gas_left` up
-    to `state_gas_spilled`, then the reservoir. This restores the
-    exact pools the charge drew from, so the two never drift.
-
-    Parameters
-    ----------
-    evm :
-        The frame crediting the refund.
-    amount :
-        The refund amount to credit.
-
-    """
-    from_gas_left = min(amount, evm.state_gas_spilled)
-    evm.gas_left += from_gas_left
-    evm.state_gas_spilled -= from_gas_left
-    evm.state_gas_left += amount - from_gas_left
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
@@ -229,91 +200,11 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
         The child evm to incorporate.
 
     """
-    evm.gas_left += child_evm.gas_left
-    evm.state_gas_left += child_evm.state_gas_left
-    evm.state_gas_spilled += child_evm.state_gas_spilled
+    absorb_child_gas_on_success(evm.gas_meter, child_evm.gas_meter)
     evm.logs += child_evm.logs
-    evm.refund_counter += child_evm.refund_counter
     evm.accounts_to_delete.update(child_evm.accounts_to_delete)
     evm.accessed_addresses.update(child_evm.accessed_addresses)
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
-    evm.regular_gas_used += child_evm.regular_gas_used
-
-
-def refill_frame_state_gas(evm: Evm) -> None:
-    """
-    Roll back the frame's state gas in LIFO order on revert or halt.
-
-    The frame's state changes are undone, so the state gas it consumed
-    is credited back to `gas_left` first and then to the reservoir,
-    restoring the pools the charges drew from.
-
-    Parameters
-    ----------
-    evm :
-        The frame whose state gas is rolled back.
-
-    """
-    evm.gas_left += evm.state_gas_spilled
-    evm.state_gas_left = evm.message.state_gas_reservoir
-    evm.state_gas_spilled = Uint(0)
-
-
-def frame_state_gas_used(evm: Evm) -> int:
-    """
-    Return the net state gas consumed by a finished frame, including
-    any state gas committed as non-refillable earlier in the frame.
-
-    Equal to the reservoir drawn down ([`state_gas_reservoir`][sgr] at
-    the last commit -- or frame entry, absent one -- minus the
-    reservoir now) plus [`state_gas_spilled`][sgs] plus
-    [`committed_state_gas`][csg]. May be negative when refunds exceed
-    charges.
-
-    Parameters
-    ----------
-    evm :
-        The finished frame.
-
-    [sgr]: ref:ethereum.forks.amsterdam.vm.Message.state_gas_reservoir
-    [sgs]: ref:ethereum.forks.amsterdam.vm.Evm.state_gas_spilled
-    [csg]: ref:ethereum.forks.amsterdam.vm.Evm.committed_state_gas
-
-    """
-    return (
-        int(evm.message.state_gas_reservoir)
-        - int(evm.state_gas_left)
-        + int(evm.state_gas_spilled)
-        + evm.committed_state_gas
-    )
-
-
-def commit_frame_state_gas(evm: Evm) -> None:
-    """
-    Mark the state gas consumed so far as non-refillable and reset the
-    refill baseline.
-
-    The state this gas paid for (the delegations applied by
-    [`set_delegation`][sd]) outlives a later failure of the dispatched
-    code, so a subsequent [`refill_frame_state_gas`][refill] must not
-    credit it back. The consumption so far is folded into
-    [`committed_state_gas`][csg] and the reservoir baseline moves down
-    to the current level, so only charges made after this commit are
-    refillable.
-
-    Parameters
-    ----------
-    evm :
-        The frame whose state gas consumption is committed.
-
-    [sd]: ref:ethereum.forks.amsterdam.vm.eoa_delegation.set_delegation
-    [refill]: ref:ethereum.forks.amsterdam.vm.refill_frame_state_gas
-    [csg]: ref:ethereum.forks.amsterdam.vm.Evm.committed_state_gas
-
-    """
-    evm.committed_state_gas = frame_state_gas_used(evm)
-    evm.message.state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_spilled = Uint(0)
 
 
 def incorporate_child_on_error(
@@ -323,10 +214,10 @@ def incorporate_child_on_error(
     """
     Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
 
-    The child rolls back its own state gas via `refill_frame_state_gas`
-    before returning (on both reverts and exceptional halts), so its
-    `gas_left` and reservoir already reflect the LIFO refill. The parent
-    therefore only reabsorbs the child's `gas_left` and reservoir.
+    The child rolls back its own state gas before returning (on both
+    reverts and exceptional halts), so its `gas_left` and reservoir
+    already reflect the LIFO refill. The parent therefore only reabsorbs
+    the child's `gas_left` and reservoir.
 
     Parameters
     ----------
@@ -336,9 +227,7 @@ def incorporate_child_on_error(
         The child evm to incorporate.
 
     """
-    evm.gas_left += child_evm.gas_left
-    evm.state_gas_left += child_evm.state_gas_left
-    evm.regular_gas_used += child_evm.regular_gas_used
+    absorb_child_gas_on_error(evm.gas_meter, child_evm.gas_meter)
 
 
 def emit_transfer_log(

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -29,11 +29,7 @@ from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Authorization, VersionedHash
 from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
-from .gas import (
-    GasMeter,
-    absorb_child_gas_on_error,
-    absorb_child_gas_on_success,
-)
+from .gas import GasMeter
 
 __all__ = ("Environment", "Evm", "Message")
 TRANSFER_TOPIC = keccak256(b"Transfer(address,address,uint256)")
@@ -188,9 +184,19 @@ class Evm:
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 
 
-def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
+def incorporate_child(evm: Evm, child_evm: Evm) -> None:
     """
-    Incorporate the state of a successful `child_evm` into the parent `evm`.
+    Incorporate the state of a returning `child_evm` into the parent
+    `evm`.
+
+    Gas flows back to the parent regardless of the child's fate. A
+    failed child settles its own meter before returning -- its state
+    gas rolled back to the baseline, its [spill] refilled, and its
+    refunds discarded -- so absorbing the meter unconditionally
+    reclaims exactly the gas the child gives back. Everything else the
+    child accumulated -- logs, scheduled self-destructs, refunds, and
+    warmed access sets -- survives only on success, dying with a
+    failed child's reverted state.
 
     Parameters
     ----------
@@ -199,35 +205,34 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     child_evm :
         The child evm to incorporate.
 
-    """
-    absorb_child_gas_on_success(evm.gas_meter, child_evm.gas_meter)
-    evm.logs += child_evm.logs
-    evm.accounts_to_delete.update(child_evm.accounts_to_delete)
-    evm.accessed_addresses.update(child_evm.accessed_addresses)
-    evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
-
-
-def incorporate_child_on_error(
-    evm: Evm,
-    child_evm: Evm,
-) -> None:
-    """
-    Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
-
-    The child rolls back its own state gas before returning (on both
-    reverts and exceptional halts), so its `gas_left` and reservoir
-    already reflect the LIFO refill. The parent therefore only reabsorbs
-    the child's `gas_left` and reservoir.
-
-    Parameters
-    ----------
-    evm :
-        The parent `EVM`.
-    child_evm :
-        The child evm to incorporate.
+    [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
 
     """
-    absorb_child_gas_on_error(evm.gas_meter, child_evm.gas_meter)
+    child_meter = child_evm.gas_meter
+    # Only the top frame commits state gas; a child never carries any.
+    assert child_meter.state_gas_committed_spill == Uint(0)
+
+    if child_evm.error:
+        # A failed child arrives settled: rolled back to its baseline,
+        # spill refilled, refunds discarded.
+        assert child_meter.state_gas_spilled == Uint(0)
+        assert child_meter.refund_counter == 0
+        assert child_meter.state_gas_left == child_meter.state_gas_baseline
+
+    # Gas returns to the parent regardless of the child's fate.
+    # Note that upon failure, the child already arrives settled.
+    gas_meter = evm.gas_meter
+    gas_meter.gas_left += child_meter.gas_left
+    gas_meter.state_gas_left += child_meter.state_gas_left
+    gas_meter.state_gas_spilled += child_meter.state_gas_spilled
+    gas_meter.refund_counter += child_meter.refund_counter
+
+    # Everything else survives only on success.
+    if not child_evm.error:
+        evm.logs += child_evm.logs
+        evm.accounts_to_delete.update(child_evm.accounts_to_delete)
+        evm.accessed_addresses.update(child_evm.accessed_addresses)
+        evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
 
 
 def emit_transfer_log(

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -447,7 +447,8 @@ def restore_state_gas(gas_meter: GasMeter) -> None:
     The frame's state changes are undone, so the state gas consumed
     since the [baseline] is credited back in LIFO order: the [spill]
     returns to `gas_left` first, then the reservoir resets to the
-    baseline. State gas committed as non-refillable stays charged.
+    baseline. The refunds accrued on the undone changes are discarded
+    with them. State gas committed as non-refillable stays charged.
 
     Parameters
     ----------
@@ -461,6 +462,7 @@ def restore_state_gas(gas_meter: GasMeter) -> None:
     gas_meter.gas_left += gas_meter.state_gas_spilled
     gas_meter.state_gas_spilled = Uint(0)
     gas_meter.state_gas_left = gas_meter.state_gas_baseline
+    gas_meter.refund_counter = 0
 
 
 def restore_state_gas_to_entry(
@@ -487,6 +489,9 @@ def restore_state_gas_to_entry(
     """
     # The baseline starts at the grant and only ever moves down.
     assert gas_meter.state_gas_baseline <= state_gas_reservoir
+    # Only pre-dispatch failures roll back to entry, and no refund
+    # accrues before dispatch.
+    assert gas_meter.refund_counter == 0
     gas_meter.gas_left += (
         gas_meter.state_gas_spilled + gas_meter.state_gas_committed_spill
     )
@@ -640,59 +645,6 @@ def restore_child_gas(
     """
     gas_meter.gas_left += gas
     gas_meter.state_gas_left += state_gas_reservoir
-
-
-def absorb_child_gas_on_success(
-    gas_meter: GasMeter, child_gas_meter: GasMeter
-) -> None:
-    """
-    Absorb a successful child frame's gas into the parent's meter.
-
-    The child returns its unused `gas_left` and reservoir to the parent,
-    along with the refunds it accrued and the spill it built up.
-
-    Parameters
-    ----------
-    gas_meter :
-        The parent frame's gas meter.
-    child_gas_meter :
-        The child frame's gas meter.
-
-    """
-    # Only the top frame commits state gas; a child never carries any.
-    assert child_gas_meter.state_gas_committed_spill == Uint(0)
-    gas_meter.gas_left += child_gas_meter.gas_left
-    gas_meter.state_gas_left += child_gas_meter.state_gas_left
-    gas_meter.state_gas_spilled += child_gas_meter.state_gas_spilled
-    gas_meter.refund_counter += child_gas_meter.refund_counter
-
-
-def absorb_child_gas_on_error(
-    gas_meter: GasMeter, child_gas_meter: GasMeter
-) -> None:
-    """
-    Absorb a failed child frame's gas into the parent's meter.
-
-    The child rolls back its own state gas before returning, so its
-    `gas_left` and reservoir already reflect the LIFO refill. The parent
-    reabsorbs only that gas; the child's refunds and spill are discarded
-    with its reverted state.
-
-    Parameters
-    ----------
-    gas_meter :
-        The parent frame's gas meter.
-    child_gas_meter :
-        The child frame's gas meter.
-
-    """
-    # Only the top frame commits state gas; a child never carries any.
-    assert child_gas_meter.state_gas_committed_spill == Uint(0)
-    # A failed child arrives already rolled back to its baseline.
-    assert child_gas_meter.state_gas_spilled == Uint(0)
-    assert child_gas_meter.state_gas_left == child_gas_meter.state_gas_baseline
-    gas_meter.gas_left += child_gas_meter.gas_left
-    gas_meter.state_gas_left += child_gas_meter.state_gas_left
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -12,7 +12,7 @@ EVM gas constants and calculators.
 """
 
 from dataclasses import dataclass
-from typing import Final, List, Tuple, final
+from typing import TYPE_CHECKING, Final, List, Tuple, final
 
 from ethereum_types.numeric import U64, U256, Uint, ulen
 
@@ -22,9 +22,16 @@ from ethereum.utils.numeric import ceil32, taylor_exponential
 
 from ..blocks import Header
 from ..fork_types import StateGas, StateGasPerByte
-from ..transactions import BlobTransaction, Transaction
-from . import Evm
+from ..transactions import (
+    TX_MAX_GAS_LIMIT,
+    BlobTransaction,
+    IntrinsicGasCost,
+    Transaction,
+)
 from .exceptions import OutOfGasError
+
+if TYPE_CHECKING:
+    from . import Evm
 
 
 # These may be patched at runtime by a future gas repricing utility to
@@ -235,6 +242,71 @@ class GasCosts:
 
 @final
 @dataclass
+class GasMeter:
+    """
+    Track a frame's gas consumption across both gas dimensions.
+
+    Bundle every mutable gas quantity a frame maintains, so the frame
+    and its settlement work against one object instead of a scatter of
+    fields on the [`Evm`].
+
+    [`Evm`]: ref:ethereum.forks.amsterdam.vm.Evm
+    """
+
+    gas_left: Uint
+    """
+    Gas still available from the frame's regular grant. Pays regular
+    charges, and state charges as [spill] once the reservoir empties.
+
+    [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
+    """
+
+    state_gas_left: Uint
+    """
+    State gas still available in the frame's reservoir. Charges draw
+    from here first and spill into `gas_left` once it is empty.
+    """
+
+    state_gas_baseline: Uint
+    """
+    Reservoir level a rollback refills to: the frame's grant at entry,
+    moved down by [`commit_state_gas`][commit] when charges become
+    non-refillable.
+
+    [commit]: ref:ethereum.forks.amsterdam.vm.gas.commit_state_gas
+    """
+
+    refund_counter: int = 0
+    """Gas eligible for refund at the end of the transaction."""
+
+    state_gas_spilled: Uint = Uint(0)
+    """
+    Regular gas spent covering state charges after the reservoir
+    emptied. Credited back to `gas_left` first, in LIFO order, on a
+    refund or failure. [EIP-8037] names this quantity
+    `state_gas_from_gas_left`.
+
+    [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
+    """
+
+    state_gas_committed_spill: Uint = Uint(0)
+    """
+    [Spill] that [`commit_state_gas`][commit] marked non-refillable.
+    It outlives the rollbacks [`restore_state_gas`][restore] performs;
+    only [`restore_state_gas_to_entry`][entry] credits it back to
+    `gas_left`. Committed reservoir draw needs no counter of its own:
+    each commit lowers the baseline, so it is the frame's grant minus
+    `state_gas_baseline`.
+
+    [Spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
+    [commit]: ref:ethereum.forks.amsterdam.vm.gas.commit_state_gas
+    [restore]: ref:ethereum.forks.amsterdam.vm.gas.restore_state_gas
+    [entry]: ref:ethereum.forks.amsterdam.vm.gas.restore_state_gas_to_entry
+    """
+
+
+@final
+@dataclass
 class ExtendMemory:
     """
     Define the parameters for memory extension in opcodes.
@@ -268,7 +340,7 @@ class MessageCallGas:
     sub_call: Uint
 
 
-def check_gas(evm: Evm, amount: Uint) -> None:
+def check_gas(evm: "Evm", amount: Uint) -> None:
     """
     Checks if `amount` gas is available without charging it.
     Raises OutOfGasError if insufficient gas.
@@ -281,13 +353,13 @@ def check_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas to check.
 
     """
-    if evm.gas_left < amount:
+    if evm.gas_meter.gas_left < amount:
         raise OutOfGasError
 
 
-def charge_gas(evm: Evm, amount: Uint) -> None:
+def charge_gas(evm: "Evm", amount: Uint) -> None:
     """
-    Subtracts `amount` from `evm.gas_left` (regular gas) and records usage.
+    Subtracts `amount` from `gas_left` (regular gas).
 
     Parameters
     ----------
@@ -299,17 +371,16 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     evm_trace(evm, GasAndRefund(int(amount)))
 
-    if evm.gas_left < amount:
+    gas_meter = evm.gas_meter
+    if gas_meter.gas_left < amount:
         raise OutOfGasError
-    evm.gas_left -= amount
-
-    evm.regular_gas_used += amount
+    gas_meter.gas_left -= amount
 
 
-def charge_state_gas(evm: Evm, amount: StateGas) -> None:
+def charge_state_gas(evm: "Evm", amount: StateGas) -> None:
     """
     Subtracts `amount` from the state gas reservoir, then from
-    `evm.gas_left` when the reservoir is empty, tracking any [spill].
+    `gas_left` when the reservoir is empty, tracking any [spill].
 
     Parameters
     ----------
@@ -318,20 +389,310 @@ def charge_state_gas(evm: Evm, amount: StateGas) -> None:
     amount :
         The amount of state gas the current operation requires.
 
-    [spill]: ref:ethereum.forks.amsterdam.vm.Evm.state_gas_spilled
+    [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
 
     """
     evm_trace(evm, StateGasAndRefund(int(amount)))
 
-    if evm.state_gas_left >= amount:
-        evm.state_gas_left -= amount
-    elif evm.state_gas_left + evm.gas_left >= amount:
-        remainder = amount - evm.state_gas_left
-        evm.state_gas_left = Uint(0)
-        evm.gas_left -= remainder
-        evm.state_gas_spilled += remainder
+    gas_meter = evm.gas_meter
+    if gas_meter.state_gas_left >= amount:
+        gas_meter.state_gas_left -= amount
+    elif gas_meter.state_gas_left + gas_meter.gas_left >= amount:
+        remainder = amount - gas_meter.state_gas_left
+        gas_meter.state_gas_left = Uint(0)
+        gas_meter.gas_left -= remainder
+        gas_meter.state_gas_spilled += remainder
     else:
         raise OutOfGasError
+
+
+def commit_state_gas(gas_meter: GasMeter) -> None:
+    """
+    Mark the state gas spent so far as non-refillable.
+
+    A later rollback via [`restore_state_gas`][restore] leaves the
+    state bought so far in place, so it must not credit this gas back.
+    In the top frame that protects the delegations applied by
+    [`set_delegation`][sd], which survive a failure of the dispatched
+    code. A failure that reverts the committed state as well -- one
+    raised before dispatch -- must instead undo the commit with
+    [`restore_state_gas_to_entry`][entry].
+
+    Move the baseline down to the current reservoir level and fold the
+    spill into `state_gas_committed_spill`, so later refunds route to
+    the reservoir instead of back into `gas_left`.
+
+    Parameters
+    ----------
+    gas_meter :
+        The frame's gas meter.
+
+    [sd]: ref:ethereum.forks.amsterdam.vm.eoa_delegation.set_delegation
+    [restore]: ref:ethereum.forks.amsterdam.vm.gas.restore_state_gas
+    [entry]: ref:ethereum.forks.amsterdam.vm.gas.restore_state_gas_to_entry
+
+    """
+    # Only charges precede a commit, so no refund has pushed the
+    # reservoir above the baseline: a commit only ever lowers it.
+    assert gas_meter.state_gas_left <= gas_meter.state_gas_baseline
+    gas_meter.state_gas_committed_spill += gas_meter.state_gas_spilled
+    gas_meter.state_gas_baseline = gas_meter.state_gas_left
+    gas_meter.state_gas_spilled = Uint(0)
+
+
+def restore_state_gas(gas_meter: GasMeter) -> None:
+    """
+    Roll the frame's state gas back to the baseline on revert or halt.
+
+    The frame's state changes are undone, so the state gas consumed
+    since the [baseline] is credited back in LIFO order: the [spill]
+    returns to `gas_left` first, then the reservoir resets to the
+    baseline. State gas committed as non-refillable stays charged.
+
+    Parameters
+    ----------
+    gas_meter :
+        The frame's gas meter.
+
+    [baseline]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_baseline
+    [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
+
+    """  # noqa: E501
+    gas_meter.gas_left += gas_meter.state_gas_spilled
+    gas_meter.state_gas_spilled = Uint(0)
+    gas_meter.state_gas_left = gas_meter.state_gas_baseline
+
+
+def restore_state_gas_to_entry(
+    gas_meter: GasMeter, state_gas_reservoir: Uint
+) -> None:
+    """
+    Roll the frame's state gas back to frame entry, undoing any commit.
+
+    Used when the transaction-state rollback also reverts the applied
+    delegations a [`commit_state_gas`][commit] protected: every state
+    charge refills -- all spill, committed or not, returns to
+    `gas_left` -- and the baseline resets to the frame's [grant].
+
+    Parameters
+    ----------
+    gas_meter :
+        The frame's gas meter.
+    state_gas_reservoir :
+        The frame's immutable state gas grant.
+
+    [commit]: ref:ethereum.forks.amsterdam.vm.gas.commit_state_gas
+    [grant]: ref:ethereum.forks.amsterdam.vm.Message.state_gas_reservoir
+
+    """
+    # The baseline starts at the grant and only ever moves down.
+    assert gas_meter.state_gas_baseline <= state_gas_reservoir
+    gas_meter.gas_left += (
+        gas_meter.state_gas_spilled + gas_meter.state_gas_committed_spill
+    )
+    gas_meter.state_gas_spilled = Uint(0)
+    gas_meter.state_gas_committed_spill = Uint(0)
+    gas_meter.state_gas_left = state_gas_reservoir
+    gas_meter.state_gas_baseline = state_gas_reservoir
+
+
+def tx_state_gas_used(gas_meter: GasMeter, state_gas_reservoir: Uint) -> int:
+    """
+    Return the net state gas a transaction's execution consumed.
+
+    Measured off the top frame's finished gas meter: the reservoir
+    drawn down since the transaction's grant plus the [spill],
+    outstanding or committed. May be negative when refunds exceed
+    charges.
+
+    Parameters
+    ----------
+    gas_meter :
+        The top frame's finished gas meter.
+    state_gas_reservoir :
+        The transaction's immutable state gas grant.
+
+    Returns
+    -------
+    state_gas_used : `int`
+        The net state gas consumed.
+
+    [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
+
+    """
+    # The baseline starts at the grant and only ever moves down.
+    assert gas_meter.state_gas_baseline <= state_gas_reservoir
+    return (
+        int(state_gas_reservoir)
+        - int(gas_meter.state_gas_left)
+        + int(gas_meter.state_gas_spilled)
+        + int(gas_meter.state_gas_committed_spill)
+    )
+
+
+def credit_state_gas_refund(gas_meter: GasMeter, amount: StateGas) -> None:
+    """
+    Credit a state gas refund to the local frame, in LIFO order.
+
+    State-gas charges draw from the reservoir first and from `gas_left`
+    last, so refunds credit the pool charged last first: `gas_left` up
+    to the [spill], then the reservoir. This restores the exact pools
+    the charge drew from, so the two never drift.
+
+    Parameters
+    ----------
+    gas_meter :
+        The gas meter crediting the refund.
+    amount :
+        The refund amount to credit.
+
+    [spill]: ref:ethereum.forks.amsterdam.vm.gas.GasMeter.state_gas_spilled
+
+    """
+    from_gas_left = min(amount, gas_meter.state_gas_spilled)
+    gas_meter.gas_left += from_gas_left
+    gas_meter.state_gas_spilled -= from_gas_left
+    gas_meter.state_gas_left += amount - from_gas_left
+
+
+def forfeit_remaining_gas(gas_meter: GasMeter) -> None:
+    """
+    Consume all remaining regular gas on an exceptional halt.
+
+    Parameters
+    ----------
+    gas_meter :
+        The halted frame's gas meter.
+
+    """
+    # A rollback owes any outstanding spill back to `gas_left`; it
+    # must be restored before the remainder burns.
+    assert gas_meter.state_gas_spilled == Uint(0)
+    gas_meter.gas_left = Uint(0)
+
+
+def withhold_create_gas(gas_meter: GasMeter) -> Uint:
+    """
+    Withhold and return the gas made available to a `CREATE*` child.
+
+    Deduct the all-but-one-64th share from the frame's `gas_left` and
+    return it as the child frame's regular gas grant.
+
+    Parameters
+    ----------
+    gas_meter :
+        The creating frame's gas meter.
+
+    Returns
+    -------
+    child_gas : `ethereum.base_types.Uint`
+        The regular gas granted to the child frame.
+
+    """
+    child_gas = max_message_call_gas(gas_meter.gas_left)
+    gas_meter.gas_left -= child_gas
+    return child_gas
+
+
+def drain_state_gas_reservoir(gas_meter: GasMeter) -> Uint:
+    """
+    Empty the frame's state gas reservoir for a child frame.
+
+    A child frame receives the parent's entire reservoir; there is no
+    all-but-one-64th rule for state gas. The parent's reservoir is
+    restored when the child returns.
+
+    Parameters
+    ----------
+    gas_meter :
+        The parent frame's gas meter.
+
+    Returns
+    -------
+    reservoir : `ethereum.base_types.Uint`
+        The state gas granted to the child frame.
+
+    """
+    reservoir = gas_meter.state_gas_left
+    gas_meter.state_gas_left = Uint(0)
+    return reservoir
+
+
+def restore_child_gas(
+    gas_meter: GasMeter, gas: Uint, state_gas_reservoir: Uint
+) -> None:
+    """
+    Return a child frame's unused gas grant to the parent.
+
+    Used when the child frame is never entered (for example, a stack
+    depth or balance check fails): the withheld regular gas and drained
+    reservoir are returned untouched.
+
+    Parameters
+    ----------
+    gas_meter :
+        The parent frame's gas meter.
+    gas :
+        The regular gas grant to return.
+    state_gas_reservoir :
+        The state gas reservoir to return.
+
+    """
+    gas_meter.gas_left += gas
+    gas_meter.state_gas_left += state_gas_reservoir
+
+
+def absorb_child_gas_on_success(
+    gas_meter: GasMeter, child_gas_meter: GasMeter
+) -> None:
+    """
+    Absorb a successful child frame's gas into the parent's meter.
+
+    The child returns its unused `gas_left` and reservoir to the parent,
+    along with the refunds it accrued and the spill it built up.
+
+    Parameters
+    ----------
+    gas_meter :
+        The parent frame's gas meter.
+    child_gas_meter :
+        The child frame's gas meter.
+
+    """
+    # Only the top frame commits state gas; a child never carries any.
+    assert child_gas_meter.state_gas_committed_spill == Uint(0)
+    gas_meter.gas_left += child_gas_meter.gas_left
+    gas_meter.state_gas_left += child_gas_meter.state_gas_left
+    gas_meter.state_gas_spilled += child_gas_meter.state_gas_spilled
+    gas_meter.refund_counter += child_gas_meter.refund_counter
+
+
+def absorb_child_gas_on_error(
+    gas_meter: GasMeter, child_gas_meter: GasMeter
+) -> None:
+    """
+    Absorb a failed child frame's gas into the parent's meter.
+
+    The child rolls back its own state gas before returning, so its
+    `gas_left` and reservoir already reflect the LIFO refill. The parent
+    reabsorbs only that gas; the child's refunds and spill are discarded
+    with its reverted state.
+
+    Parameters
+    ----------
+    gas_meter :
+        The parent frame's gas meter.
+    child_gas_meter :
+        The child frame's gas meter.
+
+    """
+    # Only the top frame commits state gas; a child never carries any.
+    assert child_gas_meter.state_gas_committed_spill == Uint(0)
+    # A failed child arrives already rolled back to its baseline.
+    assert child_gas_meter.state_gas_spilled == Uint(0)
+    assert child_gas_meter.state_gas_left == child_gas_meter.state_gas_baseline
+    gas_meter.gas_left += child_gas_meter.gas_left
+    gas_meter.state_gas_left += child_gas_meter.state_gas_left
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
@@ -593,4 +954,141 @@ def calculate_data_fee(excess_blob_gas: U64, tx: Transaction) -> Uint:
     """
     return Uint(calculate_total_blob_gas(tx)) * calculate_blob_gas_price(
         excess_blob_gas
+    )
+
+
+@final
+@dataclass
+class ExecutionGasAllocation:
+    """
+    Split of a transaction's execution gas across the two dimensions.
+    """
+
+    regular_gas: Uint
+    """Regular gas granted to the top frame, capped by the budget."""
+
+    state_gas_reservoir: Uint
+    """State gas set aside for the top frame's reservoir."""
+
+
+def allocate_execution_gas(
+    tx_gas: Uint, intrinsic: IntrinsicGasCost
+) -> ExecutionGasAllocation:
+    """
+    Split execution gas into a regular grant and a state reservoir.
+
+    After the intrinsic cost is removed, the remaining execution gas is
+    divided into regular gas -- capped by the regular-gas budget that
+    remains below `TX_MAX_GAS_LIMIT` -- and a state gas reservoir that
+    holds whatever exceeds that cap.
+
+    Only valid once `validate_transaction` has confirmed the transaction
+    can afford its intrinsic cost, which guarantees the subtractions
+    below do not underflow.
+
+    Parameters
+    ----------
+    tx_gas :
+        The transaction's gas limit.
+    intrinsic :
+        The transaction's intrinsic gas cost.
+
+    Returns
+    -------
+    allocation : `ExecutionGasAllocation`
+        The regular gas grant and state gas reservoir.
+
+    """
+    execution_gas = tx_gas - Uint(intrinsic.regular)
+    regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic.regular
+    regular_gas = min(regular_gas_budget, execution_gas)
+    state_gas_reservoir = Uint(execution_gas - regular_gas)
+    return ExecutionGasAllocation(regular_gas, state_gas_reservoir)
+
+
+@final
+@dataclass
+class TransactionGasSettlement:
+    """
+    Settled gas amounts for a finished transaction.
+
+    Hold only gas figures; the caller turns them into fee payments and
+    block-accounting updates.
+    """
+
+    gas_used: Uint
+    """Total gas charged to the sender, after refund and floor."""
+
+    gas_left: Uint
+    """Gas returned to the sender, priced at the effective gas price."""
+
+    regular_gas_used: Uint
+    """Regular gas the transaction contributes to the block total."""
+
+    state_gas_used: Uint
+    """State gas the transaction contributes to the block total."""
+
+
+def settle_transaction_gas(
+    tx_gas: Uint,
+    intrinsic: IntrinsicGasCost,
+    gas_left: Uint,
+    state_gas_left: Uint,
+    refund_counter: U256,
+    state_gas_used: int,
+) -> TransactionGasSettlement:
+    """
+    Settle a transaction's gas after execution.
+
+    Compute, in order:
+
+    - the gas used before refunds, from the gas limit less the regular
+      gas and reservoir the top frame returned;
+    - the refund, capped at one fifth of that pre-refund usage;
+    - the gas used, taken as the larger of the post-refund usage and the
+      calldata floor, so a transaction never pays below the floor; and
+    - the per-dimension block amounts: the state gas used (clamped to
+      zero, since refunds can drive it negative) and the regular gas
+      used, which carries the floor because the floor binds the regular
+      dimension. Unlike the sender-facing `gas_used`, it ignores
+      refunds: block accounting counts pre-refund gas ([EIP-7778]).
+
+    Parameters
+    ----------
+    tx_gas :
+        The transaction's gas limit.
+    intrinsic :
+        The transaction's intrinsic gas cost.
+    gas_left :
+        Regular gas the top frame returned.
+    state_gas_left :
+        State gas reservoir the top frame returned.
+    refund_counter :
+        The refund the top frame accrued.
+    state_gas_used :
+        Net state gas the top frame consumed, possibly negative.
+
+    Returns
+    -------
+    settlement : `TransactionGasSettlement`
+        The settled gas amounts.
+
+    [EIP-7778]: https://eips.ethereum.org/EIPS/eip-7778
+
+    """
+    gas_used_before_refund = tx_gas - gas_left - state_gas_left
+    gas_refund = min(gas_used_before_refund // Uint(5), Uint(refund_counter))
+    gas_used_after_refund = gas_used_before_refund - gas_refund
+    gas_used = max(gas_used_after_refund, intrinsic.calldata_floor)
+
+    settled_state_gas_used = Uint(max(0, state_gas_used))
+    regular_gas_used = max(
+        gas_used_before_refund - settled_state_gas_used,
+        intrinsic.calldata_floor,
+    )
+    return TransactionGasSettlement(
+        gas_used=gas_used,
+        gas_left=tx_gas - gas_used,
+        regular_gas_used=regular_gas_used,
+        state_gas_used=settled_state_gas_used,
     )

--- a/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
@@ -143,7 +143,7 @@ def gas_left(evm: Evm) -> None:
     charge_gas(evm, GasCosts.OPCODE_GAS)
 
     # OPERATION
-    push(evm.stack, U256(evm.gas_left))
+    push(evm.stack, U256(evm.gas_meter.gas_left))
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -21,7 +21,7 @@ from ...state_tracker import (
     set_storage,
     set_transient_storage,
 )
-from .. import Evm, credit_state_gas_refund
+from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (
     GasCosts,
@@ -29,6 +29,7 @@ from ..gas import (
     charge_gas,
     charge_state_gas,
     check_gas,
+    credit_state_gas_refund,
 )
 from ..stack import pop, push
 
@@ -117,16 +118,16 @@ def sstore(evm: Evm) -> None:
     if current_value != new_value:
         if original_value != 0 and current_value != 0 and new_value == 0:
             # Storage is cleared for the first time in the transaction
-            evm.refund_counter += GasCosts.REFUND_STORAGE_CLEAR
+            evm.gas_meter.refund_counter += GasCosts.REFUND_STORAGE_CLEAR
 
         if original_value != 0 and current_value == 0:
             # Gas refund issued earlier to be reversed
-            evm.refund_counter -= GasCosts.REFUND_STORAGE_CLEAR
+            evm.gas_meter.refund_counter -= GasCosts.REFUND_STORAGE_CLEAR
 
         if original_value == new_value:
             # Slot restored to its original value: refund the STORAGE_WRITE
             # charged on the first-time change earlier this transaction.
-            evm.refund_counter += int(GasCosts.STORAGE_WRITE)
+            evm.gas_meter.refund_counter += int(GasCosts.STORAGE_WRITE)
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
@@ -135,7 +136,7 @@ def sstore(evm: Evm) -> None:
     if current_value != new_value and original_value == new_value:
         if original_value == 0:
             # Slot set then cleared: refund the state gas charge.
-            credit_state_gas_refund(evm, StateGasCosts.STORAGE_SET)
+            credit_state_gas_refund(evm.gas_meter, StateGasCosts.STORAGE_SET)
 
     # Charge regular gas before state gas so that a regular-gas OOG
     # does not consume state gas that would inflate the parent's

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -82,6 +82,9 @@ def sstore(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
 
+    # GAS (STATE-INDEPENDENT)
+    # Price what is computable without touching state, and check it is
+    # affordable before any state access is performed.
     gas_cost = Uint(0)
 
     # Access cost: cold or warm, always charged.
@@ -99,6 +102,11 @@ def sstore(evm: Evm) -> None:
     # access cost can exceed the stipend, so the EIP-2200 stipend sentry
     # (`gas_left > CALL_STIPEND`) is no longer sufficient on its own.
     check_gas(evm, max(gas_cost, GasCosts.CALL_STIPEND + Uint(1)))
+
+    # STATE ACCESS (STATE-DEPENDENT GAS)
+    # Perform the access and complete the state-dependent pricing from
+    # the slot's original and current values, adjusting the
+    # transaction's refunds.
     if is_cold_access:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
 
@@ -129,6 +137,9 @@ def sstore(evm: Evm) -> None:
             # charged on the first-time change earlier this transaction.
             evm.gas_meter.refund_counter += int(GasCosts.STORAGE_WRITE)
 
+    # STATE GAS
+    # A first-time set of a zero slot pays for the state it creates; a
+    # slot set then cleared refills the earlier charge.
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
             state_gas = StateGasCosts.STORAGE_SET

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -42,8 +42,7 @@ from .. import (
     Evm,
     Message,
     emit_transfer_log,
-    incorporate_child_on_error,
-    incorporate_child_on_success,
+    incorporate_child,
 )
 from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
 from ..gas import (
@@ -167,8 +166,8 @@ def generic_create(
     # The child settled its own gas; absorb it and resolve the
     # account-creation charge by the state's fate: it refills when a
     # charged creation failed.
+    incorporate_child(evm, child_evm)
     if child_evm.error:
-        incorporate_child_on_error(evm, child_evm)
         if new_account_charged:
             credit_state_gas_refund(
                 evm.gas_meter, StateGasCosts.NEW_ACCOUNT
@@ -176,7 +175,6 @@ def generic_create(
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
-        incorporate_child_on_success(evm, child_evm)
         evm.return_data = b""
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
 
@@ -423,15 +421,13 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     # OUTCOME
     # The child settled its own gas; absorb it and resolve the
     # account-creation charge by the state's fate.
+    incorporate_child(evm, child_evm)
+    evm.return_data = child_evm.output
     if child_evm.error:
-        incorporate_child_on_error(evm, child_evm)
         if params.new_account_charged:
             credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
-        evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
-        incorporate_child_on_success(evm, child_evm)
-        evm.return_data = child_evm.output
         push(evm.stack, CALL_SUCCESS)
 
     actual_output_size = min(

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -72,19 +72,17 @@ def generic_create(
     memory_size: U256,
 ) -> None:
     """
-    Core logic used by the `CREATE*` family of opcodes.
+    Run the child-frame lifecycle for the `CREATE*` family of opcodes.
+
+    The opcode has already priced the operation itself; this function
+    runs the lifecycle: preflight checks that abort without spawning,
+    the destination access with its account-creation charge and
+    collision check, the child's gas grant, the child frame itself,
+    and the resolution of its outcome back into the creating frame.
     """
     # This import causes a circular import error
     # if it's not moved inside this method
-    from ...vm.interpreter import (
-        MAX_INIT_CODE_SIZE,
-        STACK_DEPTH_LIMIT,
-        process_create_message,
-    )
-
-    # Check max init code size early before memory read
-    if memory_size > U256(MAX_INIT_CODE_SIZE):
-        raise OutOfGasError
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     tx_state = evm.message.tx_env.state
 
@@ -94,6 +92,9 @@ def generic_create(
 
     evm.return_data = b""
 
+    # PREFLIGHT
+    # Abort without spawning the child: nothing has been charged or
+    # withheld for it yet.
     sender_address = evm.message.current_target
     sender = get_account(tx_state, sender_address)
 
@@ -105,20 +106,24 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    # DESTINATION ACCESS
+    # The account-creation charge is decided by existence alone,
+    # independently of the collision outcome below.
     evm.accessed_addresses.add(contract_address)
 
-    # The charge is decided by existence alone, independently of the
-    # collision outcome.
     new_account_charged = not is_account_alive(tx_state, contract_address)
     if new_account_charged:
         charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
 
+    # CHILD GRANT
+    # Withhold all but one 64th of the regular gas.
     create_message_gas = withhold_create_gas(evm.gas_meter)
 
+    # On a collision the child's regular grant is consumed and no
+    # account is created; a storage-only collision target is
+    # non-existent: charged above, refilled here.
     if not account_deployable(tx_state, contract_address):
         increment_nonce(tx_state, sender_address)
-        # A storage-only collision target is non-existent: charged
-        # above, refilled here.
         if new_account_charged:
             credit_state_gas_refund(
                 evm.gas_meter, StateGasCosts.NEW_ACCOUNT
@@ -126,13 +131,15 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
-    # Move full reservoir to child (no 63/64 rule for state gas). Parent's
-    # `state_gas_left` is zeroed and restored when the child returns.
+    # The whole state gas reservoir rides along (no 63/64 rule for
+    # state gas) and is restored when the child returns.
     create_message_state_gas_reservoir = drain_state_gas_reservoir(
         evm.gas_meter
     )
 
     increment_nonce(tx_state, sender_address)
+
+    # DISPATCH
 
     child_message = Message(
         block_env=evm.message.block_env,
@@ -156,6 +163,10 @@ def generic_create(
     )
     child_evm = process_create_message(child_message)
 
+    # OUTCOME
+    # The child settled its own gas; absorb it and resolve the
+    # account-creation charge by the state's fate: it refills when a
+    # charged creation failed.
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         if new_account_charged:
@@ -180,6 +191,10 @@ def create(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    # This import causes a circular import error
+    # if it's not moved inside this method
+    from ...vm.interpreter import MAX_INIT_CODE_SIZE
+
     if evm.message.is_static:
         raise WriteInStaticContext
 
@@ -197,6 +212,9 @@ def create(evm: Evm) -> None:
         evm,
         GasCosts.CREATE_ACCESS + extend_memory.cost + init_code_gas,
     )
+
+    if memory_size > U256(MAX_INIT_CODE_SIZE):
+        raise OutOfGasError
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -232,6 +250,10 @@ def create2(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    # This import causes a circular import error
+    # if it's not moved inside this method
+    from ...vm.interpreter import MAX_INIT_CODE_SIZE
+
     if evm.message.is_static:
         raise WriteInStaticContext
 
@@ -254,6 +276,9 @@ def create2(evm: Evm) -> None:
         + extend_memory.cost
         + init_code_gas,
     )
+
+    if memory_size > U256(MAX_INIT_CODE_SIZE):
+        raise OutOfGasError
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -330,17 +355,33 @@ class GenericCall:
     code: Bytes
     disable_precompiles: bool
     new_account_charged: bool = False
+    insufficient_balance: bool = False
+    """
+    True when the calling account cannot cover `value`; the call then
+    aborts in preflight without spawning the child frame.
+    """
 
 
 def generic_call(evm: Evm, params: GenericCall) -> None:
     """
-    Perform the core logic of the `CALL*` family of opcodes.
+    Run the child-frame lifecycle for the `CALL*` family of opcodes.
+
+    The opcode has already priced the call and withheld the child's
+    grant; this function only runs the lifecycle: preflight checks
+    that abort without spawning, the child frame itself, and the
+    resolution of its outcome back into the calling frame.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     evm.return_data = b""
 
-    if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
+    # PREFLIGHT
+    # Abort without spawning the child: both grants return untouched
+    # and any account-creation charge refills.
+    if (
+        evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT
+        or params.insufficient_balance
+    ):
         restore_child_gas(
             evm.gas_meter, params.gas, params.state_gas_reservoir
         )
@@ -349,6 +390,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         push(evm.stack, U256(0))
         return
 
+    # DISPATCH
     call_data = memory_read_bytes(
         evm.memory,
         params.memory_input_start_position,
@@ -378,6 +420,9 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
 
     child_evm = process_message(child_message)
 
+    # OUTCOME
+    # The child settled its own gas; absorb it and resolve the
+    # account-creation charge by the state's fate.
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         if params.new_account_charged:
@@ -421,7 +466,9 @@ def call(evm: Evm) -> None:
     if evm.message.is_static and value != U256(0):
         raise WriteInStaticContext
 
-    # GAS
+    # GAS (STATE-INDEPENDENT)
+    # Price what is computable without touching state, and check it is
+    # affordable before any state access is performed.
     extend_memory = calculate_gas_extend_memory(
         evm.memory,
         [
@@ -438,13 +485,15 @@ def call(evm: Evm) -> None:
 
     transfer_gas_cost = Uint(0) if value == 0 else GasCosts.CALL_VALUE
 
-    # check static gas before state access
     check_gas(
         evm,
         access_gas_cost + transfer_gas_cost + extend_memory.cost,
     )
 
-    # STATE ACCESS
+    # STATE ACCESS (STATE-DEPENDENT GAS)
+    # Perform the accesses and complete the state-dependent pricing --
+    # a delegation adds its access cost -- then charge the regular
+    # gas.
     tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(to)
@@ -467,11 +516,20 @@ def call(evm: Evm) -> None:
     code = get_code(tx_state, code_hash)
 
     charge_gas(evm, extra_gas + extend_memory.cost)
+
+    # STATE GAS
+    # A value transfer that will create the recipient is charged by
+    # the frame whose opcode causes it; refilled in `generic_call`
+    # whenever the creation fails or never happens.
     has_value = value != 0
     new_account_charged = has_value and not is_account_alive(tx_state, to)
     if new_account_charged:
         charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
 
+    # CHILD GRANT
+    # Computed after every charge above, so any state-gas spill has
+    # already thinned `gas_left`. The whole reservoir rides along (no
+    # 63/64 rule for state gas).
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
@@ -480,45 +538,34 @@ def call(evm: Evm) -> None:
         extra_gas=Uint(0),
     )
     charge_gas(evm, message_call_gas.cost)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
 
-    # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
-
     sender_balance = get_account(tx_state, evm.message.current_target).balance
-    if sender_balance < value:
-        push(evm.stack, U256(0))
-        evm.return_data = b""
-        restore_child_gas(
-            evm.gas_meter,
-            message_call_gas.sub_call,
-            call_state_gas_reservoir,
-        )
-        if new_account_charged:
-            credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
-    else:
-        generic_call(
-            evm,
-            GenericCall(
-                gas=message_call_gas.sub_call,
-                state_gas_reservoir=call_state_gas_reservoir,
-                value=value,
-                caller=evm.message.current_target,
-                to=to,
-                code_address=code_address,
-                should_transfer_value=True,
-                is_staticcall=False,
-                memory_input_start_position=memory_input_start_position,
-                memory_input_size=memory_input_size,
-                memory_output_start_position=memory_output_start_position,
-                memory_output_size=memory_output_size,
-                code=code,
-                disable_precompiles=is_delegated,
-                new_account_charged=new_account_charged,
-            ),
-        )
+
+    generic_call(
+        evm,
+        GenericCall(
+            gas=message_call_gas.sub_call,
+            state_gas_reservoir=call_state_gas_reservoir,
+            value=value,
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=is_delegated,
+            new_account_charged=new_account_charged,
+            insufficient_balance=sender_balance < value,
+        ),
+    )
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)
@@ -543,7 +590,9 @@ def callcode(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    # GAS
+    # GAS (STATE-INDEPENDENT)
+    # Price what is computable without touching state, and check it is
+    # affordable before any state access is performed.
     to = evm.message.current_target
 
     extend_memory = calculate_gas_extend_memory(
@@ -562,13 +611,15 @@ def callcode(evm: Evm) -> None:
 
     transfer_gas_cost = Uint(0) if value == 0 else GasCosts.CALL_VALUE
 
-    # check static gas before state access
     check_gas(
         evm,
         access_gas_cost + extend_memory.cost + transfer_gas_cost,
     )
 
-    # STATE ACCESS
+    # STATE ACCESS (STATE-DEPENDENT GAS)
+    # Perform the accesses and complete the state-dependent pricing --
+    # a delegation adds its access cost; the regular gas is charged
+    # with the child grant.
     tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
@@ -590,6 +641,10 @@ def callcode(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
+    # CHILD GRANT
+    # Charge the call's cost and withhold the child's regular gas
+    # share in one step. The whole reservoir rides along (no 63/64
+    # rule for state gas).
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
@@ -598,43 +653,33 @@ def callcode(evm: Evm) -> None:
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
 
-    # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
-
     sender_balance = get_account(tx_state, evm.message.current_target).balance
 
-    if sender_balance < value:
-        push(evm.stack, U256(0))
-        evm.return_data = b""
-        restore_child_gas(
-            evm.gas_meter,
-            message_call_gas.sub_call,
-            call_state_gas_reservoir,
-        )
-    else:
-        generic_call(
-            evm,
-            GenericCall(
-                gas=message_call_gas.sub_call,
-                state_gas_reservoir=call_state_gas_reservoir,
-                value=value,
-                caller=evm.message.current_target,
-                to=to,
-                code_address=code_address,
-                should_transfer_value=True,
-                is_staticcall=False,
-                memory_input_start_position=memory_input_start_position,
-                memory_input_size=memory_input_size,
-                memory_output_start_position=memory_output_start_position,
-                memory_output_size=memory_output_size,
-                code=code,
-                disable_precompiles=is_delegated,
-            ),
-        )
+    generic_call(
+        evm,
+        GenericCall(
+            gas=message_call_gas.sub_call,
+            state_gas_reservoir=call_state_gas_reservoir,
+            value=value,
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=is_delegated,
+            insufficient_balance=sender_balance < value,
+        ),
+    )
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)
@@ -656,21 +701,28 @@ def selfdestruct(evm: Evm) -> None:
     # STACK
     beneficiary = to_address_masked(pop(evm.stack))
 
-    # GAS
+    # GAS (STATE-INDEPENDENT)
+    # Price what is computable without touching state, and check it is
+    # affordable before any state access is performed.
     gas_cost = GasCosts.OPCODE_SELFDESTRUCT_BASE
 
     is_cold_access = beneficiary not in evm.accessed_addresses
     if is_cold_access:
         gas_cost += GasCosts.COLD_ACCOUNT_ACCESS
 
-    # check access gas cost before state access
     check_gas(evm, gas_cost)
 
-    # STATE ACCESS
+    # STATE ACCESS (STATE-DEPENDENT GAS)
+    # Perform the access; the pricing completes with the state gas
+    # below.
     tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
+    # STATE GAS
+    # A sweep that will create the beneficiary pays the account write
+    # and the creation, charged by the frame whose opcode causes it;
+    # it refills only through the frame's own rollback.
     state_gas = StateGas(Uint(0))
     account_write_gas = Uint(0)
     if (
@@ -686,6 +738,7 @@ def selfdestruct(evm: Evm) -> None:
     charge_gas(evm, gas_cost + account_write_gas)
     charge_state_gas(evm, state_gas)
 
+    # OPERATION
     originator = evm.message.current_target
     originator_balance = get_account(tx_state, originator).balance
 
@@ -725,7 +778,9 @@ def delegatecall(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    # GAS
+    # GAS (STATE-INDEPENDENT)
+    # Price what is computable without touching state, and check it is
+    # affordable before any state access is performed.
     extend_memory = calculate_gas_extend_memory(
         evm.memory,
         [
@@ -740,10 +795,12 @@ def delegatecall(evm: Evm) -> None:
     else:
         access_gas_cost = GasCosts.WARM_ACCESS
 
-    # check static gas before state access
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
-    # STATE ACCESS
+    # STATE ACCESS (STATE-DEPENDENT GAS)
+    # Perform the accesses and complete the state-dependent pricing --
+    # a delegation adds its access cost; the regular gas is charged
+    # with the child grant.
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
 
@@ -765,6 +822,10 @@ def delegatecall(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
+    # CHILD GRANT
+    # Charge the call's cost and withhold the child's regular gas
+    # share in one step. The whole reservoir rides along (no 63/64
+    # rule for state gas).
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
@@ -773,12 +834,10 @@ def delegatecall(evm: Evm) -> None:
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
-
-    # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     generic_call(
         evm,
@@ -822,7 +881,9 @@ def staticcall(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    # GAS
+    # GAS (STATE-INDEPENDENT)
+    # Price what is computable without touching state, and check it is
+    # affordable before any state access is performed.
     extend_memory = calculate_gas_extend_memory(
         evm.memory,
         [
@@ -837,10 +898,12 @@ def staticcall(evm: Evm) -> None:
     else:
         access_gas_cost = GasCosts.WARM_ACCESS
 
-    # check static gas before state access
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
-    # STATE ACCESS
+    # STATE ACCESS (STATE-DEPENDENT GAS)
+    # Perform the accesses and complete the state-dependent pricing --
+    # a delegation adds its access cost; the regular gas is charged
+    # with the child grant.
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
@@ -862,6 +925,10 @@ def staticcall(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
+    # CHILD GRANT
+    # Charge the call's cost and withhold the child's regular gas
+    # share in one step. The whole reservoir rides along (no 63/64
+    # rule for state gas).
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
@@ -870,12 +937,10 @@ def staticcall(evm: Evm) -> None:
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
-
-    # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     generic_call(
         evm,

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -41,7 +41,6 @@ from .. import (
     CALL_SUCCESS,
     Evm,
     Message,
-    credit_state_gas_refund,
     emit_transfer_log,
     incorporate_child_on_error,
     incorporate_child_on_success,
@@ -55,8 +54,11 @@ from ..gas import (
     charge_gas,
     charge_state_gas,
     check_gas,
+    credit_state_gas_refund,
+    drain_state_gas_reservoir,
     init_code_cost,
-    max_message_call_gas,
+    restore_child_gas,
+    withhold_create_gas,
 )
 from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
@@ -111,23 +113,24 @@ def generic_create(
     if new_account_charged:
         charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
 
-    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= create_message_gas
+    create_message_gas = withhold_create_gas(evm.gas_meter)
 
     if not account_deployable(tx_state, contract_address):
         increment_nonce(tx_state, sender_address)
-        evm.regular_gas_used += create_message_gas
         # A storage-only collision target is non-existent: charged
         # above, refilled here.
         if new_account_charged:
-            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+            credit_state_gas_refund(
+                evm.gas_meter, StateGasCosts.NEW_ACCOUNT
+            )
         push(evm.stack, U256(0))
         return
 
     # Move full reservoir to child (no 63/64 rule for state gas). Parent's
     # `state_gas_left` is zeroed and restored when the child returns.
-    create_message_state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_left = Uint(0)
+    create_message_state_gas_reservoir = drain_state_gas_reservoir(
+        evm.gas_meter
+    )
 
     increment_nonce(tx_state, sender_address)
 
@@ -156,7 +159,9 @@ def generic_create(
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         if new_account_charged:
-            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+            credit_state_gas_refund(
+                evm.gas_meter, StateGasCosts.NEW_ACCOUNT
+            )
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
@@ -336,10 +341,11 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += params.gas
-        evm.state_gas_left += params.state_gas_reservoir
+        restore_child_gas(
+            evm.gas_meter, params.gas, params.state_gas_reservoir
+        )
         if params.new_account_charged:
-            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+            credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
         push(evm.stack, U256(0))
         return
 
@@ -375,7 +381,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         if params.new_account_charged:
-            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+            credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
@@ -469,28 +475,29 @@ def call(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
-        Uint(evm.gas_left),
+        Uint(evm.gas_meter.gas_left),
         memory_cost=Uint(0),
         extra_gas=Uint(0),
     )
     charge_gas(evm, message_call_gas.cost)
-    evm.regular_gas_used -= message_call_gas.sub_call
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
 
     # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_left = Uint(0)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     sender_balance = get_account(tx_state, evm.message.current_target).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.sub_call
-        evm.state_gas_left += call_state_gas_reservoir
+        restore_child_gas(
+            evm.gas_meter,
+            message_call_gas.sub_call,
+            call_state_gas_reservoir,
+        )
         if new_account_charged:
-            credit_state_gas_refund(evm, StateGasCosts.NEW_ACCOUNT)
+            credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
     else:
         generic_call(
             evm,
@@ -586,27 +593,28 @@ def callcode(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
-        Uint(evm.gas_left),
+        Uint(evm.gas_meter.gas_left),
         extend_memory.cost,
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
-    evm.regular_gas_used -= message_call_gas.sub_call
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
 
     # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_left = Uint(0)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     sender_balance = get_account(tx_state, evm.message.current_target).balance
 
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.sub_call
-        evm.state_gas_left += call_state_gas_reservoir
+        restore_child_gas(
+            evm.gas_meter,
+            message_call_gas.sub_call,
+            call_state_gas_reservoir,
+        )
     else:
         generic_call(
             evm,
@@ -760,19 +768,17 @@ def delegatecall(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
-        Uint(evm.gas_left),
+        Uint(evm.gas_meter.gas_left),
         extend_memory.cost,
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
-    evm.regular_gas_used -= message_call_gas.sub_call
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
 
     # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_left = Uint(0)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     generic_call(
         evm,
@@ -859,19 +865,17 @@ def staticcall(evm: Evm) -> None:
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
-        Uint(evm.gas_left),
+        Uint(evm.gas_meter.gas_left),
         extend_memory.cost,
         extra_gas,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
-    evm.regular_gas_used -= message_call_gas.sub_call
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
 
     # Pass full reservoir to child (no 63/64 rule for state gas)
-    call_state_gas_reservoir = evm.state_gas_left
-    evm.state_gas_left = Uint(0)
+    call_state_gas_reservoir = drain_state_gas_reservoir(evm.gas_meter)
 
     generic_call(
         evm,

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -124,9 +124,7 @@ def generic_create(
     if not account_deployable(tx_state, contract_address):
         increment_nonce(tx_state, sender_address)
         if new_account_charged:
-            credit_state_gas_refund(
-                evm.gas_meter, StateGasCosts.NEW_ACCOUNT
-            )
+            credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
         push(evm.stack, U256(0))
         return
 
@@ -169,9 +167,7 @@ def generic_create(
     incorporate_child(evm, child_evm)
     if child_evm.error:
         if new_account_charged:
-            credit_state_gas_refund(
-                evm.gas_meter, StateGasCosts.NEW_ACCOUNT
-            )
+            credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -151,20 +151,20 @@ def process_message_call(message: Message) -> MessageCallOutput:
     if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
-        refund_counter = U256(0)
     else:
         logs = evm.logs
         accounts_to_delete = evm.accounts_to_delete
-        refund_counter = U256(evm.gas_meter.refund_counter)
 
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_meter.gas_left), evm.output, evm.error
     )
     evm_trace(evm, tx_end)
 
+    # A failed frame settles its meter with a zero refund counter, so
+    # the refunds can be read unconditionally.
     return MessageCallOutput(
         gas_left=evm.gas_meter.gas_left,
-        refund_counter=refund_counter,
+        refund_counter=U256(evm.gas_meter.refund_counter),
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         error=evm.error,

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -50,17 +50,20 @@ from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
 from ..vm.gas import (
     GasCosts,
+    GasMeter,
     StateGasCosts,
     charge_gas,
     charge_state_gas,
+    commit_state_gas,
+    forfeit_remaining_gas,
+    restore_state_gas,
+    restore_state_gas_to_entry,
+    tx_state_gas_used,
 )
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import (
     Evm,
-    commit_frame_state_gas,
     emit_transfer_log,
-    frame_state_gas_used,
-    refill_frame_state_gas,
 )
 from .exceptions import (
     AddressCollision,
@@ -93,7 +96,7 @@ class MessageCallOutput:
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `error`: The error from the execution if any.
           6. `return_data`: The output of the execution.
-          7. `regular_gas_used`: Regular gas used during execution.
+          7. `state_gas_left`: remaining state gas after execution.
           8. `state_gas_used`: State gas used during execution.
     """
 
@@ -104,7 +107,6 @@ class MessageCallOutput:
     error: Optional[EthereumException]
     return_data: Bytes
     state_gas_left: Uint
-    regular_gas_used: Uint
     state_gas_used: int
 
 
@@ -137,7 +139,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 error=AddressCollision(),
                 return_data=Bytes(b""),
                 state_gas_left=message.state_gas_reservoir,
-                regular_gas_used=message.gas,
                 state_gas_used=0,
             )
     else:
@@ -154,23 +155,24 @@ def process_message_call(message: Message) -> MessageCallOutput:
     else:
         logs = evm.logs
         accounts_to_delete = evm.accounts_to_delete
-        refund_counter = U256(evm.refund_counter)
+        refund_counter = U256(evm.gas_meter.refund_counter)
 
     tx_end = TransactionEnd(
-        int(message.gas) - int(evm.gas_left), evm.output, evm.error
+        int(message.gas) - int(evm.gas_meter.gas_left), evm.output, evm.error
     )
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
-        gas_left=evm.gas_left,
+        gas_left=evm.gas_meter.gas_left,
         refund_counter=refund_counter,
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         error=evm.error,
         return_data=evm.output,
-        state_gas_left=evm.state_gas_left,
-        regular_gas_used=evm.regular_gas_used,
-        state_gas_used=frame_state_gas_used(evm),
+        state_gas_left=evm.gas_meter.state_gas_left,
+        state_gas_used=tx_state_gas_used(
+            evm.gas_meter, message.state_gas_reservoir
+        ),
     )
 
 
@@ -232,9 +234,10 @@ def process_create_message(message: Message) -> Evm:
             charge_state_gas(evm, code_deposit_state_gas)
         except ExceptionalHalt as error:
             restore_tx_state(tx_state, snapshot)
-            refill_frame_state_gas(evm)
-            evm.regular_gas_used += evm.gas_left
-            evm.gas_left = Uint(0)
+            # A create frame never applies authorizations, so its
+            # baseline is still the frame's entry reservoir.
+            restore_state_gas(evm.gas_meter)
+            forfeit_remaining_gas(evm.gas_meter)
             evm.output = b""
             evm.error = error
         else:
@@ -339,11 +342,13 @@ def process_message(message: Message) -> Evm:
         stack=[],
         memory=bytearray(),
         code=Bytes(b""),
-        gas_left=message.gas,
-        state_gas_left=message.state_gas_reservoir,
+        gas_meter=GasMeter(
+            gas_left=message.gas,
+            state_gas_left=message.state_gas_reservoir,
+            state_gas_baseline=message.state_gas_reservoir,
+        ),
         valid_jump_destinations=set(),
         logs=(),
-        refund_counter=0,
         running=True,
         message=message,
         output=b"",
@@ -356,26 +361,25 @@ def process_message(message: Message) -> Evm:
 
     if message.depth == Uint(0):
         prep_snapshot = copy_tx_state(tx_state)
-        prep_reservoir = message.state_gas_reservoir
         try:
             if message.tx_env.authorizations != ():
                 set_delegation(evm)
                 # The applied delegations outlive a failure of the
-                # dispatched code, so their state gas must not refill
-                # with it.
-                commit_frame_state_gas(evm)
+                # dispatched code, so their state gas is committed as
+                # non-refillable; a later failure restores only to the
+                # post-commit baseline.
+                commit_state_gas(evm.gas_meter)
             prepare_dispatch(evm)
         except ExceptionalHalt as error:
             evm_trace(evm, OpException(error))
             restore_tx_state(tx_state, prep_snapshot)
             # The rollback reverts any applied delegations, so the
-            # commit above is undone with it and every state charge is
-            # refilled.
-            message.state_gas_reservoir = prep_reservoir
-            evm.committed_state_gas = 0
-            refill_frame_state_gas(evm)
-            evm.regular_gas_used += evm.gas_left
-            evm.gas_left = Uint(0)
+            # commit above is undone with it: roll state gas back to
+            # frame entry, refilling every state charge.
+            restore_state_gas_to_entry(
+                evm.gas_meter, message.state_gas_reservoir
+            )
+            forfeit_remaining_gas(evm.gas_meter)
             evm.error = error
             return evm
 
@@ -421,14 +425,13 @@ def process_message(message: Message) -> Evm:
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
-        refill_frame_state_gas(evm)
-        evm.regular_gas_used += evm.gas_left
-        evm.gas_left = Uint(0)
+        restore_state_gas(evm.gas_meter)
+        forfeit_remaining_gas(evm.gas_meter)
         evm.output = b""
         evm.error = error
     except Revert as error:
         evm_trace(evm, OpException(error))
-        refill_frame_state_gas(evm)
+        restore_state_gas(evm.gas_meter)
         evm.error = error
 
     if evm.error:

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -425,12 +425,18 @@ def process_message(message: Message) -> Evm:
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
+        # Frame settlement: refill state gas to the baseline, then
+        # forfeit -- a halted frame returns no regular gas to its
+        # parent. After these handlers the meter states exactly what
+        # the frame gives back, so parents absorb unconditionally.
         restore_state_gas(evm.gas_meter)
         forfeit_remaining_gas(evm.gas_meter)
         evm.output = b""
         evm.error = error
     except Revert as error:
         evm_trace(evm, OpException(error))
+        # Frame settlement: refill state gas to the baseline -- a
+        # reverted frame returns its unspent `gas_left` to its parent.
         restore_state_gas(evm.gas_meter)
         evm.error = error
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
@@ -27,8 +27,10 @@ from ethereum.trace import (
 from .protocols import (
     Evm,
     EvmWithReturnData,
-    EvmWithStateGas,
     TransactionEnvironment,
+    evm_gas_left,
+    evm_refund_counter,
+    evm_state_gas_left,
 )
 
 EXCLUDE_FROM_OUTPUT = [
@@ -132,10 +134,10 @@ class Eip3155Tracer(EvmTracer):
         if self.active_traces:
             last_trace = self.active_traces[-1]
 
-        refund_counter = evm.refund_counter
+        refund_counter = evm_refund_counter(evm)
         parent_evm = evm.message.parent_evm
         while parent_evm is not None:
-            refund_counter += parent_evm.refund_counter
+            refund_counter += evm_refund_counter(parent_evm)
             parent_evm = parent_evm.message.parent_evm
 
         len_memory = len(evm.memory)
@@ -168,7 +170,7 @@ class Eip3155Tracer(EvmTracer):
             new_trace = Trace(
                 pc=int(evm.pc),
                 op="0x" + event.address.hex().lstrip("0"),
-                gas=hex(evm.gas_left),
+                gas=hex(evm_gas_left(evm)),
                 gasCost="0x0",
                 memory=memory,
                 memSize=len_memory,
@@ -193,13 +195,14 @@ class Eip3155Tracer(EvmTracer):
                 op = "Invalid"
 
             state_gas = None
-            if isinstance(evm, EvmWithStateGas):
-                state_gas = hex(evm.state_gas_left)
+            state_gas_left = evm_state_gas_left(evm)
+            if state_gas_left is not None:
+                state_gas = hex(state_gas_left)
 
             new_trace = Trace(
                 pc=int(evm.pc),
                 op=op,
-                gas=hex(evm.gas_left),
+                gas=hex(evm_gas_left(evm)),
                 gasCost="0x0",
                 memory=memory,
                 memSize=len_memory,
@@ -244,7 +247,7 @@ class Eip3155Tracer(EvmTracer):
                 new_trace = Trace(
                     pc=int(evm.pc),
                     op=event.error.code,
-                    gas=hex(evm.gas_left),
+                    gas=hex(evm_gas_left(evm)),
                     gasCost="0x0",
                     memory=memory,
                     memSize=len_memory,

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/protocols.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/protocols.py
@@ -32,17 +32,48 @@ class Message(Protocol):
 @runtime_checkable
 class Evm(Protocol):
     """
-    The class describes the EVM interface for pre-byzantium forks trace.
+    The class describes the EVM interface common to every fork's trace.
     """
 
     pc: Uint
     stack: list[U256]
     memory: bytearray
     code: Bytes
-    gas_left: Uint
-    refund_counter: int
     running: bool
     message: Message
+
+
+@runtime_checkable
+class GasMeter(Protocol):
+    """
+    The class describes the gas meter of forks that bundle gas
+    accounting into a dedicated object (EIP-8037).
+    """
+
+    gas_left: Uint
+    state_gas_left: Uint
+    refund_counter: int
+
+
+@runtime_checkable
+class EvmWithFlatGas(Evm, Protocol):
+    """
+    The class describes the EVM interface for forks that track gas in
+    flat fields on the EVM itself.
+    """
+
+    gas_left: Uint
+    refund_counter: int
+
+
+@runtime_checkable
+class EvmWithGasMeter(Evm, Protocol):
+    """
+    The class describes the EVM interface for forks that track gas in a
+    dedicated gas meter (EIP-8037).
+    """
+
+    gas_meter: GasMeter
 
 
 @runtime_checkable
@@ -54,10 +85,30 @@ class EvmWithReturnData(Evm, Protocol):
     return_data: Bytes
 
 
-@runtime_checkable
-class EvmWithStateGas(EvmWithReturnData, Protocol):
+def evm_gas_left(evm: Evm) -> Uint:
     """
-    The class describes the EVM interface for forks with state gas (EIP-8037).
+    Read the regular gas remaining, whichever gas layout the fork uses.
     """
+    if isinstance(evm, EvmWithGasMeter):
+        return evm.gas_meter.gas_left
+    assert isinstance(evm, EvmWithFlatGas)
+    return evm.gas_left
 
-    state_gas_left: Uint
+
+def evm_refund_counter(evm: Evm) -> int:
+    """
+    Read the refund counter, whichever gas layout the fork uses.
+    """
+    if isinstance(evm, EvmWithGasMeter):
+        return evm.gas_meter.refund_counter
+    assert isinstance(evm, EvmWithFlatGas)
+    return evm.refund_counter
+
+
+def evm_state_gas_left(evm: Evm) -> Uint | None:
+    """
+    Read the state gas remaining, or `None` for forks without state gas.
+    """
+    if isinstance(evm, EvmWithGasMeter):
+        return evm.gas_meter.state_gas_left
+    return None

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1723,8 +1723,8 @@ def test_create_child_halt_refunds_state_gas(
     Verify CREATE/CREATE2 child halt refunds parent's account gas.
 
     Exceptional halts (invalid opcode, EIP-3541 invalid prefix)
-    consume all forwarded gas as `regular_gas_used`, so block
-    accounting cannot strictly discriminate via header gas. Tight
+    consume all forwarded regular gas, so block accounting cannot
+    strictly discriminate via header gas. Tight
     gas tuning via a caller wrapper leaves the factory with just
     enough `gas_left` to pay the probe SSTORE's regular portion
     but not enough to spill the state portion, so the probe SSTORE
@@ -1758,8 +1758,8 @@ def test_create_child_halt_refunds_state_gas(
         ),
     )
 
-    # Tight gas tuning: child halt consumes all forwarded gas as
-    # regular_gas_used. Factory retains
+    # Tight gas tuning: child halt consumes all forwarded regular
+    # gas. Factory retains
     # ~(forwarded - pre_sstore_regular) / 64 after CREATE. Target
     # the discrimination window `(probe_regular,
     # probe_regular + sstore_state_gas)` so the probe SSTORE
@@ -2177,7 +2177,7 @@ def test_failed_create_tx_refills_top_frame_new_account(
     initcode then fails the whole creation rolls back and no account
     persists:
 
-    * REVERT preserves ``gas_left`` and ``refill_frame_state_gas`` returns
+    * REVERT preserves ``gas_left`` and ``restore_state_gas`` returns
       the spilled ``NEW_ACCOUNT`` to it, so the state block nets to zero
       and only the regular consumption counts as work. The calldata floor
       tops up the billed amount and the block-level regular gas alike, so


### PR DESCRIPTION
### Description

Two behavior-preserving refactors of the Amsterdam two-dimensional
gas implementation:

- **Bundle frame gas into `GasMeter`** — gather the flat gas fields on `Evm` into a `GasMeter` dataclass in `vm/gas.py`, replacing scattered inline arithmetic with named operations for the state-gas rollback/commit scheme, child-frame grants, the EIP-8037 execution gas split, and transaction settlement. t8n tracer protocols gain gas-layout accessors so both `Evm` shapes trace through one path.
- **Name the gas stages in opcodes** — `CALL*`/`CREATE*` wrappers price in labeled stages (`GAS (STATE-INDEPENDENT)`, `STATE ACCESS (STATE-DEPENDENT GAS)`, `STATE GAS`, `CHILD GRANT`, `OPERATION`), also applied to `sstore` and `selfdestruct`; `generic_call` /`generic_create` reduce to the child-frame lifecycle (PREFLIGHT,
  DESTINATION ACCESS, DISPATCH, OUTCOME). Currently, it looks like an un-organised blob of operations.

Audited against EIP-8037/8038/2780 text for functional and naming consistency.

## Verification

No behavior change: the relative order of every charge, check, and trace event is preserved. Verified with the EIP-8037/2780/7778/8038
Ran `uv run hasher compare` on the full Amsterdam fixtures to make sure the fixtures did not change.


### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
