### PR TITLE
feat(ci): Backport CI Workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,51 @@
+name: Backport merged PR
+
+# Cherry-picks a merged PR onto another long-lived branch when it carries a
+# `backport <branch>` label (e.g. `backport benchmarks/amsterdam`). On a clean
+# cherry-pick it opens a PR against the target branch; on conflict it aborts
+# and comments on the source PR with manual steps — it never force-pushes nor
+# leaves a partially-applied branch behind.
+#
+# The label may be added before or after merge; backporting only happens once
+# the PR is actually merged.
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BACKPORT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Create backport PR
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
+        with:
+          # `backport <target-branch>`, e.g. `backport benchmarks/amsterdam`.
+          label_pattern: '^backport ([^ ]+)$'
+          # Only single-commit (squash-merged) PRs cherry-pick cleanly; skip
+          # PRs that landed as merge commits rather than failing the run.
+          merge_commits: skip
+          pull_title: '[backport ${target_branch}] ${pull_title}'
+          pull_description: |
+            Automated backport of #${pull_number} to `${target_branch}`.
+          # A PAT or GitHub App token stored as the `BACKPORT_TOKEN` secret
+          # lets CI run on the backport PR; the default GITHUB_TOKEN cannot
+          # trigger downstream workflows. Falls back to GITHUB_TOKEN when the
+          # secret is absent (PR is still created, CI must be re-triggered).
+          github_token: ${{ secrets.BACKPORT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -47,7 +47,7 @@ jobs:
           # Only single-commit (squash-merged) PRs cherry-pick cleanly; skip
           # PRs that landed as merge commits rather than failing the run.
           merge_commits: skip
-          pull_title: '[backport ${target_branch}] ${pull_title}'
+          pull_title: '${pull_title} [backport ${target_branch}]'
           pull_description: |
             Automated backport of #${pull_number} to `${target_branch}`.
           # Assign the original author so they shepherd the backport (best

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -24,7 +24,13 @@ permissions:
 jobs:
   backport:
     name: Backport
-    if: github.event.pull_request.merged == true
+    # Early-exit before the (full-history) checkout unless the PR is merged
+    # AND carries a `backport …` label; otherwise this ran on every merged PR.
+    # Matches the guard recommended in the action's README — the leading quote
+    # in '"backport ' anchors the match to a label-name prefix.
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -44,6 +50,13 @@ jobs:
           pull_title: '[backport ${target_branch}] ${pull_title}'
           pull_description: |
             Automated backport of #${pull_number} to `${target_branch}`.
+          # Assign the original author so they shepherd the backport (best
+          # effort — a non-assignable external author is simply skipped).
+          add_author_as_assignee: true
+          # Carry the repo's `A-<area>`/`C-<type>` labels over to the backport
+          # PR. The action excludes labels matching `label_pattern`, so the
+          # `backport …` trigger label is never copied (no re-backport loop).
+          copy_labels_pattern: '^[AC]-'
           # A PAT or GitHub App token stored as the `BACKPORT_TOKEN` secret
           # lets CI run on the backport PR; the default GITHUB_TOKEN cannot
           # trigger downstream workflows. Falls back to GITHUB_TOKEN when the


### PR DESCRIPTION
### Description

Adds a label-driven backport workflow so a merged PR can be cherry-picked onto another long-lived branch automatically (e.g. `benchmarks/amsterdam`), without blocking mainline development.

`.github/workflows/backport.yaml` does this:

- **Selective, via a label.** The workflow acts only on PRs carrying a `backport <branch>` label (e.g. `backport benchmarks/amsterdam`); the target branch is read from the label itself. PRs without such a label are untouched.
- **Fires on merge.** Triggered on `pull_request_target` (`closed`, `labeled`) and gated by `merged == true`, so the label can be applied before *or* after merge but a backport only happens once the PR is actually merged.
- **Fails safe on conflict.** On a clean cherry-pick it opens a PR against the target branch titled `[backport <branch>] <original title>`. On conflict it aborts and comments the manual cherry-pick steps on the source PR — it never force-pushes and never leaves a partially-applied branch behind. Since `benchmarks/amsterdam` is deliberately divergent, conflicts are expected to be common and are handed to a human by design.
- **Skips non-squash merges.** `merge_commits: skip` means the occasional PR that landed as a merge commit is skipped rather than failing the run; the repo squash-merges, so each PR is a single, cleanly-pickable commit.

**Operational prerequisites** (out of band, not in this PR):

- Create the `backport benchmarks/amsterdam` label in the repo. Without a matching label the workflow is a no-op.
- Optionally add a `BACKPORT_TOKEN` secret (a PAT or GitHub App token with `contents:write` + `pull_requests:write`). The workflow uses it when present and falls back to `GITHUB_TOKEN` otherwise. This matters because a PR opened with the default `GITHUB_TOKEN` cannot trigger downstream CI, so backport PRs to the divergent `benchmarks/amsterdam` branch would otherwise land without test runs until re-triggered manually.

Usage: add the `backport benchmarks/amsterdam` label to a PR (e.g. `gh pr edit <num> --add-label "backport benchmarks/amsterdam"`); on merge the bot opens the backport PR or comments if it cannot apply cleanly.

### Related Issues or PRs
N/A.

### Checklist
- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRKXG-VBDwGHj1vmEGkw0fNNUvyh3HIdVBn0EV3p6UkAn-eOt_PUBP7AiY&s=10)
