### PR TITLE
feat(8297): Add key derivation layer

### DIFF
--- a/src/ethereum/binary_trie/embedding.py
+++ b/src/ethereum/binary_trie/embedding.py
@@ -9,7 +9,7 @@ chunks are assigned keys and packed into values.
 The first byte of every key is a **zone** identifier that labels the
 category of state the key holds. Account headers live in
 [`ACCOUNT_ZONE`], content-addressed overflow code in [`CODE_ZONE`],
-and overflow storage in [`STORAGE_ZONE`]. 
+and overflow storage in [`STORAGE_ZONE`].
 
 Keys are variable length, however importantly every key of a zone has
 the same length, keeping keys prefix-free as the tree requires.
@@ -17,7 +17,7 @@ the same length, keeping keys prefix-free as the tree requires.
 A key's **stem** is every byte except its final sub-index byte. Keys
 sharing a stem form one group of up to [`STEM_SUBTREE_WIDTH`]
 co-located values, all reachable through the same branch of the
-tree. 
+tree.
 
 This keeps data that is accessed together cheap to prove: an
 account's header stem holds its basic data, code hash, first storage
@@ -34,13 +34,7 @@ through one shared path rather than one path each.
 [`CODE_ZONE`]: ref:ethereum.binary_trie.embedding.CODE_ZONE
 [`STORAGE_ZONE`]: ref:ethereum.binary_trie.embedding.STORAGE_ZONE
 [`STEM_SUBTREE_WIDTH`]: ref:ethereum.binary_trie.embedding.STEM_SUBTREE_WIDTH
