### PR TITLE
chore(ci): right-size runners for spec-tools and test-tests-pypy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -157,7 +157,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   spec-tools:
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: ubuntu-latest
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -188,7 +188,7 @@ jobs:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
 
   test-tests-pypy:
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: [self-hosted-ghr, size-l-x64]
     needs: static
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Description

Two `test.yaml` jobs hold a 16C/32G `size-xl-x64` self-hosted runner they cannot make use of, and each ephemeral runner costs ~2.5 min of provisioning before the job starts (measured on [run 29396534501](https://github.com/ethereum/execution-specs/actions/runs/29396534501)):

- `spec-tools` runs 40 tests in ~13s of pytest wall time (36-63s job runtime over recent runs): move it to `ubuntu-latest` like `static` and `test-ci-scripts`, which starts in seconds and frees a self-hosted VM per run.
- `test-tests-pypy` is capped at 6 xdist workers in the `Justfile`, leaving 10 of 16 cores idle: `size-l-x64` (8C/16G) covers its worker count and PyPy heap caps (6 x `PYPY_GC_MAX=2G` = 12G).

The remaining xl jobs are left as-is: the `fill` shards and `json-loader` scale with cores and set the run's critical path, `test-tests` needs the cores for evmone cold compiles on cache-miss days, and `fill-pypy` (7 workers x 2G) is too tight for 16G without also reducing its worker count.

### Related Issues or PRs

Related: #3171, #3175 (both reduce per-job CI overhead; all three merge cleanly in any order).

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![416 Range Not Satisfiable](https://http.cat/416.jpg)
