### PR TITLE
chore(tests): remove legacy `abstract:` prefix from test module docstrings

### DIFF
--- a/packages/testing/src/execution_testing/cli/eest/make/templates/blockchain_test.py.j2
+++ b/packages/testing/src/execution_testing/cli/eest/make/templates/blockchain_test.py.j2
@@ -1,6 +1,5 @@
 """
-abstract: Tests [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS/eip-{{eip_number}})
-    Test cases for [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS/eip-{{eip_number}})].
+Test cases for [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS/eip-{{eip_number}}).
 """
 
 import pytest

--- a/packages/testing/src/execution_testing/cli/eest/make/templates/state_test.py.j2
+++ b/packages/testing/src/execution_testing/cli/eest/make/templates/state_test.py.j2
@@ -1,6 +1,5 @@
 """
-abstract: Tests [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS/eip-{{eip_number}})
-    Test cases for [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS/eip-{{eip_number}})].
+Test cases for [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS/eip-{{eip_number}}).
 """
 
 import pytest

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-7976: Increase calldata floor cost](https://eips.ethereum.org/EIPS/eip-7976).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-7976: Increase calldata floor cost](https://eips.ethereum.org/EIPS/eip-7976).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_floor_boundary_exact_balance.py
@@ -1,6 +1,7 @@
 """
-abstract: Tests for floor-boundary rejection with exact-balance funding in [EIP-7976: Increase Calldata Floor Cost](https://eips.ethereum.org/EIPS/eip-7976).
-"""  # noqa: E501
+Tests for floor-boundary rejection with exact-balance funding in
+[EIP-7976: Increase Calldata Floor Cost](https://eips.ethereum.org/EIPS/eip-7976).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -1,6 +1,6 @@
 """
-abstract: Tests for access list cost calculations in [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
-"""  # noqa: E501
+Tests for access list cost calculations in [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
@@ -1,6 +1,7 @@
 """
-abstract: Tests for floor-boundary rejection with exact-balance funding in [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
-"""  # noqa: E501
+Tests for floor-boundary rejection with exact-balance funding in
+[EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -1,6 +1,6 @@
 """
-abstract: Tests for transaction validity with [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
-"""  # noqa: E501
+Tests for transaction validity with [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_eip_mainnet.py
@@ -1,7 +1,7 @@
 """
-abstract: Crafted tests for mainnet of
+Crafted tests for mainnet of
 [EIP-7997: Deterministic Factory Predeploy](https://eips.ethereum.org/EIPS/eip-7997).
-"""  # noqa: E501
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip8282_builder_execution_requests/test_eip_mainnet.py
+++ b/tests/amsterdam/eip8282_builder_execution_requests/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-8282: Builder Execution Requests](https://eips.ethereum.org/EIPS/eip-8282).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-8282: Builder Execution Requests](https://eips.ethereum.org/EIPS/eip-8282).
+"""
 
 from typing import List
 

--- a/tests/homestead/identity_precompile/__init__.py
+++ b/tests/homestead/identity_precompile/__init__.py
@@ -1,1 +1,1 @@
-"""abstract: EIP-2: Homestead Precompile Identity Test Cases."""
+"""EIP-2: Homestead Precompile Identity Test Cases."""

--- a/tests/homestead/identity_precompile/test_identity.py
+++ b/tests/homestead/identity_precompile/test_identity.py
@@ -1,4 +1,4 @@
-"""abstract: EIP-2: Homestead Identity Precompile Test Cases."""
+"""EIP-2: Homestead Identity Precompile Test Cases."""
 
 import pytest
 from execution_testing import (

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_eip_mainnet.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_eip_mainnet.py
@@ -1,7 +1,7 @@
 """
-abstract: Crafted tests for mainnet of
+Crafted tests for mainnet of
 [EIP-2537: Precompile for BLS12-381 curve operations](https://eips.ethereum.org/EIPS/eip-2537).
-"""  # noqa: E501
+"""
 
 import pytest
 from execution_testing import Alloc, StateTestFiller, Transaction

--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_eip_mainnet.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_eip_mainnet.py
@@ -1,7 +1,7 @@
 """
-abstract: Crafted tests for mainnet of
+Crafted tests for mainnet of
 [EIP-2935: Serve historical block hashes from state](https://eips.ethereum.org/EIPS/eip-2935).
-"""  # noqa: E501
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/prague/eip6110_deposits/test_eip_mainnet.py
+++ b/tests/prague/eip6110_deposits/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-6110: Supply validator deposits on chain](https://eips.ethereum.org/EIPS/eip-6110).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-6110: Supply validator deposits on chain](https://eips.ethereum.org/EIPS/eip-6110).
+"""
 
 from typing import List
 

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_eip_mainnet.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-7002: Execution layer triggerable withdrawals](https://eips.ethereum.org/EIPS/eip-7002).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-7002: Execution layer triggerable withdrawals](https://eips.ethereum.org/EIPS/eip-7002).
+"""
 
 from typing import List
 

--- a/tests/prague/eip7251_consolidations/test_eip_mainnet.py
+++ b/tests/prague/eip7251_consolidations/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-7251: Increase the MAX_EFFECTIVE_BALANCE](https://eips.ethereum.org/EIPS/eip-7251).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-7251: Increase the MAX_EFFECTIVE_BALANCE](https://eips.ethereum.org/EIPS/eip-7251).
+"""
 
 from typing import List
 

--- a/tests/prague/eip7623_increase_calldata_cost/test_eip_mainnet.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-7623: Increase calldata cost](https://eips.ethereum.org/EIPS/eip-7623).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-7623: Increase calldata cost](https://eips.ethereum.org/EIPS/eip-7623).
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/prague/eip7702_set_code_tx/test_eip_mainnet.py
+++ b/tests/prague/eip7702_set_code_tx/test_eip_mainnet.py
@@ -1,6 +1,6 @@
 """
-abstract: Crafted tests for mainnet of [EIP-7702: Set EOA account code for one transaction](https://eips.ethereum.org/EIPS/eip-7702).
-"""  # noqa: E501
+Crafted tests for mainnet of [EIP-7702: Set EOA account code for one transaction](https://eips.ethereum.org/EIPS/eip-7702).
+"""
 
 import pytest
 from execution_testing import (


### PR DESCRIPTION
### Description

Remove the legacy EEST `abstract:` prefix from test module docstrings; the docs pipeline no longer parses it and renders it literally. Docstring-only changes.

### Related Issues or PRs

Discovered while reviewing the stateful benchmark restructure in #3152.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![204 No Content](https://http.dog/204.jpg)
