### PR TITLE
fix(test-eest): read app version locally

### DIFF
--- a/packages/testing/src/execution_testing/cli/eest/tests/test_cli.py
+++ b/packages/testing/src/execution_testing/cli/eest/tests/test_cli.py
@@ -2,15 +2,14 @@
 
 import io
 import sys
+from unittest.mock import Mock
 
 import pytest
 from click.testing import CliRunner
 
-from ..cli import eest, ensure_utf8_output
+from execution_testing.config.app import AppConfig
 
-pytestmark = pytest.mark.skip(
-    "Issue #3241: eest info queries github.com to get release information"
-)
+from ..cli import eest, ensure_utf8_output
 
 
 def test_info_runs_successfully() -> None:
@@ -18,6 +17,19 @@ def test_info_runs_successfully() -> None:
     result = CliRunner().invoke(eest, ["info"])
     assert result.exit_code == 0
     assert "EEST" in result.output
+
+
+def test_app_version_uses_local_package_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`AppConfig.version` reads the installed package metadata."""
+    local_version = Mock(return_value="1.2.3")
+    monkeypatch.setattr(
+        "execution_testing.config.app.package_version", local_version
+    )
+
+    assert AppConfig().version == "1.2.3"
+    local_version.assert_called_once_with("ethereum-execution-testing")
 
 
 def test_info_survives_legacy_console_encoding(

--- a/packages/testing/src/execution_testing/config/app.py
+++ b/packages/testing/src/execution_testing/config/app.py
@@ -5,13 +5,10 @@ Classes:
 - AppConfig: Holds configurations for the application framework.
 """
 
+from importlib.metadata import version as package_version
 from pathlib import Path
 
 from pydantic import BaseModel
-
-from execution_testing.cli.pytest_commands.plugins.consume import (
-    releases,
-)
 
 
 class AppConfig(BaseModel):
@@ -19,15 +16,8 @@ class AppConfig(BaseModel):
 
     @property
     def version(self) -> str:
-        """Get the version of the latest mainnet `tests` release."""
-        spec = f"{releases.TESTS_FEATURE_NAME}@latest"
-        try:
-            release = releases.find_release(
-                spec, releases.get_release_information()
-            )
-        except releases.NoSuchReleaseError:
-            return "unknown"
-        return release.tag_name.split("@v")[-1]
+        """Get the locally installed EEST package version."""
+        return package_version("ethereum-execution-testing")
 
     DEFAULT_LOGS_DIR: Path = (
         Path(__file__).resolve().parent.parent.parent / "logs"


### PR DESCRIPTION
﻿### Description

- Read `AppConfig.version` from the locally installed `ethereum-execution-testing` package metadata instead of querying GitHub release data.
- Re-enable the `eest` CLI tests that were skipped while the network lookup was present.
- Add a regression test that verifies the package metadata lookup and package name.

This removes a third-party network dependency from `eest info` and prevents GitHub API rate limits from affecting the unit tests.

### Related Issues or PRs

Fixes #3241.

### Validation

- `pytest packages/testing/src/execution_testing/cli/eest/tests/test_cli.py -q` — 4 passed
- `ruff check .`
- `ruff format --check .`
- `codespell`
- `vulture src/ vulture_whitelist.py`
- `ethereum-spec-lint`
- `actionlint` with the repository config
- `uv lock --check`
- `mypy` on both changed files

The complete `just static` aggregate could not finish on this Windows environment because its optimized type-checking group requires the optional native `rust_pyspec_glue` and `ethash` packages. All other static recipes and focused type checking passed; CI can run the native optimized check in the repository environment.

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A cat](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)
