### PR TITLE
feat(test-benchmark): add missing glam eip to benchmark

### DIFF
--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -11,6 +11,7 @@ Supported Opcodes:
 - CHAINID
 - BASEFEE
 - BLOBBASEFEE
+- SLOTNUM
 """
 
 import pytest
@@ -78,4 +79,14 @@ def test_blockhash(
         code_generator=ExtCallGenerator(
             attack_block=Op.BLOCKHASH(block_number)
         ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.valid_from("Amsterdam")
+def test_slotnum(benchmark_test: BenchmarkTestFiller) -> None:
+    """Benchmark SLOTNUM instruction."""
+    benchmark_test(
+        target_opcode=Op.SLOTNUM,
+        code_generator=ExtCallGenerator(attack_block=Op.SLOTNUM),
     )

--- a/tests/benchmark/compute/instruction/test_stack.py
+++ b/tests/benchmark/compute/instruction/test_stack.py
@@ -6,6 +6,9 @@ Supported Opcodes:
 - PUSHx
 - DUPx
 - SWAPx
+- DUPN
+- SWAPN
+- EXCHANGE
 """
 
 import pytest
@@ -137,5 +140,73 @@ def test_push(
         target_opcode=opcode,
         code_generator=ExtCallGenerator(
             attack_block=opcode[1] if opcode.has_data_portion() else opcode
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.valid_from("Amsterdam")
+@pytest.mark.parametrize(
+    "stack_index",
+    [17, 107, 235],
+    ids=lambda x: f"stack_{x}",
+)
+def test_dupn(
+    benchmark_test: BenchmarkTestFiller,
+    stack_index: int,
+) -> None:
+    """Benchmark DUPN instruction."""
+    opcode = Op.DUPN[stack_index]
+    benchmark_test(
+        target_opcode=Op.DUPN,
+        code_generator=ExtCallGenerator(
+            setup=Op.PUSH0 * opcode.min_stack_height,
+            attack_block=opcode,
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.valid_from("Amsterdam")
+@pytest.mark.parametrize(
+    "stack_index",
+    [17, 107, 235],
+    ids=lambda x: f"stack_{x}",
+)
+def test_swapn(
+    benchmark_test: BenchmarkTestFiller,
+    stack_index: int,
+) -> None:
+    """Benchmark SWAPN instruction."""
+    opcode = Op.SWAPN[stack_index]
+    benchmark_test(
+        target_opcode=Op.SWAPN,
+        code_generator=JumpLoopGenerator(
+            attack_block=opcode, setup=Op.PUSH0 * opcode.min_stack_height
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.valid_from("Amsterdam")
+@pytest.mark.parametrize(
+    "n,m",
+    [
+        pytest.param(1, 2, id="n_1_m_2"),
+        pytest.param(1, 29, id="n_1_m_29"),
+        pytest.param(14, 16, id="n_14_m_16"),
+    ],
+)
+def test_exchange(
+    benchmark_test: BenchmarkTestFiller,
+    n: int,
+    m: int,
+) -> None:
+    """Benchmark EXCHANGE instruction."""
+    opcode = Op.EXCHANGE[n, m]
+    benchmark_test(
+        target_opcode=Op.EXCHANGE,
+        code_generator=JumpLoopGenerator(
+            attack_block=opcode, setup=Op.PUSH0 * opcode.min_stack_height
         ),
     )

--- a/tests/benchmark/compute/scenario/test_mix_operations.py
+++ b/tests/benchmark/compute/scenario/test_mix_operations.py
@@ -19,6 +19,9 @@ from execution_testing import (
         Op.PUSH2[bytes(Op.JUMPDEST + Op.JUMPDEST)],
         Op.PUSH1[bytes(Op.JUMPDEST)] + Op.JUMPDEST,
         Op.PUSH2[bytes(Op.JUMPDEST + Op.JUMPDEST)] + Op.JUMPDEST,
+        Op.SWAPN[bytes(Op.JUMPDEST)],
+        Op.DUPN[bytes(Op.JUMPDEST)],
+        Op.EXCHANGE[bytes(Op.JUMPDEST)],
     ],
     ids=lambda x: x.hex(),
 )


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add EIP-8024, EIP-7843 to benchmark test suite.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
