### PR TITLE
refactor(spec-specs,tests): rename REGULAR_PER_AUTH_BASE_COST to EXECUTION_PER_AUTH_BASE_COST

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
@@ -129,7 +129,7 @@ class EIP2780(BaseFork):
                 return_cost_deducted_prior_execution=True,
             )
             intrinsic_cost += (
-                authorization_count * gas_costs.REGULAR_PER_AUTH_BASE_COST
+                authorization_count * gas_costs.EXECUTION_PER_AUTH_BASE_COST
             )
 
             is_self_transfer = recipient_type == RecipientType.SELF

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
@@ -75,7 +75,7 @@ class EIP8038(BaseFork):
             TX_CREATE=create_access,
             AUTH_PER_EMPTY_ACCOUNT=account_write
             + execution_per_auth_base_cost,
-            REGULAR_PER_AUTH_BASE_COST=execution_per_auth_base_cost,
+            EXECUTION_PER_AUTH_BASE_COST=execution_per_auth_base_cost,
         )
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -51,7 +51,7 @@ class GasCosts:
     AUTH_BASE: int = 0
     # State-independent execution gas charged per EIP-7702 authorization
     # tuple; 0 before the state-access repricing introduces it.
-    REGULAR_PER_AUTH_BASE_COST: int = 0
+    EXECUTION_PER_AUTH_BASE_COST: int = 0
 
     # Utility
     MEMORY_PER_WORD: int

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -644,7 +644,7 @@ def calculate_intrinsic_cost(
     4. Calldata cost (zero and non-zero bytes).
     5. Access list entries (if applicable).
     6. Authorizations (if applicable): only the state-independent base
-       cost (`REGULAR_PER_AUTH_BASE_COST`) per tuple. The
+       cost (`EXECUTION_PER_AUTH_BASE_COST`) per tuple. The
        state-dependent account-creation and delegation-write costs are
        charged at the top frame by `set_delegation`.
 
@@ -694,7 +694,7 @@ def calculate_intrinsic_cost(
 
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
-        auth_cost = GasCosts.REGULAR_PER_AUTH_BASE_COST * ulen(
+        auth_cost = GasCosts.EXECUTION_PER_AUTH_BASE_COST * ulen(
             tx.authorizations
         )
 

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -201,7 +201,7 @@ def set_delegation(evm: Evm) -> None:
     costs at the top frame.
 
     Each valid authorization is charged, on top of the
-    state-independent ``GasCosts.REGULAR_PER_AUTH_BASE_COST`` already
+    state-independent ``GasCosts.EXECUTION_PER_AUTH_BASE_COST`` already
     paid in the intrinsic cost:
 
     - ``StateGasCosts.NEW_ACCOUNT`` (state) when the authority's

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -145,7 +145,7 @@ class GasCosts:
 
     # Authorization
     AUTH_TUPLE_BYTES: Final[Uint] = Uint(101)
-    REGULAR_PER_AUTH_BASE_COST: Final[Uint] = (
+    EXECUTION_PER_AUTH_BASE_COST: Final[Uint] = (
         AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
         + PRECOMPILE_ECRECOVER
         + COLD_ACCOUNT_ACCESS

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_intrinsic_gas_boundary.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_intrinsic_gas_boundary.py
@@ -136,7 +136,7 @@ def test_intrinsic_gas_floor_boundary_with_authorizations(
 ) -> None:
     """
     Reject a type-4 transaction when ``gas_limit = intrinsic_gas - 1``,
-    where the intrinsic includes ``REGULAR_PER_AUTH_BASE_COST`` per
+    where the intrinsic includes ``EXECUTION_PER_AUTH_BASE_COST`` per
     authorization.
 
     EIP-2780 keeps only the state-independent per-authorization base

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_with_tx_delegation.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_with_tx_delegation.py
@@ -4,7 +4,7 @@ Tests for EIP-2780 x EIP-7702 interaction.
 A type-4 transaction's authorizations are processed at the top frame
 (in ``set_delegation``), where their state-dependent costs are charged.
 Each authorization pays, on top of the state-independent
-``REGULAR_PER_AUTH_BASE_COST`` charged in the intrinsic:
+``EXECUTION_PER_AUTH_BASE_COST`` charged in the intrinsic:
 
 - ``NEW_ACCOUNT`` (state) + ``ACCOUNT_WRITE`` (execution) when the
   authority's account leaf does not yet exist, and

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_additional_coverage.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_additional_coverage.py
@@ -701,12 +701,12 @@ class TestAuthorizationListGasCost:
         """
         Verify the authorization-list intrinsic cost under EIP-2780.
 
-        Each authorization adds exactly ``REGULAR_PER_AUTH_BASE_COST`` to
+        Each authorization adds exactly ``EXECUTION_PER_AUTH_BASE_COST`` to
         the (execution) intrinsic; the state-dependent authorization costs
         moved to the top frame. Measured on the *raw* intrinsic (before
         the EIP-7623 calldata floor is applied) the per-authorization
         delta is exactly ``num_authorizations *
-        REGULAR_PER_AUTH_BASE_COST`` -- even when the floor would
+        EXECUTION_PER_AUTH_BASE_COST`` -- even when the floor would
         otherwise mask it (e.g. a single authorization whose base cost
         stays below the floor). Each existing authority then pays the
         first-write ``ACCOUNT_WRITE`` (execution) and ``AUTH_BASE``
@@ -752,9 +752,9 @@ class TestAuthorizationListGasCost:
 
         actual_auth_cost = intrinsic_with_auth - intrinsic_without_auth
         assert actual_auth_cost == (
-            num_authorizations * gas_costs.REGULAR_PER_AUTH_BASE_COST
+            num_authorizations * gas_costs.EXECUTION_PER_AUTH_BASE_COST
         ), (
-            "auth intrinsic must be n * REGULAR_PER_AUTH_BASE_COST, got: "
+            "auth intrinsic must be n * EXECUTION_PER_AUTH_BASE_COST, got: "
             f"{actual_auth_cost}"
         )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -51,6 +51,6 @@ class Spec:
     # EIP-8038 then repriced them.
     EXECUTION_GAS_CREATE = 11000
     # Total execution intrinsic per EIP-7702 authorization:
-    # ACCOUNT_WRITE (8000) + REGULAR_PER_AUTH_BASE_COST (7816).
+    # ACCOUNT_WRITE (8000) + EXECUTION_PER_AUTH_BASE_COST (7816).
     PER_AUTH_BASE_COST = 15816
     GAS_COLD_STORAGE_WRITE = 13000

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -3,7 +3,7 @@ Test EIP-7702 SetCode authorization state gas under the EIP-2780
 top-frame charge model.
 
 Under EIP-2780 (Amsterdam) an authorization's intrinsic cost is only the
-state-independent ``REGULAR_PER_AUTH_BASE_COST``; there is no intrinsic
+state-independent ``EXECUTION_PER_AUTH_BASE_COST``; there is no intrinsic
 auth state gas and there are no auth refunds. The state-dependent costs
 are charged lazily at the top frame in ``set_delegation``, keyed on each
 authority's pre-transaction state:
@@ -615,7 +615,7 @@ def test_invalid_nonce_auth_still_charges_intrinsic(
     An authorization with a wrong nonce is skipped during
     ``set_delegation``, so it writes no delegation indicator and incurs
     no top-frame charge. Its state-independent
-    ``REGULAR_PER_AUTH_BASE_COST`` is still charged in the intrinsic, and
+    ``EXECUTION_PER_AUTH_BASE_COST`` is still charged in the intrinsic, and
     the authority is left untouched.
     """
     contract = pre.deploy_contract(code=Op.STOP)
@@ -670,7 +670,7 @@ def test_invalid_chain_id_auth_still_charges_intrinsic(
 
     An authorization with a mismatched chain ID is skipped during
     ``set_delegation`` and incurs no top-frame charge, but its
-    ``REGULAR_PER_AUTH_BASE_COST`` is still charged in the intrinsic and
+    ``EXECUTION_PER_AUTH_BASE_COST`` is still charged in the intrinsic and
     the authority is left untouched.
     """
     contract = pre.deploy_contract(code=Op.STOP)
@@ -946,7 +946,7 @@ def test_mixed_valid_and_invalid_auths(
     Test mixed valid and invalid authorizations under the top-frame model.
 
     Every tuple (valid or invalid) pays the intrinsic
-    ``REGULAR_PER_AUTH_BASE_COST``. Only the valid authorizations reach
+    ``EXECUTION_PER_AUTH_BASE_COST``. Only the valid authorizations reach
     ``set_delegation`` and each writes a net-new delegation on an existing
     authority, paying the first-write ``ACCOUNT_WRITE`` and the top-frame
     ``AUTH_BASE``; the invalid (wrong nonce) tuples are skipped and pay
@@ -1923,7 +1923,7 @@ def test_invalid_auth_no_top_frame_charge(
     neither ``NEW_ACCOUNT`` / ``ACCOUNT_WRITE`` nor ``AUTH_BASE`` at the
     top frame (and, unlike the superseded EIP-8037 model, nothing is
     refilled because nothing was charged). Only the intrinsic
-    ``REGULAR_PER_AUTH_BASE_COST`` is paid and the authority is never
+    ``EXECUTION_PER_AUTH_BASE_COST`` is paid and the authority is never
     created. Swept over the reasons an authorization is rejected.
     """
     target = pre.deploy_contract(code=Op.STOP)

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_fork_transition.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_fork_transition.py
@@ -424,8 +424,8 @@ def test_auth_intrinsic_at_transition(
     The ``7702`` authorization intrinsic *falls* across the boundary.
     EIP-2780 moves the state-dependent authorization costs (account
     creation and the delegation-write base) out of the intrinsic and into
-    the top frame, leaving only the execution ``REGULAR_PER_AUTH_BASE_COST``
-    in the intrinsic. The post-fork single-authorization intrinsic is
+    the top frame, leaving only ``EXECUTION_PER_AUTH_BASE_COST`` in the
+    intrinsic. The post-fork single-authorization intrinsic is
     therefore strictly smaller than the pre-fork one, so a tx whose
     ``gas_limit`` equals the (lower) post-fork intrinsic is rejected with
     ``INTRINSIC_GAS_TOO_LOW`` before the fork but valid after.

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_gas.py
@@ -332,7 +332,7 @@ def test_mixed_validity_multi_auth_receipt_gas(
     Pin the exact receipt gas of a transaction carrying one valid and
     one invalid authorization under the EIP-2780 top-frame charge model.
 
-    Both tuples pay the state-independent ``REGULAR_PER_AUTH_BASE_COST``
+    Both tuples pay the state-independent ``EXECUTION_PER_AUTH_BASE_COST``
     in the intrinsic. The single valid authorization's authority leaf
     already exists (a funded EOA) and gains a net-new delegation
     indicator, so at the top frame it pays the first-write

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_refunds.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_refunds.py
@@ -17,7 +17,7 @@ regardless of whether the leaf pre-existed. This module pins that
 reduced, refund-free charge via the exact receipt gas:
 
 * a non-clearing delegation on an existing empty-code leaf pays the
-  intrinsic ``REGULAR_PER_AUTH_BASE_COST`` plus the top-frame
+  intrinsic ``EXECUTION_PER_AUTH_BASE_COST`` plus the top-frame
   ``ACCOUNT_WRITE`` (first leaf write) and ``AUTH_BASE`` (the net-new
   delegation indicator); and
 * a *clearing* re-authorization of an existing-delegation authority


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Follow-up to #3238: renames `REGULAR_PER_AUTH_BASE_COST` to `EXECUTION_PER_AUTH_BASE_COST`, the one constant deliberately kept in the terminology rename, now that the EIP author has confirmed it should be updated too (see [this comment](https://github.com/ethereum/execution-specs/pull/3238#issuecomment-5127845397)). Pure rename across the amsterdam spec, tests and testing framework; no behavior change.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#3238

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/HDPKdMXFrRcAAAAC/cat-typing.gif)
