### PR TITLE
fix(test-specs): parenthesize walrus when counting failing txs

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -848,7 +848,7 @@ class BlockchainTest(BaseTest):
             ]
         txs = [tx.with_signature_and_sender() for tx in txs]
 
-        if failing_tx_count := len([tx for tx in txs if tx.error]) > 0:
+        if (failing_tx_count := len([tx for tx in txs if tx.error])) > 0:
             if failing_tx_count > 1:
                 raise Exception(
                     "test correctness: only one transaction can produce "


### PR DESCRIPTION
### Description

Fix operator precedence around the walrus assignment when counting failing transactions:

```python
# Before (wrong): assigns bool because `>` binds tighter than `:=`
if failing_tx_count := len([...]) > 0:

# After (correct): assigns the count, then compares
if (failing_tx_count := len([...])) > 0:
```

Previously `failing_tx_count` was always `True`/`False`, so `failing_tx_count > 1` never detected multiple failing transactions and the correctness check was effectively dead.

### Related Issues or PRs
N/A.

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![walrus](https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Pacific_Walrus_-_Bull_%288247646616%29.jpg/640px-Pacific_Walrus_-_Bull_%288247646616%29.jpg)