### PR TITLE
fix(test-ci): Skip `test_cli.py` until #3241 is resolved

### DIFF
--- a/packages/testing/src/execution_testing/cli/eest/tests/test_cli.py
+++ b/packages/testing/src/execution_testing/cli/eest/tests/test_cli.py
@@ -8,6 +8,10 @@ from click.testing import CliRunner
 
 from ..cli import eest, ensure_utf8_output
 
+pytestmark = pytest.mark.skip(
+    "Issue #3241: eest info queries github.com to get release information"
+)
+
 
 def test_info_runs_successfully() -> None:
     """`eest info` exits cleanly and reports the EEST banner."""


### PR DESCRIPTION
### Description

Currently `eest info` queries github.com, which results in us getting rate limited by the server.

This is documented in #3241 and needs to be addressed but for now this PR skips these tests.

### Related Issues or PRs
N/A.

### Checklist
- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRCjm20iOV3n9gDLX8CN5pqk7aW4kR1TaMxLl4MW8X5R14wbr0TLYz3O7pc&s=10)
