### PR TITLE
feat: re-enable external t8n filling only for benchmarks

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -11,12 +11,12 @@ tests:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
+  fill-params: --fork=Amsterdam --generate-all-formats --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
   feature_only: true
 
 benchmark_fast:
   evm-type: benchmark
-  fill-params: --fork=Osaka --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
+  fill-params: --fork=Amsterdam --generate-all-formats --gas-benchmark-values 60 ./tests/benchmark/compute
   feature_only: true
 
 # Shared entry for all `<feat>-devnet` releases; matched by `-devnet` suffix.

--- a/.github/workflows/benchmark-fill-parity.yaml
+++ b/.github/workflows/benchmark-fill-parity.yaml
@@ -13,7 +13,7 @@ on:
         description: "Geth branch to build"
         required: false
         type: string
-        default: "jsign-master-t8n-fill-executionwitness"
+        default: "jsign-glamsterdam-devnet-7-t8n-zkevm"
       benchmark_file:
         description: "Benchmark test file to fill"
         required: false
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   GETH_REPO: ${{ inputs.geth_repo || 'jsign/go-ethereum' }}
-  GETH_BRANCH: ${{ inputs.geth_branch || 'jsign-master-t8n-fill-executionwitness' }}
+  GETH_BRANCH: ${{ inputs.geth_branch || 'jsign-glamsterdam-devnet-7-t8n-zkevm' }}
   BENCHMARK_FILE: ${{ inputs.benchmark_file || 'tests/benchmark/compute/instruction/test_memory.py' }}
   FILL_FORK: ${{ inputs.fill_fork || 'Amsterdam' }}
   XDIST_WORKERS: ${{ inputs.xdist_workers || 'auto' }}

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -35,6 +35,7 @@ from execution_testing.base_types import (
 from execution_testing.client_clis import (
     BlockExceptionWithMessage,
     ClientBackend,
+    ExecutionSpecsTransitionTool,
     FillerBackend,
     LazyAlloc,
     Result,
@@ -1107,6 +1108,28 @@ class BlockchainTest(BaseTest):
             parent_hash=header.parent_hash,
             execution_witness=t8n_witness,
         )
+        missing_stateless_artifacts = (
+            not stateless_options.skip_validation
+            and t8n_witness is not None
+            and bal is not None
+            and (
+                transition_tool_output.result.stateless_input_bytes is None
+                or transition_tool_output.result.stateless_output_bytes is None
+            )
+        )
+        if missing_stateless_artifacts:
+            # Temporary trust path for external benchmark filling until Geth
+            # emits both stateless byte fields.
+            assert not isinstance(t8n, ExecutionSpecsTransitionTool), (
+                "EELS must provide stateless input and output bytes"
+            )
+            assert self.operation_mode == OpMode.BENCHMARKING, (
+                "Missing stateless artifacts are only supported for external "
+                "benchmark fills"
+            )
+            assert block.exception is None, (
+                "Missing stateless artifacts require a valid benchmark block"
+            )
         stateless_artifacts = stateless_artifacts_from_t8n(
             options=stateless_options,
             artifacts=stateless_artifacts,

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -889,10 +889,15 @@ def build_amsterdam_stateless_artifacts_from_t8n(
     from ethereum.forks.amsterdam.execution_engine.requests import (
         decode_execution_requests,
     )
+    from ethereum.forks.amsterdam.stateless import (
+        StatelessValidationResult,
+        compute_new_payload_request_root,
+    )
     from ethereum.forks.amsterdam.stateless_guest import (
-        run_stateless_guest,
+        serialize_stateless_output,
     )
     from ethereum.forks.amsterdam.stateless_host import (
+        build_chain_config,
         build_stateless_input,
         serialize_stateless_input,
     )
@@ -949,7 +954,16 @@ def build_amsterdam_stateless_artifacts_from_t8n(
         chain_id=U64(chain_id),
     )
     stateless_input_bytes = serialize_stateless_input(stateless_input)
-    stateless_output_bytes = run_stateless_guest(stateless_input_bytes)
+    # Temporary trust path for external benchmark filling until Geth emits
+    # both stateless byte fields.
+    stateless_output = StatelessValidationResult(
+        new_payload_request_root=compute_new_payload_request_root(
+            stateless_input
+        ),
+        successful_validation=True,
+        chain_config=build_chain_config(U64(chain_id)),
+    )
+    stateless_output_bytes = serialize_stateless_output(stateless_output)
     return (
         Bytes(bytes(stateless_input_bytes)),
         Bytes(bytes(stateless_output_bytes)),


### PR DESCRIPTION
### Description
This PR re-enables correctly being able to fill stateless benchmark fixtures with Geth t8n.

Geth isn't ready yet to output `statelessInputBytes` and `statelessOutputBytes` as part of t8n results, but only return the `executionWitness`. I think we can do it eventually, but until EIP-8025 is CFIed, it might be a hard expectation on them to do it.

Meanwhile, we can assume a smaller change from Geth t8n side which is basically [this PR](https://github.com/ethereum/go-ethereum/pull/35257). It basically returns the `executionWitness` as part of t8n. Then on EELS side, **only for benchmark fillings** we construct the `statelessInputBytes` and `statelessOutputBytes` (benchmarks are assumed to always produce valid blocks).

Example on how to fill stateless benchmarks today with Geth:
1. Pull https://github.com/jsign/go-ethereum/tree/jsign-glamsterdam-devnet-7-t8n-zkevm -- this branch is literally their `glamsterdam-devnet-7` plus cherry-picking the [PR](https://github.com/ethereum/go-ethereum/pull/35257) I mentioned before. Easy to rebase.
2. `go build -o /tmp/geth-witness-bin/evm ./cmd/evm`
3. Use that binary to fill benchmarks, example: `uv run fill --clean --gas-benchmark-values 60 --fork Amsterdam --evm-bin /tmp/geth-witness-bin/evm -m blockchain_test -n 12 ./tests/benchmark/compute/precompile/test_blake2f.py`
(Please remember to fill benchmarks in `projects/zkevm-releases` to be meaningful for a devnet)

How can this be simplified:
- If https://github.com/ethereum/go-ethereum/pull/35257 can be merged, at least we could use geth `glamsterdam-devnet-7` directly in step 1. which would be nice.
- Whenever we can make Geth t8n actually output `stateless{Input|Output}Bytes`, then most of this PR workaround can be removed since would behave exactly as EELS t8n.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
