### PR TITLE
chore(ci): run `just test-ci-scripts` in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -204,3 +204,14 @@ jobs:
         env:
           PYPY_GC_MAX: "2G"
           PYPY_GC_MIN: "1G"
+
+  test-ci-scripts:
+    runs-on: ubuntu-latest
+    needs: static
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-uv
+      - name: Run test-ci-scripts
+        run: just test-ci-scripts


### PR DESCRIPTION
### Description

Add a `test-ci-scripts` job so the CI release script tests under `.github/scripts/tests/` actually run in CI.

### Related Issues or PRs
N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![HTTP 200 OK](https://http.cat/200)
