### PR TITLE
tests(amsterdam): pin receipt status of top-frame OOG txs in multi-tx blocks

### DIFF
--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
@@ -20,6 +20,8 @@ empty, and — being consumed on any successful halt — survives the
 created account's own destruction.
 """
 
+from enum import Enum, auto
+
 import pytest
 from execution_testing import (
     Account,
@@ -811,4 +813,219 @@ def test_initcode_selfdestruct_state_gas_in_header(
             sender: Account(nonce=1),
             created: None,
         },
+    )
+
+
+class TopFrameFailureMode(Enum):
+    """The top-frame charge the failing transaction out-of-gases on."""
+
+    CREATE_STATE_OOG = auto()
+    NEW_ACCOUNT_STATE_OOG = auto()
+    DELEGATED_REGULAR_OOG = auto()
+
+
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param(
+            TopFrameFailureMode.CREATE_STATE_OOG,
+            id="create_state_oog",
+        ),
+        pytest.param(
+            TopFrameFailureMode.NEW_ACCOUNT_STATE_OOG,
+            id="new_account_state_oog",
+        ),
+        pytest.param(
+            TopFrameFailureMode.DELEGATED_REGULAR_OOG,
+            id="delegated_regular_oog",
+        ),
+    ],
+)
+def test_receipt_status_top_frame_oog_between_successful_txs(
+    fork: Fork,
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    failure_mode: TopFrameFailureMode,
+) -> None:
+    """
+    Pin the failed receipt status of a top-frame OOG transaction that
+    sits between two successful transactions in one block.
+
+    A transaction that out-of-gases on a top-frame charge never
+    dispatches into the EVM but is still included and must produce a
+    ``succeeded=False`` receipt, committed to the header
+    ``receiptsRoot``. The other top-frame OOG tests place the failing
+    transaction alone in its block, so an implementation that derives
+    the receipt status from stale shared per-block execution state
+    still passes them: the stale value in a fresh block happens to be
+    "failed". Sandwiching the failure between successful transactions
+    makes the status byte load-bearing. (Regression: nimbus-eth1
+    ``1f8dd2122`` receipted top-frame failures with the previous
+    transaction's status and rejected finalized canonical blocks on
+    glamsterdam-devnet-7 with ``receiptRoot mismatch``.)
+
+    The middle transaction passes the intrinsic check but out-of-gases
+    on a top-frame charge before any EVM bytecode runs:
+
+    - ``create_state_oog``: contract creation; the created account's
+      ``NEW_ACCOUNT`` state charge fires at the top frame and the gas
+      limit is one short of covering it.
+    - ``new_account_state_oog``: value transfer to an empty recipient;
+      the ``NEW_ACCOUNT`` state charge fires and the gas limit is one
+      short.
+    - ``delegated_regular_oog``: recipient holds an EIP-7702
+      delegation; the ``COLD_ACCOUNT_ACCESS`` regular charge fires and
+      the gas limit is one short.
+
+    The failing transaction burns its full gas limit, bumps the sender
+    nonce, and must produce a ``succeeded=False`` receipt between two
+    ``succeeded=True`` receipts.
+    """
+    gas_price = 1_000_000_000
+    value = 1
+
+    sender_initial_balance = 10**18
+    ok_sender_1 = pre.fund_eoa(sender_initial_balance)
+    ok_sender_2 = pre.fund_eoa(sender_initial_balance)
+    fail_sender = pre.fund_eoa(sender_initial_balance)
+    # Alive via balance, so the successful transfers to it incur no
+    # top-frame charge and consume exactly their intrinsic gas.
+    ok_recipient = pre.fund_eoa(amount=1)
+
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+
+    fail_target: Address | None = None
+    fail_target_post: Account | None = None
+    if failure_mode is TopFrameFailureMode.CREATE_STATE_OOG:
+        intrinsic_gas = intrinsic_cost(
+            contract_creation=True,
+            return_cost_deducted_prior_execution=True,
+        )
+        top_frame_state_gas = fork.transaction_top_frame_state_gas(
+            contract_creation=True,
+        )
+        assert top_frame_state_gas > 0, (
+            "contract creation must charge NEW_ACCOUNT at the top frame"
+        )
+        fail_gas_limit = intrinsic_gas + top_frame_state_gas - 1
+        fail_to: Address | None = None
+    elif failure_mode is TopFrameFailureMode.NEW_ACCOUNT_STATE_OOG:
+        intrinsic_gas = intrinsic_cost(
+            sends_value=True,
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+            return_cost_deducted_prior_execution=True,
+        )
+        top_frame_state_gas = fork.transaction_top_frame_state_gas(
+            sends_value=True,
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+        )
+        assert top_frame_state_gas > 0, (
+            "value transfer to an empty recipient must charge "
+            "NEW_ACCOUNT at the top frame"
+        )
+        fail_gas_limit = intrinsic_gas + top_frame_state_gas - 1
+        fail_to = pre.fund_eoa(amount=0)
+        fail_target = fail_to
+        # The rolled-back transfer must not bring the recipient into
+        # existence.
+        fail_target_post = None
+    elif failure_mode is TopFrameFailureMode.DELEGATED_REGULAR_OOG:
+        delegated_to = pre.deploy_contract(code=Op.STOP)
+        target_code = Spec7702.delegation_designation(delegated_to)
+        fail_to = pre.deploy_contract(code=target_code)
+        intrinsic_gas = intrinsic_cost(
+            recipient_type=RecipientType.DELEGATION_7702,
+            return_cost_deducted_prior_execution=True,
+        )
+        top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+            recipient_type=RecipientType.DELEGATION_7702,
+        )
+        assert top_frame_gas > 0, (
+            "a delegated recipient must charge COLD_ACCOUNT_ACCESS "
+            "at the top frame"
+        )
+        fail_gas_limit = intrinsic_gas + top_frame_gas - 1
+        fail_target = fail_to
+        fail_target_post = Account(balance=0, code=target_code)
+    else:
+        raise ValueError(f"unhandled failure mode: {failure_mode}")
+
+    # The successful transfers go to an alive EOA: no top-frame charge,
+    # no EVM execution, so each consumes exactly its intrinsic gas.
+    ok_intrinsic_gas = intrinsic_cost(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        return_cost_deducted_prior_execution=True,
+    )
+    assert (
+        fork.transaction_top_frame_state_gas(
+            sends_value=True,
+            recipient_type=RecipientType.EOA,
+        )
+        == 0
+    ), "an alive recipient must not incur a top-frame state charge"
+
+    ok_tx_1 = Transaction(
+        sender=ok_sender_1,
+        to=ok_recipient,
+        value=value,
+        gas_limit=ok_intrinsic_gas,
+        gas_price=gas_price,
+        expected_receipt=TransactionReceipt(
+            status=1,
+            cumulative_gas_used=ok_intrinsic_gas,
+        ),
+    )
+    fail_tx = Transaction(
+        sender=fail_sender,
+        to=fail_to,
+        value=(
+            value
+            if failure_mode is TopFrameFailureMode.NEW_ACCOUNT_STATE_OOG
+            else 0
+        ),
+        gas_limit=fail_gas_limit,
+        gas_price=gas_price,
+        expected_receipt=TransactionReceipt(
+            status=0,
+            gas_used=fail_gas_limit,
+            cumulative_gas_used=ok_intrinsic_gas + fail_gas_limit,
+        ),
+    )
+    ok_tx_2 = Transaction(
+        sender=ok_sender_2,
+        to=ok_recipient,
+        value=value,
+        gas_limit=ok_intrinsic_gas,
+        gas_price=gas_price,
+        expected_receipt=TransactionReceipt(
+            status=1,
+            cumulative_gas_used=2 * ok_intrinsic_gas + fail_gas_limit,
+        ),
+    )
+
+    ok_sender_final_balance = (
+        sender_initial_balance - value - ok_intrinsic_gas * gas_price
+    )
+    post: dict[Address, Account | None] = {
+        ok_sender_1: Account(nonce=1, balance=ok_sender_final_balance),
+        ok_sender_2: Account(nonce=1, balance=ok_sender_final_balance),
+        ok_recipient: Account(balance=1 + 2 * value),
+        # The failing transaction is included: the nonce bumps and the
+        # full gas limit is paid, but nothing else happens.
+        fail_sender: Account(
+            nonce=1,
+            balance=sender_initial_balance - fail_gas_limit * gas_price,
+        ),
+    }
+    if failure_mode is TopFrameFailureMode.CREATE_STATE_OOG:
+        post[fail_tx.created_contract] = None
+    else:
+        assert fail_target is not None
+        post[fail_target] = fail_target_post
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[ok_tx_1, fail_tx, ok_tx_2])],
+        post=post,
     )


### PR DESCRIPTION
## Motivation

A transaction that out-of-gases on an EIP-2780/EIP-8037 top-frame charge is included in the block but must produce a `succeeded=False` receipt. Every existing top-frame OOG test (`test_top_frame_charges.py`, `test_authorization_oog.py`, `test_state_gas_set_code.py::test_authorization_exact_state_gas_boundary`, the `test_state_gas_create.py` deposit-fail cases) places the failing transaction **alone in its block**, and every existing multi-tx block test carries only succeeding transactions. A client that derives the receipt status from stale shared per-block execution state passes all of them, because the stale value in a fresh block happens to be "failed" — the wrong-status bug is structurally invisible to the current suite.

This is not hypothetical: nimbus-eth1 `1f8dd2122` skipped its post-execution hook (the only writer of the per-block status flag) for top-frame failures. It passed the v7.2.0 fixtures, was deployed to glamsterdam-devnet-7 on 2026-07-24 05:30 UTC, and within minutes every nimbus-el node rejected canonical **finalized** blocks with `receiptRoot mismatch` — e.g. block 61754 (`0xecbd618c…`), where flipping the status byte of exactly its two top-frame-OOG CREATEs (txs 22, 29 — each following a successful tx) reproduces nimbus's wrong root `0x22f0346a…` bit-for-bit.

## Test

One blockchain test in `eip2780_reduce_intrinsic_tx_gas/` (the top-frame charge layer's home): a block carrying `[success, top-frame OOG, success]`, which makes the status byte of the middle receipt load-bearing in the header `receiptsRoot`. Parametrized over the three top-frame charge classes:

- `create_state_oog` — contract creation, OOG on the created account's `NEW_ACCOUNT` state charge (the devnet trigger shape)
- `new_account_state_oog` — value transfer to an empty recipient, OOG on `NEW_ACCOUNT`
- `delegated_regular_oog` — EIP-7702 delegated recipient, OOG on `COLD_ACCOUNT_ACCESS`

Following the house style of the neighboring tests, every transaction pins `expected_receipt=TransactionReceipt(status=…, cumulative_gas_used=…)` (the failing tx additionally `gas_used=gas_limit`), the successful transfers run at exactly their intrinsic gas, and the post-state pins all sender balances/nonces plus the failing target's non-existence (or unchanged delegation code).

## Verification

Filled with `--until Amsterdam` and consumed:

| client | result |
|---|---|
| nimbus-el `1f8dd21` (the regression) | 3/3 FAILED — `newPayload` INVALID, `receiptRoot mismatch` |
| nimbus-el + fix (status-im/nimbus-eth1#4559) | 3/3 passed |
| geth `glamsterdam-devnet-7` head (`5749cbce`) | 3/3 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpkqKnXjpdXGJ4ChNGsxEY