-[`chunkify_code`]: ref:ethereum.binary_trie.embedding.chunkify_code
-[`encode_basic_data`]: ref:ethereum.binary_trie.embedding.encode_basic_data
-[`get_tree_key_for_basic_data`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_basic_data
-[`get_tree_key_for_code_hash`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_code_hash
-[`get_tree_key_for_storage_slot`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_storage_slot
-[`get_tree_key_for_code_chunk`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_code_chunk
-"""  # noqa: E501
+"""
 
 from typing import List
 
@@ -59,7 +53,7 @@ prepended as the first byte of every key.
 
 Zones are the partitions of the Partitioned Binary Tree: because the
 tree consumes key bits most significant first, every zone owns its
-own region of the key space. 
+own region of the key space.
 Defined zones are [`ACCOUNT_ZONE`],[`CODE_ZONE`], and [`STORAGE_ZONE`]
 The remaining values are reserved for future state categories.
 
@@ -146,10 +140,10 @@ STORAGE_ZONE = Zone(255)
 Zone byte of overflow storage stems.
 
 Storage sits at the far end of the zone byte, leaving zones `2`
-through `254` reserved for future state categories. 
+through `254` reserved for future state categories.
 
-Note: Because keys are variable length, a zone's one-byte label 
-says nothing about its capacity so every zone's key space is 
+Note: Because keys are variable length, a zone's one-byte label
+says nothing about its capacity so every zone's key space is
 unbounded behind its prefix.
 """
 
@@ -202,7 +196,8 @@ def key_hash(data: Bytes) -> Hash32:
     """
     Hash `data` for use in tree key derivation.
 
-    In practice, we reuse the hash being used for tree merkelization.
+    In practice, we reuse [`blake3_hash`], the hash being used for
+    tree merkelization.
 
     [`blake3_hash`]: ref:ethereum.binary_trie.trie.blake3_hash
     """
@@ -326,9 +321,10 @@ def get_tree_key_for_code_chunk(
 
     [`CODE_ZONE`]: ref:ethereum.binary_trie.embedding.CODE_ZONE
     """
-    if chunk_id < STEM_SUBTREE_WIDTH - CODE_OFFSET:
+    header_chunk_count = STEM_SUBTREE_WIDTH - CODE_OFFSET
+    if chunk_id < header_chunk_count:
         return get_tree_key_for_header(address, CODE_OFFSET + chunk_id)
-    overflow = chunk_id - (STEM_SUBTREE_WIDTH - CODE_OFFSET)
+    overflow = chunk_id - header_chunk_count
     tree_index = overflow // STEM_SUBTREE_WIDTH
     sub_index = overflow % STEM_SUBTREE_WIDTH
     key = get_tree_key(
@@ -347,8 +343,8 @@ def chunkify_code(code: Bytes) -> List[Bytes32]:
     Chunk `i` holds the `i`-th 31-byte slice of the code in bytes `1`
     through `31`, preceded by one byte counting how many of the
     slice's leading bytes are data of a push instruction that began in
-    an earlier chunk. 
-    
+    an earlier chunk.
+
     The count lets a chunk be interpreted without
     its predecessors and is capped at `31`, the chunk payload size.
     """

--- a/src/ethereum/binary_trie/embedding.py
+++ b/src/ethereum/binary_trie/embedding.py
@@ -1,0 +1,419 @@
+"""
+The [EIP-8297] embedding of Ethereum state into the binary tree.
+
+Account and storage tries are merged into the single key/value tree
+defined in [`ethereum.binary_trie.trie`], which also holds contract
+code. This module defines how accounts, storage slots, and code
+chunks are assigned keys and packed into values.
+
+The first byte of every key is a **zone** identifier that labels the
+category of state the key holds. Account headers live in
+[`ACCOUNT_ZONE`], content-addressed overflow code in [`CODE_ZONE`],
+and overflow storage in [`STORAGE_ZONE`]. 
+
+Keys are variable length, however importantly every key of a zone has
+the same length, keeping keys prefix-free as the tree requires.
+
+A key's **stem** is every byte except its final sub-index byte. Keys
+sharing a stem form one group of up to [`STEM_SUBTREE_WIDTH`]
+co-located values, all reachable through the same branch of the
+tree. 
+
+This keeps data that is accessed together cheap to prove: an
+account's header stem holds its basic data, code hash, first storage
+slots, and first code chunks, so one proof path covers them all.
+
+Data past the header keeps the grouping at coarser granularity;
+overflow storage and code share a stem per [`STEM_SUBTREE_WIDTH`]
+consecutive slots or chunks, so neighboring values are still proved
+through one shared path rather than one path each.
+
+[EIP-8297]: https://eips.ethereum.org/EIPS/eip-8297
+[`ethereum.binary_trie.trie`]: ref:ethereum.binary_trie.trie
+[`ACCOUNT_ZONE`]: ref:ethereum.binary_trie.embedding.ACCOUNT_ZONE
+[`CODE_ZONE`]: ref:ethereum.binary_trie.embedding.CODE_ZONE
+[`STORAGE_ZONE`]: ref:ethereum.binary_trie.embedding.STORAGE_ZONE
+[`STEM_SUBTREE_WIDTH`]: ref:ethereum.binary_trie.embedding.STEM_SUBTREE_WIDTH
+[`chunkify_code`]: ref:ethereum.binary_trie.embedding.chunkify_code
+[`encode_basic_data`]: ref:ethereum.binary_trie.embedding.encode_basic_data
+[`get_tree_key_for_basic_data`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_basic_data
+[`get_tree_key_for_code_hash`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_code_hash
+[`get_tree_key_for_storage_slot`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_storage_slot
+[`get_tree_key_for_code_chunk`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_code_chunk
+"""  # noqa: E501
+
+from typing import List
+
+from ethereum_types.bytes import Bytes, Bytes20, Bytes32
+from ethereum_types.numeric import U8, U32, U64, U256, Uint
+
+from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.utils.byte import left_pad_zero_bytes, right_pad_zero_bytes
+
+from .trie import Key, blake3_hash
+
+Zone = U8
+"""
+One-byte identifier labeling the category of state a key holds,
+prepended as the first byte of every key.
+
+Zones are the partitions of the Partitioned Binary Tree: because the
+tree consumes key bits most significant first, every zone owns its
+own region of the key space. 
+Defined zones are [`ACCOUNT_ZONE`],[`CODE_ZONE`], and [`STORAGE_ZONE`]
+The remaining values are reserved for future state categories.
+
+[`ACCOUNT_ZONE`]: ref:ethereum.binary_trie.embedding.ACCOUNT_ZONE
+[`CODE_ZONE`]: ref:ethereum.binary_trie.embedding.CODE_ZONE
+[`STORAGE_ZONE`]: ref:ethereum.binary_trie.embedding.STORAGE_ZONE
+"""
+
+Address32 = Bytes32
+"""
+32-byte address used to key the tree.
+
+Legacy 20-byte addresses are converted by [`address20_to_address32`].
+
+[`address20_to_address32`]: ref:ethereum.binary_trie.embedding.address20_to_address32
+"""  # noqa: E501
+
+BASIC_DATA_LEAF_KEY = Uint(0)
+"""
+Sub-index of the account header leaf packing version, code size,
+nonce, and balance.
+"""
+
+BASIC_DATA_VERSION = Uint(0)
+"""
+Version of the basic data leaf layout, packed as the leaf's first
+byte by [`encode_basic_data`]. A future change to the layout bumps
+the version so readers can tell the encodings apart.
+
+[`encode_basic_data`]: ref:ethereum.binary_trie.embedding.encode_basic_data
+"""
+
+CODE_HASH_LEAF_KEY = Uint(1)
+"""
+Sub-index of the account header leaf holding the code hash.
+"""
+
+EMPTY_CODE_HASH = keccak256(b"")
+"""
+Code hash for accounts without code.
+
+The leaf is written on account creation; EOAs included and holds
+the Keccak hash of empty bytecode: `EXTCODEHASH` of an existing
+codeless account must keep returning this value (and new accounts).
+
+Note: The tree's own hash function is different to the hash
+function being used for `code_hash`. `code_hash` is an
+EVM-observable value stored in a leaf, not a tree commitment, so it
+stays Keccak even though the tree hashes with [`blake3_hash`].
+
+[`blake3_hash`]: ref:ethereum.binary_trie.trie.blake3_hash
+"""
+
+HEADER_STORAGE_OFFSET = Uint(64)
+"""
+Sub-index of storage slot `0` within the account header stem. Slots
+`0` through `63` live in the header.
+"""
+
+CODE_OFFSET = Uint(128)
+"""
+Sub-index of code chunk `0` within the account header stem. Chunks
+`0` through `127` live in the header.
+"""
+
+STEM_SUBTREE_WIDTH = Uint(256)
+"""
+Maximum number of values grouped under a single stem: the size of
+the sub-index byte's space.
+"""
+
+ACCOUNT_ZONE = Zone(0)
+"""
+Zone byte of account header stems.
+"""
+
+CODE_ZONE = Zone(1)
+"""
+Zone byte of content-addressed overflow code stems.
+"""
+
+STORAGE_ZONE = Zone(255)
+"""
+Zone byte of overflow storage stems.
+
+Storage sits at the far end of the zone byte, leaving zones `2`
+through `254` reserved for future state categories. 
+
+Note: Because keys are variable length, a zone's one-byte label 
+says nothing about its capacity so every zone's key space is 
+unbounded behind its prefix.
+"""
+
+ACCOUNT_KEY_LENGTH = Uint(34)
+"""
+Length of every account zone key: the zone byte, a full address
+digest, and the sub-index byte.
+"""
+
+CODE_KEY_LENGTH = Uint(34)
+"""
+Length of every code zone key: the zone byte, a full digest of the
+code hash and group index, and the sub-index byte.
+"""
+
+STORAGE_KEY_LENGTH = Uint(66)
+"""
+Length of every storage zone key: the zone byte, two full digests
+binding the account and its group index, and the sub-index byte.
+"""
+
+PUSH_OFFSET = Uint(95)
+"""
+Opcode value one below `PUSH1`, so `PUSH_OFFSET + n` is the opcode
+pushing `n` bytes.
+"""
+
+PUSH1 = PUSH_OFFSET + Uint(1)
+"""
+Opcode of the smallest push instruction.
+"""
+
+PUSH32 = PUSH_OFFSET + Uint(32)
+"""
+Opcode of the largest push instruction.
+"""
+
+
+def address20_to_address32(address: Bytes20) -> Address32:
+    """
+    Convert a legacy 20-byte address by prepending 12 zero bytes.
+
+    The embedding keys the tree by 32-byte addresses so that a future
+    address-space extension needs no re-keying.
+    """
+    return Address32(left_pad_zero_bytes(address, 32))
+
+
+def key_hash(data: Bytes) -> Hash32:
+    """
+    Hash `data` for use in tree key derivation.
+
+    In practice, we reuse the hash being used for tree merkelization.
+
+    [`blake3_hash`]: ref:ethereum.binary_trie.trie.blake3_hash
+    """
+    return blake3_hash(data)
+
+
+def get_tree_key(zone: Zone, tree_position: Bytes, sub_index: U8) -> Key:
+    """
+    Build a key from its three parts: the `zone` byte, the
+    hash-derived `tree_position`, and the final `sub_index` byte.
+    """
+    return Key(bytes([int(zone)]) + tree_position + bytes([int(sub_index)]))
+
+
+def get_tree_key_for_header(address: Address32, sub_index: Uint) -> Key:
+    """
+    Compute the key of the account header leaf at `sub_index`.
+
+    The header stem is in [`ACCOUNT_ZONE`] and is keyed by the address
+    alone, so each account has exactly one header stem. The header is
+    not one key: it is up to [`STEM_SUBTREE_WIDTH`] separate leaves
+    sharing that stem, and `sub_index` selects which one; basic
+    data, code hash, an early storage slot, or an early code chunk.
+
+    [`ACCOUNT_ZONE`]: ref:ethereum.binary_trie.embedding.ACCOUNT_ZONE
+    [`STEM_SUBTREE_WIDTH`]: ref:ethereum.binary_trie.embedding.STEM_SUBTREE_WIDTH
+    """  # noqa: E501
+    key = get_tree_key(ACCOUNT_ZONE, key_hash(address), U8(sub_index))
+    assert len(key) == int(ACCOUNT_KEY_LENGTH)
+    return key
+
+
+def get_tree_key_for_basic_data(address: Address32) -> Key:
+    """
+    Compute the key of the account's basic data leaf.
+    """
+    return get_tree_key_for_header(address, BASIC_DATA_LEAF_KEY)
+
+
+def get_tree_key_for_code_hash(address: Address32) -> Key:
+    """
+    Compute the key of the account's code hash leaf.
+    """
+    return get_tree_key_for_header(address, CODE_HASH_LEAF_KEY)
+
+
+def storage_tree_position(address: Address32, tree_index: U256) -> Bytes:
+    """
+    Build the hash-derived position of an account's overflow storage
+    group at `tree_index`.
+
+    The position carries two full digests:
+
+    - `key_hash(address)` gathers all of an account's overflow
+      storage under one subtree, which future expiry and sync
+      schemes could use as their unit of work: a contract's whole
+      storage is one contiguous key range that can be expired or
+      served as a single subtree, rather than locations scattered
+      across the whole tree.
+    - `key_hash(address ‖ tree_index)` spreads the account's groups
+      within that subtree.
+
+    Both digests depend on the address, so storage keys that an
+    attacker grinds to sit close together under one contract cannot
+    be reused against a different contract.
+
+    `key_hash(address)` is the same digest [`get_tree_key_for_header`]
+    uses for the account's header stem; the two never collide because
+    they sit in different zones, differing in the key's first byte.
+
+    [`get_tree_key_for_header`]: ref:ethereum.binary_trie.embedding.get_tree_key_for_header
+    """  # noqa: E501
+    prefix = key_hash(address)
+    suffix = key_hash(address + tree_index.to_be_bytes32())
+    return Bytes(prefix + suffix)
+
+
+def get_tree_key_for_storage_slot(
+    address: Address32, storage_key: U256
+) -> Key:
+    """
+    Compute the key of a storage slot.
+
+    Slots `0` through `63` live in the account header stem and all other
+    slots live in the storage zone.
+
+    This leaves group `0` (`tree_index == 0`) short; its
+    storage-zone leaves are only sub-indices `64`-`255`, 192 slots
+    rather than the full 256 every later group has.
+    # TODO: still need to check why first 64
+    """
+    if storage_key < U256(CODE_OFFSET - HEADER_STORAGE_OFFSET):
+        return get_tree_key_for_header(
+            address, HEADER_STORAGE_OFFSET + Uint(storage_key)
+        )
+    tree_index = storage_key // U256(STEM_SUBTREE_WIDTH)
+    sub_index = storage_key % U256(STEM_SUBTREE_WIDTH)
+    key = get_tree_key(
+        STORAGE_ZONE,
+        storage_tree_position(address, tree_index),
+        U8(sub_index),
+    )
+    assert len(key) == int(STORAGE_KEY_LENGTH)
+    return key
+
+
+def get_tree_key_for_code_chunk(
+    address: Address32, code_hash: Hash32, chunk_id: Uint
+) -> Key:
+    """
+    Compute the key of a code chunk.
+
+    Chunks `0` through `127` live in the account header stem: the
+    start of a contract's code (usually dispatchers and entry points)
+    is its most executed region, so the first chunks open with the
+    same branch as the account's basic data.
+
+    Chunks at index `128` and above live in [`CODE_ZONE`],
+    content-addressed by `code_hash` so contracts with identical
+    bytecode share leaves.
+
+    [`CODE_ZONE`]: ref:ethereum.binary_trie.embedding.CODE_ZONE
+    """
+    if chunk_id < STEM_SUBTREE_WIDTH - CODE_OFFSET:
+        return get_tree_key_for_header(address, CODE_OFFSET + chunk_id)
+    overflow = chunk_id - (STEM_SUBTREE_WIDTH - CODE_OFFSET)
+    tree_index = overflow // STEM_SUBTREE_WIDTH
+    sub_index = overflow % STEM_SUBTREE_WIDTH
+    key = get_tree_key(
+        CODE_ZONE,
+        key_hash(code_hash + tree_index.to_be_bytes32()),
+        U8(sub_index),
+    )
+    assert len(key) == int(CODE_KEY_LENGTH)
+    return key
+
+
+def chunkify_code(code: Bytes) -> List[Bytes32]:
+    """
+    Split `code` into the 32-byte chunks stored in the tree.
+
+    Chunk `i` holds the `i`-th 31-byte slice of the code in bytes `1`
+    through `31`, preceded by one byte counting how many of the
+    slice's leading bytes are data of a push instruction that began in
+    an earlier chunk. 
+    
+    The count lets a chunk be interpreted without
+    its predecessors and is capped at `31`, the chunk payload size.
+    """
+    if len(code) % 31 != 0:
+        pad_amount = 31 - (len(code) % 31)
+        code = Bytes(right_pad_zero_bytes(code, len(code) + pad_amount))
+
+    # Number of push-data bytes remaining at each position, counting
+    # the position itself; `0` marks executable bytes. The extra 32
+    # entries let the largest push record data past the end of the
+    # code.
+    remaining_push_data = [0] * (len(code) + 32)
+    position = 0
+    while position < len(code):
+        opcode = Uint(code[position])
+        if PUSH1 <= opcode <= PUSH32:
+            push_data_bytes = int(opcode - PUSH_OFFSET)
+        else:
+            push_data_bytes = 0
+        position += 1
+        for offset in range(push_data_bytes):
+            remaining_push_data[position + offset] = push_data_bytes - offset
+        position += push_data_bytes
+
+    return [
+        Bytes32(
+            bytes([min(remaining_push_data[start], 31)])
+            + code[start : start + 31]
+        )
+        for start in range(0, len(code), 31)
+    ]
+
+
+def encode_basic_data(code_size: U32, nonce: U64, balance: U256) -> Bytes32:
+    """
+    Pack an account's basic data into the 32-byte value stored at
+    [`BASIC_DATA_LEAF_KEY`].
+
+    The fields are packed big-endian, consistent with every other
+    encoding in the embedding:
+
+    - one version byte, currently zero
+    - three reserved zero bytes
+    - four bytes of code size
+    - eight bytes of nonce
+    - sixteen bytes of balance
+
+    The code size and nonce parameters are typed at their field
+    widths; the nonce cannot exceed eight bytes by [EIP-2681].
+    Balances are protocol-level `U256` values, so the parameter
+    keeps that type and the sixteen-byte field bound is asserted
+    here instead.
+
+    TODO: `code_size` is four bytes at offset four here, one
+    byte wider than EIP-7864's three-byte field at offset five.
+
+    [`BASIC_DATA_LEAF_KEY`]: ref:ethereum.binary_trie.embedding.BASIC_DATA_LEAF_KEY
+    [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
+    """  # noqa: E501
+    assert balance < U256(2) ** U256(128)  # U128 doesn't exist
+    return Bytes32(
+        bytes([int(BASIC_DATA_VERSION)])
+        # Reserved bytes: headroom for future header fields.
+        + b"\x00" * 3
+        + code_size.to_be_bytes4()
+        + nonce.to_be_bytes8()
+        + int(balance).to_bytes(16, "big")
+    )

--- a/tests/binary_trie/test_embedding.py
+++ b/tests/binary_trie/test_embedding.py
@@ -101,7 +101,6 @@ def test_header_key_vectors() -> None:
 
     assert get_tree_key_for_basic_data(ADDRESS) == stem + b"\x00"
     assert get_tree_key_for_code_hash(ADDRESS) == stem + b"\x01"
-    assert len(get_tree_key_for_basic_data(ADDRESS)) == 34
 
 
 def test_storage_slot_in_header_vector() -> None:
@@ -124,9 +123,6 @@ def test_storage_slot_overflow_vector() -> None:
 
     key = get_tree_key_for_storage_slot(ADDRESS, U256(1000))
     assert key == stem + bytes([0xE8])
-    assert len(key) == 66
-    # Storage keys carry the storage zone byte.
-    assert key[0] == 0xFF
 
 
 def test_storage_slot_boundary_is_64() -> None:
@@ -170,7 +166,6 @@ def test_code_chunk_overflow_vector() -> None:
 
     key = get_tree_key_for_code_chunk(ADDRESS, code_hash, Uint(300))
     assert key == stem + bytes([0xAC])
-    assert len(key) == 34
 
 
 def test_overflow_code_is_content_addressed() -> None:

--- a/tests/binary_trie/test_embedding.py
+++ b/tests/binary_trie/test_embedding.py
@@ -1,0 +1,299 @@
+"""
+Tests for the embedding of state into the binary tree.
+"""
+
+import pytest
+from blake3 import blake3
+from ethereum_types.bytes import Bytes, Bytes20, Bytes32
+from ethereum_types.numeric import U8, U32, U64, U256, Uint
+
+from ethereum.binary_trie.embedding import (
+    EMPTY_CODE_HASH,
+    Address32,
+    Zone,
+    address20_to_address32,
+    chunkify_code,
+    encode_basic_data,
+    get_tree_key,
+    get_tree_key_for_basic_data,
+    get_tree_key_for_code_chunk,
+    get_tree_key_for_code_hash,
+    get_tree_key_for_header,
+    get_tree_key_for_storage_slot,
+    key_hash,
+)
+from ethereum.state import EMPTY_CODE_HASH as MPT_STATE_EMPTY_CODE_HASH
+
+ADDRESS = Address32(b"\x00" * 12 + b"\xaa" * 20)
+
+
+def _header_stem(address: Address32) -> bytes:
+    """
+    Build `0x00 || H(address)`, the 33-byte account header stem, from
+    scratch.
+    """
+    return bytes([0]) + blake3(bytes(address)).digest()
+
+
+def test_address20_to_address32_prepends_zeros() -> None:
+    """
+    Legacy addresses convert by prepending 12 zero bytes.
+    """
+    address = Bytes20(b"\xaa" * 20)
+    expected = Address32(b"\x00" * 12 + b"\xaa" * 20)
+    assert address20_to_address32(address) == expected
+
+
+def test_empty_code_hash_is_keccak_of_empty() -> None:
+    """
+    The empty-code leaf value is the classic Keccak empty-code hash,
+    and agrees with the shared MPT state module's definition.
+    """
+    assert EMPTY_CODE_HASH == bytes.fromhex(
+        "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    )
+    assert EMPTY_CODE_HASH == MPT_STATE_EMPTY_CODE_HASH
+
+
+def test_key_hash_is_blake3() -> None:
+    """
+    Key derivation hashes with BLAKE3.
+    """
+    assert key_hash(ADDRESS) == blake3(bytes(ADDRESS)).digest()
+
+
+def test_get_tree_key_concatenates_its_three_parts() -> None:
+    """
+    A key is the zone byte, the whole hash-derived position, and the
+    sub-index byte.
+    """
+    digest = blake3(b"digest").digest()
+    for zone in (0, 1, 2, 254, 255):
+        key = get_tree_key(Zone(zone), digest, U8(7))
+        assert len(key) == 34
+        assert key == bytes([zone]) + digest + b"\x07"
+
+
+def test_zone_wider_than_one_byte_is_unrepresentable() -> None:
+    """
+    A zone identifier that does not fit in the zone byte fails at
+    construction: the type is one byte wide.
+    """
+    with pytest.raises(OverflowError):
+        Zone(256)
+
+
+def test_header_sub_index_wider_than_one_byte_is_rejected() -> None:
+    """
+    A header sub-index that does not fit the key's final byte fails
+    at the narrowing to one byte inside the derivation.
+    """
+    with pytest.raises(OverflowError):
+        get_tree_key_for_header(ADDRESS, Uint(256))
+
+
+def test_header_key_vectors() -> None:
+    """
+    Header keys are `0x00 || H(A)` plus the leaf's sub-index,
+    34 bytes in total.
+    """
+    stem = _header_stem(ADDRESS)
+
+    assert get_tree_key_for_basic_data(ADDRESS) == stem + b"\x00"
+    assert get_tree_key_for_code_hash(ADDRESS) == stem + b"\x01"
+    assert len(get_tree_key_for_basic_data(ADDRESS)) == 34
+
+
+def test_storage_slot_in_header_vector() -> None:
+    """
+    EIP sub-index vector: storage slot 5 lives in the header at
+    sub-index 0x45.
+    """
+    key = get_tree_key_for_storage_slot(ADDRESS, U256(5))
+    assert key == _header_stem(ADDRESS) + bytes([0x45])
+
+
+def test_storage_slot_overflow_vector() -> None:
+    """
+    Slot 1000 maps to tree index 3, sub-index 0xE8, with the 65-byte
+    stem `0xFF || H(A) || H(A || 3)`.
+    """
+    prefix = blake3(bytes(ADDRESS)).digest()
+    suffix = blake3(bytes(ADDRESS) + (3).to_bytes(32, "big")).digest()
+    stem = bytes([255]) + prefix + suffix
+
+    key = get_tree_key_for_storage_slot(ADDRESS, U256(1000))
+    assert key == stem + bytes([0xE8])
+    assert len(key) == 66
+    # Storage keys carry the storage zone byte.
+    assert key[0] == 0xFF
+
+
+def test_storage_slot_boundary_is_64() -> None:
+    """
+    Slot 63 is the last header slot and slot 64 the first overflow
+    slot, landing at tree index 0, sub-index 64.
+    """
+    assert get_tree_key_for_storage_slot(ADDRESS, U256(63)) == _header_stem(
+        ADDRESS
+    ) + bytes([127])
+
+    overflow_stem = (
+        bytes([255])
+        + blake3(bytes(ADDRESS)).digest()
+        + blake3(bytes(ADDRESS) + (0).to_bytes(32, "big")).digest()
+    )
+    assert get_tree_key_for_storage_slot(
+        ADDRESS, U256(64)
+    ) == overflow_stem + bytes([64])
+
+
+def test_code_chunk_in_header_vector() -> None:
+    """
+    EIP sub-index vector: code chunk 5 lives in the header at
+    sub-index 0x85.
+    """
+    code_hash = Bytes32(blake3(b"some code").digest())
+
+    key = get_tree_key_for_code_chunk(ADDRESS, code_hash, Uint(5))
+    assert key == _header_stem(ADDRESS) + bytes([0x85])
+
+
+def test_code_chunk_overflow_vector() -> None:
+    """
+    Chunk 300 overflows to sub-index 0xAC with the 33-byte stem
+    `0x01 || H(C || 0)`.
+    """
+    code_hash = Bytes32(blake3(b"some code").digest())
+    digest = blake3(code_hash + (0).to_bytes(32, "big")).digest()
+    stem = bytes([1]) + digest
+
+    key = get_tree_key_for_code_chunk(ADDRESS, code_hash, Uint(300))
+    assert key == stem + bytes([0xAC])
+    assert len(key) == 34
+
+
+def test_overflow_code_is_content_addressed() -> None:
+    """
+    Overflow chunks depend only on the code hash; header chunks stay
+    per-account.
+    """
+    code_hash = Bytes32(blake3(b"shared bytecode").digest())
+    other = Address32(b"\x00" * 12 + b"\xbb" * 20)
+
+    assert get_tree_key_for_code_chunk(
+        ADDRESS, code_hash, Uint(200)
+    ) == get_tree_key_for_code_chunk(other, code_hash, Uint(200))
+    assert get_tree_key_for_code_chunk(
+        ADDRESS, code_hash, Uint(5)
+    ) != get_tree_key_for_code_chunk(other, code_hash, Uint(5))
+
+
+def test_chunkify_empty_code() -> None:
+    """
+    Empty code produces no chunks.
+    """
+    assert chunkify_code(Bytes(b"")) == []
+
+
+def test_chunkify_code_without_pushes_pads_to_31_bytes() -> None:
+    """
+    Code shorter than a chunk is zero-padded to 31 bytes.
+    """
+    code = Bytes(b"\x01\x02\x03")  # ADD MUL SUB
+
+    chunks = chunkify_code(code)
+
+    # The leading byte is the push-data offset count (zero here), not
+    # padding; only the trailing zeros pad the code to 31 bytes.
+    assert chunks == [Bytes32(b"\x00" + code + b"\x00" * 28)]
+
+
+def test_chunkify_code_eip_example() -> None:
+    """
+    EIP example: push data spanning a chunk boundary is recorded in
+    the second chunk's leading byte.
+    """
+    # `...PUSH4 99 98 | 97 96 PUSH1 128 MSTORE...` where `|` begins a
+    # new chunk; the second chunk records that its first 2 bytes are
+    # push data.
+    push4 = 0x63
+    push1 = 0x60
+    mstore = 0x52
+    code = Bytes(
+        b"\x00" * 28 + bytes([push4, 99, 98, 97, 96, push1, 128, mstore])
+    )
+
+    chunks = chunkify_code(code)
+
+    assert len(chunks) == 2
+    assert chunks[0] == Bytes32(b"\x00" * 29 + bytes([push4, 99, 98]))
+    assert chunks[1] == Bytes32(
+        bytes([2, 97, 96, push1, 128, mstore]) + b"\x00" * 26
+    )
+
+
+def test_chunkify_code_caps_leading_push_data_count_at_31() -> None:
+    """
+    A chunk consisting entirely of push data reports 31 leading push
+    data bytes, the chunk-payload maximum, rather than 32.
+    """
+    push32 = 0x7F
+    push_data = bytes(range(1, 33))
+    code = Bytes(b"\x00" * 30 + bytes([push32]) + push_data)
+
+    chunks = chunkify_code(code)
+
+    assert len(chunks) == 3
+    assert chunks[0] == Bytes32(b"\x00" * 31 + bytes([push32]))
+    assert chunks[1] == Bytes32(bytes([31]) + push_data[:31])
+    assert chunks[2] == Bytes32(bytes([1]) + push_data[31:] + b"\x00" * 30)
+
+
+def test_chunkify_code_push_data_truncated_by_end_of_code() -> None:
+    """
+    A push instruction with its data cut off by the end of the code
+    still chunks cleanly.
+    """
+    push32 = 0x7F
+    code = Bytes(bytes([push32]))
+
+    chunks = chunkify_code(code)
+
+    assert chunks == [Bytes32(b"\x00" + bytes([push32]) + b"\x00" * 30)]
+
+
+def test_encode_basic_data_layout() -> None:
+    """
+    Basic data packs version, code size, nonce, and balance at the
+    offsets given by the EIP.
+    """
+    code_size_hex = "11223344"
+    nonce_hex = "5566778899aabbcc"
+    balance_hex = "0123456789abcdef0123456789abcdef"
+
+    value = encode_basic_data(
+        code_size=U32(int(code_size_hex, 16)),
+        nonce=U64(int(nonce_hex, 16)),
+        balance=U256(int(balance_hex, 16)),
+    )
+
+    assert len(value) == 32
+    assert value[0] == 0  # version
+    assert value[1:4] == b"\x00" * 3  # reserved
+    assert value[4:8] == bytes.fromhex(code_size_hex)
+    assert value[8:16] == bytes.fromhex(nonce_hex)
+    assert value[16:32] == bytes.fromhex(balance_hex)
+
+
+def test_encode_basic_data_rejects_balance_past_sixteen_bytes() -> None:
+    """
+    A balance that does not fit the sixteen-byte field is rejected,
+    rather than silently truncated by `to_bytes`.
+    """
+    with pytest.raises(AssertionError):
+        encode_basic_data(
+            code_size=U32(0),
+            nonce=U64(0),
+            balance=U256(2) ** U256(128),
+        )

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -9,6 +9,15 @@ imports. Each bare expression tells Vulture to ignore that specific symbol.
 from ethereum.cancun.blocks import Withdrawal
 from ethereum_spec_tools.evm_tools.t8n.transition_tool import EELST8N
 
+from ethereum.binary_trie.embedding import (
+    address20_to_address32,
+    chunkify_code,
+    encode_basic_data,
+    get_tree_key_for_basic_data,
+    get_tree_key_for_code_chunk,
+    get_tree_key_for_code_hash,
+    get_tree_key_for_storage_slot,
+)
 from ethereum.ethash import *
 from ethereum.fork_criteria import Unscheduled
 from ethereum.trace import EvmTracer
@@ -37,6 +46,16 @@ from ethereum_spec_tools.new_fork.codemod.constant import SetConstantCommand
 from ethereum_spec_tools.new_fork.codemod.string_replace import (
     StringReplaceCommand,
 )
+
+# src/ethereum/binary_trie/embedding.py - EIP-8297 public API, exercised
+# via tests
+address20_to_address32
+chunkify_code
+encode_basic_data
+get_tree_key_for_basic_data
+get_tree_key_for_code_chunk
+get_tree_key_for_code_hash
+get_tree_key_for_storage_slot
 
 # src/ethereum/utils/hexadecimal.py
 hex_to_bytes256

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -10,6 +10,7 @@ from ethereum.cancun.blocks import Withdrawal
 from ethereum_spec_tools.evm_tools.t8n.transition_tool import EELST8N
 
 from ethereum.binary_trie.embedding import (
+    EMPTY_CODE_HASH,
     address20_to_address32,
     chunkify_code,
     encode_basic_data,
@@ -49,6 +50,7 @@ from ethereum_spec_tools.new_fork.codemod.string_replace import (
 
 # src/ethereum/binary_trie/embedding.py - EIP-8297 public API, exercised
 # via tests
+EMPTY_CODE_HASH
 address20_to_address32
 chunkify_code
 encode_basic_data


### PR DESCRIPTION
### Description

Adds the code that maps accounts, storage and code to keys and values

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
