### PR TITLE
feat(tests): EIP-7928 - cover system-address zero-tip coinbase BAL

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1683,7 +1683,7 @@ def test_bal_system_address_coinbase_zero_tip(
         pre=pre,
         blocks=[block],
         post={
-            alice: Account(nonce=1, balance=alice_final_balance),
+            alice: Account(nonce=1),
             bob: Account(balance=5),
         },
         genesis_environment=genesis_env,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1642,20 +1642,6 @@ def test_bal_system_address_coinbase_zero_tip(
     """
     bob = pre.fund_eoa(amount=0)
 
-    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_gas = intrinsic_gas_calculator(
-        calldata=b"",
-        contract_creation=False,
-        access_list=[],
-        recipient_type=RecipientType.EMPTY_ACCOUNT,
-        sends_value=True,
-    )
-    top_frame_state_gas = fork.transaction_top_frame_state_gas(
-        sends_value=True,
-        recipient_type=RecipientType.EMPTY_ACCOUNT,
-    )
-    tx_gas_limit = intrinsic_gas + top_frame_state_gas + 1000
-
     genesis_env = Environment(base_fee_per_gas=0x7)
     base_fee_per_gas = fork.base_fee_per_gas_calculator()(
         parent_base_fee_per_gas=int(genesis_env.base_fee_per_gas or 0),

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1685,7 +1685,7 @@ def test_bal_system_address_coinbase_zero_tip(
         post={
             alice: Account(nonce=1),
             bob: Account(balance=5),
-        SYSTEM_ADDRESS: Account.NONEXISTENT,
+            SYSTEM_ADDRESS: Account.NONEXISTENT,
         },
         genesis_environment=genesis_env,
     )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1655,7 +1655,6 @@ def test_bal_system_address_coinbase_zero_tip(
         sender=alice,
         to=bob,
         value=tx_value,
-        gas_limit=tx_gas_limit,
         gas_price=base_fee_per_gas,
     )
 

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1658,12 +1658,6 @@ def test_bal_system_address_coinbase_zero_tip(
         gas_price=base_fee_per_gas,
     )
 
-    alice_final_balance = (
-        alice_initial_balance
-        - tx_value
-        - ((intrinsic_gas + top_frame_state_gas) * base_fee_per_gas)
-    )
-
     block = Block(
         txs=[tx],
         fee_recipient=SYSTEM_ADDRESS,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -44,6 +44,7 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_7928.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7928.version
 
 pytestmark = pytest.mark.valid_from("Amsterdam")
+SYSTEM_ADDRESS = Address(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE)
 
 
 @EIPChecklist.BlockHeaderField.Test.ValueBehavior.Accept()
@@ -1616,6 +1617,92 @@ def test_bal_coinbase_zero_tip(
                 ),
                 # Coinbase must be included even with zero tip
                 coinbase: BalAccountExpectation.empty(),
+            }
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[block],
+        post={
+            alice: Account(nonce=1, balance=alice_final_balance),
+            bob: Account(balance=5),
+        },
+        genesis_environment=genesis_env,
+    )
+
+
+def test_bal_system_address_coinbase_zero_tip(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+) -> None:
+    """
+    Ensure BAL includes SYSTEM_ADDRESS when it is the zero-tip fee recipient.
+    """
+    bob = pre.fund_eoa(amount=0)
+
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas = intrinsic_gas_calculator(
+        calldata=b"",
+        contract_creation=False,
+        access_list=[],
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+        sends_value=True,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EMPTY_ACCOUNT,
+    )
+    tx_gas_limit = intrinsic_gas + top_frame_state_gas + 1000
+
+    genesis_env = Environment(base_fee_per_gas=0x7)
+    base_fee_per_gas = fork.base_fee_per_gas_calculator()(
+        parent_base_fee_per_gas=int(genesis_env.base_fee_per_gas or 0),
+        parent_gas_used=0,
+        parent_gas_limit=genesis_env.gas_limit,
+    )
+
+    tx_value = 5
+    alice_initial_balance = (tx_gas_limit * base_fee_per_gas) + tx_value
+    alice = pre.fund_eoa(amount=alice_initial_balance)
+    tx = Transaction(
+        sender=alice,
+        to=bob,
+        value=tx_value,
+        gas_limit=tx_gas_limit,
+        gas_price=base_fee_per_gas,
+    )
+
+    alice_final_balance = (
+        alice_initial_balance
+        - tx_value
+        - ((intrinsic_gas + top_frame_state_gas) * base_fee_per_gas)
+    )
+
+    block = Block(
+        txs=[tx],
+        fee_recipient=SYSTEM_ADDRESS,
+        header_verify=Header(base_fee_per_gas=base_fee_per_gas),
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                alice: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=1)
+                    ],
+                    balance_changes=[
+                        BalBalanceChange(
+                            block_access_index=1,
+                            post_balance=alice_final_balance,
+                        )
+                    ],
+                ),
+                bob: BalAccountExpectation(
+                    balance_changes=[
+                        BalBalanceChange(block_access_index=1, post_balance=5)
+                    ]
+                ),
+                SYSTEM_ADDRESS: BalAccountExpectation.empty(),
             }
         ),
     )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1685,6 +1685,7 @@ def test_bal_system_address_coinbase_zero_tip(
         post={
             alice: Account(nonce=1),
             bob: Account(balance=5),
+        SYSTEM_ADDRESS: Account.NONEXISTENT,
         },
         genesis_environment=genesis_env,
     )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1650,8 +1650,7 @@ def test_bal_system_address_coinbase_zero_tip(
     )
 
     tx_value = 5
-    alice_initial_balance = (tx_gas_limit * base_fee_per_gas) + tx_value
-    alice = pre.fund_eoa(amount=alice_initial_balance)
+    alice = pre.fund_eoa()
     tx = Transaction(
         sender=alice,
         to=bob,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1668,12 +1668,6 @@ def test_bal_system_address_coinbase_zero_tip(
                     nonce_changes=[
                         BalNonceChange(block_access_index=1, post_nonce=1)
                     ],
-                    balance_changes=[
-                        BalBalanceChange(
-                            block_access_index=1,
-                            post_balance=alice_final_balance,
-                        )
-                    ],
                 ),
                 bob: BalAccountExpectation(
                     balance_changes=[


### PR DESCRIPTION
### Description

Adds an Amsterdam BAL fixture for the case where `SYSTEM_ADDRESS` is the fee recipient and the transaction priority fee is zero. The expected block access list includes `SYSTEM_ADDRESS` as an empty account entry because it is still touched by the transaction fee-credit path.

Validation performed:

- `uv run ruff check tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py`
- `uv run ruff format --check tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py`
- `uv run pytest tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py::test_bal_system_address_coinbase_zero_tip --collect-only -q`

Attempted targeted `uv run fill ... --fork Amsterdam`, but the local WSL run timed out before producing fixture output.

### Related Issues or PRs

N/A.

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

N/A for draft.
