### PR TITLE
bug(test-eest): reconfigure output streams to UTF-8 on Windows consoles

### DIFF
--- a/packages/testing/src/execution_testing/cli/eest/cli.py
+++ b/packages/testing/src/execution_testing/cli/eest/cli.py
@@ -3,10 +3,32 @@
 Invoke using `uv run eest`.
 """
 
+import sys
+
 import click
 
 from .commands import clean, info
 from .make.cli import make
+
+
+def ensure_utf8_output() -> None:
+    """
+    Reconfigure the standard streams to UTF-8 so output cannot crash.
+
+    The `eest` commands print Unicode characters (box drawing, emoji)
+    that a legacy console code page such as Windows `cp1252` cannot
+    encode, otherwise raising `UnicodeEncodeError` mid-command. Streams
+    that do not support reconfiguration (for example when output is
+    captured in tests) are left untouched.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
 
 
 @click.group(
@@ -17,7 +39,7 @@ from .make.cli import make
 )
 def eest() -> None:
     """`eest` is a CLI tool that helps with routine tasks."""
-    pass
+    ensure_utf8_output()
 
 
 """

--- a/packages/testing/src/execution_testing/cli/eest/tests/__init__.py
+++ b/packages/testing/src/execution_testing/cli/eest/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test cases for the `eest` CLI group."""

--- a/packages/testing/src/execution_testing/cli/eest/tests/test_cli.py
+++ b/packages/testing/src/execution_testing/cli/eest/tests/test_cli.py
@@ -1,0 +1,47 @@
+"""Tests for the `eest` CLI group."""
+
+import io
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from ..cli import eest, ensure_utf8_output
+
+
+def test_info_runs_successfully() -> None:
+    """`eest info` exits cleanly and reports the EEST banner."""
+    result = CliRunner().invoke(eest, ["info"])
+    assert result.exit_code == 0
+    assert "EEST" in result.output
+
+
+def test_info_survives_legacy_console_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    `eest info` must not crash on a non-UTF-8 console code page.
+
+    Regression test for the Windows `cp1252` console, whose codec
+    cannot encode the box-drawing characters printed by the command.
+    """
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    # Without the UTF-8 reconfiguration this raises UnicodeEncodeError.
+    eest.main(["info"], standalone_mode=False)
+
+    stream.flush()
+    assert "EEST" in stream.buffer.getvalue().decode("utf-8")
+
+
+def test_ensure_utf8_output_reconfigures_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`ensure_utf8_output` switches a legacy stream to UTF-8."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    ensure_utf8_output()
+
+    assert stream.encoding.lower() == "utf-8"


### PR DESCRIPTION
The `eest` commands print Unicode characters (box drawing in `info`, emoji in `clean` and `make`) via `click.echo`. On a Windows console using a legacy code page such as `cp1252`, these characters cannot be encoded and the command aborts with `UnicodeEncodeError`.

Reconfigure `sys.stdout`/`sys.stderr` to UTF-8 in the `eest` group callback, guarded so streams that do not support reconfiguration (for example captured output under tests) are left untouched. Add regression tests covering a legacy-encoded stdout.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![cat](https://img.magnific.com/premium-photo/cute-animal-illustration_961307-48178.jpg?semt=ais_test_b&w=740&q=80)
