### PR TITLE
feat(tests): add EIP-7997 case where factory is not present at fork block

### DIFF
--- a/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
+++ b/tests/amsterdam/eip7997_deterministic_factory_predeploy/test_fork_transition.py
@@ -104,3 +104,71 @@ def test_factory_deploys_across_transition(
             ),
         },
     )
+
+
+@pytest.mark.valid_at_transition_to("Amsterdam")
+@pytest.mark.pre_alloc_mutable
+def test_factory_absent_across_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    A chain that never deployed the factory transitions to Amsterdam
+    through valid blocks, and the factory address stays nonexistent.
+
+    The client MUST NOT check for the existence of the contract at
+    the fork boundary. Therefore, we verify that the BAL does
+    not contain the factory account read.
+    The block itself is valid. It is the responsibility of the
+    chain activating EIP-7997 to ensure the factory is valid
+    at the start of the fork block.
+    """
+    factory = Address(Spec.FACTORY_ADDRESS)
+    # Merging an all-zero account into the fork's pre-allocation removes
+    # the factory predeploy from the genesis allocation entirely.
+    pre[factory] = Account(nonce=0, balance=0, code=b"")
+
+    sender = pre.fund_eoa()
+    receiver = pre.fund_eoa(amount=0)
+    transfer_value = 1
+
+    timestamps = [FORK_TIMESTAMP - 1, FORK_TIMESTAMP, FORK_TIMESTAMP + 1]
+
+    blocks = []
+    for i, timestamp in enumerate(timestamps):
+        blocks.append(
+            Block(
+                timestamp=timestamp,
+                txs=[
+                    Transaction(
+                        sender=sender,
+                        to=receiver,
+                        value=transfer_value,
+                    )
+                ],
+                expected_block_access_list=BlockAccessListExpectation(
+                    account_expectations={
+                        factory: None,
+                        sender: BalAccountExpectation(
+                            nonce_changes=[
+                                BalNonceChange(
+                                    block_access_index=1,
+                                    post_nonce=i + 1,
+                                )
+                            ],
+                        ),
+                    }
+                )
+                if timestamp >= FORK_TIMESTAMP
+                else None,
+            )
+        )
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={
+            factory: Account.NONEXISTENT,
+            receiver: Account(balance=len(timestamps) * transfer_value),
+        },
+    )


### PR DESCRIPTION
### Description
Implements tests where CREATE2 factory is not present at fork block. This also verifies that the factory account is not part of the BAL reads.

### Related Issues or PRs
Discussed in https://github.com/ethereum/pm/issues/2170

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

<img width="1536" height="2048" alt="image" src="https://github.com/user-attachments/assets/214153a3-5906-400e-b056-16338e48ab8a" />

This is Harry who has been keeping me company on my home's ceiling for a while. Hi Harry!
