### PR TITLE
chore(tests): fix joblib cache race in eip2537 BLS precompile tests

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/helpers.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/helpers.py
@@ -167,8 +167,14 @@ class BLSPointGenerator:
     # G2 cofactor h₂: (x⁸ - 4x⁷ + 5x⁶ - 4x⁴ + 6x³ - 4x² - 4x + 13)/9
     G2_COFACTOR = 0x5D543A95414E7F1091D50792876A202CD91DE4547085ABAA68A205B2E5A7DDFA628F1CB4D9E82EF21537E293A6691AE1616EC6E786F0C70CF1C38E31C7238E5  # noqa: E501
 
-    # Memory cache for expensive functions
-    memory = Memory(location=".cache", verbose=0)
+    # Memory cache for expensive functions. Give each xdist worker its own
+    # cache dir: joblib's disk cache races on concurrent writes, and these
+    # functions run at collection time in every worker.
+    _xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "")
+    _cache_location = (
+        f".cache/joblib-{_xdist_worker}" if _xdist_worker else ".cache"
+    )
+    memory = Memory(location=_cache_location, verbose=0)
 
     @staticmethod
     def is_on_curve_g1(x: int, y: int) -> bool:


### PR DESCRIPTION
### Description

Why: on a cold cache the eip2537 BLS point generators race across xdist workers to write joblib's `func_code.py` at collection time, intermittently erroring the whole module with `FileNotFoundError` (seen in [CI](https://github.com/ethereum/execution-specs/actions/runs/29401926083/job/87308402417#step:4:420)).
How: give each xdist worker its own joblib cache directory so no two processes write the same location.

### Related Issues or PRs
N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![HTTP 409 Conflict cat](https://http.cat/409)
