### PR TITLE
fix: skip ported static tests for amsterdam and later

### DIFF
--- a/tests/ported_static/conftest.py
+++ b/tests/ported_static/conftest.py
@@ -1,9 +1,10 @@
 """
 Conftest for ported static tests.
 
-Temporarily skip ported static tests that fail for Amsterdam due to EIP-8037's
-two-dimensional gas model. The gas limits in these ported static test cases
-have not yet been updated to account for state gas.
+Temporarily skip ported static tests that fail on Amsterdam and its
+descendant forks due to EIP-8037's two-dimensional gas model. The gas
+limits in these ported static test cases have not yet been updated to
+account for state gas.
 
 TODO: Update gas limits in the 3452 failing ported static test cases and
 remove this skip list.
@@ -12,6 +13,7 @@ remove this skip list.
 from pathlib import Path
 
 import pytest
+from execution_testing.forks import Amsterdam
 
 _SKIP_LIST_PATH = Path(__file__).parent / "amsterdam_skip_list.txt"
 _AMSTERDAM_SKIP_CASES: frozenset[str] = frozenset(
@@ -49,9 +51,17 @@ def pytest_collection_modifyitems(
     for item in items:
         if "ported_static" not in item.nodeid:
             continue
-        if "fork_Amsterdam" not in item.nodeid:
+        callspec = getattr(item, "callspec", None)
+        fork = callspec.params.get("fork") if callspec else None
+        if fork is None or not fork >= Amsterdam:
             continue
-        normalized = _normalize_nodeid(item.nodeid)
+        # The skip list is written against fork_Amsterdam, but the
+        # EIP-8037 breakage applies equally to its descendant forks.
+        # Rewriting the item's fork token to Amsterdam's lets one list
+        # cover them all.
+        normalized = _normalize_nodeid(item.nodeid).replace(
+            f"fork_{fork.name()}", "fork_Amsterdam"
+        )
         for skip_case in _AMSTERDAM_SKIP_CASES:
             if skip_case in normalized:
                 item.add_marker(skip_marker)


### PR DESCRIPTION
### Description

Extended the code to also skip forks after amsterdam since the note about 8037 also applies to later forks too 

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
