### PR TITLE
feat(tests): enhance test coverage, add mainnet test for eip-2780

### DIFF
--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
@@ -240,8 +240,6 @@ def setup_target(
             return sender
         case RecipientType.DELEGATION_7702:
             delegated_to = pre.deploy_contract(code=Op.STOP)
-            return pre.deploy_contract(
-                code=Spec7702.delegation_designation(delegated_to)
-            )
+            return pre.fund_eoa(amount=0, delegation=delegated_to)
         case _:
             raise ValueError(f"Unsupported recipient type {recipient_type}")

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
@@ -5,6 +5,7 @@ from enum import Enum, auto
 
 from execution_testing import (
     EOA,
+    AccessList,
     Account,
     Address,
     Alloc,
@@ -16,7 +17,7 @@ from execution_testing import (
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
 
-EOA_INITIAL_BALANCE = 100
+EOA_INITIAL_BALANCE = 1
 NULL_ADDRESS = Address(0)
 
 RECIPIENT_TYPES_NON_CREATE = [
@@ -186,7 +187,10 @@ def build_authorization(
 
 
 def authorization_transaction_cost(
-    fork: Fork, authorization_list: list[AuthorizationTuple]
+    fork: Fork,
+    authorization_list: list[AuthorizationTuple],
+    *,
+    access_list: list[AccessList] | None = None,
 ) -> int:
     """
     Return the exact gas a value-free type-4 transaction to a plain
@@ -199,6 +203,7 @@ def authorization_transaction_cost(
     ``writes_delegation`` / ``first_write`` annotations.
     """
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
         recipient_type=RecipientType.CONTRACT,
         authorization_list_or_count=authorization_list,
         return_cost_deducted_prior_execution=True,

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
@@ -36,7 +36,7 @@ from .spec import ref_spec_2780
 REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
 REFERENCE_SPEC_VERSION = ref_spec_2780.version
 
-pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
+pytestmark = [pytest.mark.valid_at("EIP2780"), pytest.mark.mainnet]
 
 
 @EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
@@ -1,0 +1,172 @@
+"""
+Mainnet-marked tests for
+[EIP-2780: Resource-based intrinsic transaction gas](https://eips.ethereum.org/EIPS/eip-2780).
+
+One case per row of the EIP's transaction reference table. This EIP only
+reprices, so the pinned ``cumulative_gas_used`` is the sole observable
+that catches a client still charging the legacy intrinsic.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Address,
+    Alloc,
+    Fork,
+    Initcode,
+    Op,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+    TransactionReceipt,
+    compute_create_address,
+)
+from execution_testing.checklists import EIPChecklist
+
+from .helpers import (
+    EOA_INITIAL_BALANCE,
+    RECIPIENT_TYPES_NON_CREATE,
+    AuthorizationAction,
+    authorization_transaction_cost,
+    build_authorization,
+    setup_target,
+)
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.parametrize("recipient_type", RECIPIENT_TYPES_NON_CREATE)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_transaction_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    recipient_type: RecipientType,
+    value: int,
+) -> None:
+    """Gas for a non-create transaction, per recipient type and value."""
+    sender = pre.fund_eoa()
+    target = setup_target(pre, recipient_type, sender)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+    gas_used = intrinsic_gas + top_frame_gas + top_frame_state_gas
+
+    tx = Transaction(
+        to=target,
+        value=value,
+        gas_limit=gas_used,
+        sender=sender,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
+
+    post: dict[Address, Account | None] = {sender: Account(nonce=1)}
+    if recipient_type != RecipientType.SELF:
+        target_initial_balance = (
+            EOA_INITIAL_BALANCE if recipient_type == RecipientType.EOA else 0
+        )
+        if recipient_type == RecipientType.EMPTY_ACCOUNT and value == 0:
+            post[target] = None
+        else:
+            post[target] = Account(balance=target_initial_balance + value)
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_contract_creation_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    value: int,
+) -> None:
+    """Gas for a contract-creation transaction, per value."""
+    sender = pre.fund_eoa()
+    deploy_code = Op.STOP
+    init_code = Initcode(deploy_code=deploy_code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+    new_account_state_gas = fork.transaction_top_frame_state_gas(
+        contract_creation=True,
+    )
+    gas_used = intrinsic_gas + new_account_state_gas + init_code.gas_cost(fork)
+
+    tx = Transaction(
+        to=None,
+        value=value,
+        data=init_code,
+        gas_limit=gas_used,
+        sender=sender,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
+
+    created = compute_create_address(address=sender, nonce=0)
+    post = {created: Account(balance=value, code=deploy_code)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.parametrize(
+    "action",
+    [
+        pytest.param(AuthorizationAction.CREATES_ACCOUNT, id="new_authority"),
+        pytest.param(
+            AuthorizationAction.SETS_NEW_DELEGATION, id="existing_authority"
+        ),
+    ],
+)
+def test_authorization_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    action: AuthorizationAction,
+) -> None:
+    """Gas for one EIP-7702 authorization, per authority pre-state."""
+    scenario = build_authorization(pre, action)
+    authorization_list = [scenario.authorization]
+    gas_used = authorization_transaction_cost(fork, authorization_list)
+
+    tx = Transaction(
+        to=pre.deploy_contract(code=Op.STOP),
+        authorization_list=authorization_list,
+        gas_limit=gas_used,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
+
+    post = {scenario.authority: scenario.applied_account}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
@@ -13,23 +13,30 @@ Test gas costs with EIP-2780 for value-moving transactions to:
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Address,
     Alloc,
     Fork,
+    Hash,
     Initcode,
     Op,
     RecipientType,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
+    add_kzg_version,
     compute_create_address,
 )
 
+from ...cancun.eip4844_blobs.spec import Spec as EIP4844_Spec
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
 from ..eip7708_eth_transfer_logs.spec import transfer_log
 from .helpers import (
     EOA_INITIAL_BALANCE,
     RECIPIENT_TYPES_NON_CREATE,
+    AuthorizationAction,
+    build_authorization,
     setup_target,
 )
 from .spec import ref_spec_2780
@@ -124,6 +131,142 @@ def test_value_moving_transactions(
             post[target] = None
         else:
             post[target] = Account(balance=target_initial_balance + value)
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "delegation_warm",
+    [
+        pytest.param(False, id="cold_delegation_target"),
+        pytest.param(True, id="warm_delegation_target"),
+    ],
+)
+def test_self_transfer_with_delegated_sender(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    delegation_warm: bool,
+) -> None:
+    """
+    Gas for a self-transfer whose sender already holds a delegation.
+
+    The EIP's prose skips the delegation-target access for a
+    self-transfer; its reference-case row charges it.
+    """
+    value = 1
+    delegated_to = pre.deploy_contract(code=Op.STOP)
+    sender = pre.fund_eoa(delegation=delegated_to)
+
+    access_list = (
+        [AccessList(address=delegated_to, storage_keys=[])]
+        if delegation_warm
+        else []
+    )
+
+    intrinsic_recipient_type = RecipientType.SELF
+    top_frame_recipient_type = RecipientType.DELEGATION_7702
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        sends_value=True,
+        recipient_type=intrinsic_recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=True,
+        recipient_type=top_frame_recipient_type,
+        delegation_warm=delegation_warm,
+    )
+    total_gas_cost = intrinsic_gas + top_frame_gas
+
+    tx = Transaction(
+        sender=sender,
+        to=sender,
+        value=value,
+        access_list=access_list,
+        gas_limit=total_gas_cost,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=total_gas_cost, logs=[]
+        ),
+    )
+
+    post = {
+        sender: Account(
+            nonce=2, code=Spec7702.delegation_designation(delegated_to)
+        ),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.with_all_tx_types
+def test_intrinsic_decomposition_across_tx_types(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    tx_type: int,
+) -> None:
+    """
+    The decomposed intrinsic keys on the transaction's fields, not its
+    type: every type pays the same recipient and value primitives, with
+    type-specific costs riding on top.
+    """
+    value = 1
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+
+    scenario = (
+        build_authorization(pre, AuthorizationAction.SETS_NEW_DELEGATION)
+        if tx_type == 4
+        else None
+    )
+    authorizations = [scenario.authorization] if scenario else []
+
+    blob_versioned_hashes = (
+        add_kzg_version([Hash(1)], EIP4844_Spec.BLOB_COMMITMENT_VERSION_KZG)
+        if tx_type == 3
+        else None
+    )
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorization_list_or_count=authorizations,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorizations=authorizations,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorizations=authorizations,
+    )
+    total_gas_cost = intrinsic_gas + top_frame_gas + top_frame_state_gas
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=recipient,
+        value=value,
+        authorization_list=authorizations or None,
+        blob_versioned_hashes=blob_versioned_hashes,
+        gas_limit=total_gas_cost,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=total_gas_cost,
+            logs=[transfer_log(sender, recipient, value)],
+        ),
+    )
+
+    post: dict[Address, Account] = {
+        sender: Account(nonce=1),
+        recipient: Account(balance=EOA_INITIAL_BALANCE + value),
+    }
+    if scenario:
+        post[scenario.authority] = scenario.applied_account
 
     state_test(pre=pre, tx=tx, post=post)
 

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -175,7 +175,7 @@ def test_intrinsic_charges_authority_in_access_list(
 ) -> None:
     """
     Authority is listed in the access list. The intrinsic charge still
-    includes the full ``REGULAR_PER_AUTH_BASE_COST``, whose folded-in
+    includes the full ``EXECUTION_PER_AUTH_BASE_COST``, whose folded-in
     authority access is charged at the cold rate.
     """
     sender = pre.fund_eoa()

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -9,7 +9,7 @@ differently:
   listing ``tx.to`` in the access list pays the access-list cost but
   does not waive it, and the protocol-warmed coinbase is still charged
   cold when it is the recipient. The same holds for the authority
-  access folded into ``REGULAR_PER_AUTH_BASE_COST``.
+  access folded into ``EXECUTION_PER_AUTH_BASE_COST``.
 - A delegated recipient's delegation-target access is a *top-frame*
   charge that reads state, so it follows normal warm/cold accounting:
   ``WARM_ACCESS`` when the target is already warm -- the sender, the

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -8,7 +8,8 @@ differently:
   intrinsic phase, without reading state, so it is *always cold*:
   listing ``tx.to`` in the access list pays the access-list cost but
   does not waive it, and the protocol-warmed coinbase is still charged
-  cold when it is the recipient.
+  cold when it is the recipient. The same holds for the authority
+  access folded into ``REGULAR_PER_AUTH_BASE_COST``.
 - A delegated recipient's delegation-target access is a *top-frame*
   charge that reads state, so it follows normal warm/cold accounting:
   ``WARM_ACCESS`` when the target is already warm -- the sender, the
@@ -38,6 +39,11 @@ from execution_testing import (
 )
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .helpers import (
+    AuthorizationAction,
+    authorization_transaction_cost,
+    build_authorization,
+)
 from .spec import ref_spec_2780
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
@@ -157,6 +163,49 @@ def test_intrinsic_charges_recipient_is_coinbase(
 
     post = {
         sender: Account(nonce=1, balance=sender_final_balance),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+def test_intrinsic_charges_authority_in_access_list(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    Authority is listed in the access list. The intrinsic charge still
+    includes the full ``REGULAR_PER_AUTH_BASE_COST``, whose folded-in
+    authority access is charged at the cold rate.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.deploy_contract(code=Op.STOP)
+
+    scenario = build_authorization(
+        pre, AuthorizationAction.SETS_NEW_DELEGATION
+    )
+    authorization_list = [scenario.authorization]
+    access_list = [AccessList(address=scenario.authority, storage_keys=[])]
+
+    total_gas_cost = authorization_transaction_cost(
+        fork, authorization_list, access_list=access_list
+    )
+
+    tx = Transaction(
+        ty=4,
+        sender=sender,
+        to=recipient,
+        value=0,
+        access_list=access_list,
+        authorization_list=authorization_list,
+        gas_limit=total_gas_cost,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=total_gas_cost,
+        ),
+    )
+
+    post = {
+        scenario.authority: scenario.applied_account,
     }
 
     state_test(pre=pre, tx=tx, post=post)


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add more EIP-2780 test coverage, and mainnet test cases.

New coverage:

- `test_intrinsic_charges_authority_in_access_list`
- `test_self_transfer_with_delegated_sender`
- `test_intrinsic_decomposition_across_tx_types`

The mainnet test cases are duplicated as tests already in this directory, and
cover less than the originals do:

| `test_eip_mainnet.py` | Duplicates | Evidence |
| :--- | :--- | :--- |
| `test_transaction_gas`, all 10 | `test_value_moving_transactions`, all 10 | Same parametrization, identical gas per case; the original also asserts the EIP-7708 transfer log |
| `test_contract_creation_gas`, both | `test_value_contract_creation_tx[success-*]` | Both fill at 185,130; the original also covers `init_reverts` |
| `test_authorization_gas[existing_authority]` | `test_single_authorization_charges[sets_new_delegation]`, `test_account_write_first_write_of_authority[existing_eoa]` | All three at 66,006 |
| `test_authorization_gas[new_authority]` | `test_single_authorization_charges[creates_account]`, `test_account_write_first_write_of_authority[non_existent]` | All three at 249,606 |

I am consider removing `test_eip_mainnet.py` and marking those existing tests with the `mainnet` marker instead.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
issue #1940, #3217 

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
