### PR TITLE
chore(ci): don't fetch the benchmark assets submodule where unused

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -220,7 +220,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && needs.check-should-publish.outputs.commit_sha || '' }}
           fetch-depth: 0
-          submodules: recursive
 
       - uses: ./.github/actions/setup-uv
 
@@ -253,7 +252,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && needs.check-should-publish.outputs.commit_sha || '' }}
           fetch-depth: 0
-          submodules: recursive
 
       - uses: ./.github/actions/setup-uv
 

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          submodules: recursive
 
       - uses: ./.github/actions/setup-uv
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@70c4af2ed5282c51ba40566d026d6647852ffa3e # v5.0.1
       - uses: ./.github/actions/setup-uv
@@ -98,8 +96,6 @@ jobs:
             until_fork: Amsterdam
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "3.14"
@@ -122,8 +118,6 @@ jobs:
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "pypy3.11"
@@ -139,8 +133,6 @@ jobs:
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "3.14"
@@ -161,8 +153,6 @@ jobs:
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "3.14"
@@ -177,8 +167,6 @@ jobs:
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
       - uses: ./.github/actions/setup-env
       - uses: ./.github/actions/build-evmone
@@ -192,8 +180,6 @@ jobs:
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "pypy3.11"
@@ -210,8 +196,6 @@ jobs:
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: recursive
       - uses: ./.github/actions/setup-uv
       - name: Run test-ci-scripts
         run: just test-ci-scripts


### PR DESCRIPTION
### Description

Drop `submodules: recursive` from checkouts that don't need it (`test.yaml`, `docs-build.yaml`, `gh-pages.yaml`). The `.worst_case_miner` submodule is ~82 MB of pre-mined benchmark assets used only when filling `tests/benchmark/`, which is excluded from collection unless `--include-benchmark` is passed; fetching it adds up to ~18s to every checkout on GitHub-hosted runners (e.g., 22s → ~3s for the `static` job's checkout, which gates all other jobs in `test.yaml`). `benchmark.yaml`, `release_fixtures.yaml` and `hive-execute.yaml` still fetch it.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![413 Content Too Large](https://http.cat/413.jpg)
