### PR TITLE
fix(test-client-clis): map Nethermind signature errors for Devnet-7

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -328,6 +328,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
         ),
+        TransactionException.INVALID_SIGNATURE_VRS: (
+            "InvalidTxSignature: Signature is invalid."
+        ),
         TransactionException.TYPE_1_TX_PRE_FORK: (
             "InvalidTxType: Transaction type in Custom is not supported"
         ),

--- a/packages/testing/src/execution_testing/client_clis/tests/test_nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_nethermind.py
@@ -1,0 +1,19 @@
+"""Tests for Nethermind client CLI support."""
+
+from execution_testing.client_clis.clis.nethermind import (
+    NethermindExceptionMapper,
+)
+from execution_testing.exceptions import TransactionException
+
+
+def test_invalid_signature_vrs_mapping() -> None:
+    """Map Nethermind invalid signatures to INVALID_SIGNATURE_VRS."""
+    mapped_exceptions = NethermindExceptionMapper().message_to_exception(
+        "InvalidTxSignature: Signature is invalid."
+    )
+
+    assert isinstance(mapped_exceptions, list)
+    assert set(mapped_exceptions) == {
+        TransactionException.INVALID_SIGNATURE_VRS,
+        TransactionException.INVALID_CHAINID,
+    }


### PR DESCRIPTION
### Description

Backport the Nethermind invalid V/R/S mapper entry to `devnets/glamsterdam/7`.

Nethermind correctly returns `PayloadStatus.INVALID` with
`InvalidTxSignature: Signature is invalid.` for malformed V/R/S values. The
Devnet-7 mapper currently reports that message only as `INVALID_CHAINID`,
causing the 40 `test_bad_v_r_s` Hive failures. Add
`INVALID_SIGNATURE_VRS` while deliberately retaining `INVALID_CHAINID`:
`ExceptionMapper` returns every matching category, so this preserves the
existing compatibility behavior while also reporting the precise V/R/S error.

Add a focused regression test that verifies both mappings are returned.

### Testing

- `uv run --frozen --no-dev --package ethereum-execution-testing pytest packages/testing/src/execution_testing/client_clis/tests/test_nethermind.py -q`
- Targeted Ruff, mypy, codespell, and `uv lock --check`
- The full framework suite is not supported on this Windows host because it
  imports `socketserver.UnixStreamServer`.

### Related Issues or PRs

- #3131

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Sea otter](https://images.unsplash.com/photo-1698435354379-b10bcc803369?auto=format&fit=crop&fm=jpg&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&ixlib=rb-4.1.0&q=60&w=3000)
