### PR TITLE
refactor(test): Make max balance < 2^128 wei

### DIFF
--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -315,7 +315,7 @@ def non_zero_blob_gas_used_genesis_block(
         f"with base_fee_per_gas {block_base_fee_per_gas}"
     )
 
-    sender = pre.fund_eoa(10**42)
+    sender = pre.fund_eoa(10**36)
     empty_account_destination = pre.fund_eoa(0)
     blob_gas_price_calculator = block_fork.blob_gas_price_calculator()
 


### PR DESCRIPTION
### Description

Currently this fails on binary trie filling because the binary trie encodes the balance as a 16 bytes

Reference: #3229 

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
