### PR TITLE
bug(test-client-clis): pass str to shutil.which for Windows support

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/ethereum_cli.py
+++ b/packages/testing/src/execution_testing/client_clis/ethereum_cli.py
@@ -64,7 +64,7 @@ class EthereumCLI:
             resolved_path = Path(os.path.expanduser(binary)).resolve()
             if resolved_path.exists():
                 binary = resolved_path
-        binary = shutil.which(binary)  # type: ignore
+        binary = shutil.which(str(binary))  # type: ignore
         if not binary:
             raise CLINotFoundInPathError(binary=binary)
         self.binary = Path(binary)
@@ -239,7 +239,7 @@ class EthereumCLI:
             resolved_path = Path(os.path.expanduser(binary_path)).resolve()
             if resolved_path.exists():
                 binary_path = resolved_path
-        binary = shutil.which(binary_path)
+        binary = shutil.which(str(binary_path))
         return binary is not None
 
     @classmethod

--- a/packages/testing/src/execution_testing/client_clis/tests/test_ethereum_cli.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_ethereum_cli.py
@@ -1,0 +1,29 @@
+"""Tests for the `EthereumCLI` base class."""
+
+from pathlib import Path
+
+import pytest
+
+from execution_testing.client_clis.ethereum_cli import (
+    CLINotFoundInPathError,
+    EthereumCLI,
+)
+
+
+class _MissingCLI(EthereumCLI):
+    """A CLI whose binary is guaranteed not to be on `PATH`."""
+
+    default_binary = Path("eels-nonexistent-binary-xyz")
+
+
+def test_is_installed_accepts_path_binary() -> None:
+    """`is_installed` handles a `Path` binary without raising."""
+    # `shutil.which` must receive a `str`; a `Path` crashes on some
+    # platforms (e.g. Windows under Python 3.11).
+    assert _MissingCLI.is_installed() is False
+
+
+def test_init_missing_path_binary_raises_cli_not_found() -> None:
+    """Constructing a CLI with a missing `Path` binary raises cleanly."""
+    with pytest.raises(CLINotFoundInPathError):
+        _MissingCLI()


### PR DESCRIPTION
`EthereumCLI.__init__` and `is_installed` passed a `Path` to `shutil.which`. On Windows under Python 3.11 (a supported version) `shutil.which` calls `.lower()` on the argument, so a `Path` raises `AttributeError` instead of resolving the binary. Convert the path to `str` at both call sites and add tests covering a `Path` binary.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Baby Elephant](https://static.vecteezy.com/system/resources/thumbnails/059/522/086/small/cute-baby-elephant-sitting-cartoon-style-adorable-animal-with-big-eyes-free-vector.jpg)
