### PR TITLE
fix(ci): skip new-commit check on manual fixture release dispatches

### DIFF
--- a/.github/workflows/release_fixtures.yaml
+++ b/.github/workflows/release_fixtures.yaml
@@ -67,7 +67,9 @@ jobs:
       # A cached release skips the fill: `build` (and with it `combine`)
       # keys off `run`, and the release job downloads the resolved
       # nightly's artifact and tags the commit it was built from.
-      run: ${{ (inputs.cached || inputs.commit != '') && 'false' || steps.check.outputs.run }}
+      # Manual dispatches skip the new-commit check (its script may not
+      # exist on the checked-out devnet branch) and default to `true`.
+      run: ${{ (inputs.cached || inputs.commit != '') && 'false' || steps.check.outputs.run || 'true' }}
       build_matrix: ${{ steps.matrix.outputs.build_matrix }}
       feature_name: ${{ steps.matrix.outputs.feature_name }}
       combine_labels: ${{ steps.matrix.outputs.combine_labels }}
@@ -95,6 +97,7 @@ jobs:
 
       - name: Check for new commits (scheduled runs)
         id: check
+        if: github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
#3100's new-commit check runs `.github/scripts/check_new_commits.py` from the checkout, but manual devnet releases check out `inputs.branch`, which can predate the script — the `glamsterdam-devnet@v7.2.1` dispatch [failed to spawn it](https://github.com/ethereum/execution-specs/actions/runs/29829915805/job/88631906548). Gate the step on scheduled runs and default the `run` output to `true` for dispatches, which is all the script did for them anyway.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Introduced by #3100.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/pFz1Q12_hXEAAAAM/cat-holding-head-cat.gif)
