### PR TITLE
fix(ci): Rename backports branches

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -11,7 +11,7 @@ name: Backport merged PR
 
 on:
   pull_request_target:
-    types: [closed, labeled]
+    types: [ closed, labeled ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -47,6 +47,9 @@ jobs:
           # Only single-commit (squash-merged) PRs cherry-pick cleanly; skip
           # PRs that landed as merge commits rather than failing the run.
           merge_commits: skip
+          # Create the working branch under `backports/**`: it is exempt from
+          # the `branch-only-forks` creation rule.
+          branch_name: 'backports/${pull_number}-to-${target_branch}'
           pull_title: '${pull_title} [backport ${target_branch}]'
           pull_description: |
             Automated backport of #${pull_number} to `${target_branch}`.


### PR DESCRIPTION
### Description

Minor fix to rename backport branches as `backports/**` to allow us to create a new ruleset for this branch pattern to be created and the workflow to be able to function.

### Related Issues or PRs
N/A.

### Checklist
- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://plus.unsplash.com/premium_photo-1661963423747-686b37c59aea?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8Y3V0ZSUyMGZveHxlbnwwfHwwfHx8MA%3D%3D)
