### PR TITLE
fix(tests): test tx max nonce at u64 boundary, add nonce overflow test

### DIFF
--- a/tests/frontier/validation/test_transaction.py
+++ b/tests/frontier/validation/test_transaction.py
@@ -8,6 +8,7 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionTestFiller,
     add_kzg_version,
 )
 from execution_testing.base_types.base_types import ZeroPaddedHexNumber
@@ -101,25 +102,53 @@ def test_tx_nonce(
     state_test(pre=pre, post={}, tx=tx)
 
 
+@pytest.mark.pre_alloc_mutable
 @pytest.mark.exception_test
 @pytest.mark.eels_base_coverage
 def test_tx_max_nonce(state_test: StateTestFiller, pre: Alloc) -> None:
     """
-    Test that a transaction that exceeds the maximum allowed value for the
-    nonce (U64.MAX_VALUE) is rejected.
+    Test that a transaction with the maximum nonce value (`2**64 - 1`) is
+    rejected, as the maximum usable nonce is `2**64 - 2`.
+
+    The sender account is funded at the same nonce so that clients which
+    check nonce equality first reach the max-nonce check instead of
+    rejecting the transaction with a nonce mismatch.
     """
-    sender = pre.fund_eoa()
+    max_nonce = 2**64 - 1
+    sender = pre.fund_eoa(nonce=max_nonce)
     to = pre.nonexistent_account()
 
     tx = Transaction(
         to=to,
-        nonce=2**64,
+        nonce=max_nonce,
         sender=sender,
         protected=False,
         error=TransactionException.NONCE_IS_MAX,
     )
 
-    state_test(pre=pre, post={sender: Account(nonce=0)}, tx=tx)
+    state_test(pre=pre, post={sender: Account(nonce=max_nonce)}, tx=tx)
+
+
+@pytest.mark.exception_test
+def test_tx_nonce_overflow(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    fork: BaseFork,
+) -> None:
+    """
+    Test that a transaction with a nonce that does not fit in 64 bits is
+    rejected at deserialization.
+    """
+    tx = Transaction(
+        to=pre.nonexistent_account(),
+        nonce=2**64,
+        gas_limit=fork.transaction_intrinsic_cost_calculator()(),
+        sender=pre.fund_eoa(),
+        protected=False,
+        error=TransactionException.NONCE_OVERFLOW,
+    )
+
+    transaction_test(pre=pre, tx=tx)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
`test_tx_max_nonce` used `nonce=2**64`, which does not fit the u64 nonce field, so clients reject the transaction at deserialization rather than at the max-nonce check the test asserts. Pin the test to the `2**64 - 1` boundary, funding the sender at the same nonce so clients that check nonce equality first still reach the max-nonce check.

Keep coverage for the old value with a new `transaction_test` expecting `NONCE_OVERFLOW` (note: client exception mappers have no `NONCE_OVERFLOW` entries yet).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to #3036, see [this comment](https://github.com/ethereum/execution-specs/pull/3036#discussion_r3576444396).

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/pFz1Q12_hXEAAAAM/cat-holding-head-cat.gif)
