### PR TITLE
feat: change StatelessInput SSZ serialization to be EIP-7688 aligned

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1357,16 +1357,31 @@ def test_execution_witness_expected_true_reuses_canonical_stateless_result(
     fixture = next(iter(fixture_data.values()))
     block = fixture["blocks"][-1]
 
+    from ethereum.crypto.hash import Hash32
+    from ethereum.forks.amsterdam.stateless import (
+        compute_new_payload_request_root,
+    )
+    from ethereum.forks.amsterdam.stateless_guest import (
+        deserialize_stateless_input,
+    )
     from ethereum.forks.amsterdam.stateless_host import (
         deserialize_stateless_output,
     )
     from ethereum_types.bytes import Bytes as EthereumBytes
 
+    stateless_input = deserialize_stateless_input(
+        EthereumBytes(bytes.fromhex(block["statelessInputBytes"][2:]))
+    )
     stateless_output = deserialize_stateless_output(
         EthereumBytes(bytes.fromhex(block["statelessOutputBytes"][2:]))
     )
 
     assert stateless_output.successful_validation is True
+    assert stateless_output.new_payload_request_root != Hash32(b"\0" * 32)
+    assert (
+        stateless_output.new_payload_request_root
+        == compute_new_payload_request_root(stateless_input)
+    )
 
 
 def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
@@ -1402,6 +1417,10 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
 
     assert len(block["executionWitness"]["headers"]) == 1
 
+    from ethereum.crypto.hash import Hash32
+    from ethereum.forks.amsterdam.stateless import (
+        compute_new_payload_request_root,
+    )
     from ethereum.forks.amsterdam.stateless_guest import (
         deserialize_stateless_input,
     )
@@ -1418,6 +1437,11 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
     )
 
     assert stateless_output.successful_validation is False
