### PR TITLE
test(spec-tests): add RLP canonical `Uint` decoding test

### DIFF
--- a/tests/json_loader/test_rlp.py
+++ b/tests/json_loader/test_rlp.py
@@ -1,13 +1,9 @@
 """
-Test that decoding RLP into integer types rejects non-canonical
-integers.
+Test that RLP decoding rejects non-canonical integer encodings.
 
-Canonical RLP encodes integers without leading zero bytes, so `0` is
-the empty byte string rather than `0x00`. Decoding an encoding that
-carries a leading zero must fail, otherwise the specification tooling
-would accept inputs that execution clients reject.
-
-See https://github.com/ethereum/ethereum-rlp/issues/10.
+RLP encodes integers big-endian without leading zero bytes; zero is
+the empty byte string, not `0x00`. Execution clients enforce this, so
+the `ethereum-rlp` dependency must too.
 """
 
 from typing import Union
@@ -31,7 +27,7 @@ from ethereum_types.numeric import U64, U256, Uint
 def test_decode_to_uint_accepts_canonical(
     encoded: bytes, expected: int
 ) -> None:
-    """Decode canonical `Uint` encodings with no leading zero byte."""
+    """Decode canonical integer encodings to the expected value."""
     assert rlp.decode_to(Uint, encoded) == Uint(expected)
 
 
@@ -49,6 +45,6 @@ def test_decode_to_uint_accepts_canonical(
 def test_decode_to_integer_rejects_leading_zeros(
     integer_type: type[Union[Uint, U64, U256]], encoded: bytes
 ) -> None:
-    """Reject integer encodings that carry a non-canonical leading zero."""
+    """Reject integer encodings with leading zero bytes."""
     with pytest.raises(DecodingError, match="non-canonical"):
         rlp.decode_to(integer_type, encoded)

--- a/tests/json_loader/test_rlp_canonical_uint.py
+++ b/tests/json_loader/test_rlp_canonical_uint.py
@@ -1,18 +1,21 @@
 """
-Test that decoding RLP into `Uint` rejects non-canonical integers.
+Test that decoding RLP into integer types rejects non-canonical
+integers.
 
-Canonical RLP encodes integers without leading zero bytes, so ``0`` is
-the empty byte string rather than ``0x00``. Decoding an encoding that
+Canonical RLP encodes integers without leading zero bytes, so `0` is
+the empty byte string rather than `0x00`. Decoding an encoding that
 carries a leading zero must fail, otherwise the specification tooling
 would accept inputs that execution clients reject.
 
 See https://github.com/ethereum/ethereum-rlp/issues/10.
 """
 
+from typing import Union
+
 import pytest
 from ethereum_rlp import rlp
 from ethereum_rlp.exceptions import DecodingError
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import U64, U256, Uint
 
 
 @pytest.mark.parametrize(
@@ -21,6 +24,7 @@ from ethereum_types.numeric import Uint
         pytest.param(b"\x80", 0, id="zero-empty-string"),
         pytest.param(b"\x01", 1, id="one"),
         pytest.param(b"\x7f", 0x7F, id="single-byte-max"),
+        pytest.param(b"\x81\x80", 0x80, id="smallest-prefixed"),
         pytest.param(b"\x82\x01\x00", 0x0100, id="two-bytes"),
     ],
 )
@@ -32,6 +36,9 @@ def test_decode_to_uint_accepts_canonical(
 
 
 @pytest.mark.parametrize(
+    "integer_type", [Uint, U64, U256], ids=["Uint", "U64", "U256"]
+)
+@pytest.mark.parametrize(
     "encoded",
     [
         pytest.param(b"\x00", id="single-zero-byte"),
@@ -39,7 +46,9 @@ def test_decode_to_uint_accepts_canonical(
         pytest.param(b"\x83\x00\x00\x01", id="leading-zeros-three-bytes"),
     ],
 )
-def test_decode_to_uint_rejects_leading_zeros(encoded: bytes) -> None:
-    """Reject `Uint` encodings that carry a non-canonical leading zero."""
+def test_decode_to_integer_rejects_leading_zeros(
+    integer_type: type[Union[Uint, U64, U256]], encoded: bytes
+) -> None:
+    """Reject integer encodings that carry a non-canonical leading zero."""
     with pytest.raises(DecodingError, match="non-canonical"):
-        rlp.decode_to(Uint, encoded)
+        rlp.decode_to(integer_type, encoded)

--- a/tests/json_loader/test_rlp_canonical_uint.py
+++ b/tests/json_loader/test_rlp_canonical_uint.py
@@ -1,0 +1,45 @@
+"""
+Test that decoding RLP into `Uint` rejects non-canonical integers.
+
+Canonical RLP encodes integers without leading zero bytes, so ``0`` is
+the empty byte string rather than ``0x00``. Decoding an encoding that
+carries a leading zero must fail, otherwise the specification tooling
+would accept inputs that execution clients reject.
+
+See https://github.com/ethereum/ethereum-rlp/issues/10.
+"""
+
+import pytest
+from ethereum_rlp import rlp
+from ethereum_rlp.exceptions import DecodingError
+from ethereum_types.numeric import Uint
+
+
+@pytest.mark.parametrize(
+    "encoded, expected",
+    [
+        pytest.param(b"\x80", 0, id="zero-empty-string"),
+        pytest.param(b"\x01", 1, id="one"),
+        pytest.param(b"\x7f", 0x7F, id="single-byte-max"),
+        pytest.param(b"\x82\x01\x00", 0x0100, id="two-bytes"),
+    ],
+)
+def test_decode_to_uint_accepts_canonical(
+    encoded: bytes, expected: int
+) -> None:
+    """Decode canonical `Uint` encodings with no leading zero byte."""
+    assert rlp.decode_to(Uint, encoded) == Uint(expected)
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        pytest.param(b"\x00", id="single-zero-byte"),
+        pytest.param(b"\x82\x00\x01", id="leading-zero-two-bytes"),
+        pytest.param(b"\x83\x00\x00\x01", id="leading-zeros-three-bytes"),
+    ],
+)
+def test_decode_to_uint_rejects_leading_zeros(encoded: bytes) -> None:
+    """Reject `Uint` encodings that carry a non-canonical leading zero."""
+    with pytest.raises(DecodingError, match="non-canonical"):
+        rlp.decode_to(Uint, encoded)


### PR DESCRIPTION
Cover decoding RLP into `Uint`: canonical encodings (including `0` as the empty byte string) decode to the expected value, and encodings that carry a non-canonical leading zero byte raise `DecodingError`. This locks in the strict, client-matching behavior of the `ethereum-rlp` dependency.

Fixes #2202.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![coala bear](https://img.magnific.com/premium-photo/png-cute-baby-koala-bear-background-cartoon-mammal-animal_53876-919863.jpg?semt=ais_test_b&w=740&q=80)
