### PR TITLE
chore(tests): improve EIP-7708 coverage, checklist, and ref-spec pin

### DIFF
--- a/tests/amsterdam/eip7708_eth_transfer_logs/eip_checklist_not_applicable.txt
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/eip_checklist_not_applicable.txt
@@ -12,3 +12,4 @@ execution_layer_request = EIP does not introduce an execution layer request
 new_transaction_validity_constraint = EIP does not introduce a new transaction validity constraint
 modified_transaction_validity_constraint = EIP does not introduce a modified transaction validity constraint
 block_level_constraint = EIP does not introduce a block-level validation constraint
+general/code_coverage/second_client = Optional

--- a/tests/amsterdam/eip7708_eth_transfer_logs/spec.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/spec.py
@@ -14,7 +14,7 @@ class ReferenceSpec:
 
 
 ref_spec_7708 = ReferenceSpec(
-    "EIPS/eip-7708.md", "172188d7b090ed1afb876140f45e19ac00cba4bb"
+    "EIPS/eip-7708.md", "f7230c46a743313957d8f38a159bda934cc735b2"
 )
 
 
@@ -30,7 +30,6 @@ class Spec:
     TRANSFER_TOPIC: Hash = Hash(
         keccak256(b"Transfer(address,address,uint256)")
     )
