### PR TITLE
chore(ci): only install a native build toolchain for PyPy jobs

### DIFF
--- a/.github/actions/build-evmone/action.yaml
+++ b/.github/actions/build-evmone/action.yaml
@@ -66,10 +66,10 @@ runs:
       with:
         cmake-version: '3.x'
 
-    - name: Install GMP Linux
+    - name: Install build dependencies Linux
       if: runner.os == 'Linux' && steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
-      run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
+      run: sudo apt-get -q update && sudo apt-get -qy install build-essential libgmp-dev
 
     - name: Install GMP macOS
       if: runner.os == 'macOS' && steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -28,7 +28,6 @@ runs:
     - uses: ./.github/actions/setup-uv
       with:
         enable-cache: "false"
-    - uses: ./.github/actions/setup-env
     - name: Install EEST
       shell: bash
       run: uv sync --no-progress

--- a/.github/actions/setup-env-pypy/action.yaml
+++ b/.github/actions/setup-env-pypy/action.yaml
@@ -1,4 +1,4 @@
-name: Setup Environment
+name: Setup PyPy Build Toolchain
 description: |
   Install the native toolchain needed to build sdists for PyPy jobs.
   Several dependencies publish no PyPy wheels and are built from source:

--- a/.github/actions/setup-env-pypy/action.yaml
+++ b/.github/actions/setup-env-pypy/action.yaml
@@ -10,5 +10,6 @@ runs:
     - name: Install C and Rust toolchains
       shell: bash
       run: |
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential rustup
+        sudo apt-get -q update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install build-essential rustup
         rustup update --no-self-update 1.89.0 && rustup default 1.89.0

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -1,14 +1,14 @@
 name: Setup Environment
-description: Common setup for Ethereum Spec jobs
+description: |
+  Install the native toolchain needed to build sdists for PyPy jobs.
+  Several dependencies publish no PyPy wheels and are built from source:
+  libcst needs Rust; pycryptodome, PyYAML, regex, and MarkupSafe need a C
+  compiler. CPython jobs install wheels only and must not use this action.
 runs:
   using: "composite"
   steps:
-    - name: Install Rust
+    - name: Install C and Rust toolchains
       shell: bash
       run: |
         sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential rustup
         rustup update --no-self-update 1.89.0 && rustup default 1.89.0
-
-    - name: Install build dependencies
-      shell: bash
-      run: sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential pkg-config libsecp256k1-dev

--- a/.github/actions/setup-uv/action.yaml
+++ b/.github/actions/setup-uv/action.yaml
@@ -6,10 +6,7 @@ inputs:
     default: "3.13"
   enable-cache:
     description: Enable uv dependency cache
-    # Temporary (revert before merge): default to "false" so the setup-uv
-    # post step does not run `uv cache prune`, which fails when the
-    # UV_NO_CACHE cold-cache validation leaves no cache directory behind.
-    default: "false"
+    default: "true"
   cache-dependency-glob:
     description: Glob for cache invalidation
     default: "uv.lock"

--- a/.github/actions/setup-uv/action.yaml
+++ b/.github/actions/setup-uv/action.yaml
@@ -6,7 +6,10 @@ inputs:
     default: "3.13"
   enable-cache:
     description: Enable uv dependency cache
-    default: "true"
+    # Temporary (revert before merge): default to "false" so the setup-uv
+    # post step does not run `uv cache prune`, which fails when the
+    # UV_NO_CACHE cold-cache validation leaves no cache directory behind.
+    default: "false"
   cache-dependency-glob:
     description: Glob for cache invalidation
     default: "uv.lock"

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -161,10 +161,6 @@ jobs:
         with:
           cache-dependency-glob: "execution-specs/uv.lock"
 
-      - name: Setup environment
-        if: matrix.mode == 'dev'
-        uses: ./execution-specs/.github/actions/setup-env
-
       - name: Load cached Docker images
         uses: ./execution-specs/.github/actions/load-docker-images
 

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -65,6 +65,9 @@ concurrency:
 env:
   # Use direct URL instead of release spec (e.g., develop@v5.3.0) to avoid GitHub API rate limits
   FIXTURES_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
