### PR TITLE
refactor(spec-specs): decode withdrawal amount as uint64 per EIP-4895

### DIFF
--- a/src/ethereum/forks/amsterdam/blocks.py
+++ b/src/ethereum/forks/amsterdam/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1156,7 +1156,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * GWEI_TO_WEI)
+        create_ether(wd_state, wd.address, U256(wd.amount) * GWEI_TO_WEI)
 
     incorporate_tx_into_block(wd_state, block_env.block_access_list_builder)
 

--- a/src/ethereum/forks/bpo1/blocks.py
+++ b/src/ethereum/forks/bpo1/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/bpo1/fork.py
+++ b/src/ethereum/forks/bpo1/fork.py
@@ -1002,7 +1002,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/bpo2/blocks.py
+++ b/src/ethereum/forks/bpo2/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/bpo2/fork.py
+++ b/src/ethereum/forks/bpo2/fork.py
@@ -1002,7 +1002,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/bpo3/blocks.py
+++ b/src/ethereum/forks/bpo3/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/bpo3/fork.py
+++ b/src/ethereum/forks/bpo3/fork.py
@@ -1002,7 +1002,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/bpo4/blocks.py
+++ b/src/ethereum/forks/bpo4/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/bpo4/fork.py
+++ b/src/ethereum/forks/bpo4/fork.py
@@ -1002,7 +1002,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/bpo5/blocks.py
+++ b/src/ethereum/forks/bpo5/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/bpo5/fork.py
+++ b/src/ethereum/forks/bpo5/fork.py
@@ -1002,7 +1002,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/cancun/blocks.py
+++ b/src/ethereum/forks/cancun/blocks.py
@@ -58,9 +58,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/cancun/fork.py
+++ b/src/ethereum/forks/cancun/fork.py
@@ -820,7 +820,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/osaka/blocks.py
+++ b/src/ethereum/forks/osaka/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/osaka/fork.py
+++ b/src/ethereum/forks/osaka/fork.py
@@ -1002,7 +1002,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/prague/blocks.py
+++ b/src/ethereum/forks/prague/blocks.py
@@ -59,9 +59,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/prague/fork.py
+++ b/src/ethereum/forks/prague/fork.py
@@ -985,7 +985,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum/forks/shanghai/blocks.py
+++ b/src/ethereum/forks/shanghai/blocks.py
@@ -57,9 +57,9 @@ class Withdrawal:
     The execution-layer address receiving the withdrawn ETH.
     """
 
-    amount: U256
+    amount: U64
     """
-    The amount of ETH being withdrawn.
+    The amount of ETH being withdrawn, in Gwei.
     """
 
 

--- a/src/ethereum/forks/shanghai/fork.py
+++ b/src/ethereum/forks/shanghai/fork.py
@@ -654,7 +654,7 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        create_ether(wd_state, wd.address, wd.amount * U256(10**9))
+        create_ether(wd_state, wd.address, U256(wd.amount) * U256(10**9))
 
     incorporate_tx_into_block(wd_state)
 

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -27,7 +27,7 @@ class Body:
 
     transactions: rlp.Extended
     ommers: rlp.Extended
-    withdrawals: Optional[List[Tuple[U64, U64, Bytes20, Uint]]]
+    withdrawals: Optional[List[Tuple[U64, U64, Bytes20, U64]]]
 
     def __init__(self, options: Any, stdin: Any = None):
         # Parse transactions
@@ -83,7 +83,7 @@ class Body:
                     parse_hex_or_int(wd["index"], U64),
                     parse_hex_or_int(wd["validatorIndex"], U64),
                     Bytes20(hex_to_bytes(wd["address"])),
-                    parse_hex_or_int(wd["amount"], Uint),
+                    parse_hex_or_int(wd["amount"], U64),
                 )
             )
 

--- a/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
@@ -96,7 +96,7 @@ class Load(BaseLoad):
             hex_to_u64(raw.get("index")),
             hex_to_u64(raw.get("validatorIndex")),
             self.fork.hex_to_address(raw.get("address")),
-            hex_to_u256(raw.get("amount")),
+            hex_to_u64(raw.get("amount")),
         ]
 
         return self.fork.Withdrawal(*parameters)

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -401,10 +401,10 @@ class T8N(Load):
             withdrawals = self.env.withdrawals or []
             fork_withdrawals = tuple(
                 self.fork.Withdrawal(
-                    Uint(int(w.index)),
-                    Uint(int(w.validator_index)),
+                    U64(int(w.index)),
+                    U64(int(w.validator_index)),
                     self.fork.hex_to_address(w.address.hex()),
-                    U256(int(w.amount)),
+                    U64(int(w.amount)),
                 )
                 for w in withdrawals
             )

--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -616,7 +616,7 @@ class BlockDownloader(ForkTracking):
                         self.module("utils.hexadecimal").hex_to_address(
                             j["address"]
                         ),
-                        hex_to_u256(j["amount"]),
+                        hex_to_u64(j["amount"]),
                     )
                 )
 

--- a/tests/json_loader/test_withdrawal_codec.py
+++ b/tests/json_loader/test_withdrawal_codec.py
@@ -1,0 +1,28 @@
+"""Test that withdrawal amounts decode as 64-bit unsigned integers."""
+
+import pytest
+from ethereum_rlp import rlp
+from ethereum_rlp.exceptions import RLPException
+from ethereum_types.numeric import U64, U256
+
+from ethereum.forks.amsterdam.blocks import Withdrawal
+from ethereum.state import Address
+
+
+def test_decode_max_withdrawal_amount() -> None:
+    """Round-trip a withdrawal with the largest valid amount."""
+    withdrawal = Withdrawal(
+        index=U64(0),
+        validator_index=U64(0),
+        address=Address(b"\x00" * 20),
+        amount=U64(2**64 - 1),
+    )
+    encoded = rlp.encode(withdrawal)
+    assert rlp.decode_to(Withdrawal, encoded) == withdrawal
+
+
+def test_decode_oversized_withdrawal_amount() -> None:
+    """Reject a withdrawal whose amount does not fit in 64 bits."""
+    encoded = rlp.encode((U64(0), U64(0), Address(b"\x00" * 20), U256(2**64)))
+    with pytest.raises(RLPException):
+        rlp.decode_to(Withdrawal, encoded)


### PR DESCRIPTION
### Description

EIP-4895 defines a withdrawal's `amount` as a `uint64`, but EELS models it as `U256`. This allows RLP decoding to accept withdrawal amounts outside the consensus type's valid range.

This PR:

- Models withdrawal amounts as `U64` across Shanghai and later forks.
- Converts withdrawal amounts to `U256` explicitly before applying the Gwei-to-Wei multiplier.
- Updates the fixture loader, b11r types, and sync paths to use the corrected type.
- Adds codec coverage for the maximum valid amount and rejection of values larger than 64 bits.

Valid withdrawal amounts continue to decode and process normally. Oversized amounts are now rejected at decoding time.

#### Validation

- `just static` on GitHub's current PR merge ref: passed
- `uv run pytest tests/json_loader/test_withdrawal_codec.py`: 2 passed

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A curious cat](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)