### PR TITLE
fix(test-execute): prune fork-less items before evaluating filter_combinations

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -504,12 +504,17 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             )
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(
     items: List[pytest.Item],
 ) -> None:
     """
     Remove transition tests and add the appropriate execute markers to the
     test.
+
+    Runs tryfirst so that items collected without a fork parametrization
+    (tests not valid for the session's fork) are removed before other
+    plugins inspect item params, as in the filler plugin.
     """
     items_for_removal = []
     for i, item in enumerate(items):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from execution_testing.test_types.block_types import EnvironmentDefaults
 
 from ..execute import pytest_configure
@@ -55,3 +57,54 @@ def test_pytest_configure_applies_explicit_transaction_gas_limit() -> None:
     assert config.engine_rpc_supported is False
 
     EnvironmentDefaults.gas_limit = original_gas_limit
+
+
+EXECUTE_COLLECTION_PLUGINS = [
+    "execution_testing.cli.pytest_commands.plugins.shared.execute_fill",
+    "execution_testing.cli.pytest_commands.plugins.shared.live_client_flags",
+    "execution_testing.cli.pytest_commands.plugins.execute.execute",
+    "execution_testing.cli.pytest_commands.plugins.forks.forks",
+]
+
+
+def test_forkless_items_pruned_before_filter_combinations(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Collect a test that is not valid for the session's fork in execute mode.
+
+    Such a test is collected without a fork parametrization and hence
+    without its covariant params; it must be pruned before the forks
+    plugin evaluates filter_combinations predicates, which would
+    otherwise fail with a TypeError and abort the whole session.
+    """
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize("a", [1, 2])
+        @pytest.mark.with_all_refund_types()
+        @pytest.mark.filter_combinations(
+            lambda refund_type, a, **_: True,
+            reason="requires the covariant refund_type param",
+        )
+        @pytest.mark.valid_from("Amsterdam")
+        def test_case(state_test, refund_type, a):
+            pass
+        """
+    )
+    plugin_args = [
+        arg for name in EXECUTE_COLLECTION_PLUGINS for arg in ("-p", name)
+    ]
+    result = pytester.runpytest(
+        *plugin_args,
+        "--fork=Osaka",
+        "--collect-only",
+        "-q",
+    )
+    output = "\n".join(result.outlines + result.errlines)
+    assert "INTERNALERROR" not in output
+    assert result.ret in (
+        pytest.ExitCode.OK,
+        pytest.ExitCode.NO_TESTS_COLLECTED,
+    )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -1584,7 +1584,16 @@ def _combination_filter_reason(
                 f"{predicate!r}",
                 returncode=pytest.ExitCode.USAGE_ERROR,
             )
-        if not predicate(**params):
+        try:
+            keep = predicate(**params)
+        except TypeError as e:
+            pytest.exit(
+                f"filter_combinations predicate for "
+                f"'{item.nodeid}' cannot be called with the "
+                f"item's params: {e}",
+                returncode=pytest.ExitCode.USAGE_ERROR,
+            )
+        if not keep:
             return marker.kwargs.get(
                 "reason", "rejected by filter_combinations"
             )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_covariant_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_covariant_markers.py
@@ -617,6 +617,25 @@ def test_fork_covariant_markers(
             "filter_combinations deselected all",
             id="filter_combinations_empty_set_error",
         ),
+        pytest.param(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("a", [1, 2])
+            @pytest.mark.filter_combinations(
+                lambda nonexistent_param, **_: True,
+                reason="predicate names a parameter that does not exist",
+            )
+            @pytest.mark.valid_from("Cancun")
+            @pytest.mark.valid_until("Cancun")
+            @pytest.mark.state_test_only
+            def test_case(state_test, a):
+                pass
+            """,
+            {},
+            "cannot be called with the item's params",
+            id="filter_combinations_bad_predicate_signature_error",
+        ),
     ],
 )
 def test_filter_combinations(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

In execute mode, tests that are not valid for the session fork are still collected as fork-less items without their covariant params, and the forks plugin's `filter_combinations` predicates ran before these items were pruned, aborting the whole session with an `INTERNALERROR` (e.g. any full tree `execute hive --fork=Osaka` run).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Surfaced by running execute blobs hive mode runs of #2948.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
