### PR TITLE
fix(test-specs): use integer division for genesis base fee

### DIFF
--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -280,7 +280,7 @@ class StateTest(BaseTest):
         if self.env.base_fee_per_gas:
             # Calculate genesis base fee per gas from state test's block#1 env
             kwargs["base_fee_per_gas"] = HexNumber(
-                int(int(str(self.env.base_fee_per_gas), 0) * 8 / 7)
+                int(str(self.env.base_fee_per_gas), 0) * 8 // 7
             )
 
         if self.env.excess_blob_gas:


### PR DESCRIPTION
### Description

When deriving the genesis `base_fee_per_gas` from a state test's block#1 env (`* 8 / 7`), the previous code used float division (`/` → `float`), then cast back with `int(...)`.

IEEE-754 `float64` only has a **53-bit mantissa**, so integers larger than `2^53` are not represented exactly. For large `base_fee_per_gas` values this can silently round before the integer conversion, producing an incorrect genesis base fee.

This change switches to pure integer arithmetic (`* 8 // 7`) so the scaling stays exact for arbitrary-size integers.

### Related Issues or PRs
N/A.

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![integer beaver](https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/American_Beaver.jpg/640px-American_Beaver.jpg)