### PR TITLE
feat(tests): add more EIP-2780 tests

### DIFF
--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_oog.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_oog.py
@@ -400,7 +400,10 @@ def test_recipient_charge_oog_rolls_back_delegations(
 
     The recipient and both authorities were accessed before the halt,
     so per EIP-7928 all three must still appear in the block access
-    list, with no recorded changes.
+    list, with no recorded changes. The recipient's delegation target
+    is only ever loaded by the resolution the starved charge pays for,
+    so it must be absent from the list on the out-of-gas side and
+    present (with no changes) on the succeeding side.
 
     The ``succeeds`` control restores the one starved gas: the
     recipient charge is covered exactly, the dispatch completes (the
@@ -416,6 +419,7 @@ def test_recipient_charge_oog_rolls_back_delegations(
     auth_charges = _auth_top_frame_charges(fork, authorization_list)
 
     recipient_bal = BalAccountExpectation.empty()
+    delegation_target_bal: dict[Address, BalAccountExpectation | None] = {}
     if recipient_charge == "new_account":
         recipient = pre.fund_eoa(amount=0)
         value = 1
@@ -443,6 +447,13 @@ def test_recipient_charge_oog_rolls_back_delegations(
             balance=EOA_INITIAL_BALANCE,
             code=Spec7702.delegation_designation(delegated_to),
         )
+        # The delegation target is only loaded by the resolution access
+        # the starved charge pays for: read (unchanged) on success,
+        # never accessed -- so absent from the block access list -- when
+        # the charge runs out.
+        delegation_target_bal = {
+            delegated_to: BalAccountExpectation.empty() if succeeds else None
+        }
 
     intrinsic_regular = _intrinsic_regular(
         fork,
@@ -481,6 +492,7 @@ def test_recipient_charge_oog_rolls_back_delegations(
                 recipient: recipient_bal,
                 auth_a.authority: _applied_delegation_bal(auth_a),
                 auth_b.authority: _applied_delegation_bal(auth_b),
+                **delegation_target_bal,
             }
         )
     else:
@@ -494,6 +506,7 @@ def test_recipient_charge_oog_rolls_back_delegations(
                 recipient: BalAccountExpectation.empty(),
                 auth_a.authority: BalAccountExpectation.empty(),
                 auth_b.authority: BalAccountExpectation.empty(),
+                **delegation_target_bal,
             }
         )
 
@@ -564,6 +577,10 @@ def test_reservoir_settlement_by_failure_point(
 
     sender = pre.fund_eoa()
 
+    # Two distinct delegation targets are in play. ``delegation_target``
+    # is the address every *authority's* authorization designates:
+    # ``set_delegation`` writes it into the authorities' code but never
+    # reads the account itself.
     delegation_target = pre.deploy_contract(code=Op.STOP)
     recipient_code: Bytecode
     if failure_point == "execution_halt":
@@ -572,6 +589,9 @@ def test_reservoir_settlement_by_failure_point(
         recipient_code = Op.REVERT(0, 0)
     else:
         recipient_code = Op.STOP
+    # ``code_target`` is the *recipient's* pre-existing delegation
+    # target: the top-frame dispatch pays a cold access to resolve it
+    # and, once paid, loads and runs its code.
     code_target = pre.deploy_contract(code=recipient_code)
     recipient = pre.fund_eoa(
         amount=EOA_INITIAL_BALANCE, delegation=code_target
@@ -698,7 +718,11 @@ def test_reservoir_settlement_by_failure_point(
     # with their persisted nonce and code writes past an execution
     # failure, with no recorded changes past a preparation rollback.
     # The recipient is only loaded once preparation reaches the
-    # dispatch charge.
+    # dispatch charge, and its delegation target only once that charge
+    # is paid and the delegated code loads -- so both out-of-gas
+    # scenarios must leave the target absent from the list. The
+    # authorities' delegation target is never read at all: writing a
+    # designation does not access the designated account.
     if delegations_persist:
         authority_bal = BalAccountExpectation(
             nonce_changes=[BalNonceChange(block_access_index=1, post_nonce=1)],
@@ -718,9 +742,14 @@ def test_reservoir_settlement_by_failure_point(
         if failure_point == "set_delegation_oog"
         else BalAccountExpectation.empty()
     )
+    code_target_bal = (
+        BalAccountExpectation.empty() if delegations_persist else None
+    )
     expected_block_access_list = BlockAccessListExpectation(
         account_expectations={
             recipient: recipient_bal,
+            code_target: code_target_bal,
+            delegation_target: None,
             **dict.fromkeys(authorities, authority_bal),
         }
     )
@@ -902,7 +931,9 @@ def test_reservoir_settlement_with_value_to_empty_recipient(
     # The recipient is first loaded for its NEW_ACCOUNT alive-check, so
     # it is absent from the block access list only when the halt lands
     # inside set_delegation; afterwards it appears with no net change
-    # (the transfer, if any, rolled back).
+    # (the transfer, if any, rolled back). The authorities' delegation
+    # target is never read at all: writing a designation does not
+    # access the designated account.
     if delegations_persist:
         authority_bal = BalAccountExpectation(
             nonce_changes=[BalNonceChange(block_access_index=1, post_nonce=1)],
@@ -925,6 +956,7 @@ def test_reservoir_settlement_with_value_to_empty_recipient(
     expected_block_access_list = BlockAccessListExpectation(
         account_expectations={
             recipient: recipient_bal,
+            delegation_target: None,
             **dict.fromkeys(authorities, authority_bal),
         }
     )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
@@ -109,8 +109,7 @@ def test_calldata_floor(
       thing that can reject it, with
       ``INTRINSIC_GAS_BELOW_FLOOR_GAS_COST``.
     """
-    sender_initial_balance = 10**18
-    sender = pre.fund_eoa(sender_initial_balance)
+    sender = pre.fund_eoa()
     is_self_transfer = recipient_type == RecipientType.SELF
     target = (
         sender
@@ -271,8 +270,7 @@ def test_calldata_floor_contract_creation(
       the creation intrinsic, so the rejection is pinned to the floor,
       with ``INTRINSIC_GAS_BELOW_FLOOR_GAS_COST``.
     """
-    sender_initial_balance = 10**18
-    sender = pre.fund_eoa(sender_initial_balance)
+    sender = pre.fund_eoa()
     created = compute_create_address(address=sender, nonce=sender.nonce)
 
     init_code = _floor_dominating_initcode(fork)
@@ -316,7 +314,7 @@ def test_calldata_floor_contract_creation(
             to=None,
             value=value,
             data=init_code,
-            gas_limit=calldata_floor + 1_000,
+            gas_limit=calldata_floor,
             expected_receipt=TransactionReceipt(
                 cumulative_gas_used=calldata_floor,
             ),

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
@@ -1,20 +1,4 @@
-"""
-EIP-2780 interaction with the EIP-7623/7976 calldata floor.
-
-A transaction's gas accounting uses ``max(intrinsic, calldata_floor)``.
-EIP-2780 decomposes the intrinsic (``TX_BASE`` + recipient access +
-value-transfer charges) and lowers ``TX_BASE`` to 12_000; that lowered
-base also feeds the calldata floor. These tests pin the data-heavy
-regime where the floor dominates:
-
-- The floor binds, so ``gas_used`` equals the floor and the
-  recipient/value charges folded into the intrinsic are masked: the
-  gas paid is identical for a zero-value and a value-bearing
-  transaction of the same calldata size.
-- One gas below the floor, the transaction is rejected with
-  ``INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`` even though it covers the
-  (smaller) decomposed intrinsic.
-"""
+"""EIP-2780 interaction with the EIP-7623/7976 calldata floor."""
 
 import pytest
 from execution_testing import (
@@ -27,6 +11,8 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
     TransactionException,
+    TransactionReceipt,
+    compute_create_address,
 )
 
 from ...prague.eip7623_increase_calldata_cost.helpers import (
@@ -44,13 +30,15 @@ pytestmark = pytest.mark.valid_from("Amsterdam")
 def _floor_dominating_calldata(fork: Fork) -> Bytes:
     """
     Return zero-byte calldata sized so its calldata floor strictly
-    exceeds the decomposed value-transfer intrinsic for a non-create
-    call to an existing EOA.
+    exceeds the decomposed intrinsic of every non-create shape
+    ``test_calldata_floor`` runs.
 
     Reuses the shared EIP-7623 ``find_floor_cost_threshold`` binary
-    search against this transaction shape, then steps one byte past the
-    threshold (the last size where the floor does not yet dominate) so
-    the floor strictly binds.
+    search against the costliest such shape (a value-bearing transfer
+    to a distinct EOA), then steps one byte past the threshold (the
+    last size where the floor does not yet dominate) so the floor
+    strictly binds -- for that shape, and a fortiori for the cheaper
+    self-transfer shape.
     """
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     floor_calc = fork.transaction_data_floor_cost_calculator()
@@ -94,7 +82,170 @@ def _floor_dominating_calldata(fork: Fork) -> Bytes:
         pytest.param(1, id="non-zero_value"),
     ],
 )
+@pytest.mark.parametrize(
+    "recipient_type",
+    [
+        pytest.param(RecipientType.EOA, id="other_eoa"),
+        pytest.param(RecipientType.SELF, id="self_transfer"),
+    ],
+)
 def test_calldata_floor(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    outcome: str,
+    value: int,
+    recipient_type: RecipientType,
+) -> None:
+    """
+    A data-heavy transaction to an existing EOA -- a distinct account
+    or the sender itself -- whose calldata floor exceeds the decomposed
+    value-transfer intrinsic.
+
+    - ``floor_binds``: with a gas limit above the floor, ``gas_used``
+      pins to the floor.
+    - ``below_floor``: a gas limit one short of the floor still covers
+      the (smaller) decomposed intrinsic, so the floor is the only
+      thing that can reject it, with
+      ``INTRINSIC_GAS_BELOW_FLOOR_GAS_COST``.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+    is_self_transfer = recipient_type == RecipientType.SELF
+    target = (
+        sender
+        if is_self_transfer
+        else pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+    )
+
+    calldata = _floor_dominating_calldata(fork)
+    calldata_floor = fork.transaction_data_floor_cost_calculator()(
+        data=calldata,
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata,
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+    # The calldata was sized against the costliest shape (value moving
+    # to a distinct EOA), so the floor dominates the carved-out
+    # self-transfer intrinsic a fortiori.
+    assert intrinsic_gas < calldata_floor, (
+        "the calldata floor must dominate the decomposed intrinsic"
+    )
+
+    post: dict[Address, Account] = {}
+    if outcome == "below_floor":
+        # ``gas_limit`` one short of the floor still covers the
+        # decomposed intrinsic, so the floor is the only thing that can
+        # reject it; the post state is empty (transaction rejected).
+        # The transaction is rejected, never included in a block, so
+        # there is no receipt to assert against; the ``error`` is the
+        # whole expectation.
+        gas_limit = calldata_floor - 1
+        tx = Transaction(
+            sender=sender,
+            to=target,
+            value=value,
+            data=calldata,
+            gas_limit=gas_limit,
+            error=TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+        )
+    else:
+        # ``floor_binds``: no explicit gas limit (auto-fills above the
+        # floor). Each shape pays exactly its own floor -- the
+        # decomposed base survives into it -- and the transferred wei
+        # nets to zero on a self-transfer.
+        tx = Transaction(
+            sender=sender,
+            to=target,
+            value=value,
+            data=calldata,
+            expected_receipt=TransactionReceipt(
+                cumulative_gas_used=calldata_floor,
+            ),
+        )
+        post = {
+            sender: Account(nonce=1),
+        }
+        if not is_self_transfer:
+            post[target] = Account(balance=EOA_INITIAL_BALANCE + value)
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+def _floor_dominating_initcode(fork: Fork) -> Bytes:
+    """
+    Return zero-byte init code sized so its calldata floor strictly
+    exceeds a creation transaction's full cost, for
+    ``test_calldata_floor_contract_creation`` (the only creation-
+    transaction test in this module; ``test_calldata_floor`` uses
+    ``_floor_dominating_calldata`` instead).
+
+    All-zero init code executes a single free ``STOP`` and deploys
+    empty code, so the transaction's cost is the creation intrinsic
+    plus the created account's top-frame ``NEW_ACCOUNT`` state charge,
+    with no execution or deposit gas. The threshold search runs against
+    that total, then steps one byte past it so the floor strictly
+    binds.
+    """
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    floor_calc = fork.transaction_data_floor_cost_calculator()
+    new_account_state_gas = fork.transaction_top_frame_state_gas(
+        contract_creation=True,
+    )
+
+    def total(byte_count: int) -> int:
+        return (
+            intrinsic_calc(
+                calldata=b"\x00" * byte_count,
+                contract_creation=True,
+                sends_value=True,
+                return_cost_deducted_prior_execution=True,
+            )
+            + new_account_state_gas
+        )
+
+    def floor(byte_count: int) -> int:
+        return floor_calc(
+            data=b"\x00" * byte_count,
+            contract_creation=True,
+        )
+
+    threshold = find_floor_cost_threshold(
+        floor_data_gas_cost_calculator=floor,
+        intrinsic_gas_cost_calculator=total,
+    )
+    byte_count = threshold + 1
+
+    assert floor(byte_count) > total(byte_count)
+    assert byte_count <= fork.max_initcode_size()
+    return Bytes(b"\x00" * byte_count)
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        pytest.param("floor_binds", id="floor_binds"),
+        pytest.param(
+            "below_floor",
+            id="below_floor_rejected",
+            marks=pytest.mark.exception_test,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_calldata_floor_contract_creation(
     fork: Fork,
     pre: Alloc,
     state_test: StateTestFiller,
@@ -102,74 +253,77 @@ def test_calldata_floor(
     value: int,
 ) -> None:
     """
-    A data-heavy transaction to an existing EOA whose calldata floor
-    exceeds the decomposed value-transfer intrinsic.
+    A contract creation whose calldata floor exceeds the creation
+    intrinsic plus the created account's ``NEW_ACCOUNT`` state charge.
 
-    - ``floor_binds``: with a gas limit above the floor, ``gas_used``
-      pins to the floor, so the value-transfer charges
-      (``TRANSFER_LOG_COST + TX_VALUE_COST``) folded into the intrinsic
-      are masked -- the gas paid is identical at ``value == 0`` and
-      ``value == 1`` and only the moved wei differs.
+    The init code is all zeros: it executes a free ``STOP``, deploys
+    empty code, and prices every byte as one floor token.
+
+    - ``floor_binds``: ``gas_used`` pins to the floor, which anchors
+      on the creation regular base (``TX_BASE + CREATE_ACCESS``, plus
+      ``TRANSFER_LOG_COST`` when value moves) but excludes the created
+      account's ``NEW_ACCOUNT`` *state* charge and the init-code word
+      cost -- both masked by the binding floor -- while the deploy
+      (and any moved wei) still lands. The receipt pins the floor
+      exactly, so the value-bearing case sits precisely
+      ``TRANSFER_LOG_COST`` above the zero-value one.
     - ``below_floor``: a gas limit one short of the floor still covers
-      the (smaller) decomposed intrinsic, so the floor -- built on the
-      EIP-2780-lowered ``TX_BASE`` -- is the only thing that can reject
-      it, with ``INTRINSIC_GAS_BELOW_FLOOR_GAS_COST``.
+      the creation intrinsic, so the rejection is pinned to the floor,
+      with ``INTRINSIC_GAS_BELOW_FLOOR_GAS_COST``.
     """
     sender_initial_balance = 10**18
     sender = pre.fund_eoa(sender_initial_balance)
-    target = pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+    created = compute_create_address(address=sender, nonce=sender.nonce)
 
-    calldata = _floor_dominating_calldata(fork)
+    init_code = _floor_dominating_initcode(fork)
     calldata_floor = fork.transaction_data_floor_cost_calculator()(
-        data=calldata,
+        data=init_code,
+        contract_creation=True,
         sends_value=bool(value),
-        recipient_type=RecipientType.EOA,
     )
-    gas_price = 1_000_000_000
 
-    post: dict[Address, Account] = {}
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+    assert intrinsic_gas < calldata_floor, (
+        "the calldata floor must dominate the creation intrinsic"
+    )
+
+    post: dict[Address, Account | None] = {}
     if outcome == "below_floor":
-        # ``gas_limit`` one short of the floor still covers the
-        # decomposed intrinsic, so the floor is the only thing that can
-        # reject it; the post state is empty (transaction rejected).
-        intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
-            calldata=calldata,
-            sends_value=bool(value),
-            recipient_type=RecipientType.EOA,
-            return_cost_deducted_prior_execution=True,
-        )
+        # One gas short of the floor still covers the creation
+        # intrinsic, so the floor is the only thing that can reject it;
+        # the post state is empty and there is no receipt to assert
+        # against (transaction rejected, never included).
         gas_limit = calldata_floor - 1
-        assert intrinsic_gas <= gas_limit, (
-            "gas_limit must still cover the decomposed intrinsic so the "
-            "rejection is pinned to the calldata floor"
-        )
         tx = Transaction(
             sender=sender,
-            to=target,
+            to=None,
             value=value,
-            data=calldata,
+            data=init_code,
             gas_limit=gas_limit,
-            gas_price=gas_price,
             error=TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
         )
     else:
-        # ``floor_binds``: no explicit gas limit (auto-fills above the
-        # floor). The gas component is the floor regardless of value
-        # (charges masked); only the transferred wei changes the
-        # balance.
+        # ``floor_binds``: headroom above the floor; the receipt pins
+        # ``gas_used`` to exactly the floor, so the ``NEW_ACCOUNT``
+        # state charge is masked while the deploy still happens.
         tx = Transaction(
             sender=sender,
-            to=target,
+            to=None,
             value=value,
-            data=calldata,
-            gas_price=gas_price,
-        )
-        sender_final_balance = (
-            sender_initial_balance - value - calldata_floor * gas_price
+            data=init_code,
+            gas_limit=calldata_floor + 1_000,
+            expected_receipt=TransactionReceipt(
+                cumulative_gas_used=calldata_floor,
+            ),
         )
         post = {
-            sender: Account(nonce=1, balance=sender_final_balance),
-            target: Account(balance=EOA_INITIAL_BALANCE + value),
+            sender: Account(nonce=1),
+            created: Account(nonce=1, balance=value, code=b""),
         }
 
     state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py
@@ -17,6 +17,9 @@ pre-fork ``TX_BASE`` of 21_000 as follows:
 - A self-transfer is fully carved out post-fork: it pays only the
   lowered ``TX_BASE`` with no recipient or value-transfer charge,
   regardless of value, the largest reduction.
+- A contract creation splits the flat pre-fork ``TX_CREATE`` into the
+  ``CREATE_ACCESS`` regular intrinsic and a top-frame ``NEW_ACCOUNT``
+  state charge.
 """
 
 import pytest
@@ -26,9 +29,11 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Op,
     RecipientType,
     Transaction,
     TransitionFork,
+    compute_create_address,
 )
 
 from .helpers import EOA_INITIAL_BALANCE
@@ -150,5 +155,122 @@ def test_intrinsic_reduction_across_amsterdam_transition(
         post[sender] = Account(nonce=1, balance=sender_final_balance)
         if not self_transfer:
             post[target] = Account(balance=EOA_INITIAL_BALANCE + value)
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_creation_tx_intrinsic_across_amsterdam_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: TransitionFork,
+    value: int,
+) -> None:
+    """
+    Pin the EIP-2780 creation-transaction change across the Amsterdam
+    boundary.
+
+    The same creation transaction (``to=None``, ``STOP`` init code that
+    deploys empty code) is sent in a pre-fork block and a post-fork
+    block, each from a fresh sender with the gas limit pinned exactly.
+    Pre-fork the whole cost is regular intrinsic: ``TX_BASE`` plus the
+    flat ``TX_CREATE``. Post-fork the intrinsic keeps only the
+    ``CREATE_ACCESS`` regular portion of ``TX_CREATE`` (plus the
+    transfer-log charge when value moves), while the created account's
+    ``NEW_ACCOUNT`` is charged as *state* gas at the top frame — the
+    sender-facing total is the sum of both.
+
+    The per-fork costs are hand-derived from each fork's gas constants
+    and checked against the calculators, so a calculator regression
+    fails with a clear message rather than only as a downstream balance
+    mismatch.
+    """
+    gas_price = 1_000_000_000
+    init_code = Op.STOP
+
+    pre_fork = fork.fork_at(timestamp=PRE_FORK_TIMESTAMP)
+    post_fork = fork.fork_at(timestamp=POST_FORK_TIMESTAMP)
+    pre_costs = pre_fork.gas_costs()
+    post_costs = post_fork.gas_costs()
+
+    # Shared calldata terms for the one-byte STOP init code: a single
+    # zero-byte token, plus the EIP-3860 metering of one 32-byte init
+    # code word at 2 gas. Identical on both sides of the fork.
+    assert (
+        post_costs.TX_DATA_TOKEN_STANDARD == pre_costs.TX_DATA_TOKEN_STANDARD
+    )
+    init_code_terms = pre_costs.TX_DATA_TOKEN_STANDARD + 2
+
+    # Pre-fork: flat regular intrinsic, no top-frame charge.
+    expected_pre = pre_costs.TX_BASE + pre_costs.TX_CREATE + init_code_terms
+    # Post-fork: EIP-8037 folds ``NEW_ACCOUNT`` into ``TX_CREATE``;
+    # EIP-2780 moves that state portion to the top frame, leaving the
+    # ``CREATE_ACCESS`` regular remainder in the intrinsic.
+    expected_post = (
+        post_costs.TX_BASE
+        + (post_costs.TX_CREATE - post_costs.NEW_ACCOUNT)
+        + init_code_terms
+    )
+    if value:
+        expected_post += post_costs.TRANSFER_LOG_COST
+    expected_post_state = post_costs.NEW_ACCOUNT
+
+    timestamps = [PRE_FORK_TIMESTAMP, POST_FORK_TIMESTAMP]
+    expected_intrinsics = [expected_pre, expected_post]
+    expected_top_frame_states = [0, expected_post_state]
+    blocks = []
+    post: dict[Address, Account] = {}
+
+    for timestamp, expected_intrinsic, expected_state in zip(
+        timestamps, expected_intrinsics, expected_top_frame_states, strict=True
+    ):
+        sub_fork = fork.fork_at(timestamp=timestamp)
+        intrinsic_gas = sub_fork.transaction_intrinsic_cost_calculator()(
+            calldata=init_code,
+            contract_creation=True,
+            sends_value=bool(value),
+            return_cost_deducted_prior_execution=True,
+        )
+        assert intrinsic_gas == expected_intrinsic, (
+            f"creation intrinsic at timestamp {timestamp} ({sub_fork}) is "
+            f"{intrinsic_gas}, expected {expected_intrinsic}"
+        )
+        top_frame_state_gas = sub_fork.transaction_top_frame_state_gas(
+            contract_creation=True,
+        )
+        assert top_frame_state_gas == expected_state, (
+            f"top-frame state gas at timestamp {timestamp} ({sub_fork}) is "
+            f"{top_frame_state_gas}, expected {expected_state}"
+        )
+
+        sender_initial_balance = 10**18
+        sender = pre.fund_eoa(sender_initial_balance)
+        created = compute_create_address(address=sender, nonce=sender.nonce)
+
+        # The STOP init code costs no execution gas and deploys empty
+        # code (no deposit charges), so the gas limit is pinned to
+        # exactly the intrinsic plus the fork's top-frame state charge.
+        total_gas = intrinsic_gas + top_frame_state_gas
+        tx = Transaction(
+            sender=sender,
+            to=None,
+            data=init_code,
+            value=value,
+            gas_limit=total_gas,
+            gas_price=gas_price,
+        )
+        blocks.append(Block(timestamp=timestamp, txs=[tx]))
+
+        post[sender] = Account(
+            nonce=1,
+            balance=sender_initial_balance - value - total_gas * gas_price,
+        )
+        post[created] = Account(nonce=1, balance=value, code=b"")
 
     blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
@@ -6,14 +6,18 @@ The top-frame layer applies *after* intrinsic gas is deducted but
 charges may fire there, depending on the recipient:
 
 - ``NEW_ACCOUNT`` (state gas) when the recipient is empty and the
-  transaction transfers value.
+  transaction transfers value, or when a creation transaction's target
+  leaf did not exist before the transaction.
 - ``COLD_ACCOUNT_ACCESS`` (regular gas) when the recipient holds an
   EIP-7702 delegation.
 
 Each test parametrizes over the interesting outcomes for that charge:
 running out of gas at the boundary, succeeding through the charge and
 into the EVM, and (for the regular charge) succeeding through the
-charge but reverting from the delegated code.
+charge but reverting from the delegated code. For creation
+transactions, the charge keys on the *transaction pre-state* being
+empty, and — being consumed on any successful halt — survives the
+created account's own destruction.
 """
 
 import pytest
@@ -23,15 +27,19 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     Fork,
     Header,
     Op,
     RecipientType,
     StateTestFiller,
     Transaction,
+    TransactionReceipt,
+    compute_create_address,
 )
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .helpers import EOA_INITIAL_BALANCE
 from .spec import ref_spec_2780
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
@@ -296,6 +304,227 @@ def test_top_frame_new_account_skipped_for_nonce_only_recipient(
     state_test(pre=pre, tx=tx, post=post)
 
 
+def creation_tx_init_code(fork: Fork) -> tuple[Bytecode, int]:
+    """
+    Build init code for exact-gas creation-transaction tests and return
+    it with its execution gas.
+
+    The code deploys empty code (no deposit charges) and expands memory
+    so that its execution gas lifts the transaction's exact total above
+    the calldata floor, which would otherwise bind once the top-frame
+    ``NEW_ACCOUNT`` charge is skipped.
+    """
+    memory_offset = 30_000
+    init_code = (
+        Op.MSTORE.with_metadata(
+            new_memory_size=memory_offset + 32, old_memory_size=0
+        )(memory_offset, 0)
+        + Op.STOP
+    )
+    return init_code, init_code.gas_cost(fork)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_new_account_skipped_for_prefunded_create_target(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    A creation transaction whose nonce-derived target address already
+    holds a balance does not incur the top-frame ``NEW_ACCOUNT`` state
+    charge.
+
+    The create branch of ``prepare_dispatch`` keys the charge on the
+    *transaction pre-state* being empty — a live check would always see
+    the account, because ``process_create_message`` bumps the target's
+    nonce before dispatch. Pre-funding the create address makes the
+    pre-state leaf non-empty, so the charge must be skipped; a
+    balance-only leaf does not trigger the create-collision check
+    (only nonce or code do), so the deployment still succeeds.
+
+    The gas limit carries headroom above the exact total so the
+    transaction never runs out of gas, and the receipt pins
+    ``cumulative_gas_used`` to exactly the intrinsic plus the init-code
+    execution gas: a wrongly charged ``NEW_ACCOUNT`` for the
+    pre-existing leaf (or a spurious refill) shifts the receipt by
+    183,600 in either direction.
+    """
+    sender = pre.fund_eoa()
+    created = compute_create_address(address=sender, nonce=sender.nonce)
+    prefund = 1
+    pre.fund_address(created, prefund)
+
+    init_code, exec_gas = creation_tx_init_code(fork)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+    # The amount a fresh create target would be charged at the top
+    # frame -- the charge this test asserts is skipped.
+    fresh_target_state_gas = fork.transaction_top_frame_state_gas(
+        contract_creation=True,
+    )
+    assert fresh_target_state_gas > 0, (
+        "a fresh create target must be charged top-frame state gas"
+    )
+
+    total_gas = intrinsic_gas + exec_gas
+    calldata_floor = fork.transaction_data_floor_cost_calculator()(
+        data=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+    )
+    assert total_gas > calldata_floor, (
+        "the exact total must exceed the calldata floor for the "
+        "gas pin to observe the skipped charge"
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=init_code,
+        value=value,
+        gas_limit=total_gas + 1_000,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=total_gas),
+    )
+
+    post = {
+        sender: Account(nonce=1),
+        created: Account(nonce=1, balance=prefund + value, code=b""),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_new_account_skipped_for_create_target_funded_same_block(
+    fork: Fork,
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    value: int,
+) -> None:
+    """
+    A creation transaction whose target was funded by an *earlier
+    transaction of the same block* does not incur the top-frame
+    ``NEW_ACCOUNT`` state charge.
+
+    This discriminates the transaction pre-state from the block
+    pre-state: ``get_pre_state_account`` consults the block's
+    accumulated same-block transaction writes before falling back to
+    the block pre-state, so the funding transaction's new leaf counts
+    as pre-existing for the creation transaction. An implementation
+    snapshotting at block start would charge a second ``NEW_ACCOUNT``,
+    shifting the creation transaction's receipt by 183,600 and
+    doubling the state dimension pinned by the header.
+
+    The funding transaction pays its own top-frame ``NEW_ACCOUNT`` for
+    materializing the leaf, which the block header pins as the block's
+    entire state-gas dimension: ``gas_used = max(regular, state)`` must
+    equal exactly one ``NEW_ACCOUNT``.
+    """
+    funder = pre.fund_eoa()
+    sender = pre.fund_eoa()
+    created = compute_create_address(address=sender, nonce=sender.nonce)
+
+    # Transaction 1: fund the future create address. The value transfer
+    # to the not-yet-existing leaf pays the top-frame ``NEW_ACCOUNT``.
+    prefund = 1
+    fund_intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        return_cost_deducted_prior_execution=True,
+    )
+    fund_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    assert fund_state_gas > 0, (
+        "funding an empty leaf must charge top-frame state gas"
+    )
+    fund_total = fund_intrinsic + fund_state_gas
+    fund_tx = Transaction(
+        sender=funder,
+        to=created,
+        value=prefund,
+        gas_limit=fund_total,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=fund_total),
+    )
+
+    # Transaction 2: the creation transaction, with gas headroom; the
+    # receipt pins the consumed gas to exactly the ``NEW_ACCOUNT``-free
+    # total.
+    init_code, exec_gas = creation_tx_init_code(fork)
+    create_intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+    create_total = create_intrinsic + exec_gas
+    calldata_floor = fork.transaction_data_floor_cost_calculator()(
+        data=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+    )
+    assert create_total > calldata_floor, (
+        "the exact total must exceed the calldata floor for the "
+        "gas pin to observe the skipped charge"
+    )
+    create_tx = Transaction(
+        sender=sender,
+        to=None,
+        data=init_code,
+        value=value,
+        gas_limit=create_total + 1_000,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=fund_total + create_total
+        ),
+    )
+
+    # Header pin: the block's state dimension is exactly the funding
+    # transaction's ``NEW_ACCOUNT``; both regular intrinsics sit at or
+    # above their calldata floors, so no floor term enters the block's
+    # regular dimension either.
+    block_regular = fund_intrinsic + create_total
+    assert fund_state_gas > block_regular, (
+        "the state dimension must dominate for the header to pin it"
+    )
+
+    post = {
+        funder: Account(nonce=1),
+        sender: Account(nonce=1),
+        created: Account(nonce=1, balance=prefund + value, code=b""),
+    }
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[fund_tx, create_tx],
+                header_verify=Header(gas_used=fund_state_gas),
+            ),
+        ],
+        post=post,
+    )
+
+
 @pytest.mark.parametrize("outcome", ["oog", "success", "evm_reverts"])
 @pytest.mark.parametrize(
     "value",
@@ -391,3 +620,194 @@ def test_top_frame_regular_charge(
     }
 
     state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "beneficiary_kind",
+    [
+        pytest.param("self", id="self_beneficiary"),
+        pytest.param("funded_external", id="funded_external_beneficiary"),
+        pytest.param("empty_external", id="empty_external_beneficiary"),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_initcode_selfdestruct_keeps_top_frame_state_charge(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    beneficiary_kind: str,
+    value: int,
+) -> None:
+    """
+    A creation transaction whose init code ``SELFDESTRUCT``s keeps the
+    top-frame ``NEW_ACCOUNT`` state charge consumed.
+
+    ``SELFDESTRUCT`` is a *successful* halt: the frame returns no
+    output (an empty deposit, so no deposit charges) and no rollback
+    runs, so the refill machinery that returns state gas on a revert or
+    exceptional halt never triggers — even though the created account
+    is destroyed at the end of the transaction (EIP-6780 same-tx
+    deletion) and its leaf never persists. Deletion itself carries no
+    state-gas credit: freeing state is not refunded.
+
+    Where the endowment ends up follows EIP-8246: destruction preserves
+    a nonzero balance, so a self beneficiary leaves a balance-only leaf
+    behind, while sweeping to an external beneficiary (or a zero
+    endowment) removes the account entirely. Sweeping value to a
+    not-yet-existing beneficiary additionally pays the opcode-level
+    ``NEW_ACCOUNT`` and ``ACCOUNT_WRITE`` for the beneficiary — both
+    the destroyed target's top-frame charge and the sweep's charge stay
+    paid.
+
+    The receipt pins the exact total; a regression refilling the
+    top-frame charge shows up as a 183,600 shortfall in
+    ``cumulative_gas_used`` and a matching sender refund.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+    created = compute_create_address(address=sender, nonce=sender.nonce)
+
+    beneficiary: Address | None = None
+    if beneficiary_kind == "self":
+        # The created address is warmed for the create frame itself.
+        init_code = Op.SELFDESTRUCT.with_metadata(
+            address_warm=True, account_new=False
+        )(Op.ADDRESS)
+    elif beneficiary_kind == "funded_external":
+        beneficiary = pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+        init_code = Op.SELFDESTRUCT.with_metadata(
+            address_warm=False, account_new=False
+        )(beneficiary)
+    else:
+        beneficiary = pre.nonexistent_account()
+        # Sweeping a non-zero balance into a non-existent leaf creates
+        # the beneficiary, paying NEW_ACCOUNT (state) and ACCOUNT_WRITE
+        # (regular) at the opcode.
+        init_code = Op.SELFDESTRUCT.with_metadata(
+            address_warm=False, account_new=bool(value)
+        )(beneficiary)
+
+    # Combined regular + state execution gas, including any sweep
+    # charges modeled by the metadata above.
+    exec_gas = init_code.gas_cost(fork)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        contract_creation=True,
+    )
+    assert top_frame_state_gas > 0, (
+        "a fresh create target must be charged top-frame state gas"
+    )
+    total_gas = intrinsic_gas + top_frame_state_gas + exec_gas
+
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=init_code,
+        value=value,
+        gas_limit=total_gas + 1_000,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=total_gas),
+    )
+
+    post: dict[Address, Account | None] = {sender: Account(nonce=1)}
+    if beneficiary_kind == "self":
+        # EIP-8246: destruction preserves the balance, so a non-zero
+        # endowment survives as a balance-only leaf.
+        post[created] = (
+            Account(balance=value, nonce=0, code=b"") if value else None
+        )
+    elif beneficiary_kind == "funded_external":
+        assert beneficiary is not None
+        post[created] = None
+        post[beneficiary] = Account(balance=EOA_INITIAL_BALANCE + value)
+    else:
+        assert beneficiary is not None
+        post[created] = None
+        # A zero-value sweep does not bring the beneficiary to life.
+        post[beneficiary] = Account(balance=value) if value else None
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+def test_initcode_selfdestruct_state_gas_in_header(
+    fork: Fork,
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    The top-frame ``NEW_ACCOUNT`` surviving an init-code
+    ``SELFDESTRUCT`` stays in the *state* dimension after settlement.
+
+    Receipts and balances only observe the sum of the two gas
+    dimensions, so the sibling
+    ``test_initcode_selfdestruct_keeps_top_frame_state_charge`` cannot
+    distinguish which dimension the surviving charge settled into. The
+    block header can: ``gas_used = max(block_regular, block_state)``,
+    and with a zero endowment and a self beneficiary the whole created
+    account vanishes while the state side (one ``NEW_ACCOUNT``,
+    dominating the small regular side) must still show in the header.
+
+    Bug signatures: a refill regression collapses the header to the
+    small regular sum; a regular-gas mis-classification raises it to
+    ``regular + NEW_ACCOUNT``.
+    """
+    sender = pre.fund_eoa(10**18)
+    created = compute_create_address(address=sender, nonce=sender.nonce)
+
+    init_code = Op.SELFDESTRUCT.with_metadata(
+        address_warm=True, account_new=False
+    )(Op.ADDRESS)
+    exec_regular = init_code.regular_cost(fork)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        return_cost_deducted_prior_execution=True,
+    )
+    state_side = fork.transaction_top_frame_state_gas(
+        contract_creation=True,
+    )
+    calldata_floor = fork.transaction_data_floor_cost_calculator()(
+        data=init_code,
+        contract_creation=True,
+    )
+    # Block accounting carries the calldata floor in the regular
+    # dimension.
+    regular_side = max(intrinsic_gas + exec_regular, calldata_floor)
+    assert state_side > regular_side, (
+        "the state dimension must dominate for the header to pin it"
+    )
+
+    total_gas = intrinsic_gas + state_side + exec_regular
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=init_code,
+        gas_limit=total_gas + 1_000,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=total_gas),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=state_side),
+            ),
+        ],
+        post={
+            sender: Account(nonce=1),
+            created: None,
+        },
+    )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
@@ -386,8 +386,9 @@ def test_top_frame_new_account_skipped_for_prefunded_create_target(
         sends_value=bool(value),
     )
     assert total_gas > calldata_floor, (
-        "the exact total must exceed the calldata floor for the "
-        "gas pin to observe the skipped charge"
+        "The exact total must exceed the calldata floor for the "
+        "gas pin to observe the skipped charge."
+        "Lift memory expansion in `creation_tx_init_code` to fix."
     )
 
     tx = Transaction(
@@ -395,7 +396,7 @@ def test_top_frame_new_account_skipped_for_prefunded_create_target(
         to=None,
         data=init_code,
         value=value,
-        gas_limit=total_gas + 1_000,
+        gas_limit=total_gas,
         expected_receipt=TransactionReceipt(cumulative_gas_used=total_gas),
     )
 
@@ -485,14 +486,15 @@ def test_top_frame_new_account_skipped_for_create_target_funded_same_block(
     )
     assert create_total > calldata_floor, (
         "the exact total must exceed the calldata floor for the "
-        "gas pin to observe the skipped charge"
+        "gas pin to observe the skipped charge."
+        "Lift memory expansion in `creation_tx_init_code` to fix."
     )
     create_tx = Transaction(
         sender=sender,
         to=None,
         data=init_code,
         value=value,
-        gas_limit=create_total + 1_000,
+        gas_limit=create_total,
         expected_receipt=TransactionReceipt(
             cumulative_gas_used=fund_total + create_total
         ),
@@ -669,8 +671,7 @@ def test_initcode_selfdestruct_keeps_top_frame_state_charge(
     top-frame charge shows up as a 183,600 shortfall in
     ``cumulative_gas_used`` and a matching sender refund.
     """
-    sender_initial_balance = 10**18
-    sender = pre.fund_eoa(sender_initial_balance)
+    sender = pre.fund_eoa()
     created = compute_create_address(address=sender, nonce=sender.nonce)
 
     beneficiary: Address | None = None
@@ -716,7 +717,7 @@ def test_initcode_selfdestruct_keeps_top_frame_state_charge(
         to=None,
         data=init_code,
         value=value,
-        gas_limit=total_gas + 1_000,
+        gas_limit=total_gas,
         expected_receipt=TransactionReceipt(cumulative_gas_used=total_gas),
     )
 
@@ -762,7 +763,7 @@ def test_initcode_selfdestruct_state_gas_in_header(
     small regular sum; a regular-gas mis-classification raises it to
     ``regular + NEW_ACCOUNT``.
     """
-    sender = pre.fund_eoa(10**18)
+    sender = pre.fund_eoa()
     created = compute_create_address(address=sender, nonce=sender.nonce)
 
     init_code = Op.SELFDESTRUCT.with_metadata(
@@ -794,7 +795,7 @@ def test_initcode_selfdestruct_state_gas_in_header(
         sender=sender,
         to=None,
         data=init_code,
-        gas_limit=total_gas + 1_000,
+        gas_limit=total_gas,
         expected_receipt=TransactionReceipt(cumulative_gas_used=total_gas),
     )
 

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -568,8 +568,7 @@ def test_top_frame_charges_self_delegation_oog(
     read to discover the delegation: per EIP-7928 it must appear in the
     block access list exactly once, with no recorded changes.
     """
-    sender_initial_balance = 10**18
-    sender = pre.fund_eoa(sender_initial_balance)
+    sender = pre.fund_eoa()
 
     # Pre-allocate an EOA that delegates to itself. The 1-wei balance
     # keeps the account alive at top-frame check time so the

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -25,12 +25,16 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    BalAccountExpectation,
+    BalBalanceChange,
+    BlockAccessListExpectation,
     Environment,
     Fork,
     Op,
     RecipientType,
     StateTestFiller,
     Transaction,
+    TransactionReceipt,
 )
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
@@ -215,12 +219,18 @@ def test_top_frame_charges_delegation_in_access_list(
     total_gas_cost = intrinsic_gas + top_frame_gas
     gas_price = 1_000_000_000
 
+    delegated_to_bal: BalAccountExpectation | None
     if outcome == "oog":
         # Runs out one gas short of the warm charge, before dispatch:
         # no value moves and the sender pays the full gas_limit.
         gas_limit = total_gas_cost - 1
         sender_final_balance = sender_initial_balance - gas_limit * gas_price
         target_balance = 0
+        # The access-list entry warmed the delegation target but never
+        # read it, and the starved charge is the one access that would
+        # have: the target must be absent from the block access list.
+        delegated_to_bal = None
+        target_bal = BalAccountExpectation.empty()
     else:
         # Exact gas: the delegated STOP costs nothing, so the warm
         # charge is the last gas spent and the value transfer lands.
@@ -229,6 +239,18 @@ def test_top_frame_charges_delegation_in_access_list(
             sender_initial_balance - value - total_gas_cost * gas_price
         )
         target_balance = value
+        # The paid warm access loads the target's code for dispatch, so
+        # it enters the block access list, unchanged.
+        delegated_to_bal = BalAccountExpectation.empty()
+        target_bal = (
+            BalAccountExpectation(
+                balance_changes=[
+                    BalBalanceChange(block_access_index=1, post_balance=value)
+                ]
+            )
+            if value
+            else BalAccountExpectation.empty()
+        )
 
     tx = Transaction(
         ty=1,
@@ -245,7 +267,17 @@ def test_top_frame_charges_delegation_in_access_list(
         target: Account(balance=target_balance, code=target_code),
     }
 
-    state_test(pre=pre, tx=tx, post=post)
+    state_test(
+        pre=pre,
+        tx=tx,
+        post=post,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                target: target_bal,
+                delegated_to: delegated_to_bal,
+            }
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -504,6 +536,89 @@ def test_top_frame_charges_delegation_is_recipient(
     }
 
     state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_top_frame_charges_self_delegation_oog(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    value: int,
+) -> None:
+    """
+    Recipient holds a pre-existing EIP-7702 delegation pointing back at
+    itself, and the transaction is one gas short of the delegation
+    target's ``WARM_ACCESS`` charge.
+
+    The target of the resolution is the recipient itself, which is warm
+    as ``tx.to``, so the starved charge is the warm access --
+    a cold charge here would be a self-delegation warmth bug. The halt
+    lands before dispatch, so the delegation prefix (whose leading
+    ``0xef`` decodes as ``INVALID``) never runs; the sender pays the
+    full ``gas_limit`` and no value moves.
+
+    Unlike a delegation to a distinct never-accessed account, the
+    delegated address here *is* the recipient, whose code was already
+    read to discover the delegation: per EIP-7928 it must appear in the
+    block access list exactly once, with no recorded changes.
+    """
+    sender_initial_balance = 10**18
+    sender = pre.fund_eoa(sender_initial_balance)
+
+    # Pre-allocate an EOA that delegates to itself. The 1-wei balance
+    # keeps the account alive at top-frame check time so the
+    # ``NEW_ACCOUNT`` charge does not fire.
+    target = pre.fund_eoa(amount=1, delegation="Self")
+    target_code = Spec7702.delegation_designation(target)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=RecipientType.DELEGATION_7702,
+        delegation_warm=True,
+    )
+
+    # One gas short of the warm self-access: the frame halts before
+    # dispatching the (self-)delegated code. The receipt pins the full
+    # ``gas_limit`` as consumed -- the out-of-gas signature (receipt
+    # ``status`` is not verified by the filler).
+    gas_limit = intrinsic_gas + top_frame_gas - 1
+
+    tx = Transaction(
+        sender=sender,
+        to=target,
+        value=value,
+        gas_limit=gas_limit,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=gas_limit,
+        ),
+    )
+
+    post = {
+        sender: Account(nonce=1),
+        target: Account(balance=1, code=target_code),
+    }
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post=post,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                target: BalAccountExpectation.empty(),
+            }
+        ),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Add more EIP-2780 related tests.

### Related Issues or PRs
#1940

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