-    BURN_TOPIC: Hash = Hash(keccak256(b"Burn(address,uint256)"))
 
 
 def transfer_log(

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
@@ -91,7 +91,7 @@ def test_create_endowment_mainnet(
 ) -> None:
     """Test that a CREATE endowment emits a transfer log on mainnet."""
     sender = pre.fund_eoa()
-    create_value = 100
+    create_value = 1
 
     contract = pre.deploy_contract(
         Op.CREATE(value=create_value, offset=0, size=0),
@@ -100,10 +100,8 @@ def test_create_endowment_mainnet(
     created = compute_create_address(address=contract, nonce=1)
 
     tx = Transaction(
-        ty=0x02,
         sender=sender,
         to=contract,
-        value=0,
         expected_receipt=TransactionReceipt(
             logs=[transfer_log(contract, created, create_value)]
         ),

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
@@ -13,6 +13,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
     TransactionReceipt,
+    compute_create_address,
 )
 
 from .spec import ref_spec_7708, transfer_log
@@ -81,6 +82,34 @@ def test_call_with_value_mainnet(
     )
 
     post = {recipient: Account(balance=100)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_create_endowment_mainnet(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """Test that a CREATE endowment emits a transfer log on mainnet."""
+    sender = pre.fund_eoa()
+    create_value = 100
+
+    contract = pre.deploy_contract(
+        Op.CREATE(value=create_value, offset=0, size=0),
+        balance=create_value,
+    )
+    created = compute_create_address(address=contract, nonce=1)
+
+    tx = Transaction(
+        ty=0x02,
+        sender=sender,
+        to=contract,
+        value=0,
+        expected_receipt=TransactionReceipt(
+            logs=[transfer_log(contract, created, create_value)]
+        ),
+    )
+
+    post = {created: Account(balance=create_value)}
     state_test(pre=pre, post=post, tx=tx)
 
 

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
@@ -112,15 +112,12 @@ def test_emission_point_fork_transition(
     recipient = pre.deploy_contract(Op.STOP)
 
     if emission_point == "call":
-        contract = pre.deploy_contract(
-            Op.CALL(address=recipient, value=Op.CALLVALUE)
-        )
+        code = Op.CALL(address=recipient, value=Op.CALLVALUE)
     elif emission_point == "create":
-        contract = pre.deploy_contract(
-            Op.CREATE(value=Op.CALLVALUE, offset=0, size=0)
-        )
+        code = Op.CREATE(value=Op.CALLVALUE, offset=0, size=0)
     else:
-        contract = pre.deploy_contract(Op.SELFDESTRUCT(recipient))
+        code = Op.SELFDESTRUCT(recipient)
+    contract = pre.deploy_contract(code)
 
     blocks = []
     for nonce, (timestamp, active) in enumerate(

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
@@ -11,8 +11,10 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Op,
     Transaction,
     TransactionReceipt,
+    compute_create_address,
 )
 
 from .spec import ref_spec_7708, transfer_log
@@ -81,3 +83,85 @@ def test_transfer_log_fork_transition(
             recipient: Account(balance=300),
         },
     )
+
+
+@pytest.mark.parametrize(
+    "emission_point",
+    [
+        pytest.param("call", id="call"),
+        pytest.param("create", id="create"),
+        pytest.param("selfdestruct", id="selfdestruct"),
+    ],
+)
+@pytest.mark.valid_at_transition_to("EIP7708")
+def test_emission_point_fork_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    emission_point: str,
+) -> None:
+    """
+    Test the CALL, CREATE, and SELFDESTRUCT emission points at the fork
+    transition boundary.
+
+    Clients gate each emission site in a separate code path, so every
+    site is checked at the transition independently of the
+    transaction-level log.
+    """
+    sender = pre.fund_eoa()
+    value = 100
+    recipient = pre.deploy_contract(Op.STOP)
+
+    if emission_point == "call":
+        contract = pre.deploy_contract(
+            Op.CALL(address=recipient, value=Op.CALLVALUE)
+        )
+    elif emission_point == "create":
+        contract = pre.deploy_contract(
+            Op.CREATE(value=Op.CALLVALUE, offset=0, size=0)
+        )
+    else:
+        contract = pre.deploy_contract(Op.SELFDESTRUCT(recipient))
+
+    blocks = []
+    for nonce, (timestamp, active) in enumerate(
+        [(14_999, False), (15_000, True), (15_001, True)], start=1
+    ):
+        if emission_point == "create":
+            inner_recipient = compute_create_address(
+                address=contract, nonce=nonce
+            )
+        else:
+            inner_recipient = recipient
+        logs = (
+            [
+                transfer_log(sender, contract, value),
+                transfer_log(contract, inner_recipient, value),
+            ]
+            if active
+            else []
+        )
+        blocks.append(
+            Block(
+                timestamp=timestamp,
+                txs=[
+                    Transaction(
+                        to=contract,
+                        sender=sender,
+                        value=value,
+                        expected_receipt=TransactionReceipt(logs=logs),
+                    )
+                ],
+            )
+        )
+
+    if emission_point == "create":
+        post = {
+            compute_create_address(address=contract, nonce=nonce): Account(
+                balance=value
+            )
+            for nonce in (1, 2, 3)
+        }
+    else:
+        post = {recipient: Account(balance=3 * value)}
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7708.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7708.py
@@ -1,0 +1,188 @@
+"""
+Cross-EIP tests for EIP-7928 block-level access lists and EIP-7708
+transfer logs.
+
+A single block pins both views of the same value flows: the receipts
+carry the EIP-7708 Transfer logs while the block access list carries the
+matching balance changes, and the priority-fee payment appears in the
+access list only, with no Transfer log.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    BalAccountExpectation,
+    BalBalanceChange,
+    BalNonceChange,
+    Block,
+    BlockAccessListExpectation,
+    BlockchainTestFiller,
+    Environment,
+    Fork,
+    Header,
+    Op,
+    RecipientType,
+    Transaction,
+    TransactionReceipt,
+)
+
+from ..eip7708_eth_transfer_logs.spec import transfer_log
+from .spec import ref_spec_7928
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7928.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7928.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+def test_transfer_logs_and_bal_balance_changes(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+) -> None:
+    """
+    Ensure Transfer logs and BAL balance changes stay consistent within
+    one block.
+
+    The first transaction is a plain value transfer paying a priority
+    fee: both parties get BAL balance changes, the receipt carries one
+    Transfer log, and the coinbase tip appears in the BAL only. The
+    second transaction sweeps a contract balance via SELFDESTRUCT with a
+    zero tip: the sweep shows up both as a Transfer log and as BAL
+    balance changes, while the coinbase entry stays fee-only from the
+    first transaction.
+    """
+    coinbase = pre.fund_eoa(amount=0)
+
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas = intrinsic_gas_calculator(
+        calldata=b"",
+        contract_creation=False,
+        access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    expected_gas_used = intrinsic_gas + top_frame_state_gas
+    tx_gas_limit = expected_gas_used + 1000  # add a small buffer
+    gas_price = 0xA
+    tx_value = 100
+    extra_balance = 1000
+
+    alice_initial_balance = (
+        (tx_gas_limit * gas_price) + tx_value + extra_balance
+    )
+    alice = pre.fund_eoa(amount=alice_initial_balance)
+    bob = pre.fund_eoa(amount=0)
+
+    genesis_env = Environment(base_fee_per_gas=0x7)
+    base_fee_per_gas = fork.base_fee_per_gas_calculator()(
+        parent_base_fee_per_gas=int(genesis_env.base_fee_per_gas or 0),
+        parent_gas_used=0,
+        parent_gas_limit=genesis_env.gas_limit,
+    )
+    tip_to_coinbase = (gas_price - base_fee_per_gas) * expected_gas_used
+    alice_final_balance = (
+        alice_initial_balance - tx_value - expected_gas_used * gas_price
+    )
+
+    tx_transfer = Transaction(
+        sender=alice,
+        to=bob,
+        value=tx_value,
+        gas_limit=tx_gas_limit,
+        gas_price=gas_price,
+        expected_receipt=TransactionReceipt(
+            logs=[transfer_log(alice, bob, tx_value)]
+        ),
+    )
+
+    # SELFDESTRUCT sweep with a zero tip, so the coinbase BAL entry
+    # stays fee-only from the first transaction.
+    sweep_value = 500
+    carol = pre.fund_eoa()
+    dave = pre.fund_eoa(amount=0)
+    sweeper = pre.deploy_contract(
+        code=Op.SELFDESTRUCT(dave), balance=sweep_value
+    )
+
+    tx_sweep = Transaction(
+        sender=carol,
+        to=sweeper,
+        max_fee_per_gas=base_fee_per_gas,
+        max_priority_fee_per_gas=0,
+        expected_receipt=TransactionReceipt(
+            logs=[transfer_log(sweeper, dave, sweep_value)]
+        ),
+    )
+
+    block = Block(
+        txs=[tx_transfer, tx_sweep],
+        fee_recipient=coinbase,
+        header_verify=Header(base_fee_per_gas=base_fee_per_gas),
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                alice: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=1)
+                    ],
+                    balance_changes=[
+                        BalBalanceChange(
+                            block_access_index=1,
+                            post_balance=alice_final_balance,
+                        )
+                    ],
+                ),
+                bob: BalAccountExpectation(
+                    balance_changes=[
+                        BalBalanceChange(
+                            block_access_index=1, post_balance=tx_value
+                        )
+                    ],
+                ),
+                carol: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=2, post_nonce=1)
+                    ],
+                ),
+                sweeper: BalAccountExpectation(
+                    balance_changes=[
+                        BalBalanceChange(block_access_index=2, post_balance=0)
+                    ],
+                ),
+                dave: BalAccountExpectation(
+                    balance_changes=[
+                        BalBalanceChange(
+                            block_access_index=2, post_balance=sweep_value
+                        )
+                    ],
+                ),
+                # The tip is a BAL-only flow: it must never produce a
+                # Transfer log, and the zero-tip second transaction must
+                # not add a second balance change.
+                coinbase: BalAccountExpectation(
+                    balance_changes=[
+                        BalBalanceChange(
+                            block_access_index=1,
+                            post_balance=tip_to_coinbase,
+                        )
+                    ],
+                ),
+            }
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[block],
+        post={
+            bob: Account(balance=tx_value),
+            dave: Account(balance=sweep_value),
+            sweeper: Account(balance=0),
+        },
+        genesis_environment=genesis_env,
+    )


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Aims to close out EIP-7708 test coverage for the `tests@v21.0.0` tracker by adding fork transition tests for the CALL/CREATE/SELFDESTRUCT emission points (previously only the transaction level log was transition tested), a mainnet CREATE endowment test, and a cross EIP test pinning EIP-7708 Transfer logs and EIP-7928 BAL balance changes in one block (fee payment as a BAL only flow, SELFDESTRUCT sweep in both views).

Re pins the reference spec (old pin was a dangling pre merge commit), removes the dead `BURN_TOPIC` constant, and completes the testing checklist by marking the optional second client item N/A. Checks off the 7928 x 7708 cross EIP item on the `tests@v21.0.0` tracker.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1875, #1878.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fwww.drodd.com%2Fimages10%2Ffunny-animal-gifs7.gif&f=1&nofb=1&ipt=24c39c99fb0f645b439913803666109f016c0ed2630e6890987e9fef294a738b)
