### PR TITLE
fix: max balance < 2^128 in ported static tests

### DIFF
--- a/tests/ported_static/stCreate2/test_create2_bounds.py
+++ b/tests/ported_static/stCreate2/test_create2_bounds.py
@@ -56,9 +56,7 @@ def test_create2_bounds(
     """Test_create2_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stCreate2/test_create2_bounds.py
+++ b/tests/ported_static/stCreate2/test_create2_bounds.py
@@ -57,7 +57,7 @@ def test_create2_bounds(
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stCreate2/test_create2_bounds2.py
+++ b/tests/ported_static/stCreate2/test_create2_bounds2.py
@@ -57,7 +57,7 @@ def test_create2_bounds2(
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stCreate2/test_create2_bounds2.py
+++ b/tests/ported_static/stCreate2/test_create2_bounds2.py
@@ -56,9 +56,7 @@ def test_create2_bounds2(
     """Test_create2_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stCreate2/test_create2_bounds3.py
+++ b/tests/ported_static/stCreate2/test_create2_bounds3.py
@@ -63,7 +63,7 @@ def test_create2_bounds3(
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stCreate2/test_create2_bounds3.py
+++ b/tests/ported_static/stCreate2/test_create2_bounds3.py
@@ -62,9 +62,7 @@ def test_create2_bounds3(
     """Test_create2_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds.py
@@ -55,7 +55,7 @@ def test_call_bounds(
     """Test_call_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds.py
@@ -54,9 +54,7 @@ def test_call_bounds(
 ) -> None:
     """Test_call_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds2.py
@@ -54,9 +54,7 @@ def test_call_bounds2(
 ) -> None:
     """Test_call_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds2.py
@@ -55,7 +55,7 @@ def test_call_bounds2(
     """Test_call_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds2a.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds2a.py
@@ -55,7 +55,7 @@ def test_call_bounds2a(
     """Test_call_bounds2a."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds2a.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds2a.py
@@ -54,9 +54,7 @@ def test_call_bounds2a(
 ) -> None:
     """Test_call_bounds2a."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds3.py
@@ -61,7 +61,7 @@ def test_call_bounds3(
     """Test_call_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_call_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_call_bounds3.py
@@ -60,9 +60,7 @@ def test_call_bounds3(
 ) -> None:
     """Test_call_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds.py
@@ -54,9 +54,7 @@ def test_callcode_bounds(
 ) -> None:
     """Test_callcode_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds.py
@@ -55,7 +55,7 @@ def test_callcode_bounds(
     """Test_callcode_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds2.py
@@ -54,9 +54,7 @@ def test_callcode_bounds2(
 ) -> None:
     """Test_callcode_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds2.py
@@ -55,7 +55,7 @@ def test_callcode_bounds2(
     """Test_callcode_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds3.py
@@ -55,7 +55,7 @@ def test_callcode_bounds3(
     """Test_callcode_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds3.py
@@ -54,9 +54,7 @@ def test_callcode_bounds3(
 ) -> None:
     """Test_callcode_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds4.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds4.py
@@ -61,7 +61,7 @@ def test_callcode_bounds4(
     """Test_callcode_bounds4."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_callcode_bounds4.py
+++ b/tests/ported_static/stMemoryStressTest/test_callcode_bounds4.py
@@ -60,9 +60,7 @@ def test_callcode_bounds4(
 ) -> None:
     """Test_callcode_bounds4."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_create_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_create_bounds.py
@@ -56,9 +56,7 @@ def test_create_bounds(
     """Test_create_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_create_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_create_bounds.py
@@ -57,7 +57,7 @@ def test_create_bounds(
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_create_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_create_bounds2.py
@@ -56,9 +56,7 @@ def test_create_bounds2(
     """Test_create_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_create_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_create_bounds2.py
@@ -57,7 +57,7 @@ def test_create_bounds2(
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_create_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_create_bounds3.py
@@ -62,9 +62,7 @@ def test_create_bounds3(
     """Test_create_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_create_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_create_bounds3.py
@@ -63,7 +63,7 @@ def test_create_bounds3(
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     contract_0 = Address(0x1000000000000000000000000000000000000000)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds.py
@@ -55,7 +55,7 @@ def test_delegatecall_bounds(
     """Test_delegatecall_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds.py
@@ -54,9 +54,7 @@ def test_delegatecall_bounds(
 ) -> None:
     """Test_delegatecall_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds2.py
@@ -55,7 +55,7 @@ def test_delegatecall_bounds2(
     """Test_delegatecall_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds2.py
@@ -54,9 +54,7 @@ def test_delegatecall_bounds2(
 ) -> None:
     """Test_delegatecall_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds3.py
@@ -60,9 +60,7 @@ def test_delegatecall_bounds3(
 ) -> None:
     """Test_delegatecall_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_delegatecall_bounds3.py
@@ -61,7 +61,7 @@ def test_delegatecall_bounds3(
     """Test_delegatecall_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_mstore_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_mstore_bounds.py
@@ -55,7 +55,7 @@ def test_mstore_bounds(
     """Test_mstore_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_mstore_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_mstore_bounds.py
@@ -54,9 +54,7 @@ def test_mstore_bounds(
 ) -> None:
     """Test_mstore_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_mstore_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_mstore_bounds2.py
@@ -54,9 +54,7 @@ def test_mstore_bounds2(
 ) -> None:
     """Test_mstore_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_mstore_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_mstore_bounds2.py
@@ -55,7 +55,7 @@ def test_mstore_bounds2(
     """Test_mstore_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_return_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_return_bounds.py
@@ -63,9 +63,7 @@ def test_return_bounds(
 ) -> None:
     """Test_return_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_return_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_return_bounds.py
@@ -64,7 +64,7 @@ def test_return_bounds(
     """Test_return_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds.py
@@ -55,7 +55,7 @@ def test_static_call_bounds(
     """Test_static_call_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds.py
@@ -54,9 +54,7 @@ def test_static_call_bounds(
 ) -> None:
     """Test_static_call_bounds."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds2.py
@@ -54,9 +54,7 @@ def test_static_call_bounds2(
 ) -> None:
     """Test_static_call_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds2.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds2.py
@@ -55,7 +55,7 @@ def test_static_call_bounds2(
     """Test_static_call_bounds2."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds2a.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds2a.py
@@ -54,9 +54,7 @@ def test_static_call_bounds2a(
 ) -> None:
     """Test_static_call_bounds2a."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds2a.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds2a.py
@@ -55,7 +55,7 @@ def test_static_call_bounds2a(
     """Test_static_call_bounds2a."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds3.py
@@ -54,9 +54,7 @@ def test_static_call_bounds3(
 ) -> None:
     """Test_static_call_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
-    sender = pre.fund_eoa(
-        amount=2**128 - 1
-    )
+    sender = pre.fund_eoa(amount=2**128 - 1)
 
     env = Environment(
         fee_recipient=coinbase,

--- a/tests/ported_static/stMemoryStressTest/test_static_call_bounds3.py
+++ b/tests/ported_static/stMemoryStressTest/test_static_call_bounds3.py
@@ -55,7 +55,7 @@ def test_static_call_bounds3(
     """Test_static_call_bounds3."""
     coinbase = Address(0x2ADC25665018AA1FE0E6BC666DAC8FC2697FF9BA)
     sender = pre.fund_eoa(
-        amount=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        amount=2**128 - 1
     )
 
     env = Environment(

--- a/tests/ported_static/stTransactionTest/test_high_gas_limit.py
+++ b/tests/ported_static/stTransactionTest/test_high_gas_limit.py
@@ -56,7 +56,7 @@ def test_high_gas_limit(
     )
 
     pre[sender] = Account(
-        balance=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF  # noqa: E501
+        balance=2**128 - 1
     )
 
     # EIP-2780 charges ``NEW_ACCOUNT`` state gas at the top frame when

--- a/tests/ported_static/stTransactionTest/test_high_gas_limit.py
+++ b/tests/ported_static/stTransactionTest/test_high_gas_limit.py
@@ -55,9 +55,7 @@ def test_high_gas_limit(
         gas_limit=9223372036854775807,
     )
 
-    pre[sender] = Account(
-        balance=2**128 - 1
-    )
+    pre[sender] = Account(balance=2**128 - 1)
 
     # EIP-2780 charges ``NEW_ACCOUNT`` state gas at the top frame when
     # value is sent to an empty recipient; with the default zero


### PR DESCRIPTION
### Description

Related to #3229 

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
