### PR TITLE
chore(tests): improve EIP-7981 coverage, checklist, and ref-spec pin

### DIFF
--- a/tests/amsterdam/eip7981_increase_access_list_cost/eip_checklist_external_coverage.txt
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/eip_checklist_external_coverage.txt
@@ -1,0 +1,3 @@
+general/code_coverage/eels = Covered in EELS
+general/code_coverage/test_coverage = Run locally
+general/code_coverage/missed_lines = No missed lines; the EIP adds only the access list token accounting in calculate_intrinsic_cost, fully exercised by this suite

--- a/tests/amsterdam/eip7981_increase_access_list_cost/eip_checklist_not_applicable.txt
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/eip_checklist_not_applicable.txt
@@ -1,0 +1,13 @@
+general/code_coverage/second_client = Optional
+opcode = EIP does not introduce or modify an opcode
+precompile = EIP does not introduce a precompile
+removed_precompile = EIP does not remove a precompile
+system_contract = EIP does not introduce a system contract
+transaction_type = EIP does not introduce a new transaction type
+block_header_field = EIP does not add any new block header fields
+block_body_field = EIP does not add any new block body fields
+gas_refunds_changes = EIP does not introduce any gas refund changes
+blob_count_changes = EIP does not introduce any blob count changes
+execution_layer_request = EIP does not introduce an execution layer request
+new_transaction_validity_constraint = EIP modifies the existing intrinsic and floor gas validity constraints rather than introducing a new one
+block_level_constraint = EIP does not introduce a block-level validation constraint

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,16 +12,5 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "954963fb6315dffadd9c40d48e4dae313e20cff5"
+    "EIPS/eip-7981.md", "747b78c0edfdf04e9e2933ad1bec592d3318e1d9"
 )
