### PR TITLE
feat(tests): add ef_prefix deposit-halt mode to EIP-8037 state-gas test

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1243,6 +1243,7 @@ def test_create_no_double_charge_new_account(
     [
         pytest.param("oversized_code", id="oversized_code"),
         pytest.param("oog_deposit", id="oog_deposit"),
+        pytest.param("ef_prefix", id="ef_prefix"),
     ],
 )
 @pytest.mark.valid_from("EIP8037")
@@ -1258,11 +1259,12 @@ def test_code_deposit_halt_discards_initcode_state_gas(
 
     A CREATE tx runs initcode that first performs a state-creating
     operation (charging GAS_NEW_ACCOUNT state gas), then returns
-    code that triggers a deposit failure (oversized or OOG). The
-    exceptional halt reverts all initcode state changes including
-    the new account. The reverted GAS_NEW_ACCOUNT must NOT count
-    in block_state_gas_used, which determines the block header
-    gas_used via max(block_regular_gas, block_state_gas).
+    code that triggers a deposit failure (oversized, OOG, or an
+    EIP-3541 0xEF prefix). The exceptional halt reverts all initcode
+    state changes including the new account. The reverted
+    GAS_NEW_ACCOUNT must NOT count in block_state_gas_used, which
+    determines the block header gas_used via
+    max(block_regular_gas, block_state_gas).
     """
     subcall_forwarded_value = 1
     entry_account_value = 1
@@ -1278,11 +1280,15 @@ def test_code_deposit_halt_discards_initcode_state_gas(
 
     if deposit_fail_mode == "oversized_code":
         deposit_fail = Op.RETURN(0, fork.max_code_size() + 1)
-    else:
-        # Return code at max size — passes the size check but code
+    elif deposit_fail_mode == "oog_deposit":
+        # Return code at max size: passes the size check but code
         # deposit state gas (max_code_size * cost_per_state_byte)
         # exceeds available state gas in the child frame, causing OOG.
         deposit_fail = Op.RETURN(0, fork.max_code_size())
+    else:
+        # Return single 0xEF byte: passes the size check but EIP-3541
+        # rejects the 0xEF-prefixed code, halting the deposit.
+        deposit_fail = Op.MSTORE8(0, 0xEF) + Op.RETURN(0, 1)
 
     initcode = state_op + deposit_fail
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1286,8 +1286,8 @@ def test_code_deposit_halt_discards_initcode_state_gas(
         # exceeds available state gas in the child frame, causing OOG.
         deposit_fail = Op.RETURN(0, fork.max_code_size())
     else:
-        # Return single 0xEF byte: passes the size check but EIP-3541
-        # rejects the 0xEF-prefixed code, halting the deposit.
+        # Return single 0xEF byte: EIP-3541 rejects the code before
+        # the size check or any deposit charging, halting the deposit.
         deposit_fail = Op.MSTORE8(0, 0xEF) + Op.RETURN(0, 1)
 
     initcode = state_op + deposit_fail


### PR DESCRIPTION
### Description

`test_code_deposit_halt_discards_initcode_state_gas` parametrized `deposit_fail_mode` over `oversized_code` and `oog_deposit` only. Add a third `ef_prefix` mode returning a single 0xEF byte: it passes the code-size check but is rejected by EIP-3541, a distinct deployment-halt path. With stateful initcode (`call_new_account` / `inner_create`) it must discard the initcode GAS_NEW_ACCOUNT state gas exactly like the other two modes. Filled fixtures confirm identical block gasUsed across all three modes.

### Related Issues or PRs


Closes #2963

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.