### PR TITLE
perf(ci): run the PR docker-image cache gate on a GitHub-hosted runner

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -69,7 +69,14 @@ env:
 jobs:
   cache-docker-images:
     name: Cache Docker Images
-    runs-on: [self-hosted-ghr, size-l-x64]
+    # On PRs this job is normally a pure cache restore (~12s), so run it on a
+    # GitHub-hosted runner instead of paying the ~2.5 min self-hosted
+    # provisioning wait, which would gate every test-hive job. Push and
+    # dispatch runs stay on self-hosted so the weekly cache is populated from
+    # GHR egress IPs, avoiding Docker Hub's per-IP rate limits on the shared
+    # GitHub-hosted IPs. A PR that lands right after the weekly cache-key
+    # rollover pulls the 3 images unauthenticated; that rare miss is accepted.
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted-ghr", "size-l-x64"]') }}
     steps:
       - name: Checkout execution-specs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Description

On pull requests the `cache-docker-images` job is normally a pure weekly-cache restore (~12s), but it gates all `test-hive` jobs and paid ~2.5 min of self-hosted runner provisioning before starting, roughly a quarter of the workflow's wall time.

Select the runner by event: PRs use `ubuntu-latest` (picked up in seconds), while push and dispatch runs stay on self-hosted so the weekly cache is populated from GHR egress IPs, avoiding Docker Hub's per-IP rate limits on the shared GitHub-hosted IPs.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![429 Too Many Requests](https://http.cat/429.jpg)
