### PR TITLE
fix(tests,test-fill): isolate the scenarios BLOCKHASH program pre-alloc group

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1657,10 +1657,15 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     "pre_alloc_group"
                 ):
                     # Get the group name/salt from marker args
-                    if pre_alloc_group_marker.args:
+                    if (
+                        pre_alloc_group_marker.args
+                        and pre_alloc_group_marker.args[0] != "separate"
+                    ):
                         group_salt = str(pre_alloc_group_marker.args[0])
                     else:
-                        # We got the marker but unspecified, pass test name
+                        # "separate" (or a bare marker): salt with the
+                        # test's node id so the test gets its own genesis
+                        # instead of a group named literally "separate".
                         group_salt = _strip_xdist_group_suffix(
                             request.node.nodeid
                         )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
@@ -397,7 +397,7 @@ class FormattedTest:
     template: ClassVar[str]
 
     def __init__(self, **kwargs: str) -> None:  # noqa: D107
-        self.kwargs = kwargs
+        self.kwargs = {"markers": ""} | kwargs
 
     def format(self) -> str:  # noqa: D102
         return self.template.format(**self.kwargs)
@@ -418,7 +418,7 @@ class StateTest(FormattedTest):  # noqa: D101
         )
 
         @pytest.mark.valid_from("Istanbul")
-        def test_chainid(state_test: StateTestFiller, pre: Alloc) -> None:
+        {markers}def test_chainid(state_test: StateTestFiller, pre: Alloc) -> None:
             contract_address = pre.deploy_contract(Op.SSTORE(1, Op.CHAINID) + Op.STOP)
             sender = pre.fund_eoa()
 
@@ -455,7 +455,7 @@ class BlockchainTest(FormattedTest):  # noqa: D101
         )
 
         @pytest.mark.valid_from("Istanbul")
-        def test_chainid_blockchain(blockchain_test: BlockchainTestFiller, pre: Alloc) -> None:
+        {markers}def test_chainid_blockchain(blockchain_test: BlockchainTestFiller, pre: Alloc) -> None:
             contract_address = pre.deploy_contract(Op.SSTORE(1, Op.CHAINID) + Op.STOP)
             sender = pre.fund_eoa()
 
@@ -589,6 +589,53 @@ class BlockchainTest(FormattedTest):  # noqa: D101
             ],
             2,
             id="different_excess_blob_gas",
+        ),
+        # The `pre_alloc_group` marker
+        pytest.param(
+            [
+                StateTest(
+                    env="Environment()",
+                    markers="@pytest.mark.pre_alloc_group("
+                    '"separate", reason="isolate")\n',
+                ),
+                StateTest(
+                    env="Environment()",
+                    markers="@pytest.mark.pre_alloc_group("
+                    '"separate", reason="isolate")\n',
+                ),
+            ],
+            2,
+            id="separate_marker_isolates_each_test",
+        ),
+        pytest.param(
+            [
+                StateTest(
+                    env="Environment()",
+                    markers='@pytest.mark.pre_alloc_group(reason="isolate")\n',
+                ),
+                StateTest(
+                    env="Environment()",
+                    markers='@pytest.mark.pre_alloc_group(reason="isolate")\n',
+                ),
+            ],
+            2,
+            id="bare_marker_isolates_each_test",
+        ),
+        pytest.param(
+            [
+                StateTest(
+                    env="Environment()",
+                    markers="@pytest.mark.pre_alloc_group("
+                    '"custom_group", reason="shared setup")\n',
+                ),
+                StateTest(
+                    env="Environment()",
+                    markers="@pytest.mark.pre_alloc_group("
+                    '"custom_group", reason="shared setup")\n',
+                ),
+            ],
+            1,
+            id="named_group_marker_shares_one_group",
         ),
     ],
 )