-
-
-# Constants
-class Spec:
-    """
-    Parameters from the EIP-7981 specifications as defined at
-    https://eips.ethereum.org/EIPS/eip-7981.
-    """
-
-    ACCESS_LIST_ADDRESS_COST = 2400
-    ACCESS_LIST_STORAGE_KEY_COST = 1900

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -8,8 +8,10 @@ from execution_testing import (
     Address,
     Alloc,
     Bytes,
+    EIPChecklist,
     Fork,
     Hash,
+    Op,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
@@ -24,6 +26,7 @@ REFERENCE_SPEC_VERSION = ref_spec_7981.version
 pytestmark = pytest.mark.valid_at("EIP7981")
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list,expected_floor_tokens",
@@ -137,6 +140,7 @@ def test_access_list_token_calculation(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list,tx_data",
@@ -190,6 +194,7 @@ def test_access_list_floor_cost_with_calldata(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list",
@@ -220,7 +225,8 @@ def test_large_access_list_cost(
     Test gas costs for large access lists.
 
     With EIP-7981, large access lists should incur:
-    1. Storage access costs (2400 per address + 1900 per key)
+    1. Storage access costs (per-address and per-key charges, priced
+       at the fork's cold access costs since EIP-8038)
     2. Data footprint costs (16 per floor token)
     """
     state_test(
@@ -230,6 +236,7 @@ def test_large_access_list_cost(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list",
@@ -259,6 +266,96 @@ def test_duplicate_access_list_entries(
     According to EIP-2930, non-unique addresses and storage keys are allowed
     and charged multiple times. EIP-7981 should maintain this behavior.
     """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type in (1, 2))
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(0), Hash(1)],
+                )
+            ],
+            id="single_address_two_keys",
+        ),
+    ],
+)
+def test_access_list_data_cost_with_execution(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_type: int,
+    access_list: list,
+) -> None:
+    """
+    Test that the access list data cost is charged when execution gas
+    dominates.
+
+    EIP-7981 charges the access list data cost as a flat surcharge on
+    both sides of the gas-used max, so it is paid in full even when the
+    intrinsic-plus-execution side exceeds the floor. An implementation
+    that only counts access list bytes toward the floor undercharges
+    exactly the surcharge here, failing the receipt pin.
+    """
+    gas_costs = fork.gas_costs()
+    surcharge = (
+        calculate_access_list_floor_tokens(access_list)
+        * gas_costs.TX_DATA_TOKEN_FLOOR
+    )
+    # One gas per JUMPDEST, sized so the execution gas strictly exceeds
+    # the surcharge under test.
+    code = Op.JUMPDEST * (surcharge + 1) + Op.STOP
+    contract = pre.deploy_contract(code)
+    execution_gas = code.gas_cost(fork)
+    assert execution_gas > surcharge
+
+    intrinsic_cost_calculator = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas = intrinsic_cost_calculator(
+        access_list=access_list,
+        return_cost_deducted_prior_execution=True,
+    )
+    # The surcharge must be an explicit term of the intrinsic cost, on
+    # top of the per-entry access charges of the same transaction
+    # without an access list.
+    entry_charges = (
+        gas_costs.TX_ACCESS_LIST_ADDRESS
+        + 2 * gas_costs.TX_ACCESS_LIST_STORAGE_KEY
+    )
+    intrinsic_gas_no_access_list = intrinsic_cost_calculator(
+        return_cost_deducted_prior_execution=True,
+    )
+    assert (
+        intrinsic_gas
+        == intrinsic_gas_no_access_list + entry_charges + surcharge
+    )
+
+    # The execution side must win the max against the floor.
+    expected_gas_used = intrinsic_gas + execution_gas
+    floor_gas = fork.transaction_data_floor_cost_calculator()(
+        data=b"", access_list=access_list
+    )
+    assert expected_gas_used > floor_gas
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=pre.fund_eoa(),
+        to=contract,
+        access_list=access_list,
+        gas_limit=expected_gas_used,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used
+        ),
+    )
+
     state_test(
         pre=pre,
         post={},

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
@@ -7,6 +7,7 @@ from execution_testing import (
     AccessList,
     Address,
     Alloc,
+    EIPChecklist,
     Hash,
     StateTestFiller,
     Transaction,
@@ -20,6 +21,7 @@ REFERENCE_SPEC_VERSION = ref_spec_7981.version
 pytestmark = [pytest.mark.valid_at("EIP7981"), pytest.mark.mainnet]
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list",
@@ -92,6 +94,7 @@ def test_access_list_gas_cost(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list",

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_floor_boundary_exact_balance.py
@@ -9,6 +9,7 @@ from execution_testing import (
     Address,
     Alloc,
     Bytes,
+    EIPChecklist,
     Fork,
     Hash,
     StateTestFiller,
@@ -24,6 +25,7 @@ REFERENCE_SPEC_VERSION = ref_spec_7981.version
 pytestmark = pytest.mark.valid_at("EIP7981")
 
 
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.exception_test
 @pytest.mark.parametrize(
     "tx_type",

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_fork_transition.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_fork_transition.py
@@ -31,6 +31,7 @@ from execution_testing import (
     Hash,
     Transaction,
     TransactionException,
+    TransactionReceipt,
     TransitionFork,
 )
 
@@ -40,7 +41,7 @@ from .spec import ref_spec_7981
 REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7981.version
 
-pytestmark = pytest.mark.valid_at_transition_to("Amsterdam")
+pytestmark = pytest.mark.valid_at_transition_to("EIP7981")
 
 # Transition forks switch at timestamp 15_000.
 PRE_FORK_TIMESTAMP = 14_999
@@ -273,3 +274,104 @@ def test_access_list_validity_across_amsterdam_transition(
     ]
 
     blockchain_test(pre=pre, blocks=blocks, post={})
+
+
+@EIPChecklist.GasCostChanges.Test.ForkTransition.Before()
+@EIPChecklist.GasCostChanges.Test.ForkTransition.After()
+def test_access_list_floor_across_amsterdam_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: TransitionFork,
+) -> None:
+    """
+    Pin access list bytes entering the calldata floor at the boundary.
+
+    A calldata-heavy access-list transaction binds the floor on both
+    sides of the transition: pre-fork the floor counts calldata bytes
+    only (access list bytes contribute nothing), post-fork the EIP-7981
+    tokens raise it. Each block's gas limit is pinned to its fork's
+    floor, so the billed gas equals the floor exactly and an
+    implementation that mistimes the floor change fails the receipt and
+    balance pins.
+    """
+    gas_price = 1_000_000_000
+    # Sized so the floor dominates the intrinsic on both sides
+    # (asserted below): each non-zero byte adds 40 - 16 = 24 gas of
+    # floor headroom pre-fork and 64 - 16 = 48 post-fork, outgrowing
+    # the per-entry access charges that only the intrinsic carries.
+    data = b"\x01" * 400
+    access_list = access_list_shape(addresses=1, keys_per_address=2)
+
+    pre_fork = fork.fork_at(timestamp=PRE_FORK_TIMESTAMP)
+    post_fork = fork.fork_at(timestamp=POST_FORK_TIMESTAMP)
+    pre_costs = pre_fork.gas_costs()
+    post_costs = post_fork.gas_costs()
+
+    # Pre-fork (EIP-7623): content-weighted calldata tokens only; the
+    # access list bytes contribute nothing to the floor.
+    pre_tokens = len(data) * 4
+    expected_pre = int(
+        pre_costs.TX_BASE + pre_tokens * pre_costs.TX_DATA_TOKEN_FLOOR
+    )
+    assert pre_fork.transaction_data_floor_cost_calculator()(
+        data=data, access_list=access_list
+    ) == pre_fork.transaction_data_floor_cost_calculator()(data=data)
+    # Post-fork: uniform calldata tokens plus the EIP-7981 access list
+    # tokens, anchored on the EIP-2780 decomposed base.
+    post_tokens = len(data) * int(
+        post_costs.TX_DATA_TOKEN_STANDARD
+    ) + calculate_access_list_floor_tokens(access_list)
+    expected_post = int(
+        post_costs.TX_BASE
+        + post_costs.COLD_ACCOUNT_ACCESS
+        + post_tokens * post_costs.TX_DATA_TOKEN_FLOOR
+    )
+
+    timestamps = [PRE_FORK_TIMESTAMP, POST_FORK_TIMESTAMP]
+    expected_floors = [expected_pre, expected_post]
+    blocks = []
+    post: dict[Address, Account] = {}
+
+    for timestamp, expected_floor in zip(
+        timestamps, expected_floors, strict=True
+    ):
+        sub_fork = fork.fork_at(timestamp=timestamp)
+        floor_gas = sub_fork.transaction_data_floor_cost_calculator()(
+            data=data, access_list=access_list
+        )
+        assert floor_gas == expected_floor, (
+            f"floor at timestamp {timestamp} ({sub_fork}) is {floor_gas}, "
+            f"expected {expected_floor}"
+        )
+        # The floor must dominate the intrinsic so the transaction is
+        # billed exactly the floor.
+        intrinsic_gas = sub_fork.transaction_intrinsic_cost_calculator()(
+            calldata=data,
+            access_list=access_list,
+            return_cost_deducted_prior_execution=True,
+        )
+        assert floor_gas > intrinsic_gas, (
+            f"floor {floor_gas} does not dominate intrinsic "
+            f"{intrinsic_gas} at timestamp {timestamp} ({sub_fork})"
+        )
+
+        sender_initial_balance = 10**18
+        sender = pre.fund_eoa(sender_initial_balance)
+
+        tx = Transaction(
+            sender=sender,
+            to=pre.fund_eoa(amount=0),
+            data=data,
+            gas_limit=floor_gas,
+            gas_price=gas_price,
+            access_list=access_list,
+            expected_receipt=TransactionReceipt(cumulative_gas_used=floor_gas),
+        )
+        blocks.append(Block(timestamp=timestamp, txs=[tx]))
+
+        post[sender] = Account(
+            nonce=1,
+            balance=sender_initial_balance - floor_gas * gas_price,
+        )
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_fork_transition.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_fork_transition.py
@@ -1,0 +1,275 @@
+"""
+Fork-transition tests for [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+
+EIP-7981 adds a data-footprint surcharge for access list bytes at the
+Amsterdam fork boundary. These tests send identical access-list
+transactions in a pre-fork block and a post-fork block (straddling the
+transition timestamp) and pin the per-transaction gas paid on each side,
+plus the validity flip for gas limits inside the uplift gap.
+
+The post-fork intrinsic composes three repricings; the hand-derived
+expectations below keep each term explicit so the EIP-7981 surcharge is
+individually visible:
+
+- EIP-2780 decomposes the flat pre-fork `TX_BASE` into the lowered base
+  plus the `COLD_ACCOUNT_ACCESS` recipient charge.
+- EIP-8038 reprices the per-address and per-storage-key access list
+  charges to the fork's cold access costs.
+- EIP-7981 adds four floor tokens per access list byte, charged at
+  `TX_DATA_TOKEN_FLOOR` in the intrinsic and counted in the floor.
+"""
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Account,
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    EIPChecklist,
+    Hash,
+    Transaction,
+    TransactionException,
+    TransitionFork,
+)
+
+from .helpers import calculate_access_list_floor_tokens
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = pytest.mark.valid_at_transition_to("Amsterdam")
+
+# Transition forks switch at timestamp 15_000.
+PRE_FORK_TIMESTAMP = 14_999
+POST_FORK_TIMESTAMP = 15_000
+
+
+def access_list_shape(addresses: int, keys_per_address: int) -> list:
+    """Build an access list with the given shape."""
+    return [
+        AccessList(
+            address=Address(i + 1),
+            storage_keys=[Hash(k) for k in range(keys_per_address)],
+        )
+        for i in range(addresses)
+    ]
+
+
+@EIPChecklist.GasCostChanges.Test.ForkTransition.Before()
+@EIPChecklist.GasCostChanges.Test.ForkTransition.After()
+@pytest.mark.parametrize(
+    "addresses,keys_per_address",
+    [
+        pytest.param(1, 0, id="single_address_no_keys"),
+        pytest.param(1, 2, id="single_address_two_keys"),
+        pytest.param(2, 3, id="two_addresses_three_keys_each"),
+    ],
+)
+def test_access_list_intrinsic_across_amsterdam_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: TransitionFork,
+    addresses: int,
+    keys_per_address: int,
+) -> None:
+    """
+    Pin the access list intrinsic change across the Amsterdam boundary.
+
+    The same access-list transaction shape is sent in a pre-fork block
+    (flat base plus the EIP-2930 per-entry charges, no data cost) and a
+    post-fork block (decomposed base, repriced entries, plus the
+    EIP-7981 byte surcharge). Each block uses a distinct sender so its
+    post-tx balance pins the fork-appropriate intrinsic; the recipient
+    is an existing EOA, so no EVM bytecode runs and `gas_used` equals
+    the intrinsic exactly.
+
+    The per-fork intrinsic returned by the calculator is also checked
+    against a hand-derived per-EIP decomposition, so a calculator
+    regression fails here with a clear message rather than only as a
+    downstream balance mismatch.
+    """
+    gas_price = 1_000_000_000
+    access_list = access_list_shape(addresses, keys_per_address)
+    total_keys = addresses * keys_per_address
+
+    pre_fork = fork.fork_at(timestamp=PRE_FORK_TIMESTAMP)
+    post_fork = fork.fork_at(timestamp=POST_FORK_TIMESTAMP)
+    pre_costs = pre_fork.gas_costs()
+    post_costs = post_fork.gas_costs()
+
+    # Pre-fork: flat base plus the EIP-2930 per-entry charges; access
+    # list bytes carry no data cost.
+    expected_pre = (
+        pre_costs.TX_BASE
+        + addresses * pre_costs.TX_ACCESS_LIST_ADDRESS
+        + total_keys * pre_costs.TX_ACCESS_LIST_STORAGE_KEY
+    )
+    # Post-fork: EIP-2780 decomposed base and recipient charge, EIP-8038
+    # repriced entry charges, and the EIP-7981 byte surcharge.
+    surcharge = (
+        calculate_access_list_floor_tokens(access_list)
+        * post_costs.TX_DATA_TOKEN_FLOOR
+    )
+    expected_post = (
+        post_costs.TX_BASE
+        + post_costs.COLD_ACCOUNT_ACCESS
+        + addresses * post_costs.TX_ACCESS_LIST_ADDRESS
+        + total_keys * post_costs.TX_ACCESS_LIST_STORAGE_KEY
+        + surcharge
+    )
+
+    timestamps = [PRE_FORK_TIMESTAMP, POST_FORK_TIMESTAMP]
+    expected_intrinsics = [expected_pre, expected_post]
+    blocks = []
+    post: dict[Address, Account] = {}
+
+    for timestamp, expected_intrinsic in zip(
+        timestamps, expected_intrinsics, strict=True
+    ):
+        sub_fork = fork.fork_at(timestamp=timestamp)
+        intrinsic_gas = sub_fork.transaction_intrinsic_cost_calculator()(
+            access_list=access_list,
+            return_cost_deducted_prior_execution=True,
+        )
+        assert intrinsic_gas == expected_intrinsic, (
+            f"intrinsic at timestamp {timestamp} ({sub_fork}) is "
+            f"{intrinsic_gas}, expected {expected_intrinsic}"
+        )
+        # The intrinsic side must bind so gas_used equals the intrinsic.
+        floor_gas = sub_fork.transaction_data_floor_cost_calculator()(
+            data=b"", access_list=access_list
+        )
+        assert floor_gas <= intrinsic_gas
+
+        sender_initial_balance = 10**18
+        sender = pre.fund_eoa(sender_initial_balance)
+        target = pre.fund_eoa(amount=0)
+
+        tx = Transaction(
+            sender=sender,
+            to=target,
+            gas_limit=intrinsic_gas,
+            gas_price=gas_price,
+            access_list=access_list,
+        )
+        blocks.append(Block(timestamp=timestamp, txs=[tx]))
+
+        post[sender] = Account(
+            nonce=1,
+            balance=sender_initial_balance - intrinsic_gas * gas_price,
+        )
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedBeforeFork()
+@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedBeforeFork()
+@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedAfterFork()
+@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedAfterFork()
+@pytest.mark.exception_test
+def test_access_list_validity_across_amsterdam_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: TransitionFork,
+) -> None:
+    """
+    Pin the intrinsic-validity flip across the Amsterdam boundary.
+
+    For an access list with one address and two storage keys the
+    EIP-7981 byte surcharge (plus the EIP-8038 entry repricing) outgrows
+    the EIP-2780 base reduction, so the post-fork intrinsic is strictly
+    higher than the pre-fork one. Off-by-one gas limits around each
+    fork's requirement then pin all four boundary behaviors:
+
+    1. Pre-fork block with `gas_limit` one below the pre-fork intrinsic
+       is rejected.
+    2. Pre-fork block accepts both the exact pre-fork intrinsic and a
+       gas limit one below the post-fork intrinsic (the new constraint
+       is not met, the old one is).
+    3. Post-fork block with that same one-below gas limit is rejected.
+    4. Post-fork block with the exact post-fork intrinsic is accepted.
+    """
+    gas_price = 1_000_000_000
+    access_list = access_list_shape(addresses=1, keys_per_address=2)
+
+    pre_fork = fork.fork_at(timestamp=PRE_FORK_TIMESTAMP)
+    post_fork = fork.fork_at(timestamp=POST_FORK_TIMESTAMP)
+
+    intrinsic_pre = pre_fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        return_cost_deducted_prior_execution=True,
+    )
+    intrinsic_post = post_fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        return_cost_deducted_prior_execution=True,
+    )
+    # The gas limit straddling the boundary must be valid pre-fork and
+    # invalid post-fork.
+    straddle_gas_limit = intrinsic_post - 1
+    assert intrinsic_pre <= straddle_gas_limit, (
+        f"access list shape does not discriminate: pre-fork intrinsic "
+        f"{intrinsic_pre} exceeds post-fork intrinsic - 1 "
+        f"({straddle_gas_limit})"
+    )
+    # The intrinsic side must bind over the floor on both forks.
+    for sub_fork, intrinsic in [
+        (pre_fork, intrinsic_pre),
+        (post_fork, intrinsic_post),
+    ]:
+        floor_gas = sub_fork.transaction_data_floor_cost_calculator()(
+            data=b"", access_list=access_list
+        )
+        assert floor_gas <= intrinsic
+
+    def make_tx(
+        gas_limit: int, error: TransactionException | None = None
+    ) -> Transaction:
+        return Transaction(
+            sender=pre.fund_eoa(),
+            to=pre.fund_eoa(amount=0),
+            gas_limit=gas_limit,
+            gas_price=gas_price,
+            access_list=access_list,
+            error=error,
+        )
+
+    blocks = [
+        # 1. Rejected before the fork: below the pre-fork intrinsic.
+        Block(
+            timestamp=PRE_FORK_TIMESTAMP,
+            txs=[
+                make_tx(
+                    intrinsic_pre - 1,
+                    error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+                )
+            ],
+            exception=TransactionException.INTRINSIC_GAS_TOO_LOW,
+        ),
+        # 2. Accepted before the fork: the exact pre-fork intrinsic and
+        # the straddling gas limit that the post-fork rules will reject.
+        Block(
+            timestamp=PRE_FORK_TIMESTAMP,
+            txs=[make_tx(intrinsic_pre), make_tx(straddle_gas_limit)],
+        ),
+        # 3. Rejected after the fork: the same straddling gas limit.
+        Block(
+            timestamp=POST_FORK_TIMESTAMP,
+            txs=[
+                make_tx(
+                    straddle_gas_limit,
+                    error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+                )
+            ],
+            exception=TransactionException.INTRINSIC_GAS_TOO_LOW,
+        ),
+        # 4. Accepted after the fork: the exact post-fork intrinsic.
+        Block(
+            timestamp=POST_FORK_TIMESTAMP,
+            txs=[make_tx(intrinsic_post)],
+        ),
+    ]
+
+    blockchain_test(pre=pre, blocks=blocks, post={})

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -5,12 +5,17 @@ Tests for transaction validity with [EIP-7981: Increase Access List Cost](https:
 import pytest
 from execution_testing import (
     AccessList,
+    Account,
     Address,
     Alloc,
     Bytes,
+    EIPChecklist,
+    Fork,
     Hash,
     StateTestFiller,
     Transaction,
+    TransactionException,
+    compute_create_address,
 )
 
 from .spec import ref_spec_7981
@@ -21,6 +26,7 @@ REFERENCE_SPEC_VERSION = ref_spec_7981.version
 pytestmark = pytest.mark.valid_at("EIP7981")
 
 
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.exception_test
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
@@ -76,6 +82,7 @@ def test_insufficient_gas_for_access_list(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.exception_test
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
@@ -122,6 +129,7 @@ def test_floor_cost_validation_with_access_list(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list,tx_gas_delta",
@@ -168,6 +176,7 @@ def test_valid_gas_limits_with_access_list(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
     "access_list,tx_data",
@@ -223,6 +232,7 @@ def test_mixed_zero_nonzero_bytes_floor_cost(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.parametrize(
     "tx_type,access_list",
     [
@@ -275,5 +285,78 @@ def test_transactions_without_access_list(
     state_test(
         pre=pre,
         post={},
+        tx=tx,
+    )
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type in (1, 2))
+@pytest.mark.parametrize(
+    "valid",
+    [
+        pytest.param(True, id="exact_gas"),
+        pytest.param(
+            False,
+            id="insufficient_gas_by_one",
+            marks=pytest.mark.exception_test,
+        ),
+    ],
+)
+def test_contract_creation_with_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_type: int,
+    valid: bool,
+) -> None:
+    """
+    Test the intrinsic boundary of a contract-creating transaction with
+    an access list.
+
+    The EIP-7981 access list data cost stacks on top of the creation
+    intrinsic (creation access and init code charges). The created
+    account's state charge is applied at the top frame, after intrinsic
+    validation, so the exact-gas arm funds it separately while the
+    off-by-one arm pins the intrinsic requirement alone.
+    """
+    access_list = [
+        AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)])
+    ]
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        contract_creation=True,
+        access_list=access_list,
+        return_cost_deducted_prior_execution=True,
+    )
+    floor_gas = fork.transaction_data_floor_cost_calculator()(
+        data=b"", access_list=access_list, contract_creation=True
+    )
+    assert floor_gas <= intrinsic_gas
+
+    sender = pre.fund_eoa()
+    post: dict = {}
+    if valid:
+        gas_limit = intrinsic_gas + fork.transaction_top_frame_state_gas(
+            contract_creation=True
+        )
+        error = None
+        created = compute_create_address(address=sender, nonce=sender.nonce)
+        post[created] = Account(nonce=1, code=b"")
+    else:
+        gas_limit = intrinsic_gas - 1
+        error = TransactionException.INTRINSIC_GAS_TOO_LOW
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=None,
+        access_list=access_list,
+        gas_limit=gas_limit,
+        error=error,
+    )
+
+    state_test(
+        pre=pre,
+        post=post,
         tx=tx,
     )


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Closes out EIP-7981 test coverage for the `tests@v21.0.0` tracker.

Adds fork transition tests pinning the access list intrinsic change (hand-derived EIP-2780/8038/7981 decomposition, balance-pinned) and the validity threshold flip (one address plus two keys is the smallest shape where the EIP-7981 surcharge and EIP-8038 repricing outgrow the EIP-2780 base reduction, so the straddling gas limit is accepted pre-fork and rejected post-fork). Also adds an execution-regime receipt pin (the surcharge is flat, charged on both sides of the gas-used max, per the current spec formulation) and a contract-creation intrinsic boundary test.

Adds `EIPChecklist` markers plus the not-applicable/external-coverage files, taking the checklist to 100%, repins the reference spec (old pin was dangling), and removes the unused `Spec` constants class (pre-EIP-8038 values).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1943

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/b/b6/Felis_catus-cat_on_snow.jpg)