+  # Temporary (revert before merge): bypass the uv cache so this PR's CI
+  # proves that all dependencies install as wheels without a toolchain.
+  UV_NO_CACHE: "1"
 
 jobs:
   cache-docker-images:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -65,9 +65,6 @@ concurrency:
 env:
   # Use direct URL instead of release spec (e.g., develop@v5.3.0) to avoid GitHub API rate limits
   FIXTURES_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
-  # Temporary (revert before merge): bypass the uv cache so this PR's CI
-  # proves that all dependencies install as wheels without a toolchain.
-  UV_NO_CACHE: "1"
 
 jobs:
   cache-docker-images:

--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -21,11 +21,6 @@ concurrency:
   group: hive-execute-${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
-env:
-  # Temporary (revert before merge): bypass the uv cache so this PR's CI
-  # proves that all dependencies install as wheels without a toolchain.
-  UV_NO_CACHE: "1"
-
 jobs:
   cache-docker-images:
     name: Cache Docker Images

--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -71,9 +71,6 @@ jobs:
         with:
           cache-dependency-glob: "execution-specs/uv.lock"
 
-      - name: Setup environment
-        uses: ./execution-specs/.github/actions/setup-env
-
       - name: Load cached Docker images
         uses: ./execution-specs/.github/actions/load-docker-images
 

--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -21,6 +21,11 @@ concurrency:
   group: hive-execute-${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+env:
+  # Temporary (revert before merge): bypass the uv cache so this PR's CI
+  # proves that all dependencies install as wheels without a toolchain.
+  UV_NO_CACHE: "1"
+
 jobs:
   cache-docker-images:
     name: Cache Docker Images

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,9 +39,6 @@ jobs:
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@70c4af2ed5282c51ba40566d026d6647852ffa3e # v5.0.1
       - uses: ./.github/actions/setup-uv
-      - name: Install build dependencies
-        shell: bash
-        run: sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential pkg-config
       - name: Detect Python version
         id: python
         shell: bash
@@ -103,7 +100,6 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "3.14"
-      - uses: ./.github/actions/setup-env
       - name: Run fill (${{ matrix.label }})
         run: >
           just fill --from ${{ matrix.from_fork }} --until ${{ matrix.until_fork }}
@@ -144,7 +140,6 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "3.14"
-      - uses: ./.github/actions/setup-env
       - name: Fill and run json-loader tests
         run: just json-loader
         env:
@@ -166,7 +161,6 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "3.14"
-      - uses: ./.github/actions/setup-env
       - name: Run spec-tools tests
         run: just spec-tools
         env:
@@ -180,7 +174,6 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
-      - uses: ./.github/actions/setup-env
       - uses: ./.github/actions/build-evmone
       - name: Run test-tests
         run: just test-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,11 +29,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
-env:
-  # Temporary (revert before merge): bypass the uv cache so this PR's CI
-  # proves that all dependencies install as wheels without a toolchain.
-  UV_NO_CACHE: "1"
-
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+env:
+  # Temporary (revert before merge): bypass the uv cache so this PR's CI
+  # proves that all dependencies install as wheels without a toolchain.
+  UV_NO_CACHE: "1"
+
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,7 +123,7 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "pypy3.11"
-      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/setup-env-pypy
       - name: Run fill-pypy tests
         run: just fill-pypy
         env:
@@ -190,7 +190,7 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "pypy3.11"
-      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/setup-env-pypy
       - uses: ./.github/actions/build-evmone
       - name: Run test-tests-pypy
         run: just test-tests-pypy

--- a/Justfile
+++ b/Justfile
@@ -64,8 +64,7 @@ deadcode:
 format-check *args:
     uv run ruff format --check "$@"
 
-# Run type checking with mypy (the optimized group provides the typed
-# rust-pyspec-glue and ethash packages imported by ethereum_optimized)
+# Run type checking with mypy (installs the optimized dependency group)
 [group('static analysis')]
 typecheck *args:
     uv run --group optimized mypy "$@"

--- a/Justfile
+++ b/Justfile
@@ -64,10 +64,11 @@ deadcode:
 format-check *args:
     uv run ruff format --check "$@"
 
-# Run type checking with mypy
+# Run type checking with mypy (the optimized group provides the typed
+# rust-pyspec-glue and ethash packages imported by ethereum_optimized)
 [group('static analysis')]
 typecheck *args:
-    uv run mypy "$@"
+    uv run --group optimized mypy "$@"
 
 # Check EELS import isolation
 [group('static analysis')]

--- a/docs/dev/deps_and_packaging.md
+++ b/docs/dev/deps_and_packaging.md
@@ -61,7 +61,11 @@ Development dependencies are grouped into `[dependency-groups]`, one group per c
 Groups defined by the specs package:
 
 - `test`, `lint`, `actionlint`, `doc`, `mkdocs`.
-- `dev` includes all of the above plus the `optimized` extra.
+- `dev` includes all of the above.
+- `optimized` pulls in the `optimized` extra for the sync tool. It is not
+  part of `dev` because `ethash` has no CPython 3.14 wheels and would
+  require a C toolchain to install; enable it with
+  `uv sync --group optimized` when needed.
 
 Groups defined by the testing package:
 

--- a/docs/dev/deps_and_packaging.md
+++ b/docs/dev/deps_and_packaging.md
@@ -62,10 +62,7 @@ Groups defined by the specs package:
 
 - `test`, `lint`, `actionlint`, `doc`, `mkdocs`.
 - `dev` includes all of the above.
-- `optimized` pulls in the `optimized` extra for the sync tool. It is not
-  part of `dev` because `ethash` has no CPython 3.14 wheels and would
-  require a C toolchain to install; enable it with
-  `uv sync --group optimized` when needed.
+- `optimized` pulls in the `optimized` extra for the sync tool. It is not part of `dev` because `ethash` has no CPython 3.14 wheels and would require a C toolchain to install; enable it with `uv sync --group optimized` when needed.
 
 Groups defined by the testing package:
 

--- a/docs/specs/writing_specs.md
+++ b/docs/specs/writing_specs.md
@@ -161,7 +161,9 @@ The following must be updated manually afterwards:
 
 The sync tool uses an RPC provider to fetch and validate blocks against EELS. The validated state can be stored in a local DB. Because syncing directly with the specs is very slow, the sync tool can also leverage the `ethereum_optimized` module, which contains alternative implementations of routines in EELS optimized for speed rather than clarity/readability.
 
-Invoke the tool with `ethereum-spec-sync`. Arguments:
+Invoke the tool with `uv run --group optimized ethereum-spec-sync` (the
+`optimized` dependency group provides the `ethereum_optimized` module).
+Arguments:
 
 - `rpc-url`: Endpoint providing the Ethereum RPC API. Defaults to `http://localhost:8545/`.
 - `unoptimized`: Don't use the optimized state/ethash (this can be extremely slow).

--- a/docs/specs/writing_specs.md
+++ b/docs/specs/writing_specs.md
@@ -161,9 +161,7 @@ The following must be updated manually afterwards:
 
 The sync tool uses an RPC provider to fetch and validate blocks against EELS. The validated state can be stored in a local DB. Because syncing directly with the specs is very slow, the sync tool can also leverage the `ethereum_optimized` module, which contains alternative implementations of routines in EELS optimized for speed rather than clarity/readability.
 
-Invoke the tool with `uv run --group optimized ethereum-spec-sync` (the
-`optimized` dependency group provides the `ethereum_optimized` module).
-Arguments:
+Invoke the tool with `uv run --group optimized ethereum-spec-sync` (the `optimized` dependency group provides the `ethereum_optimized` module). Arguments:
 
 - `rpc-url`: Endpoint providing the Ethereum RPC API. Defaults to `http://localhost:8545/`.
 - `unoptimized`: Don't use the optimized state/ethash (this can be extremely slow).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,8 +255,13 @@ dev = [
     { include-group = "actionlint" },
     { include-group = "doc" },
     { include-group = "mkdocs" },
-    "ethereum-execution[optimized]",
     "psutil>=7.2.2",
+]
+# Opt-in (not part of dev): native-accelerated state and ethash for the
+# sync tool. ethash has no CPython 3.14 wheels, so installing this group
+# requires a C toolchain on 3.14.
+optimized = [
+    "ethereum-execution[optimized]",
 ]
 
 [tool.setuptools.dynamic]

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,6 @@ dev = [
     { name = "cairosvg" },
     { name = "codespell" },
     { name = "docc" },
-    { name = "ethereum-execution", extra = ["optimized"] },
     { name = "ethereum-execution-testing" },
     { name = "filelock" },
     { name = "fladrif" },
@@ -926,6 +925,9 @@ mkdocs = [
     { name = "pillow" },
     { name = "pyspelling" },
 ]
+optimized = [
+    { name = "ethereum-execution", extra = ["optimized"] },
+]
 test = [
     { name = "ethereum-execution-testing" },
     { name = "filelock" },
@@ -966,7 +968,6 @@ dev = [
     { name = "codespell", specifier = "==2.4.1" },
     { name = "codespell", specifier = ">=2.4.1,<3" },
     { name = "docc", specifier = ">=0.6.1,<0.7.0" },
-    { name = "ethereum-execution", extras = ["optimized"] },
     { name = "ethereum-execution-testing", editable = "packages/testing" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "fladrif", specifier = ">=0.2.0,<0.3.0" },
@@ -1034,6 +1035,7 @@ mkdocs = [
     { name = "pillow", specifier = ">=12,<13" },
     { name = "pyspelling", specifier = ">=2.8.2,<3" },
 ]
+optimized = [{ name = "ethereum-execution", extras = ["optimized"] }]
 test = [
     { name = "ethereum-execution-testing", editable = "packages/testing" },
     { name = "filelock", specifier = ">=3.15.1,<4" },


### PR DESCRIPTION
### Description

TLDR: #2374 replaced `coincurve` with `spec256k1` and removed the last required package (outside the scope of `ethereum-spec-sync`) that needed creating a wheel and C compilation for CPython runs. This gives us an opportunity to simplify our CI dependencies and slightly reduce CI times.

More specifically, after #2374 every locked dependency installs as a wheel on x86-64 Linux for CPython 3.13 and 3.14; the only remaining sdist builds are pure Python (the workspace packages, `actionlint-py`, and `pyyaml-ft`). A native toolchain is only genuinely needed by the PyPy jobs, where `libcst` (Rust) and `pycryptodome`, `pyyaml`, `regex`, and `markupsafe` (C) publish no wheels.

- Drop `setup-env` from all CPython jobs (`fill`, `json-loader`, `spec-tools`, `test-tests`, both hive workflows, and the `build-fixtures` action) and drop the `static` job's inline apt step; slim the action to `build-essential` plus Rust for the two PyPy jobs, removing the `coincurve` leftovers `libsecp256k1-dev` and `pkg-config`.
- Move `ethereum-execution[optimized]` from the `dev` group to a new opt-in `optimized` dependency group: `ethash` has no CPython 3.14 wheels (cf #3173) and nothing in CI imports `ethereum_optimized`. `just typecheck` installs the group for mypy; the sync tool is now invoked as:
  ```
  uv run --group optimized ethereum-spec-sync
  ```
- Make `build-evmone` install `build-essential` itself on cache miss (it previously came implicitly from the calling job's `setup-env`).

The win is mainly simplification: CPython jobs are now provably wheels-only, and the remaining `setup-env` documents exactly why it exists. Time savings are modest: the step took ~17-18s per job across 8 jobs per `test.yaml` run, and the `static` job's step sat on the critical path since all other jobs gate on it via `needs: static`.

Verified by running cold-cache `uv sync --locked` for every CI environment shape in containers with no C compiler or Rust installed. The tip commit sets `UV_NO_CACHE=1` so this PR's CI also installs everything with a cold cache; it will be reverted before merge. Since the `setup-uv` cache key is the exact `uv.lock` hash (no prefix fallback), any future lock change re-exercises wheel coverage automatically.

### Related Issues or PRs

Enabled by:
- #2374.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![204 No Content: nothing left to install](https://http.cat/images/204.jpg)