--- a/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
+++ b/packages/testing/src/execution_testing/fixtures/engine_x_checks.py
@@ -20,9 +20,11 @@ class EngineXExecutionDriftError(Exception):
     An Engine X fixture is filled against its group's merged genesis, while
     the test's `blockchain_test_engine` sibling is filled against the test's
     own pre-allocation. Their per-payload execution outputs (gas used,
-    receipts root, logs bloom, ...) must be identical; a difference means an
-    account introduced by pre-alloc group packing leaked into the test's
-    execution (see `pack_pre_alloc_groups`).
+    receipts root, logs bloom, ...) must be identical; a difference means
+    either an account introduced by pre-alloc group packing leaked into the
+    test's execution (see `pack_pre_alloc_groups`), or the test observes the
+    genesis hash itself (e.g. via `BLOCKHASH(0)`), which depends on every
+    account in the genesis and so cannot survive any grouping.
     """
 
     def __init__(self, mismatches: List[Tuple[str, str]], compared: int):
@@ -39,9 +41,11 @@ class EngineXExecutionDriftError(Exception):
             "differently against their packed pre-allocation group's genesis "
             "than against their own pre-allocation:\n"
             f"{details}\n"
-            "An account introduced by pre-alloc group packing leaked into "
-            "these tests' execution. Isolate the affected tests with "
-            "@pytest.mark.pre_alloc_group and re-fill."
+            "Sharing a genesis changed these tests' execution: either an "
+            "account introduced by pre-alloc group packing leaked into "
+            "their execution, or they observe the genesis hash itself "
+            "(e.g. via BLOCKHASH(0)). Isolate the affected tests with "
+            '@pytest.mark.pre_alloc_group("separate") and re-fill.'
         )
 
 

--- a/tests/frontier/scenarios/test_scenarios.py
+++ b/tests/frontier/scenarios/test_scenarios.py
@@ -166,7 +166,16 @@ def scenarios(
         ProgramReturnDataSize(),
         ProgramReturnDataCopy(),
         ProgramExtCodehash(),
-        ProgramBlockhash(),
+        pytest.param(
+            ProgramBlockhash(),
+            marks=pytest.mark.pre_alloc_group(
+                "separate",
+                reason="The program feeds BLOCKHASH(0), the genesis hash, "
+                "to the gas-hash contract, so gas usage depends on the "
+                "exact genesis pre-allocation; sharing a genesis with any "
+                "other test changes the execution.",
+            ),
+        ),
         ProgramCoinbase(),
         ProgramTimestamp(),
         ProgramNumber(),


### PR DESCRIPTION
### Description

Follow-up to #3122: The v20.0.1 release fill failed the Engine X execution drift check with a single mismatch, `test_scenarios[fork_Paris-blockchain_test_engine_x-test_program_program_BLOCKHASH-debug]` ([failing job](https://github.com/ethereum/execution-specs/actions/runs/29406408314/job/87322887242)). This PR fixes the root cause; pre-alloc group packing itself is safe, and the check caught exactly the kind of issue it was built for.

**Why this one test drifts.** The scenarios `BLOCKHASH` program feeds `BLOCKHASH(0)` (the genesis hash) to the scenario suite's gas-hash contract, which deliberately burns gas proportional to its input so that values unknowable at fill time still leave a trace in `gasUsed`. The genesis hash depends on every account in the genesis, so merging any other test's accounts into the shared pre-allocation changes this test's `gasUsed` and `receiptsRoot`. No grouping scheme can be transparent for a test that observes the genesis hash itself; it needs its own genesis. The drift even predates packing: the fine-grained phase 1 groups already shared this test's genesis, and the check introduced in #3122 merely exposed it.

**The fix.** Mark just the `BLOCKHASH` program parametrization with `@pytest.mark.pre_alloc_group("separate")`, so its Engine X fixture is filled against the test's own genesis on every fork; its execution then matches its `blockchain_test_engine` sibling exactly and the drift check passes. The suite's other gas-hash programs (`GASPRICE`, `TIMESTAMP`, `DIFFICULTY`, `BASEFEE`, `BLOBBASEFEE`) feed environment-fixed values and were verified to fill drift-free when packed into a single group.

Using the marker (this is its first real user) surfaced two more issues, fixed here:

- The filler used the literal marker argument as the group salt, so every test marked `"separate"` would have silently shared one named group instead of getting its own genesis. It now salts `"separate"` (and the bare marker) with the test's node id, matching the marker's documented semantics. The regression cases were committed first and fail without the fix.
- The drift error message claimed an account leak was the only possible cause; it now also names genesis-hash observation and points at the `"separate"` marker as the remedy.

Fixture impact: `blockchain_tests` and `blockchain_tests_engine` fixtures are hash-identical before and after this change (verified with `hasher compare`); only Engine X fixtures re-key, since the affected pre-alloc groups' contents change.

### Related Issues or PRs

Follow-up to #3122.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![HTTP 409 Conflict](https://http.cat/409.jpg)
