### PR TITLE
fix(tests): update withdrawal and consolidation tests to use Header for requests verification

### DIFF
--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     Bytecode,
+    Header,
     Op,
     Requests,
     SystemContractInteractionTransaction,
@@ -94,21 +95,19 @@ def test_extra_withdrawals(
     """
     modified_code: Bytecode = Bytecode()
     memory_offset: int = 0
-    amount_of_requests: int = 0
 
     for withdrawal_request in requests_list:
-        # update memory_offset with the correct value
-        withdrawal_request_bytes_amount: int = len(bytes(withdrawal_request))
-        assert withdrawal_request_bytes_amount == 76, (
+        record = bytes(withdrawal_request)
+        assert len(record) == 76, (
             "Expected withdrawal request to be of size 76 but got size "
-            f"{withdrawal_request_bytes_amount}"
+            f"{len(record)}"
         )
-        memory_offset += withdrawal_request_bytes_amount
+        # Store records contiguously from offset 0 so the returned data is
+        # exactly the concatenated records (no gap, no trailing padding).
+        modified_code += Om.MSTORE(record, memory_offset)
+        memory_offset += len(record)
 
-        modified_code += Om.MSTORE(bytes(withdrawal_request), memory_offset)
-        amount_of_requests += 1
-
-    modified_code += Op.RETURN(0, Op.MSIZE())
+    modified_code += Op.RETURN(0, memory_offset)
 
     pre[Spec_EIP7002.WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS] = Account(
         code=modified_code,
@@ -131,7 +130,7 @@ def test_extra_withdrawals(
         blocks=[
             Block(
                 txs=txs,
-                requests_hash=Requests(*requests_list),
+                header_verify=Header(requests_hash=Requests(*requests_list)),
             ),
         ],
         post={},

--- a/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
+++ b/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
@@ -12,6 +12,7 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     Bytecode,
+    Header,
     Op,
     Requests,
     SystemContractInteractionTransaction,
@@ -93,23 +94,19 @@ def test_extra_consolidations(
     """
     modified_code: Bytecode = Bytecode()
     memory_offset: int = 0
-    amount_of_requests: int = 0
 
     for consolidation_request in requests_list:
-        # update memory_offset with the correct value
-        consolidation_request_bytes_amount: int = len(
-            bytes(consolidation_request)
-        )
-        assert consolidation_request_bytes_amount == 116, (
+        record = bytes(consolidation_request)
+        assert len(record) == 116, (
             "Expected consolidation request to be of size 116 but got size "
-            f"{consolidation_request_bytes_amount}"
+            f"{len(record)}"
         )
-        memory_offset += consolidation_request_bytes_amount
+        # Store records contiguously from offset 0 so the returned data is
+        # exactly the concatenated records (no gap, no trailing padding).
+        modified_code += Om.MSTORE(record, memory_offset)
+        memory_offset += len(record)
 
-        modified_code += Om.MSTORE(bytes(consolidation_request), memory_offset)
-        amount_of_requests += 1
-
-    modified_code += Op.RETURN(0, Op.MSIZE())
+    modified_code += Op.RETURN(0, memory_offset)
 
     pre[Spec_EIP7251.CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS] = Account(
         code=modified_code,
@@ -132,7 +129,7 @@ def test_extra_consolidations(
         blocks=[
             Block(
                 txs=txs,
-                requests_hash=Requests(*requests_list),
+                header_verify=Header(requests_hash=Requests(*requests_list)),
             ),
         ],
         post={},


### PR DESCRIPTION
### Description

Fix the modified-contract tests for EIP-7002 withdrawals and EIP-7251 consolidations so they return and verify execution requests correctly.

Previously, the mock predeploys advanced the memory offset before storing the first request and returned `MSIZE()`, introducing leading zero bytes and word-aligned trailing padding. The tests also set `requests_hash` directly on the block instead of verifying the hash produced by the transition tool.

This PR:

- Stores request records contiguously starting at memory offset zero.
- Returns the exact length of the serialized request data.
- Verifies the resulting requests hash using `header_verify=Header(requests_hash=...)`.

### Related Issues or PRs

N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
