### PR TITLE
bug(spec-tools): make t8n daemon module importable on Windows

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/daemon.py
+++ b/src/ethereum_spec_tools/evm_tools/daemon.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os.path
 import socketserver
+import sys
 import time
 from http.server import BaseHTTPRequestHandler
 from io import StringIO, TextIOWrapper
@@ -116,7 +117,17 @@ class _EvmToolHandler(BaseHTTPRequestHandler):
             main(args=args, out_file=out_wrapper, in_file=input)
 
 
-class _UnixSocketHttpServer(socketserver.UnixStreamServer):
+if sys.platform == "win32":
+    # Windows has no Unix domain sockets, so ``socketserver.UnixStreamServer``
+    # is undefined there. The daemon cannot run on Windows, but this module
+    # must stay importable (``Daemon.run`` rejects the platform explicitly),
+    # so fall back to a base class that exists everywhere.
+    _UnixStreamServerBase = socketserver.TCPServer
+else:
+    _UnixStreamServerBase = socketserver.UnixStreamServer
+
+
+class _UnixSocketHttpServer(_UnixStreamServerBase):
     last_response: float
     shutdown_timeout: int
 
@@ -179,6 +190,11 @@ class Daemon:
         self.timeout = options.timeout
 
     def _run(self) -> int:
+        if sys.platform == "win32":
+            raise RuntimeError(
+                "The t8n daemon relies on Unix domain sockets, which are "
+                "not available on Windows."
+            )
         try:
             os.remove(self.uds)
         except IOError:

--- a/tests/evm_tools/test_daemon.py
+++ b/tests/evm_tools/test_daemon.py
@@ -1,0 +1,18 @@
+"""Test platform handling in the t8n daemon."""
+
+import argparse
+
+import pytest
+
+from ethereum_spec_tools.evm_tools import daemon
+from ethereum_spec_tools.evm_tools.daemon import Daemon
+
+
+def test_daemon_run_rejects_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`Daemon.run` fails clearly on Windows, which has no Unix sockets."""
+    monkeypatch.setattr(daemon.sys, "platform", "win32")
+    instance = Daemon(argparse.Namespace(uds="daemon.sock", timeout=0))
+    with pytest.raises(RuntimeError, match="Unix domain sockets"):
+        instance.run()


### PR DESCRIPTION
`daemon.py` defined `_UnixSocketHttpServer` by subclassing `socketserver.UnixStreamServer`, which does not exist on Windows. Since `ethereum_spec_tools.evm_tools` imports this module at load time, importing the tooling (and therefore collecting the test suite) crashed on Windows with `AttributeError`.

Select the base class per platform so the module stays importable everywhere, and reject running the daemon on Windows with a clear error, as it inherently relies on Unix domain sockets. Add a regression test for the platform guard.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.magnific.com/premium-photo/white-stuffed-animal-with-brown-eyes-pink-nose-pink-nose_766363-8858.jpg?semt=ais_test_b&w=740&q=80)