+    assert stateless_output.new_payload_request_root != Hash32(b"\0" * 32)
+    assert (
+        stateless_output.new_payload_request_root
+        == compute_new_payload_request_root(stateless_input)
+    )
     assert len(stateless_input.witness.headers) == 1
     assert [
         "0x" + bytes(header).hex()

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -443,6 +443,14 @@ def finalize_stateless_artifacts(
             f"want {options.expected_validation_success}"
         )
 
+    assert_amsterdam_stateless_output_request_root(
+        fork=fork,
+        block_number=block_number,
+        timestamp=timestamp,
+        stateless_input_bytes=stateless_input_bytes,
+        stateless_output=stateless_output,
+    )
+
     skip_chain_config_assertion = (
         options.has_stateless_input_bytes_modifier
         and stateless_output is not None
@@ -1065,6 +1073,57 @@ def is_invalid_stateless_input_sentinel(stateless_output: Any) -> bool:
         and activation.block_number is None
         and activation.timestamp is None
     )
+
+
+def assert_amsterdam_stateless_output_request_root(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    stateless_input_bytes: Bytes | None,
+    stateless_output: Any | None,
+) -> None:
+    """
+    Assert the output commits to the decoded Amsterdam payload request.
+    """
+    if stateless_input_bytes is None or stateless_output is None:
+        return
+
+    active_fork = fork.fork_at(
+        block_number=block_number,
+        timestamp=timestamp,
+    )
+    if active_fork.name() != "Amsterdam":
+        return
+
+    from ethereum.forks.amsterdam.stateless import (
+        compute_new_payload_request_root,
+    )
+    from ethereum.forks.amsterdam.stateless_guest import (
+        deserialize_stateless_input,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    try:
+        stateless_input = deserialize_stateless_input(
+            AmsterdamBytes(bytes(stateless_input_bytes))
+        )
+    except Exception as exc:
+        if is_invalid_stateless_input_sentinel(stateless_output):
+            return
+        raise AssertionError(
+            "Stateless input decoding failed for block "
+            f"{block_number}, but its output is not the invalid-input sentinel"
+        ) from exc
+
+    expected_root = compute_new_payload_request_root(stateless_input)
+    actual_root = stateless_output.new_payload_request_root
+    if actual_root != expected_root:
+        raise AssertionError(
+            "Stateless output new_payload_request_root mismatch for block "
+            f"{block_number}: got 0x{bytes(actual_root).hex()}, "
+            f"want 0x{bytes(expected_root).hex()}"
+        )
 
 
 def _has_execution_witness_modifier(

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -231,9 +231,6 @@ def compute_new_payload_request_root(
 ) -> Hash32:
     """
     Compute the request root for a stateless input via SSZ hash tree root.
-
-    TODO: For readability, convert to NewPayloadRequestHeader and
-    then compute the payload request root.
     """
     from .stateless_ssz import _new_payload_request_to_ssz
 

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -14,6 +14,11 @@ from remerkleable.basic import boolean, uint64, uint256
 from remerkleable.byte_arrays import ByteList, Bytes32, ByteVector
 from remerkleable.complex import Container
 from remerkleable.complex import List as SszList
+from remerkleable.progressive import (
+    ProgressiveByteList,
+    ProgressiveContainer,
+    ProgressiveList,
+)
 
 from ethereum.crypto.hash import Hash32
 from ethereum.state import Address, Root
@@ -41,19 +46,8 @@ from .stateless import (
 
 # --- SSZ max-length constants ---
 
-# Consensus-spec bounds mirrored by NewPayloadRequest and its nested
-# containers.  These should track the corresponding consensus-spec values.
 
 MAX_EXTRA_DATA_BYTES = 32
-MAX_BYTES_PER_TRANSACTION = 2**30
-MAX_TRANSACTIONS_PER_PAYLOAD = 2**20
-MAX_WITHDRAWALS_PER_PAYLOAD = 2**4
-MAX_BLOB_COMMITMENTS_PER_BLOCK = 4096
-MAX_DEPOSIT_REQUESTS_PER_PAYLOAD = 2**13
-MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD = 2**4
-MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD = 2**1
-MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD = 2**6
-MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD = 2**4
 
 # Stateless witness resource bounds.  These are local limits chosen for this
 # schema, not consensus-spec SSZ constants.
@@ -119,7 +113,9 @@ class SszWithdrawal(Container):
     amount: uint64
 
 
-class SszExecutionPayload(Container):
+class SszExecutionPayload(
+    ProgressiveContainer(active_fields=[1] * 19)  # type: ignore[misc]
+):
     """SSZ container mirroring ``ExecutionPayload``."""
 
     parent_hash: Bytes32
@@ -135,13 +131,11 @@ class SszExecutionPayload(Container):
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: uint256
     block_hash: Bytes32
-    transactions: SszList[
-        ByteList[MAX_BYTES_PER_TRANSACTION], MAX_TRANSACTIONS_PER_PAYLOAD
-    ]  # noqa: E501
-    withdrawals: SszList[SszWithdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    transactions: ProgressiveList[ProgressiveByteList]
+    withdrawals: ProgressiveList[SszWithdrawal]
     blob_gas_used: uint64
     excess_blob_gas: uint64
-    block_access_list: ByteList[MAX_BYTES_PER_TRANSACTION]
+    block_access_list: ProgressiveByteList
     slot_number: uint64
 
 
@@ -187,29 +181,23 @@ class SszBuilderExitRequest(Container):
     pubkey: ByteVector[48]
 
 
-class SszExecutionRequests(Container):
+class SszExecutionRequests(
+    ProgressiveContainer(active_fields=[1] * 5)  # type: ignore[misc]
+):
     """SSZ container mirroring ``ExecutionRequests``."""
 
-    deposits: SszList[SszDepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
-    withdrawals: SszList[
-        SszWithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
-    ]
-    consolidations: SszList[
-        SszConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
-    ]
-    builder_deposits: SszList[
-        SszBuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD
-    ]
-    builder_exits: SszList[
-        SszBuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
-    ]
+    deposits: ProgressiveList[SszDepositRequest]
+    withdrawals: ProgressiveList[SszWithdrawalRequest]
+    consolidations: ProgressiveList[SszConsolidationRequest]
+    builder_deposits: ProgressiveList[SszBuilderDepositRequest]
+    builder_exits: ProgressiveList[SszBuilderExitRequest]
 
 
 class SszNewPayloadRequest(Container):
     """SSZ container mirroring ``NewPayloadRequest``."""
 
     execution_payload: SszExecutionPayload
-    versioned_hashes: SszList[Bytes32, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    versioned_hashes: ProgressiveList[Bytes32]
     parent_beacon_block_root: Bytes32
     execution_requests: SszExecutionRequests
 
@@ -300,21 +288,15 @@ def _payload_to_ssz(
         extra_data=ByteList[MAX_EXTRA_DATA_BYTES](bytes(p.extra_data)),
         base_fee_per_gas=uint256(int(p.base_fee_per_gas)),
         block_hash=Bytes32(bytes(p.block_hash)),
-        transactions=SszList[
-            ByteList[MAX_BYTES_PER_TRANSACTION],
-            MAX_TRANSACTIONS_PER_PAYLOAD,
-        ](
-            ByteList[MAX_BYTES_PER_TRANSACTION](bytes(tx))
-            for tx in p.transactions
+        transactions=ProgressiveList[ProgressiveByteList](
+            ProgressiveByteList(bytes(tx)) for tx in p.transactions
         ),
-        withdrawals=SszList[SszWithdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
+        withdrawals=ProgressiveList[SszWithdrawal](
             _withdrawal_to_ssz(w) for w in p.withdrawals
         ),
         blob_gas_used=uint64(int(p.blob_gas_used)),
         excess_blob_gas=uint64(int(p.excess_blob_gas)),
-        block_access_list=ByteList[MAX_BYTES_PER_TRANSACTION](
-            bytes(p.block_access_list)
-        ),
+        block_access_list=ProgressiveByteList(bytes(p.block_access_list)),
         slot_number=uint64(int(p.slot_number)),
     )
 
@@ -461,22 +443,21 @@ def _execution_requests_to_ssz(
 ) -> SszExecutionRequests:
     """Convert an ExecutionRequests to its SSZ form."""
     return SszExecutionRequests(
-        deposits=SszList[SszDepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD](
+        deposits=ProgressiveList[SszDepositRequest](
             _deposit_request_to_ssz(d) for d in er.deposits
         ),
-        withdrawals=SszList[
-            SszWithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
-        ](_withdrawal_request_to_ssz(w) for w in er.withdrawals),
-        consolidations=SszList[
-            SszConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
-        ](_consolidation_request_to_ssz(c) for c in er.consolidations),
-        builder_deposits=SszList[
-            SszBuilderDepositRequest,
-            MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD,
-        ](_builder_deposit_request_to_ssz(b) for b in er.builder_deposits),
-        builder_exits=SszList[
-            SszBuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
-        ](_builder_exit_request_to_ssz(b) for b in er.builder_exits),
+        withdrawals=ProgressiveList[SszWithdrawalRequest](
+            _withdrawal_request_to_ssz(w) for w in er.withdrawals
+        ),
+        consolidations=ProgressiveList[SszConsolidationRequest](
+            _consolidation_request_to_ssz(c) for c in er.consolidations
+        ),
+        builder_deposits=ProgressiveList[SszBuilderDepositRequest](
+            _builder_deposit_request_to_ssz(b) for b in er.builder_deposits
+        ),
+        builder_exits=ProgressiveList[SszBuilderExitRequest](
+            _builder_exit_request_to_ssz(b) for b in er.builder_exits
+        ),
     )
 
 
@@ -507,7 +488,7 @@ def _new_payload_request_to_ssz(
     """Convert a NewPayloadRequest to its SSZ form."""
     return SszNewPayloadRequest(
         execution_payload=_payload_to_ssz(npr.execution_payload),
-        versioned_hashes=SszList[Bytes32, MAX_BLOB_COMMITMENTS_PER_BLOCK](
+        versioned_hashes=ProgressiveList[Bytes32](
             Bytes32(bytes(vh)) for vh in npr.versioned_hashes
         ),
         parent_beacon_block_root=Bytes32(bytes(npr.parent_beacon_block_root)),

--- a/tests/amsterdam/eip8282_builder_execution_requests/test_modified_builder_contract.py
+++ b/tests/amsterdam/eip8282_builder_execution_requests/test_modified_builder_contract.py
@@ -121,14 +121,12 @@ def run_modified_requests_test(
                 Spec.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 1
             ),
             id="max_plus_1_builder_deposit_requests",
-            marks=pytest.mark.skip_stateless_validation,
         ),
         pytest.param(
             builder_deposit_list_with_custom_fee(
                 Spec.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 2
             ),
             id="max_plus_2_builder_deposit_requests",
-            marks=pytest.mark.skip_stateless_validation,
         ),
     ],
 )
@@ -174,14 +172,12 @@ def test_extra_builder_deposits(
                 Spec.MAX_EXIT_REQUESTS_PER_BLOCK + 1
             ),
             id="max_plus_1_builder_exit_requests",
-            marks=pytest.mark.skip_stateless_validation,
         ),
         pytest.param(
             builder_exit_list_with_custom_fee(
                 Spec.MAX_EXIT_REQUESTS_PER_BLOCK + 2
             ),
             id="max_plus_2_builder_exit_requests",
-            marks=pytest.mark.skip_stateless_validation,
         ),
     ],
 )


### PR DESCRIPTION
### Description
Align Amsterdam’s zkEVM stateless SSZ types with the progressive SSZ definitions adopted by Gloas in EIP-7688.

This changes `SszExecutionPayload` and `SszExecutionRequests` to `ProgressiveContainer` and converts their dynamically sized fields—including transactions, withdrawals, execution-request lists, block access lists, and versioned hashes—to progressive types.

Progressive types retain the existing SSZ byte encoding but use different Merkleization. Therefore:

- `statelessInputBytes` remain compatible and keep schema ID `0x1501`.
- `new_payload_request_root` intentionally changes to the progressive SSZ root.
- No schema revision bump is required.

Fixture generation now verifies that every decodable Amsterdam stateless input produces the root stored in its stateless output. The zero-root sentinel remains valid only when the input cannot be decoded.

The fixed SSZ request-list limits are also removed, allowing the existing `MAX+1` and `MAX+2` builder deposit/exit fixtures to include stateless artifacts instead of skipping stateless validation.

Reference: https://github.com/ethereum/consensus-specs/pull/4630

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
