### PR TITLE
feat(tests): cover EIP-8282 builder request dequeues in block access lists

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
@@ -39,9 +39,6 @@ REFERENCE_SPEC_VERSION = ref_spec_7928.version
 
 pytestmark = pytest.mark.valid_from("Amsterdam")
 
-DEPOSIT_CONTRACT = Address(Spec8282.BUILDER_DEPOSIT_CONTRACT_ADDRESS)
-EXIT_CONTRACT = Address(Spec8282.BUILDER_EXIT_CONTRACT_ADDRESS)
-
 
 def _fees(
     request_class: Type[FeeSystemContractRequest], count: int
@@ -155,105 +152,39 @@ def _request_bus_expectation(
 
 
 @pytest.mark.parametrize(
-    "num_requests,via_contract",
-    [
-        pytest.param(1, False, id="single_deposit_from_eoa"),
-        pytest.param(
-            Spec8282.TARGET_DEPOSIT_REQUESTS_PER_BLOCK + 1,
-            False,
-            id="target_exceeded_deposits_from_eoa",
-        ),
-        pytest.param(
-            Spec8282.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 1,
-            True,
-            id="carry_over_deposits_from_contract",
-        ),
-    ],
+    "request_class",
+    [BuilderDepositRequest, BuilderExitRequest],
+    ids=["deposit", "exit"],
 )
-def test_bal_builder_deposit_dequeue(
-    pre: Alloc,
-    blockchain_test: BlockchainTestFiller,
-    num_requests: int,
-    via_contract: bool,
-) -> None:
-    """
-    Ensure BAL tracks the builder deposit predeploy across a clean sweep, a
-    target-exceeding sweep that writes the excess, and a partial sweep that
-    advances the queue head.
-    """
-    requests = [
-        _request(BuilderDepositRequest, i, fee)
-        for i, fee in enumerate(_fees(BuilderDepositRequest, num_requests))
-    ]
-    interaction: SystemContractInteractionBase
-    if via_contract:
-        interaction = SystemContractInteractionContract(requests=requests)
-    else:
-        interaction = SystemContractInteractionTransaction(requests=requests)
-    prepared = interaction.update_pre(pre)
-    txs = prepared.transactions()
-    system_call_index = len(txs) + 1
-
-    if via_contract:
-        enqueues = [(1, num_requests)]
-    else:
-        enqueues = [(i + 1, i + 1) for i in range(num_requests)]
-
-    sender = prepared.sender_account
-    assert sender is not None
-
-    block = Block(
-        txs=txs,
-        expected_block_access_list=BlockAccessListExpectation(
-            account_expectations={
-                sender: BalAccountExpectation(
-                    nonce_changes=[
-                        BalNonceChange(
-                            block_access_index=i + 1, post_nonce=i + 1
-                        )
-                        for i in range(len(txs))
-                    ],
-                ),
-                DEPOSIT_CONTRACT: _request_bus_expectation(
-                    BuilderDepositRequest, enqueues, system_call_index
-                ),
-            }
-        ),
-    )
-
-    blockchain_test(pre=pre, blocks=[block], post={})
-
-
 @pytest.mark.parametrize(
-    "num_requests,via_contract",
+    "scenario,via_contract",
     [
-        pytest.param(1, False, id="single_exit_from_eoa"),
-        pytest.param(
-            Spec8282.TARGET_EXIT_REQUESTS_PER_BLOCK + 1,
-            False,
-            id="target_exceeded_exits_from_eoa",
-        ),
-        pytest.param(
-            Spec8282.MAX_EXIT_REQUESTS_PER_BLOCK + 1,
-            True,
-            id="carry_over_exits_from_contract",
-        ),
+        pytest.param("single", False, id="single_from_eoa"),
+        pytest.param("target_exceeded", False, id="target_exceeded_from_eoa"),
+        pytest.param("carry_over", True, id="carry_over_from_contract"),
     ],
 )
-def test_bal_builder_exit_dequeue(
+def test_bal_builder_request_dequeue(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,
-    num_requests: int,
+    request_class: Type[FeeSystemContractRequest],
+    scenario: str,
     via_contract: bool,
 ) -> None:
     """
-    Ensure BAL tracks the builder exit predeploy across a clean sweep, a
+    Ensure BAL tracks a builder request predeploy across a clean sweep, a
     target-exceeding sweep that writes the excess, and a partial sweep that
     advances the queue head.
     """
+    if scenario == "single":
+        num_requests = 1
+    elif scenario == "target_exceeded":
+        num_requests = request_class.target_per_block + 1
+    else:  # carry_over: exceed the per-block dequeue cap
+        num_requests = request_class.max_per_block + 1
     requests = [
-        _request(BuilderExitRequest, i, fee)
-        for i, fee in enumerate(_fees(BuilderExitRequest, num_requests))
+        _request(request_class, i, fee)
+        for i, fee in enumerate(_fees(request_class, num_requests))
     ]
     interaction: SystemContractInteractionBase
     if via_contract:
@@ -284,8 +215,10 @@ def test_bal_builder_exit_dequeue(
                         for i in range(len(txs))
                     ],
                 ),
-                EXIT_CONTRACT: _request_bus_expectation(
-                    BuilderExitRequest, enqueues, system_call_index
+                request_class.interaction_contract_address: (
+                    _request_bus_expectation(
+                        request_class, enqueues, system_call_index
+                    )
                 ),
             }
         ),
@@ -338,11 +271,15 @@ def test_bal_builder_deposits_and_exits_same_block(
         for i, sender in enumerate(senders)
     }
     # Deposits are enqueued by transactions 1 and 3, exits by 2 and 4.
-    account_expectations[DEPOSIT_CONTRACT] = _request_bus_expectation(
+    account_expectations[
+        BuilderDepositRequest.interaction_contract_address
+    ] = _request_bus_expectation(
         BuilderDepositRequest, [(1, 1), (3, 2)], system_call_index
     )
-    account_expectations[EXIT_CONTRACT] = _request_bus_expectation(
-        BuilderExitRequest, [(2, 1), (4, 2)], system_call_index
+    account_expectations[BuilderExitRequest.interaction_contract_address] = (
+        _request_bus_expectation(
+            BuilderExitRequest, [(2, 1), (4, 2)], system_call_index
+        )
     )
 
     block = Block(

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
@@ -12,7 +12,6 @@ from typing import Dict, List, Tuple, Type
 
 import pytest
 from execution_testing import (
-    Address,
     Alloc,
     BalAccountExpectation,
     BalNonceChange,
@@ -328,7 +327,7 @@ def test_bal_builder_request_invalid(
     sender = prepared.sender_account
     assert sender is not None
 
-    contract = Address(request_obj.interaction_contract_address)
+    contract = request_obj.interaction_contract_address
 
     block = Block(
         txs=txs,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
@@ -58,20 +58,11 @@ def _fees(
     ]
 
 
-def _deposit(index: int, fee: int) -> BuilderDepositRequest:
-    """Build a builder deposit request with distinct non-zero fields."""
-    return BuilderDepositRequest(
-        pubkey=index * 3 + 1,
-        withdrawal_credentials=index * 3 + 2,
-        amount=Spec8282.BUILDER_MIN_DEPOSIT // 10**9,
-        signature=index * 3 + 3,
-        fee=fee,
-    )
-
-
-def _exit(index: int, fee: int) -> BuilderExitRequest:
-    """Build a builder exit request with a distinct non-zero pubkey."""
-    return BuilderExitRequest(pubkey=index + 1, fee=fee)
+def _request(
+    request_class: Type[FeeSystemContractRequest], index: int, fee: int
+) -> FeeSystemContractRequest:
+    """Build a request from a sequential index, paying `fee` to enqueue."""
+    return request_class.from_index(index).copy(fee=fee)
 
 
 def _request_bus_expectation(
@@ -191,7 +182,7 @@ def test_bal_builder_deposit_dequeue(
     advances the queue head.
     """
     requests = [
-        _deposit(i, fee)
+        _request(BuilderDepositRequest, i, fee)
         for i, fee in enumerate(_fees(BuilderDepositRequest, num_requests))
     ]
     interaction: SystemContractInteractionBase
@@ -261,7 +252,7 @@ def test_bal_builder_exit_dequeue(
     advances the queue head.
     """
     requests = [
-        _exit(i, fee)
+        _request(BuilderExitRequest, i, fee)
         for i, fee in enumerate(_fees(BuilderExitRequest, num_requests))
     ]
     interaction: SystemContractInteractionBase
@@ -316,16 +307,16 @@ def test_bal_builder_deposits_and_exits_same_block(
     exit_fees = _fees(BuilderExitRequest, 2)
     interactions = [
         SystemContractInteractionTransaction(
-            requests=[_deposit(0, deposit_fees[0])]
+            requests=[_request(BuilderDepositRequest, 0, deposit_fees[0])]
         ),
         SystemContractInteractionTransaction(
-            requests=[_exit(0, exit_fees[0])]
+            requests=[_request(BuilderExitRequest, 0, exit_fees[0])]
         ),
         SystemContractInteractionTransaction(
-            requests=[_deposit(1, deposit_fees[1])]
+            requests=[_request(BuilderDepositRequest, 1, deposit_fees[1])]
         ),
         SystemContractInteractionTransaction(
-            requests=[_exit(1, exit_fees[1])]
+            requests=[_request(BuilderExitRequest, 1, exit_fees[1])]
         ),
     ]
 

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip8282.py
@@ -1,0 +1,427 @@
+"""
+Tests for the effects of EIP-8282 builder requests on EIP-7928.
+
+Pin the block access list produced by the builder deposit and exit
+predeploys: the enqueuing transactions grow the count and queue tail
+slots, and the post-execution system call dequeues the records, resetting
+or advancing the bus slots depending on whether the sweep is clean or
+partial.
+"""
+
+from typing import Dict, List, Tuple, Type
+
+import pytest
+from execution_testing import (
+    Address,
+    Alloc,
+    BalAccountExpectation,
+    BalNonceChange,
+    BalStorageChange,
+    BalStorageSlot,
+    Block,
+    BlockAccessListExpectation,
+    BlockchainTestFiller,
+    FeeSystemContractRequest,
+    SystemContractInteractionBase,
+    SystemContractInteractionContract,
+    SystemContractInteractionTransaction,
+)
+
+from ..eip8282_builder_execution_requests.helpers import (
+    BuilderDepositRequest,
+    BuilderExitRequest,
+)
+from ..eip8282_builder_execution_requests.spec import Spec as Spec8282
+from .spec import ref_spec_7928
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7928.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7928.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+DEPOSIT_CONTRACT = Address(Spec8282.BUILDER_DEPOSIT_CONTRACT_ADDRESS)
+EXIT_CONTRACT = Address(Spec8282.BUILDER_EXIT_CONTRACT_ADDRESS)
+
+
+def _fees(
+    request_class: Type[FeeSystemContractRequest], count: int
+) -> List[int]:
+    """
+    Return the fee each of `count` requests enqueued in a single block must
+    pay, matching the predeploy's in-call excess computation: requests
+    already queued this block beyond the target raise the fee for the next
+    one (the stored excess starts at zero).
+    """
+    return [
+        request_class.get_fee(max(i - request_class.target_per_block, 0))
+        for i in range(count)
+    ]
+
+
+def _deposit(index: int, fee: int) -> BuilderDepositRequest:
+    """Build a builder deposit request with distinct non-zero fields."""
+    return BuilderDepositRequest(
+        pubkey=index * 3 + 1,
+        withdrawal_credentials=index * 3 + 2,
+        amount=Spec8282.BUILDER_MIN_DEPOSIT // 10**9,
+        signature=index * 3 + 3,
+        fee=fee,
+    )
+
+
+def _exit(index: int, fee: int) -> BuilderExitRequest:
+    """Build a builder exit request with a distinct non-zero pubkey."""
+    return BuilderExitRequest(pubkey=index + 1, fee=fee)
+
+
+def _request_bus_expectation(
+    request_class: Type[FeeSystemContractRequest],
+    enqueues: List[Tuple[int, int]],
+    system_call_index: int,
+) -> BalAccountExpectation:
+    """
+    Build the BAL expectation for a request-bus predeploy.
+
+    `enqueues` lists `(block_access_index, cumulative_count)` for each
+    transaction that enqueues into this predeploy. The count and queue tail
+    grow with each of them; the system call at `system_call_index` then
+    resets the count and either resets the tail (clean sweep) or advances
+    the head to `max_per_block` (partial sweep), writing the new excess if
+    the enqueued total exceeded the target.
+    """
+    total = enqueues[-1][1] if enqueues else 0
+    new_excess = max(total - request_class.target_per_block, 0)
+    partial_sweep = total > request_class.max_per_block
+
+    count_changes = [
+        BalStorageChange(block_access_index=index, post_value=cumulative)
+        for index, cumulative in enqueues
+    ] + [BalStorageChange(block_access_index=system_call_index, post_value=0)]
+
+    tail_changes = [
+        BalStorageChange(block_access_index=index, post_value=cumulative)
+        for index, cumulative in enqueues
+    ]
+    head_changes = []
+    if partial_sweep:
+        # Partial sweep: the head advances past the dequeued records and
+        # the tail keeps the queue's end.
+        head_changes.append(
+            BalStorageChange(
+                block_access_index=system_call_index,
+                post_value=request_class.max_per_block,
+            )
+        )
+    else:
+        # Clean sweep: the head stays at zero (a read) and the tail resets.
+        tail_changes.append(
+            BalStorageChange(
+                block_access_index=system_call_index, post_value=0
+            )
+        )
+
+    storage_changes = []
+    if new_excess:
+        storage_changes.append(
+            BalStorageSlot(
+                slot=Spec8282.EXCESS_STORAGE_SLOT,
+                slot_changes=[
+                    BalStorageChange(
+                        block_access_index=system_call_index,
+                        post_value=new_excess,
+                    )
+                ],
+            )
+        )
+    storage_changes.append(
+        BalStorageSlot(
+            slot=Spec8282.COUNT_STORAGE_SLOT, slot_changes=count_changes
+        )
+    )
+    if head_changes:
+        storage_changes.append(
+            BalStorageSlot(
+                slot=Spec8282.QUEUE_HEAD_STORAGE_SLOT,
+                slot_changes=head_changes,
+            )
+        )
+    storage_changes.append(
+        BalStorageSlot(
+            slot=Spec8282.QUEUE_TAIL_STORAGE_SLOT, slot_changes=tail_changes
+        )
+    )
+
+    storage_reads = []
+    if not new_excess:
+        storage_reads.append(Spec8282.EXCESS_STORAGE_SLOT)
+    if not partial_sweep:
+        storage_reads.append(Spec8282.QUEUE_HEAD_STORAGE_SLOT)
+
+    kwargs: Dict = {"storage_changes": storage_changes}
+    if storage_reads:
+        kwargs["storage_reads"] = storage_reads
+    return BalAccountExpectation(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "num_requests,via_contract",
+    [
+        pytest.param(1, False, id="single_deposit_from_eoa"),
+        pytest.param(
+            Spec8282.TARGET_DEPOSIT_REQUESTS_PER_BLOCK + 1,
+            False,
+            id="target_exceeded_deposits_from_eoa",
+        ),
+        pytest.param(
+            Spec8282.MAX_DEPOSIT_REQUESTS_PER_BLOCK + 1,
+            True,
+            id="carry_over_deposits_from_contract",
+        ),
+    ],
+)
+def test_bal_builder_deposit_dequeue(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    num_requests: int,
+    via_contract: bool,
+) -> None:
+    """
+    Ensure BAL tracks the builder deposit predeploy across a clean sweep, a
+    target-exceeding sweep that writes the excess, and a partial sweep that
+    advances the queue head.
+    """
+    requests = [
+        _deposit(i, fee)
+        for i, fee in enumerate(_fees(BuilderDepositRequest, num_requests))
+    ]
+    interaction: SystemContractInteractionBase
+    if via_contract:
+        interaction = SystemContractInteractionContract(requests=requests)
+    else:
+        interaction = SystemContractInteractionTransaction(requests=requests)
+    prepared = interaction.update_pre(pre)
+    txs = prepared.transactions()
+    system_call_index = len(txs) + 1
+
+    if via_contract:
+        enqueues = [(1, num_requests)]
+    else:
+        enqueues = [(i + 1, i + 1) for i in range(num_requests)]
+
+    sender = prepared.sender_account
+    assert sender is not None
+
+    block = Block(
+        txs=txs,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                sender: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(
+                            block_access_index=i + 1, post_nonce=i + 1
+                        )
+                        for i in range(len(txs))
+                    ],
+                ),
+                DEPOSIT_CONTRACT: _request_bus_expectation(
+                    BuilderDepositRequest, enqueues, system_call_index
+                ),
+            }
+        ),
+    )
+
+    blockchain_test(pre=pre, blocks=[block], post={})
+
+
+@pytest.mark.parametrize(
+    "num_requests,via_contract",
+    [
+        pytest.param(1, False, id="single_exit_from_eoa"),
+        pytest.param(
+            Spec8282.TARGET_EXIT_REQUESTS_PER_BLOCK + 1,
+            False,
+            id="target_exceeded_exits_from_eoa",
+        ),
+        pytest.param(
+            Spec8282.MAX_EXIT_REQUESTS_PER_BLOCK + 1,
+            True,
+            id="carry_over_exits_from_contract",
+        ),
+    ],
+)
+def test_bal_builder_exit_dequeue(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    num_requests: int,
+    via_contract: bool,
+) -> None:
+    """
+    Ensure BAL tracks the builder exit predeploy across a clean sweep, a
+    target-exceeding sweep that writes the excess, and a partial sweep that
+    advances the queue head.
+    """
+    requests = [
+        _exit(i, fee)
+        for i, fee in enumerate(_fees(BuilderExitRequest, num_requests))
+    ]
+    interaction: SystemContractInteractionBase
+    if via_contract:
+        interaction = SystemContractInteractionContract(requests=requests)
+    else:
+        interaction = SystemContractInteractionTransaction(requests=requests)
+    prepared = interaction.update_pre(pre)
+    txs = prepared.transactions()
+    system_call_index = len(txs) + 1
+
+    if via_contract:
+        enqueues = [(1, num_requests)]
+    else:
+        enqueues = [(i + 1, i + 1) for i in range(num_requests)]
+
+    sender = prepared.sender_account
+    assert sender is not None
+
+    block = Block(
+        txs=txs,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                sender: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(
+                            block_access_index=i + 1, post_nonce=i + 1
+                        )
+                        for i in range(len(txs))
+                    ],
+                ),
+                EXIT_CONTRACT: _request_bus_expectation(
+                    BuilderExitRequest, enqueues, system_call_index
+                ),
+            }
+        ),
+    )
+
+    blockchain_test(pre=pre, blocks=[block], post={})
+
+
+def test_bal_builder_deposits_and_exits_same_block(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Ensure BAL tracks both builder predeploys when a single block
+    interleaves deposit and exit requests, pinning which transaction
+    indices each contract's bus-slot changes carry.
+    """
+    deposit_fees = _fees(BuilderDepositRequest, 2)
+    exit_fees = _fees(BuilderExitRequest, 2)
+    interactions = [
+        SystemContractInteractionTransaction(
+            requests=[_deposit(0, deposit_fees[0])]
+        ),
+        SystemContractInteractionTransaction(
+            requests=[_exit(0, exit_fees[0])]
+        ),
+        SystemContractInteractionTransaction(
+            requests=[_deposit(1, deposit_fees[1])]
+        ),
+        SystemContractInteractionTransaction(
+            requests=[_exit(1, exit_fees[1])]
+        ),
+    ]
+
+    txs = []
+    senders = []
+    for interaction in interactions:
+        prepared = interaction.update_pre(pre)
+        txs += prepared.transactions()
+        assert prepared.sender_account is not None
+        senders.append(prepared.sender_account)
+    system_call_index = len(txs) + 1
+
+    account_expectations: Dict = {
+        sender: BalAccountExpectation(
+            nonce_changes=[
+                BalNonceChange(block_access_index=i + 1, post_nonce=1)
+            ],
+        )
+        for i, sender in enumerate(senders)
+    }
+    # Deposits are enqueued by transactions 1 and 3, exits by 2 and 4.
+    account_expectations[DEPOSIT_CONTRACT] = _request_bus_expectation(
+        BuilderDepositRequest, [(1, 1), (3, 2)], system_call_index
+    )
+    account_expectations[EXIT_CONTRACT] = _request_bus_expectation(
+        BuilderExitRequest, [(2, 1), (4, 2)], system_call_index
+    )
+
+    block = Block(
+        txs=txs,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations=account_expectations
+        ),
+    )
+
+    blockchain_test(pre=pre, blocks=[block], post={})
+
+
+@pytest.mark.parametrize(
+    "request_obj",
+    [
+        pytest.param(
+            BuilderDepositRequest(
+                pubkey=1,
+                withdrawal_credentials=2,
+                amount=Spec8282.BUILDER_MIN_DEPOSIT // 10**9,
+                signature=3,
+                fee=0,
+                valid=False,
+            ),
+            id="deposit_insufficient_fee",
+        ),
+        pytest.param(
+            BuilderExitRequest(pubkey=1, fee=0, valid=False),
+            id="exit_insufficient_fee",
+        ),
+    ],
+)
+def test_bal_builder_request_invalid(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    request_obj: FeeSystemContractRequest,
+) -> None:
+    """
+    Ensure BAL records only reads on a builder predeploy when the request
+    call reverts for an insufficient fee: the reverted enqueue leaves no
+    storage change and the system-call dequeue finds an empty queue.
+    """
+    interaction = SystemContractInteractionTransaction(requests=[request_obj])
+    prepared = interaction.update_pre(pre)
+    txs = prepared.transactions()
+    sender = prepared.sender_account
+    assert sender is not None
+
+    contract = Address(request_obj.interaction_contract_address)
+
+    block = Block(
+        txs=txs,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                sender: BalAccountExpectation(
+                    nonce_changes=[
+                        BalNonceChange(block_access_index=1, post_nonce=1)
+                    ],
+                ),
+                contract: BalAccountExpectation(
+                    storage_reads=[
+                        Spec8282.EXCESS_STORAGE_SLOT,
+                        Spec8282.COUNT_STORAGE_SLOT,
+                        Spec8282.QUEUE_HEAD_STORAGE_SLOT,
+                        Spec8282.QUEUE_TAIL_STORAGE_SLOT,
+                    ],
+                    storage_changes=[],
+                ),
+            }
+        ),
+    )
+
+    blockchain_test(pre=pre, blocks=[block], post={})

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_fork_transition.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_fork_transition.py
@@ -3,10 +3,13 @@
 import pytest
 from execution_testing import (
     Account,
+    Address,
     Alloc,
     BalAccountExpectation,
     BalBalanceChange,
     BalNonceChange,
+    BalStorageChange,
+    BalStorageSlot,
     Block,
     BlockAccessListExpectation,
     BlockchainTestFiller,
@@ -17,10 +20,19 @@ from execution_testing import (
     Environment,
     Hash,
     Header,
+    Op,
+    SystemContractInteractionTransaction,
     Transaction,
+    TransactionReceipt,
     TransitionFork,
 )
 
+from ..eip7708_eth_transfer_logs.spec import transfer_log
+from ..eip8282_builder_execution_requests.helpers import (
+    BuilderDepositRequest,
+    BuilderExitRequest,
+)
+from ..eip8282_builder_execution_requests.spec import Spec as Spec8282
 from .spec import ref_spec_7928
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7928.git_path
@@ -249,4 +261,255 @@ def test_fork_transition_bal_size_constraint(
         post={},
         blocks=[pre_fork_block, at_fork_block],
         genesis_environment=Environment(gas_limit=block_gas_limit),
+    )
+
+
+def _single_request_bus_expectation(
+    enqueue_index: int, system_call_index: int, post_balance: int
+) -> BalAccountExpectation:
+    """
+    Build the BAL expectation for a builder predeploy dequeuing a single
+    request in a clean sweep: count and queue tail rise to one and reset,
+    while the excess and head slots stay read-only.
+    """
+
+    def bus_slot_changes() -> list:
+        return [
+            BalStorageChange(block_access_index=enqueue_index, post_value=1),
+            BalStorageChange(
+                block_access_index=system_call_index, post_value=0
+            ),
+        ]
+
+    return BalAccountExpectation(
+        balance_changes=[
+            BalBalanceChange(
+                block_access_index=enqueue_index, post_balance=post_balance
+            )
+        ],
+        storage_changes=[
+            BalStorageSlot(
+                slot=Spec8282.COUNT_STORAGE_SLOT,
+                slot_changes=bus_slot_changes(),
+            ),
+            BalStorageSlot(
+                slot=Spec8282.QUEUE_TAIL_STORAGE_SLOT,
+                slot_changes=bus_slot_changes(),
+            ),
+        ],
+        storage_reads=[
+            Spec8282.EXCESS_STORAGE_SLOT,
+            Spec8282.QUEUE_HEAD_STORAGE_SLOT,
+        ],
+    )
+
+
+@pytest.mark.valid_at_transition_to("Amsterdam")
+def test_bal_fork_transition_builder_requests(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify the BAL of an activation block that dequeues EIP-8282 builder
+    requests.
+
+    The first Amsterdam block carries the chain's first builder deposit
+    and exit requests: the BAL must record both predeploys' request-bus
+    slots, the enqueuing transaction indices, and the clean-sweep dequeue
+    by the post-execution system calls.
+    """
+    alice = pre.fund_eoa()
+    bob = pre.fund_eoa(amount=0)
+
+    deposit = BuilderDepositRequest(
+        pubkey=1,
+        withdrawal_credentials=2,
+        amount=Spec8282.BUILDER_MIN_DEPOSIT // 10**9,
+        signature=3,
+        fee=BuilderDepositRequest.get_fee(0),
+    )
+    builder_exit = BuilderExitRequest(
+        pubkey=1, fee=BuilderExitRequest.get_fee(0)
+    )
+
+    deposit_interaction = SystemContractInteractionTransaction(
+        requests=[deposit]
+    ).update_pre(pre)
+    exit_interaction = SystemContractInteractionTransaction(
+        requests=[builder_exit]
+    ).update_pre(pre)
+    txs = deposit_interaction.transactions() + exit_interaction.transactions()
+    system_call_index = len(txs) + 1
+
+    deposit_sender = deposit_interaction.sender_account
+    exit_sender = exit_interaction.sender_account
+    assert deposit_sender is not None and exit_sender is not None
+
+    blocks = [
+        Block(
+            timestamp=FORK_TIMESTAMP - 1,
+            txs=[Transaction(sender=alice, to=bob, value=100, gas_price=10)],
+            header_verify=Header(
+                block_access_list_hash=Header.EMPTY_FIELD,
+            ),
+        ),
+        Block(
+            timestamp=FORK_TIMESTAMP,
+            txs=txs,
+            expected_block_access_list=BlockAccessListExpectation(
+                account_expectations={
+                    deposit_sender: BalAccountExpectation(
+                        nonce_changes=[
+                            BalNonceChange(block_access_index=1, post_nonce=1)
+                        ],
+                    ),
+                    exit_sender: BalAccountExpectation(
+                        nonce_changes=[
+                            BalNonceChange(block_access_index=2, post_nonce=1)
+                        ],
+                    ),
+                    Address(
+                        Spec8282.BUILDER_DEPOSIT_CONTRACT_ADDRESS
+                    ): _single_request_bus_expectation(
+                        1, system_call_index, deposit.value
+                    ),
+                    Address(
+                        Spec8282.BUILDER_EXIT_CONTRACT_ADDRESS
+                    ): _single_request_bus_expectation(
+                        2, system_call_index, builder_exit.value
+                    ),
+                }
+            ),
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={
+            Address(Spec8282.BUILDER_DEPOSIT_CONTRACT_ADDRESS): Account(
+                balance=deposit.value
+            ),
+            Address(Spec8282.BUILDER_EXIT_CONTRACT_ADDRESS): Account(
+                balance=builder_exit.value
+            ),
+        },
+    )
+
+
+@pytest.mark.valid_at_transition_to("Amsterdam")
+def test_bal_fork_transition_transfers_and_storage(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify the BAL of an activation block with ordinary transfers,
+    storage writes and Transfer logs.
+
+    The first Amsterdam block mixes a plain EOA transfer with a contract
+    call that writes storage and forwards value: the BAL must carry the
+    balance and storage changes while the receipts carry the EIP-7708
+    Transfer logs.
+    """
+    transfer_value = 100
+    forward_value = 500
+
+    alice = pre.fund_eoa()
+    bob = pre.fund_eoa(amount=0)
+    carol = pre.fund_eoa()
+    dave = pre.fund_eoa(amount=0)
+    relay = pre.deploy_contract(
+        code=Op.SSTORE(0, 1)
+        + Op.POP(Op.CALL(Op.GAS, dave, forward_value, 0, 0, 0, 0)),
+        balance=forward_value,
+    )
+
+    pre_fork_tx = Transaction(
+        sender=alice, to=bob, value=transfer_value, gas_price=10
+    )
+    tx_transfer = Transaction(
+        sender=alice,
+        to=bob,
+        value=transfer_value,
+        expected_receipt=TransactionReceipt(
+            logs=[transfer_log(alice, bob, transfer_value)]
+        ),
+    )
+    tx_relay = Transaction(
+        sender=carol,
+        to=relay,
+        expected_receipt=TransactionReceipt(
+            logs=[transfer_log(relay, dave, forward_value)]
+        ),
+    )
+
+    blocks = [
+        Block(
+            timestamp=FORK_TIMESTAMP - 1,
+            txs=[pre_fork_tx],
+            header_verify=Header(
+                block_access_list_hash=Header.EMPTY_FIELD,
+            ),
+        ),
+        Block(
+            timestamp=FORK_TIMESTAMP,
+            txs=[tx_transfer, tx_relay],
+            expected_block_access_list=BlockAccessListExpectation(
+                account_expectations={
+                    alice: BalAccountExpectation(
+                        nonce_changes=[
+                            BalNonceChange(block_access_index=1, post_nonce=2)
+                        ],
+                    ),
+                    bob: BalAccountExpectation(
+                        balance_changes=[
+                            BalBalanceChange(
+                                block_access_index=1,
+                                post_balance=transfer_value * 2,
+                            )
+                        ],
+                    ),
+                    carol: BalAccountExpectation(
+                        nonce_changes=[
+                            BalNonceChange(block_access_index=2, post_nonce=1)
+                        ],
+                    ),
+                    relay: BalAccountExpectation(
+                        balance_changes=[
+                            BalBalanceChange(
+                                block_access_index=2, post_balance=0
+                            )
+                        ],
+                        storage_changes=[
+                            BalStorageSlot(
+                                slot=0,
+                                slot_changes=[
+                                    BalStorageChange(
+                                        block_access_index=2, post_value=1
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    dave: BalAccountExpectation(
+                        balance_changes=[
+                            BalBalanceChange(
+                                block_access_index=2,
+                                post_balance=forward_value,
+                            )
+                        ],
+                    ),
+                }
+            ),
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={
+            bob: Account(balance=transfer_value * 2),
+            dave: Account(balance=forward_value),
+            relay: Account(balance=0, storage={0: 1}),
+        },
     )


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add BAL coverage for the EIP-8282 builder request dequeues, the missing sibling to the `eip7002`/`eip7251` files. Also add two fork-transition tests: the activation block dequeuing the chain's first builder requests, and an activation block of ordinary transfers, storage writes and Transfer logs.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes part of #3261

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F94%2F2d%2Fb5%2F942db508adc17a013aa3b154f1373412.gif&f=1&nofb=1&ipt=cfc967567b4b34ebc7328d7222ba7e834a360d7e13e65e8586e6e81354d05bf0)

