### PR TITLE
feat: update stateless validation to include schema fork index and refactor chain config handling

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1163,11 +1163,12 @@ def test_execution_witness_in_blockchain_fixture(
         deserialize_stateless_output,
     )
     from ethereum_types.bytes import Bytes as EthereumBytes
-    from ethereum_types.numeric import U64
+    from ethereum_types.numeric import U8, U64
 
     stateless_output = deserialize_stateless_output(EthereumBytes(bytes(sob)))
     assert stateless_output.successful_validation is True
     assert stateless_output.chain_config == build_chain_config(U64(1))
+    assert stateless_output.schema_fork_index == U8(0x15)
 
     engine_fixture_path = Path(
         "fixtures/blockchain_tests_engine/for_amsterdam/amsterdam/"
@@ -1368,6 +1369,7 @@ def test_execution_witness_expected_true_reuses_canonical_stateless_result(
         deserialize_stateless_output,
     )
     from ethereum_types.bytes import Bytes as EthereumBytes
+    from ethereum_types.numeric import U8
 
     stateless_input = deserialize_stateless_input(
         EthereumBytes(bytes.fromhex(block["statelessInputBytes"][2:]))
@@ -1377,6 +1379,7 @@ def test_execution_witness_expected_true_reuses_canonical_stateless_result(
     )
 
     assert stateless_output.successful_validation is True
+    assert stateless_output.schema_fork_index == U8(0x15)
     assert stateless_output.new_payload_request_root != Hash32(b"\0" * 32)
     assert (
         stateless_output.new_payload_request_root
@@ -1428,6 +1431,7 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
         deserialize_stateless_output,
     )
     from ethereum_types.bytes import Bytes as EthereumBytes
+    from ethereum_types.numeric import U8
 
     stateless_input = deserialize_stateless_input(
         EthereumBytes(bytes.fromhex(block["statelessInputBytes"][2:]))
@@ -1437,6 +1441,7 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
     )
 
     assert stateless_output.successful_validation is False
+    assert stateless_output.schema_fork_index == U8(0x15)
     assert stateless_output.new_payload_request_root != Hash32(b"\0" * 32)
     assert (
         stateless_output.new_payload_request_root

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1159,7 +1159,6 @@ def test_execution_witness_in_blockchain_fixture(
     assert sob is not None and len(sob) > 0
 
     from ethereum.forks.amsterdam.stateless_host import (
-        build_chain_config,
         deserialize_stateless_output,
     )
     from ethereum_types.bytes import Bytes as EthereumBytes
@@ -1167,7 +1166,7 @@ def test_execution_witness_in_blockchain_fixture(
 
     stateless_output = deserialize_stateless_output(EthereumBytes(bytes(sob)))
     assert stateless_output.successful_validation is True
-    assert stateless_output.chain_config == build_chain_config(U64(1))
+    assert stateless_output.chain_id == U64(1)
     assert stateless_output.schema_fork_index == U8(0x15)
 
     engine_fixture_path = Path(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1150,6 +1150,7 @@ def test_execution_witness_in_blockchain_fixture(
     sib = block.stateless_input_bytes
     assert sib is not None and len(sib) > 0
     from ethereum.forks.amsterdam.stateless_ssz import (
+        STATELESS_INPUT_SCHEMA_ID,
         STATELESS_INPUT_SCHEMA_ID_BYTES,
     )
 
@@ -1162,12 +1163,12 @@ def test_execution_witness_in_blockchain_fixture(
         deserialize_stateless_output,
     )
     from ethereum_types.bytes import Bytes as EthereumBytes
-    from ethereum_types.numeric import U8, U64
+    from ethereum_types.numeric import U16, U64
 
     stateless_output = deserialize_stateless_output(EthereumBytes(bytes(sob)))
     assert stateless_output.successful_validation is True
     assert stateless_output.chain_id == U64(1)
-    assert stateless_output.schema_fork_index == U8(0x15)
+    assert stateless_output.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
 
     engine_fixture_path = Path(
         "fixtures/blockchain_tests_engine/for_amsterdam/amsterdam/"
@@ -1367,8 +1368,11 @@ def test_execution_witness_expected_true_reuses_canonical_stateless_result(
     from ethereum.forks.amsterdam.stateless_host import (
         deserialize_stateless_output,
     )
+    from ethereum.forks.amsterdam.stateless_ssz import (
+        STATELESS_INPUT_SCHEMA_ID,
+    )
     from ethereum_types.bytes import Bytes as EthereumBytes
-    from ethereum_types.numeric import U8
+    from ethereum_types.numeric import U16
 
     stateless_input = deserialize_stateless_input(
         EthereumBytes(bytes.fromhex(block["statelessInputBytes"][2:]))
@@ -1378,7 +1382,7 @@ def test_execution_witness_expected_true_reuses_canonical_stateless_result(
     )
 
     assert stateless_output.successful_validation is True
-    assert stateless_output.schema_fork_index == U8(0x15)
+    assert stateless_output.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
     assert stateless_output.new_payload_request_root != Hash32(b"\0" * 32)
     assert (
         stateless_output.new_payload_request_root
@@ -1429,8 +1433,11 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
     from ethereum.forks.amsterdam.stateless_host import (
         deserialize_stateless_output,
     )
+    from ethereum.forks.amsterdam.stateless_ssz import (
+        STATELESS_INPUT_SCHEMA_ID,
+    )
     from ethereum_types.bytes import Bytes as EthereumBytes
-    from ethereum_types.numeric import U8
+    from ethereum_types.numeric import U16
 
     stateless_input = deserialize_stateless_input(
         EthereumBytes(bytes.fromhex(block["statelessInputBytes"][2:]))
@@ -1440,7 +1447,7 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
     )
 
     assert stateless_output.successful_validation is False
-    assert stateless_output.schema_fork_index == U8(0x15)
+    assert stateless_output.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
     assert stateless_output.new_payload_request_root != Hash32(b"\0" * 32)
     assert (
         stateless_output.new_payload_request_root

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -885,8 +885,11 @@ def build_amsterdam_stateless_artifacts_from_t8n(
         build_stateless_input,
         serialize_stateless_input,
     )
+    from ethereum.forks.amsterdam.stateless_ssz import (
+        STATELESS_INPUT_SCHEMA_ID,
+    )
     from ethereum_types.bytes import Bytes as AmsterdamBytes
-    from ethereum_types.numeric import U8, U64
+    from ethereum_types.numeric import U16, U64
 
     parent_number = ZeroPaddedHexNumber(block_number - 1)
     parent_header_rlp = previous_env.block_headers.get(parent_number)
@@ -946,7 +949,7 @@ def build_amsterdam_stateless_artifacts_from_t8n(
         ),
         successful_validation=True,
         chain_id=U64(chain_id),
-        schema_fork_index=U8(0x15),
+        schema_id=U16(STATELESS_INPUT_SCHEMA_ID),
     )
     stateless_output_bytes = serialize_stateless_output(stateless_output)
     return (
@@ -1012,13 +1015,13 @@ def is_invalid_input_stateless_output(stateless_output: Any) -> bool:
     """
     Return whether output is the invalid stateless input sentinel.
     """
-    from ethereum_types.numeric import U8, U64
+    from ethereum_types.numeric import U16, U64
 
     return (
         not stateless_output.successful_validation
         and bytes(stateless_output.new_payload_request_root) == b"\0" * 32
         and stateless_output.chain_id == U64(0)
-        and stateless_output.schema_fork_index == U8(0)
+        and stateless_output.schema_id == U16(0)
     )
 
 
@@ -1045,23 +1048,26 @@ def assert_amsterdam_stateless_output_request_root(
         )
 
 
-def assert_amsterdam_stateless_output_schema_fork_index(
+def assert_amsterdam_stateless_output_schema_id(
     *,
     block_number: int,
     stateless_output: Any,
 ) -> None:
     """
-    Assert the output identifies the fork rules executed by the guest.
+    Assert the output identifies the input schema executed by the guest.
     """
-    from ethereum_types.numeric import U8
+    from ethereum.forks.amsterdam.stateless_ssz import (
+        STATELESS_INPUT_SCHEMA_ID,
+    )
+    from ethereum_types.numeric import U16
 
-    expected_fork_index = U8(0x15)
+    expected_schema_id = U16(STATELESS_INPUT_SCHEMA_ID)
 
-    if stateless_output.schema_fork_index != expected_fork_index:
+    if stateless_output.schema_id != expected_schema_id:
         raise AssertionError(
-            "Stateless output schema_fork_index mismatch for block "
-            f"{block_number}: got {stateless_output.schema_fork_index}, "
-            f"want {expected_fork_index}"
+            "Stateless output schema_id mismatch for block "
+            f"{block_number}: got {stateless_output.schema_id}, "
+            f"want {expected_schema_id}"
         )
 
 
@@ -1100,7 +1106,7 @@ def verify_amsterdam_stateless_output(
         stateless_input=stateless_input,
         stateless_output=stateless_output,
     )
-    assert_amsterdam_stateless_output_schema_fork_index(
+    assert_amsterdam_stateless_output_schema_id(
         block_number=block_number,
         stateless_output=stateless_output,
     )

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -583,7 +583,7 @@ def rebuild_amsterdam_stateless_input_with_overrides(
     rebuilt_input = AmsterdamStatelessInput(
         new_payload_request=original_input.new_payload_request,
         witness=rebuilt_witness,
-        chain_config=original_input.chain_config,
+        chain_id=original_input.chain_id,
         public_keys=(
             tuple(AmsterdamBytes(bytes(key)) for key in public_keys)
             if public_keys is not None
@@ -882,7 +882,6 @@ def build_amsterdam_stateless_artifacts_from_t8n(
         serialize_stateless_output,
     )
     from ethereum.forks.amsterdam.stateless_host import (
-        build_chain_config,
         build_stateless_input,
         serialize_stateless_input,
     )
@@ -946,7 +945,7 @@ def build_amsterdam_stateless_artifacts_from_t8n(
             stateless_input
         ),
         successful_validation=True,
-        chain_config=build_chain_config(U64(chain_id)),
+        chain_id=U64(chain_id),
         schema_fork_index=U8(0x15),
     )
     stateless_output_bytes = serialize_stateless_output(stateless_output)
@@ -983,30 +982,29 @@ def decode_amsterdam_stateless_output(
     )
 
 
-def assert_amsterdam_stateless_output_chain_config(
+def assert_amsterdam_stateless_output_chain_id(
     *,
     block_number: int,
     chain_id: int,
     stateless_output: Any | None,
-    expected_chain_config: Any | None = None,
+    expected_chain_id: Any | None = None,
 ) -> None:
     """
-    Assert the stateless output reports the expected Amsterdam chain config.
+    Assert the stateless output reports the expected chain identifier.
     """
     if stateless_output is None:
         return
 
-    if expected_chain_config is None:
-        from ethereum.forks.amsterdam.stateless_host import build_chain_config
+    if expected_chain_id is None:
         from ethereum_types.numeric import U64
 
-        expected_chain_config = build_chain_config(U64(chain_id))
+        expected_chain_id = U64(chain_id)
 
-    if stateless_output.chain_config != expected_chain_config:
+    if stateless_output.chain_id != expected_chain_id:
         raise AssertionError(
-            "Stateless output chain_config mismatch for block "
-            f"{block_number}: got {stateless_output.chain_config}, "
-            f"want {expected_chain_config}"
+            "Stateless output chain_id mismatch for block "
+            f"{block_number}: got {stateless_output.chain_id}, "
+            f"want {expected_chain_id}"
         )
 
 
@@ -1016,14 +1014,10 @@ def is_invalid_input_stateless_output(stateless_output: Any) -> bool:
     """
     from ethereum_types.numeric import U8, U64
 
-    chain_config = stateless_output.chain_config
-    activation = chain_config.fork_activation
     return (
         not stateless_output.successful_validation
         and bytes(stateless_output.new_payload_request_root) == b"\0" * 32
-        and chain_config.chain_id == U64(0)
-        and activation.block_number is None
-        and activation.timestamp is None
+        and stateless_output.chain_id == U64(0)
         and stateless_output.schema_fork_index == U8(0)
     )
 
@@ -1110,12 +1104,12 @@ def verify_amsterdam_stateless_output(
         block_number=block_number,
         stateless_output=stateless_output,
     )
-    assert_amsterdam_stateless_output_chain_config(
+    assert_amsterdam_stateless_output_chain_id(
         block_number=block_number,
         chain_id=chain_id,
         stateless_output=stateless_output,
-        expected_chain_config=(
-            stateless_input.chain_config if input_bytes_modified else None
+        expected_chain_id=(
+            stateless_input.chain_id if input_bytes_modified else None
         ),
     )
 

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -443,40 +443,17 @@ def finalize_stateless_artifacts(
             f"want {options.expected_validation_success}"
         )
 
-    assert_amsterdam_stateless_output_request_root(
-        fork=fork,
-        block_number=block_number,
-        timestamp=timestamp,
-        stateless_input_bytes=stateless_input_bytes,
-        stateless_output=stateless_output,
-    )
-
-    skip_chain_config_assertion = (
-        options.has_stateless_input_bytes_modifier
-        and stateless_output is not None
-        and is_invalid_stateless_input_sentinel(stateless_output)
-    )
-    if not skip_chain_config_assertion:
-        expected_chain_config = None
-        if options.has_stateless_input_bytes_modifier:
-            if stateless_input_bytes is None:
-                raise Exception(
-                    "Stateless output chain_config assertion requires "
-                    "stateless input bytes"
-                )
-            expected_chain_config = (
-                decode_amsterdam_stateless_input_chain_config(
-                    fork=fork,
-                    block_number=block_number,
-                    timestamp=timestamp,
-                    stateless_input_bytes=stateless_input_bytes,
-                )
+    if stateless_output is not None:
+        if stateless_input_bytes is None:
+            raise Exception(
+                "Stateless output verification requires stateless input bytes"
             )
-        assert_amsterdam_stateless_output_chain_config(
+        verify_amsterdam_stateless_output(
             block_number=block_number,
             chain_id=chain_id,
+            stateless_input_bytes=stateless_input_bytes,
             stateless_output=stateless_output,
-            expected_chain_config=expected_chain_config,
+            input_bytes_modified=options.has_stateless_input_bytes_modifier,
         )
 
     return replace(
@@ -910,7 +887,7 @@ def build_amsterdam_stateless_artifacts_from_t8n(
         serialize_stateless_input,
     )
     from ethereum_types.bytes import Bytes as AmsterdamBytes
-    from ethereum_types.numeric import U64
+    from ethereum_types.numeric import U8, U64
 
     parent_number = ZeroPaddedHexNumber(block_number - 1)
     parent_header_rlp = previous_env.block_headers.get(parent_number)
@@ -970,6 +947,7 @@ def build_amsterdam_stateless_artifacts_from_t8n(
         ),
         successful_validation=True,
         chain_config=build_chain_config(U64(chain_id)),
+        schema_fork_index=U8(0x15),
     )
     stateless_output_bytes = serialize_stateless_output(stateless_output)
     return (
@@ -1005,31 +983,6 @@ def decode_amsterdam_stateless_output(
     )
 
 
-def decode_amsterdam_stateless_input_chain_config(
-    *,
-    fork: Fork,
-    block_number: int,
-    timestamp: int,
-    stateless_input_bytes: Bytes,
-) -> Any | None:
-    """
-    Decode the chain config from Amsterdam stateless input bytes.
-    """
-    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
-    if active_fork.name() != "Amsterdam":
-        return None
-
-    from ethereum.forks.amsterdam.stateless_guest import (
-        deserialize_stateless_input,
-    )
-    from ethereum_types.bytes import Bytes as AmsterdamBytes
-
-    stateless_input = deserialize_stateless_input(
-        AmsterdamBytes(bytes(stateless_input_bytes))
-    )
-    return stateless_input.chain_config
-
-
 def assert_amsterdam_stateless_output_chain_config(
     *,
     block_number: int,
@@ -1057,48 +1010,78 @@ def assert_amsterdam_stateless_output_chain_config(
         )
 
 
-def is_invalid_stateless_input_sentinel(stateless_output: Any) -> bool:
+def is_invalid_input_stateless_output(stateless_output: Any) -> bool:
     """
     Return whether output is the invalid stateless input sentinel.
     """
-    from ethereum_types.numeric import U64
+    from ethereum_types.numeric import U8, U64
 
     chain_config = stateless_output.chain_config
-    active_fork = chain_config.active_fork
-    activation = active_fork.activation
+    activation = chain_config.fork_activation
     return (
         not stateless_output.successful_validation
         and bytes(stateless_output.new_payload_request_root) == b"\0" * 32
         and chain_config.chain_id == U64(0)
         and activation.block_number is None
         and activation.timestamp is None
+        and stateless_output.schema_fork_index == U8(0)
     )
 
 
 def assert_amsterdam_stateless_output_request_root(
     *,
-    fork: Fork,
     block_number: int,
-    timestamp: int,
-    stateless_input_bytes: Bytes | None,
-    stateless_output: Any | None,
+    stateless_input: Any,
+    stateless_output: Any,
 ) -> None:
     """
     Assert the output commits to the decoded Amsterdam payload request.
     """
-    if stateless_input_bytes is None or stateless_output is None:
-        return
-
-    active_fork = fork.fork_at(
-        block_number=block_number,
-        timestamp=timestamp,
-    )
-    if active_fork.name() != "Amsterdam":
-        return
-
     from ethereum.forks.amsterdam.stateless import (
         compute_new_payload_request_root,
     )
+
+    expected_root = compute_new_payload_request_root(stateless_input)
+    actual_root = stateless_output.new_payload_request_root
+    if actual_root != expected_root:
+        raise AssertionError(
+            "Stateless output new_payload_request_root mismatch for block "
+            f"{block_number}: got 0x{bytes(actual_root).hex()}, "
+            f"want 0x{bytes(expected_root).hex()}"
+        )
+
+
+def assert_amsterdam_stateless_output_schema_fork_index(
+    *,
+    block_number: int,
+    stateless_output: Any,
+) -> None:
+    """
+    Assert the output identifies the fork rules executed by the guest.
+    """
+    from ethereum_types.numeric import U8
+
+    expected_fork_index = U8(0x15)
+
+    if stateless_output.schema_fork_index != expected_fork_index:
+        raise AssertionError(
+            "Stateless output schema_fork_index mismatch for block "
+            f"{block_number}: got {stateless_output.schema_fork_index}, "
+            f"want {expected_fork_index}"
+        )
+
+
+def verify_amsterdam_stateless_output(
+    *,
+    block_number: int,
+    chain_id: int,
+    stateless_input_bytes: Bytes,
+    stateless_output: Any,
+    input_bytes_modified: bool,
+) -> None:
+    """
+    Verify the public values returned by the Amsterdam stateless guest.
+    """
     from ethereum.forks.amsterdam.stateless_guest import (
         deserialize_stateless_input,
     )
@@ -1109,21 +1092,32 @@ def assert_amsterdam_stateless_output_request_root(
             AmsterdamBytes(bytes(stateless_input_bytes))
         )
     except Exception as exc:
-        if is_invalid_stateless_input_sentinel(stateless_output):
+        if input_bytes_modified and is_invalid_input_stateless_output(
+            stateless_output
+        ):
             return
         raise AssertionError(
             "Stateless input decoding failed for block "
             f"{block_number}, but its output is not the invalid-input sentinel"
         ) from exc
 
-    expected_root = compute_new_payload_request_root(stateless_input)
-    actual_root = stateless_output.new_payload_request_root
-    if actual_root != expected_root:
-        raise AssertionError(
-            "Stateless output new_payload_request_root mismatch for block "
-            f"{block_number}: got 0x{bytes(actual_root).hex()}, "
-            f"want 0x{bytes(expected_root).hex()}"
-        )
+    assert_amsterdam_stateless_output_request_root(
+        block_number=block_number,
+        stateless_input=stateless_input,
+        stateless_output=stateless_output,
+    )
+    assert_amsterdam_stateless_output_schema_fork_index(
+        block_number=block_number,
+        stateless_output=stateless_output,
+    )
+    assert_amsterdam_stateless_output_chain_config(
+        block_number=block_number,
+        chain_id=chain_id,
+        stateless_output=stateless_output,
+        expected_chain_config=(
+            stateless_input.chain_config if input_bytes_modified else None
+        ),
+    )
 
 
 def _has_execution_witness_modifier(

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -18,7 +18,7 @@ from ethereum.state import Root
 from .blocks import Header
 from .execution_engine.new_payload import execute_new_payload_request
 from .execution_engine.requests import ExecutionRequests
-from .execution_engine.types import ExecutionPayload, NewPayloadRequest
+from .execution_engine.types import NewPayloadRequest
 from .fork import ChainContext
 from .fork_types import VersionedHash
 from .witness_state import WitnessState, build_code_db, build_node_db
@@ -106,58 +106,6 @@ class ProtocolFork(IntEnum):
     Amsterdam = 0x15
 
 
-class ChainConfigValidationError(Exception):
-    """
-    Raised when a chain config cannot be used by this stateless guest.
-    """
-
-
-class InactiveForkConfigError(ChainConfigValidationError):
-    """
-    Raised when the configured active fork is not active for the payload.
-    """
-
-
-class InvalidForkActivationError(ChainConfigValidationError):
-    """
-    Raised when a fork entry has a malformed activation point.
-    """
-
-
-@final
-@slotted_freezable
-@dataclass
-class ForkActivation:
-    """
-    Activation point for a protocol fork.
-    """
-
-    block_number: U64 | None
-    timestamp: U64 | None
-
-
-@final
-@slotted_freezable
-@dataclass
-class ChainConfig:
-    """
-    Chain configuration needed for stateless validation.
-    """
-
-    chain_id: U64
-    """
-    Chain identifier used during payload validation and
-    execution.
-    """
-
-    fork_activation: ForkActivation
-    """
-    Activation for the fork selected by the guest schema.
-
-    Used for activation checks and retained for transition-block logic.
-    """
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -179,9 +127,9 @@ class StatelessInput:
     state transition function statelessly.
     """
 
-    chain_config: ChainConfig
+    chain_id: U64
     """
-    Chain configuration values needed during stateless validation.
+    Chain identifier used during payload validation and execution.
     """
 
     public_keys: Tuple[Bytes, ...]
@@ -218,10 +166,10 @@ class StatelessValidationResult:
     means validation failed or the guest input bytes could not be decoded.
     """
 
-    chain_config: ChainConfig
+    chain_id: U64
     """
-    Chain configuration decoded from the input. This is a sentinel default
-    when ``run_stateless_guest`` cannot decode the input bytes.
+    Chain identifier decoded from the input. This is zero when
+    ``run_stateless_guest`` cannot decode the input bytes.
     """
 
     schema_fork_index: U8
@@ -277,49 +225,6 @@ def validate_headers(
     return headers, block_hashes
 
 
-def _is_activation_active(
-    activation: ForkActivation,
-    execution_payload: ExecutionPayload,
-) -> bool:
-    """
-    Return whether an activation point is active for the payload.
-    """
-    if activation.block_number is None and activation.timestamp is None:
-        raise InvalidForkActivationError(
-            "Fork activation must set block_number or timestamp"
-        )
-
-    if activation.block_number is not None and int(
-        execution_payload.block_number
-    ) < int(activation.block_number):
-        return False
-
-    if activation.timestamp is not None and int(
-        execution_payload.timestamp
-    ) < int(activation.timestamp):
-        return False
-
-    return True
-
-
-def validate_chain_config(
-    chain_config: ChainConfig,
-    new_payload_request: NewPayloadRequest,
-) -> None:
-    """
-    Validate the chain configuration for the target payload.
-    """
-    execution_payload = new_payload_request.execution_payload
-
-    if not _is_activation_active(
-        chain_config.fork_activation,
-        execution_payload,
-    ):
-        raise InactiveForkConfigError(
-            "ChainConfig fork_activation is not active for the target payload"
-        )
-
-
 def verify_stateless_new_payload(
     stateless_input: StatelessInput,
 ) -> StatelessValidationResult:
@@ -332,10 +237,9 @@ def verify_stateless_new_payload(
     witness = stateless_input.witness
 
     try:
-        validate_chain_config(
-            stateless_input.chain_config,
-            stateless_input.new_payload_request,
-        )
+        # Note that in EEST we have one implementation per fork, so we don't need
+        # to check execution payload timestamp against the current fork activation
+        # information. A real implementation MUST do these checks!
 
         # Validate the headers are contiguous and compute their
         # blockhashes.
@@ -343,7 +247,7 @@ def verify_stateless_new_payload(
         parent_header = decoded_headers[-1]
 
         chain_context = ChainContext(
-            chain_id=stateless_input.chain_config.chain_id,
+            chain_id=stateless_input.chain_id,
             block_hashes=block_hashes,
             parent_header=parent_header,
         )
@@ -367,6 +271,6 @@ def verify_stateless_new_payload(
     return StatelessValidationResult(
         new_payload_request_root=new_payload_request_root,
         successful_validation=successful_validation,
-        chain_config=stateless_input.chain_config,
+        chain_id=stateless_input.chain_id,
         schema_fork_index=U8(int(ProtocolFork.Amsterdam)),
     )

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -237,8 +237,8 @@ def verify_stateless_new_payload(
     witness = stateless_input.witness
 
     try:
-        # Note that in EEST we have one implementation per fork, so we don't need
-        # to check execution payload timestamp against the current fork activation
+        # EEST has one implementation per fork, so it does not need to check
+        # the execution payload timestamp against the current fork activation
         # information. A real implementation MUST do these checks!
 
         # Validate the headers are contiguous and compute their

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -9,7 +9,7 @@ from typing import List, Sequence, Tuple, final
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64
+from ethereum_types.numeric import U8, U64
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.forks.bpo5.blocks import Header as PreviousForkHeader
@@ -139,24 +139,23 @@ class ForkActivation:
 @final
 @slotted_freezable
 @dataclass
-class ForkConfig:
-    """
-    Per-fork configuration needed to interpret stateless inputs.
-    """
-
-    activation: ForkActivation
-
-
-@final
-@slotted_freezable
-@dataclass
 class ChainConfig:
     """
     Chain configuration needed for stateless validation.
     """
 
     chain_id: U64
-    active_fork: ForkConfig
+    """
+    Chain identifier used during payload validation and
+    execution.
+    """
+
+    fork_activation: ForkActivation
+    """
+    Activation for the fork selected by the guest schema.
+
+    Used for activation checks and retained for transition-block logic.
+    """
 
 
 @final
@@ -222,6 +221,12 @@ class StatelessValidationResult:
     chain_config: ChainConfig
     """
     Chain configuration decoded from the input. This is a sentinel default
+    when ``run_stateless_guest`` cannot decode the input bytes.
+    """
+
+    schema_fork_index: U8
+    """
+    Fork rules executed by the guest. This uses the invalid-input sentinel
     when ``run_stateless_guest`` cannot decode the input bytes.
     """
 
@@ -300,19 +305,19 @@ def _is_activation_active(
 def validate_chain_config(
     chain_config: ChainConfig,
     new_payload_request: NewPayloadRequest,
-) -> ForkConfig:
+) -> None:
     """
-    Validate and return the target payload's active fork config.
+    Validate the chain configuration for the target payload.
     """
-    active_fork = chain_config.active_fork
     execution_payload = new_payload_request.execution_payload
 
-    if not _is_activation_active(active_fork.activation, execution_payload):
+    if not _is_activation_active(
+        chain_config.fork_activation,
+        execution_payload,
+    ):
         raise InactiveForkConfigError(
-            "ChainConfig active_fork is not active for the target payload"
+            "ChainConfig fork_activation is not active for the target payload"
         )
-
-    return active_fork
 
 
 def verify_stateless_new_payload(
@@ -363,4 +368,5 @@ def verify_stateless_new_payload(
         new_payload_request_root=new_payload_request_root,
         successful_validation=successful_validation,
         chain_config=stateless_input.chain_config,
+        schema_fork_index=U8(int(ProtocolFork.Amsterdam)),
     )

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -9,7 +9,7 @@ from typing import List, Sequence, Tuple, final
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U8, U64
+from ethereum_types.numeric import U16, U64
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.forks.bpo5.blocks import Header as PreviousForkHeader
@@ -172,10 +172,11 @@ class StatelessValidationResult:
     ``run_stateless_guest`` cannot decode the input bytes.
     """
 
-    schema_fork_index: U8
+    schema_id: U16
     """
-    Fork rules executed by the guest. This uses the invalid-input sentinel
-    when ``run_stateless_guest`` cannot decode the input bytes.
+    Exact input schema decoded and executed by the guest. This uses the
+    invalid-input sentinel when ``run_stateless_guest`` cannot decode the
+    input bytes.
     """
 
 
@@ -231,6 +232,8 @@ def verify_stateless_new_payload(
     """
     Statelessly validate the execution payload.
     """
+    from .stateless_ssz import STATELESS_INPUT_SCHEMA_ID
+
     new_payload_request_root = compute_new_payload_request_root(
         stateless_input
     )
@@ -272,5 +275,5 @@ def verify_stateless_new_payload(
         new_payload_request_root=new_payload_request_root,
         successful_validation=successful_validation,
         chain_id=stateless_input.chain_id,
-        schema_fork_index=U8(int(ProtocolFork.Amsterdam)),
+        schema_id=U16(STATELESS_INPUT_SCHEMA_ID),
     )

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -3,7 +3,7 @@ Stateless guest interfaces.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U8, U64
+from ethereum_types.numeric import U16, U64
 
 from ethereum.crypto.hash import Hash32
 
@@ -55,7 +55,7 @@ def _default_failed_stateless_output() -> StatelessValidationResult:
         new_payload_request_root=Hash32(b"\0" * 32),
         successful_validation=False,
         chain_id=U64(0),
-        schema_fork_index=U8(0),
+        schema_id=U16(0),
     )
 
 

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -3,14 +3,13 @@ Stateless guest interfaces.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U64
+from ethereum_types.numeric import U8, U64
 
 from ethereum.crypto.hash import Hash32
 
 from .stateless import (
     ChainConfig,
     ForkActivation,
-    ForkConfig,
     StatelessInput,
     StatelessValidationResult,
     verify_stateless_new_payload,
@@ -59,13 +58,12 @@ def _default_failed_stateless_output() -> StatelessValidationResult:
         successful_validation=False,
         chain_config=ChainConfig(
             chain_id=U64(0),
-            active_fork=ForkConfig(
-                activation=ForkActivation(
-                    block_number=None,
-                    timestamp=None,
-                ),
+            fork_activation=ForkActivation(
+                block_number=None,
+                timestamp=None,
             ),
         ),
+        schema_fork_index=U8(0),
     )
 
 

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -8,8 +8,6 @@ from ethereum_types.numeric import U8, U64
 from ethereum.crypto.hash import Hash32
 
 from .stateless import (
-    ChainConfig,
-    ForkActivation,
     StatelessInput,
     StatelessValidationResult,
     verify_stateless_new_payload,
@@ -56,13 +54,7 @@ def _default_failed_stateless_output() -> StatelessValidationResult:
     return StatelessValidationResult(
         new_payload_request_root=Hash32(b"\0" * 32),
         successful_validation=False,
-        chain_config=ChainConfig(
-            chain_id=U64(0),
-            fork_activation=ForkActivation(
-                block_number=None,
-                timestamp=None,
-            ),
-        ),
+        chain_id=U64(0),
         schema_fork_index=U8(0),
     )
 

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -17,9 +17,7 @@ from .execution_engine.requests import ExecutionRequests
 from .execution_engine.types import ExecutionPayload, NewPayloadRequest
 from .fork_types import VersionedHash
 from .stateless import (
-    ChainConfig,
     ExecutionWitness,
-    ForkActivation,
     StatelessInput,
     StatelessValidationResult,
 )
@@ -52,21 +50,6 @@ def deserialize_stateless_output(data: Bytes) -> StatelessValidationResult:
     """Deserialize a StatelessValidationResult from SSZ bytes."""
     ssz_obj = SszStatelessValidationResult.decode_bytes(data)
     return ssz_to_validation_result(ssz_obj)
-
-
-def build_chain_config(chain_id: U64) -> ChainConfig:
-    """
-    Build the chain configuration supported by this host.
-
-    For now the Amsterdam stateless host only describes the Amsterdam fork.
-    """
-    return ChainConfig(
-        chain_id=chain_id,
-        fork_activation=ForkActivation(
-            block_number=None,
-            timestamp=U64(0),
-        ),
-    )
 
 
 def build_stateless_input(
@@ -152,6 +135,6 @@ def build_stateless_input(
     return StatelessInput(
         new_payload_request=new_payload,
         witness=execution_witness,
-        chain_config=build_chain_config(chain_id),
+        chain_id=chain_id,
         public_keys=tuple(public_keys),
     )

--- a/src/ethereum/forks/amsterdam/stateless_host.py
+++ b/src/ethereum/forks/amsterdam/stateless_host.py
@@ -20,7 +20,6 @@ from .stateless import (
     ChainConfig,
     ExecutionWitness,
     ForkActivation,
-    ForkConfig,
     StatelessInput,
     StatelessValidationResult,
 )
@@ -63,11 +62,9 @@ def build_chain_config(chain_id: U64) -> ChainConfig:
     """
     return ChainConfig(
         chain_id=chain_id,
-        active_fork=ForkConfig(
-            activation=ForkActivation(
-                block_number=None,
-                timestamp=U64(0),
-            ),
+        fork_activation=ForkActivation(
+            block_number=None,
+            timestamp=U64(0),
         ),
     )
 

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -9,8 +9,8 @@ functions between the two representations.
 from typing import TypeAlias
 
 from ethereum_types.bytes import Bytes, Bytes48, Bytes96
-from ethereum_types.numeric import U64, U256, Uint
-from remerkleable.basic import boolean, uint64, uint256
+from ethereum_types.numeric import U8, U64, U256, Uint
+from remerkleable.basic import boolean, uint8, uint64, uint256
 from remerkleable.byte_arrays import ByteList, Bytes32, ByteVector
 from remerkleable.complex import Container
 from remerkleable.complex import List as SszList
@@ -38,7 +38,6 @@ from .stateless import (
     ChainConfig,
     ExecutionWitness,
     ForkActivation,
-    ForkConfig,
     ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
@@ -217,17 +216,11 @@ class SszForkActivation(Container):
     timestamp: SszOptionalForkActivationValue
 
 
-class SszForkConfig(Container):
-    """SSZ container mirroring ``ForkConfig``."""
-
-    activation: SszForkActivation
-
-
 class SszChainConfig(Container):
     """SSZ container mirroring ``ChainConfig``."""
 
     chain_id: uint64
-    active_fork: SszForkConfig
+    fork_activation: SszForkActivation
 
 
 class SszStatelessInput(Container):
@@ -245,6 +238,7 @@ class SszStatelessValidationResult(Container):
     new_payload_request_root: Bytes32
     successful_validation: boolean
     chain_config: SszChainConfig
+    schema_fork_index: uint8
 
 
 # --- Conversion helpers ---
@@ -576,31 +570,13 @@ def _ssz_to_fork_activation(
     )
 
 
-def _fork_config_to_ssz(
-    fork_config: ForkConfig,
-) -> SszForkConfig:
-    """Convert a ForkConfig to its SSZ form."""
-    return SszForkConfig(
-        activation=_fork_activation_to_ssz(fork_config.activation),
-    )
-
-
-def _ssz_to_fork_config(
-    ssz_fork_config: SszForkConfig,
-) -> ForkConfig:
-    """Convert an SSZ fork config back."""
-    return ForkConfig(
-        activation=_ssz_to_fork_activation(ssz_fork_config.activation),
-    )
-
-
 def _chain_config_to_ssz(
     cc: ChainConfig,
 ) -> SszChainConfig:
     """Convert a ChainConfig to its SSZ form."""
     return SszChainConfig(
         chain_id=uint64(int(cc.chain_id)),
-        active_fork=_fork_config_to_ssz(cc.active_fork),
+        fork_activation=_fork_activation_to_ssz(cc.fork_activation),
     )
 
 
@@ -610,7 +586,7 @@ def _ssz_to_chain_config(
     """Convert an SSZ chain config back."""
     return ChainConfig(
         chain_id=U64(scc.chain_id),
-        active_fork=_ssz_to_fork_config(scc.active_fork),
+        fork_activation=_ssz_to_fork_activation(scc.fork_activation),
     )
 
 
@@ -658,6 +634,7 @@ def validation_result_to_ssz(
         new_payload_request_root=Bytes32(bytes(vr.new_payload_request_root)),
         successful_validation=boolean(vr.successful_validation),
         chain_config=_chain_config_to_ssz(vr.chain_config),
+        schema_fork_index=uint8(int(vr.schema_fork_index)),
     )
 
 
@@ -671,4 +648,5 @@ def ssz_to_validation_result(
         ),
         successful_validation=bool(ssz_vr.successful_validation),
         chain_config=_ssz_to_chain_config(ssz_vr.chain_config),
+        schema_fork_index=U8(ssz_vr.schema_fork_index),
     )

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -7,8 +7,8 @@ functions between the two representations.
 """
 
 from ethereum_types.bytes import Bytes, Bytes48, Bytes96
-from ethereum_types.numeric import U8, U64, U256, Uint
-from remerkleable.basic import boolean, uint8, uint64, uint256
+from ethereum_types.numeric import U16, U64, U256, Uint
+from remerkleable.basic import boolean, uint16, uint64, uint256
 from remerkleable.byte_arrays import ByteList, Bytes32, ByteVector
 from remerkleable.complex import Container
 from remerkleable.complex import List as SszList
@@ -214,7 +214,7 @@ class SszStatelessValidationResult(Container):
     new_payload_request_root: Bytes32
     successful_validation: boolean
     chain_id: uint64
-    schema_fork_index: uint8
+    schema_id: uint16
 
 
 # --- Conversion helpers ---
@@ -552,7 +552,7 @@ def validation_result_to_ssz(
         new_payload_request_root=Bytes32(bytes(vr.new_payload_request_root)),
         successful_validation=boolean(vr.successful_validation),
         chain_id=uint64(int(vr.chain_id)),
-        schema_fork_index=uint8(int(vr.schema_fork_index)),
+        schema_id=uint16(int(vr.schema_id)),
     )
 
 
@@ -566,5 +566,5 @@ def ssz_to_validation_result(
         ),
         successful_validation=bool(ssz_vr.successful_validation),
         chain_id=U64(ssz_vr.chain_id),
-        schema_fork_index=U8(ssz_vr.schema_fork_index),
+        schema_id=U16(ssz_vr.schema_id),
     )

--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -6,8 +6,6 @@ types in ``stateless`` and ``execution_engine.types``, plus conversion
 functions between the two representations.
 """
 
-from typing import TypeAlias
-
 from ethereum_types.bytes import Bytes, Bytes48, Bytes96
 from ethereum_types.numeric import U8, U64, U256, Uint
 from remerkleable.basic import boolean, uint8, uint64, uint256
@@ -35,9 +33,7 @@ from .execution_engine.requests import (
 from .execution_engine.types import ExecutionPayload, NewPayloadRequest
 from .fork_types import Bloom, VersionedHash
 from .stateless import (
-    ChainConfig,
     ExecutionWitness,
-    ForkActivation,
     ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
@@ -72,7 +68,6 @@ MAX_BYTES_PER_HEADER = 2**10
 # 2**10 is the next power of two, with almost twice the needed capacity.
 MAX_BYTES_PER_WITNESS_NODE = 2**10
 
-MAX_OPTIONAL_FORK_ACTIVATION_VALUES = 1
 # One public key is supplied per transaction. Every valid transaction consumes
 # at least 21_000 gas, so a 500M gas block can contain at most
 # 500_000_000 // 21_000 = 23_809 transactions, rounded up to next power of 2.
@@ -96,11 +91,6 @@ STATELESS_INPUT_SCHEMA_ID_BYTES = STATELESS_INPUT_SCHEMA_ID.to_bytes(
 
 
 # --- SSZ Container types ---
-
-
-SszOptionalForkActivationValue: TypeAlias = SszList[
-    uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES
-]
 
 
 class SszWithdrawal(Container):
@@ -209,26 +199,12 @@ class SszExecutionWitness(Container):
     headers: SszList[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS]
 
 
-class SszForkActivation(Container):
-    """SSZ container mirroring ``ForkActivation``."""
-
-    block_number: SszOptionalForkActivationValue
-    timestamp: SszOptionalForkActivationValue
-
-
-class SszChainConfig(Container):
-    """SSZ container mirroring ``ChainConfig``."""
-
-    chain_id: uint64
-    fork_activation: SszForkActivation
-
-
 class SszStatelessInput(Container):
     """SSZ container mirroring ``StatelessInput``."""
 
     new_payload_request: SszNewPayloadRequest
     witness: SszExecutionWitness
-    chain_config: SszChainConfig
+    chain_id: uint64
     public_keys: SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
 
 
@@ -237,7 +213,7 @@ class SszStatelessValidationResult(Container):
 
     new_payload_request_root: Bytes32
     successful_validation: boolean
-    chain_config: SszChainConfig
+    chain_id: uint64
     schema_fork_index: uint8
 
 
@@ -532,64 +508,6 @@ def _ssz_to_witness(
     )
 
 
-def _optional_u64_to_ssz(
-    value: U64 | None,
-) -> SszOptionalForkActivationValue:
-    """Convert an optional U64 to a zero-or-one SSZ list."""
-    if value is None:
-        return SszOptionalForkActivationValue()
-    return SszOptionalForkActivationValue(uint64(int(value)))
-
-
-def _ssz_to_optional_u64(
-    ssz_value: SszOptionalForkActivationValue,
-) -> U64 | None:
-    """Convert a zero-or-one SSZ list back to an optional U64."""
-    if ssz_value.length() == 0:
-        return None
-    return U64(ssz_value.get(0))
-
-
-def _fork_activation_to_ssz(
-    activation: ForkActivation,
-) -> SszForkActivation:
-    """Convert a ForkActivation to its SSZ form."""
-    return SszForkActivation(
-        block_number=_optional_u64_to_ssz(activation.block_number),
-        timestamp=_optional_u64_to_ssz(activation.timestamp),
-    )
-
-
-def _ssz_to_fork_activation(
-    ssz_activation: SszForkActivation,
-) -> ForkActivation:
-    """Convert an SSZ fork activation back."""
-    return ForkActivation(
-        block_number=_ssz_to_optional_u64(ssz_activation.block_number),
-        timestamp=_ssz_to_optional_u64(ssz_activation.timestamp),
-    )
-
-
-def _chain_config_to_ssz(
-    cc: ChainConfig,
-) -> SszChainConfig:
-    """Convert a ChainConfig to its SSZ form."""
-    return SszChainConfig(
-        chain_id=uint64(int(cc.chain_id)),
-        fork_activation=_fork_activation_to_ssz(cc.fork_activation),
-    )
-
-
-def _ssz_to_chain_config(
-    scc: SszChainConfig,
-) -> ChainConfig:
-    """Convert an SSZ chain config back."""
-    return ChainConfig(
-        chain_id=U64(scc.chain_id),
-        fork_activation=_ssz_to_fork_activation(scc.fork_activation),
-    )
-
-
 def stateless_input_to_ssz(
     si: StatelessInput,
 ) -> SszStatelessInput:
@@ -605,7 +523,7 @@ def stateless_input_to_ssz(
             si.new_payload_request
         ),
         witness=_witness_to_ssz(si.witness),
-        chain_config=_chain_config_to_ssz(si.chain_config),
+        chain_id=uint64(int(si.chain_id)),
         public_keys=SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS](
             ByteVector[PUBLIC_KEY_BYTES](bytes(pk)) for pk in si.public_keys
         ),
@@ -621,7 +539,7 @@ def ssz_to_stateless_input(
             ssz_si.new_payload_request
         ),
         witness=_ssz_to_witness(ssz_si.witness),
-        chain_config=_ssz_to_chain_config(ssz_si.chain_config),
+        chain_id=U64(ssz_si.chain_id),
         public_keys=tuple(Bytes(bytes(pk)) for pk in ssz_si.public_keys),
     )
 
@@ -633,7 +551,7 @@ def validation_result_to_ssz(
     return SszStatelessValidationResult(
         new_payload_request_root=Bytes32(bytes(vr.new_payload_request_root)),
         successful_validation=boolean(vr.successful_validation),
-        chain_config=_chain_config_to_ssz(vr.chain_config),
+        chain_id=uint64(int(vr.chain_id)),
         schema_fork_index=uint8(int(vr.schema_fork_index)),
     )
 
@@ -647,6 +565,6 @@ def ssz_to_validation_result(
             bytes(ssz_vr.new_payload_request_root)
         ),
         successful_validation=bool(ssz_vr.successful_validation),
-        chain_config=_ssz_to_chain_config(ssz_vr.chain_config),
+        chain_id=U64(ssz_vr.chain_id),
         schema_fork_index=U8(ssz_vr.schema_fork_index),
     )

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_config.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_config.py
@@ -60,15 +60,11 @@ def future_timestamp_activation_chain_config(stateless_input: Any) -> Any:
 
     payload = stateless_input.new_payload_request.execution_payload
     chain_config = stateless_input.chain_config
-    active_fork = chain_config.active_fork
     return replace(
         chain_config,
-        active_fork=replace(
-            active_fork,
-            activation=ForkActivation(
-                block_number=None,
-                timestamp=U64(int(payload.timestamp) + 1),
-            ),
+        fork_activation=ForkActivation(
+            block_number=None,
+            timestamp=U64(int(payload.timestamp) + 1),
         ),
     )
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_id.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_chain_id.py
@@ -1,4 +1,4 @@
-"""Stateless chain-config validation tests."""
+"""Stateless chain-ID validation tests."""
 
 from dataclasses import replace
 from typing import Any, Callable
@@ -22,13 +22,13 @@ REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
 
 StatelessInputBytesModifier = Callable[[Bytes], Bytes]
-ChainConfigBuilder = Callable[[Any], Any]
+ChainIdBuilder = Callable[[Any], Any]
 
 
-def replace_chain_config(
-    build_chain_config: ChainConfigBuilder,
+def replace_chain_id(
+    build_chain_id: ChainIdBuilder,
 ) -> StatelessInputBytesModifier:
-    """Replace only the decoded stateless input chain_config."""
+    """Replace only the decoded stateless input chain ID."""
 
     def modifier(input_bytes: Bytes) -> Bytes:
         from ethereum_types.bytes import Bytes as AmsterdamBytes
@@ -45,63 +45,25 @@ def replace_chain_config(
         )
         modified_input = replace(
             stateless_input,
-            chain_config=build_chain_config(stateless_input),
+            chain_id=build_chain_id(stateless_input),
         )
         return Bytes(bytes(serialize_stateless_input(modified_input)))
 
     return modifier
 
 
-def future_timestamp_activation_chain_config(stateless_input: Any) -> Any:
-    """Move Amsterdam activation one second after the payload timestamp."""
-    from ethereum_types.numeric import U64
-
-    from ethereum.forks.amsterdam.stateless import ForkActivation
-
-    payload = stateless_input.new_payload_request.execution_payload
-    chain_config = stateless_input.chain_config
-    return replace(
-        chain_config,
-        fork_activation=ForkActivation(
-            block_number=None,
-            timestamp=U64(int(payload.timestamp) + 1),
-        ),
-    )
-
-
-def wrong_chain_id_chain_config(stateless_input: Any) -> Any:
+def wrong_chain_id(stateless_input: Any) -> Any:
     """Change chain_id from 1 to 2."""
     from ethereum_types.numeric import U64
 
-    chain_config = stateless_input.chain_config
-    if int(chain_config.chain_id) != 1:
+    if int(stateless_input.chain_id) != 1:
         raise AssertionError(
-            f"expected canonical chain_id 1, got {chain_config.chain_id}"
+            f"expected canonical chain_id 1, got {stateless_input.chain_id}"
         )
-    return replace(chain_config, chain_id=U64(2))
+    return U64(2)
 
 
-def test_validation_chain_config_future_timestamp_activation(
-    pre: Alloc,
-    blockchain_test: BlockchainTestFiller,
-) -> None:
-    """A future Amsterdam timestamp activation fails validation."""
-    blockchain_test(
-        pre=pre,
-        blocks=[
-            Block(
-                txs=[],
-                stateless_input_bytes_modifier=replace_chain_config(
-                    future_timestamp_activation_chain_config
-                ),
-                expected_stateless_validation_success=False,
-            )
-        ],
-        post={},
-    )
-
-
-def test_validation_chain_config_wrong_chain_id_legacy_signature(
+def test_validation_wrong_chain_id_legacy_signature(
     fork: Fork,
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,
@@ -122,8 +84,8 @@ def test_validation_chain_config_wrong_chain_id_legacy_signature(
         blocks=[
             Block(
                 txs=[tx],
-                stateless_input_bytes_modifier=replace_chain_config(
-                    wrong_chain_id_chain_config
+                stateless_input_bytes_modifier=replace_chain_id(
+                    wrong_chain_id
                 ),
                 expected_stateless_validation_success=False,
             )

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import pytest
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes8, Bytes32, Bytes48, Bytes96
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U8, U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.forks.amsterdam.block_access_lists import BlockAccessList
@@ -26,7 +26,6 @@ from ethereum.forks.amsterdam.stateless import (
     ChainConfig,
     ExecutionWitness,
     ForkActivation,
-    ForkConfig,
     ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
@@ -135,11 +134,9 @@ def _make_block() -> Block:
 def _expected_amsterdam_chain_config(chain_id: U64) -> ChainConfig:
     return ChainConfig(
         chain_id=chain_id,
-        active_fork=ForkConfig(
-            activation=ForkActivation(
-                block_number=None,
-                timestamp=U64(0),
-            ),
+        fork_activation=ForkActivation(
+            block_number=None,
+            timestamp=U64(0),
         ),
     )
 
@@ -203,6 +200,7 @@ def _make_stateless_output() -> StatelessValidationResult:
         new_payload_request_root=Hash32(_rb(32)),
         successful_validation=True,
         chain_config=build_chain_config(U64(1)),
+        schema_fork_index=U8(0x15),
     )
 
 
@@ -414,17 +412,21 @@ class TestSerializeStatelessOutput:
         encoded = serialize_stateless_output(original)
         recovered = deserialize_stateless_output(encoded)
         assert recovered == original
+        assert recovered.chain_config == build_chain_config(U64(1))
+        assert recovered.schema_fork_index == U8(0x15)
 
     def test_failed_validation(self) -> None:
-        """Serializes a failed validation result correctly."""
+        """Preserve the executed fork when later validation fails."""
         original = StatelessValidationResult(
             new_payload_request_root=Hash32(_rb(32)),
             successful_validation=False,
             chain_config=build_chain_config(U64(1)),
+            schema_fork_index=U8(0x15),
         )
         encoded = serialize_stateless_output(original)
         recovered = deserialize_stateless_output(encoded)
         assert recovered == original
+        assert recovered.schema_fork_index == U8(0x15)
 
 
 class TestRunStatelessGuest:
@@ -438,8 +440,23 @@ class TestRunStatelessGuest:
         assert result.new_payload_request_root == Hash32(b"\0" * 32)
         assert not result.successful_validation
         assert result.chain_config.chain_id == U64(0)
-        assert result.chain_config.active_fork.activation.block_number is None
-        assert result.chain_config.active_fork.activation.timestamp is None
+        assert result.chain_config.fork_activation.block_number is None
+        assert result.chain_config.fork_activation.timestamp is None
+        assert result.schema_fork_index == U8(0)
+
+    def test_decodable_input_reports_amsterdam_on_validation_failure(
+        self,
+    ) -> None:
+        """Decoded Amsterdam input reports its fork after execution failure."""
+        stateless_input = _make_stateless_input()
+        encoded = run_stateless_guest(
+            serialize_stateless_input(stateless_input)
+        )
+        result = deserialize_stateless_output(encoded)
+
+        assert not result.successful_validation
+        assert result.chain_config == stateless_input.chain_config
+        assert result.schema_fork_index == U8(0x15)
 
 
 class TestComputeNewPayloadRequestRoot:
@@ -474,6 +491,7 @@ class TestTransactionPublicKeys:
 
         result = verify_stateless_new_payload(invalid)
         assert not result.successful_validation
+        assert result.schema_fork_index == U8(0x15)
 
     def test_too_many_public_keys_fail_validation(self) -> None:
         """Stateless validation should fail with too many public keys."""
@@ -491,3 +509,4 @@ class TestTransactionPublicKeys:
 
         result = verify_stateless_new_payload(invalid)
         assert not result.successful_validation
+        assert result.schema_fork_index == U8(0x15)

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import pytest
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes8, Bytes32, Bytes48, Bytes96
-from ethereum_types.numeric import U8, U64, U256, Uint
+from ethereum_types.numeric import U16, U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.forks.amsterdam.block_access_lists import BlockAccessList
@@ -187,7 +187,7 @@ def _make_stateless_output() -> StatelessValidationResult:
         new_payload_request_root=Hash32(_rb(32)),
         successful_validation=True,
         chain_id=U64(1),
-        schema_fork_index=U8(0x15),
+        schema_id=U16(STATELESS_INPUT_SCHEMA_ID),
     )
 
 
@@ -387,23 +387,24 @@ class TestSerializeStatelessOutput:
         """Encoding then decoding recovers the original result."""
         original = _make_stateless_output()
         encoded = serialize_stateless_output(original)
+        assert encoded[-2:] == STATELESS_INPUT_SCHEMA_ID.to_bytes(2, "little")
         recovered = deserialize_stateless_output(encoded)
         assert recovered == original
         assert recovered.chain_id == U64(1)
-        assert recovered.schema_fork_index == U8(0x15)
+        assert recovered.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
 
     def test_failed_validation(self) -> None:
-        """Preserve the executed fork when later validation fails."""
+        """Preserve the input schema when later validation fails."""
         original = StatelessValidationResult(
             new_payload_request_root=Hash32(_rb(32)),
             successful_validation=False,
             chain_id=U64(1),
-            schema_fork_index=U8(0x15),
+            schema_id=U16(STATELESS_INPUT_SCHEMA_ID),
         )
         encoded = serialize_stateless_output(original)
         recovered = deserialize_stateless_output(encoded)
         assert recovered == original
-        assert recovered.schema_fork_index == U8(0x15)
+        assert recovered.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
 
 
 class TestRunStatelessGuest:
@@ -417,12 +418,12 @@ class TestRunStatelessGuest:
         assert result.new_payload_request_root == Hash32(b"\0" * 32)
         assert not result.successful_validation
         assert result.chain_id == U64(0)
-        assert result.schema_fork_index == U8(0)
+        assert result.schema_id == U16(0)
 
-    def test_decodable_input_reports_amsterdam_on_validation_failure(
+    def test_decodable_input_reports_schema_on_validation_failure(
         self,
     ) -> None:
-        """Decoded Amsterdam input reports its fork after execution failure."""
+        """Decoded input reports its schema after execution failure."""
         stateless_input = _make_stateless_input()
         encoded = run_stateless_guest(
             serialize_stateless_input(stateless_input)
@@ -431,7 +432,7 @@ class TestRunStatelessGuest:
 
         assert not result.successful_validation
         assert result.chain_id == stateless_input.chain_id
-        assert result.schema_fork_index == U8(0x15)
+        assert result.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
 
 
 class TestComputeNewPayloadRequestRoot:
@@ -466,7 +467,7 @@ class TestTransactionPublicKeys:
 
         result = verify_stateless_new_payload(invalid)
         assert not result.successful_validation
-        assert result.schema_fork_index == U8(0x15)
+        assert result.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)
 
     def test_too_many_public_keys_fail_validation(self) -> None:
         """Stateless validation should fail with too many public keys."""
@@ -484,4 +485,4 @@ class TestTransactionPublicKeys:
 
         result = verify_stateless_new_payload(invalid)
         assert not result.successful_validation
-        assert result.schema_fork_index == U8(0x15)
+        assert result.schema_id == U16(STATELESS_INPUT_SCHEMA_ID)

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -23,9 +23,7 @@ from ethereum.forks.amsterdam.execution_engine.types import (
 )
 from ethereum.forks.amsterdam.fork_types import Bloom
 from ethereum.forks.amsterdam.stateless import (
-    ChainConfig,
     ExecutionWitness,
-    ForkActivation,
     ProtocolFork,
     StatelessInput,
     StatelessValidationResult,
@@ -38,7 +36,6 @@ from ethereum.forks.amsterdam.stateless_guest import (
     serialize_stateless_output,
 )
 from ethereum.forks.amsterdam.stateless_host import (
-    build_chain_config,
     build_stateless_input,
     deserialize_stateless_output,
     serialize_stateless_input,
@@ -131,16 +128,6 @@ def _make_block() -> Block:
     )
 
 
-def _expected_amsterdam_chain_config(chain_id: U64) -> ChainConfig:
-    return ChainConfig(
-        chain_id=chain_id,
-        fork_activation=ForkActivation(
-            block_number=None,
-            timestamp=U64(0),
-        ),
-    )
-
-
 def _make_deposit_request() -> DepositRequest:
     return DepositRequest(
         pubkey=Bytes48(_rb(48)),
@@ -190,7 +177,7 @@ def _make_stateless_input() -> StatelessInput:
             codes=(Bytes(_rb(48)), Bytes(_rb(96))),
             headers=(Bytes(_rb(512)), Bytes(_rb(512))),
         ),
-        chain_config=build_chain_config(U64(1)),
+        chain_id=U64(1),
         public_keys=(Bytes(_rb(65)), Bytes(_rb(65))),
     )
 
@@ -199,26 +186,16 @@ def _make_stateless_output() -> StatelessValidationResult:
     return StatelessValidationResult(
         new_payload_request_root=Hash32(_rb(32)),
         successful_validation=True,
-        chain_config=build_chain_config(U64(1)),
+        chain_id=U64(1),
         schema_fork_index=U8(0x15),
     )
-
-
-class TestBuildChainConfig:
-    """Test host-side ChainConfig construction."""
-
-    def test_amsterdam_only(self) -> None:
-        """Builds a single Amsterdam fork entry."""
-        chain_config = build_chain_config(U64(123))
-        assert chain_config == _expected_amsterdam_chain_config(U64(123))
 
 
 class TestBuildStatelessInput:
     """Test host-side StatelessInput construction."""
 
-    def test_includes_amsterdam_chain_config(self) -> None:
-        """Includes the Amsterdam-only chain config."""
-        chain_config = build_chain_config(U64(123))
+    def test_includes_chain_id(self) -> None:
+        """Include the configured chain identifier."""
         block_access_list: BlockAccessList = []
         stateless_input = build_stateless_input(
             _make_block(),
@@ -237,7 +214,7 @@ class TestBuildStatelessInput:
             block_access_list=block_access_list,
             chain_id=U64(123),
         )
-        assert stateless_input.chain_config == chain_config
+        assert stateless_input.chain_id == U64(123)
 
     @pytest.mark.parametrize(
         ("v", "r", "s"),
@@ -317,7 +294,7 @@ class TestSerializeStatelessInput:
                 ),
             ),
             witness=ExecutionWitness(state=(), codes=(), headers=()),
-            chain_config=build_chain_config(U64(1)),
+            chain_id=U64(1),
             public_keys=(),
         )
         encoded = serialize_stateless_input(original)
@@ -331,7 +308,7 @@ class TestSerializeStatelessInput:
         invalid = StatelessInput(
             new_payload_request=original.new_payload_request,
             witness=original.witness,
-            chain_config=original.chain_config,
+            chain_id=original.chain_id,
             public_keys=(Bytes(_rb(64)), Bytes(_rb(65))),
         )
 
@@ -365,7 +342,7 @@ class TestDeserializeStatelessInput:
                 ),
             ),
             witness=ExecutionWitness(state=(), codes=(), headers=()),
-            chain_config=build_chain_config(U64(1)),
+            chain_id=U64(1),
             public_keys=(),
         )
         encoded = serialize_stateless_input(original)
@@ -412,7 +389,7 @@ class TestSerializeStatelessOutput:
         encoded = serialize_stateless_output(original)
         recovered = deserialize_stateless_output(encoded)
         assert recovered == original
-        assert recovered.chain_config == build_chain_config(U64(1))
+        assert recovered.chain_id == U64(1)
         assert recovered.schema_fork_index == U8(0x15)
 
     def test_failed_validation(self) -> None:
@@ -420,7 +397,7 @@ class TestSerializeStatelessOutput:
         original = StatelessValidationResult(
             new_payload_request_root=Hash32(_rb(32)),
             successful_validation=False,
-            chain_config=build_chain_config(U64(1)),
+            chain_id=U64(1),
             schema_fork_index=U8(0x15),
         )
         encoded = serialize_stateless_output(original)
@@ -439,9 +416,7 @@ class TestRunStatelessGuest:
 
         assert result.new_payload_request_root == Hash32(b"\0" * 32)
         assert not result.successful_validation
-        assert result.chain_config.chain_id == U64(0)
-        assert result.chain_config.fork_activation.block_number is None
-        assert result.chain_config.fork_activation.timestamp is None
+        assert result.chain_id == U64(0)
         assert result.schema_fork_index == U8(0)
 
     def test_decodable_input_reports_amsterdam_on_validation_failure(
@@ -455,7 +430,7 @@ class TestRunStatelessGuest:
         result = deserialize_stateless_output(encoded)
 
         assert not result.successful_validation
-        assert result.chain_config == stateless_input.chain_config
+        assert result.chain_id == stateless_input.chain_id
         assert result.schema_fork_index == U8(0x15)
 
 
@@ -485,7 +460,7 @@ class TestTransactionPublicKeys:
         invalid = StatelessInput(
             new_payload_request=original.new_payload_request,
             witness=original.witness,
-            chain_config=original.chain_config,
+            chain_id=original.chain_id,
             public_keys=(original.public_keys[0],),
         )
 
@@ -499,7 +474,7 @@ class TestTransactionPublicKeys:
         invalid = StatelessInput(
             new_payload_request=original.new_payload_request,
             witness=original.witness,
-            chain_config=original.chain_config,
+            chain_id=original.chain_id,
             public_keys=(
                 original.public_keys[0],
                 original.public_keys[1],


### PR DESCRIPTION
### Description

This PR does a couple of things, but let's first focus on the important change that we discussed with @han0110 out of band.

This is the new `StatelessValidationResult`:

```python
class StatelessValidationResult:
    new_payload_request_root: Hash32
    successful_validation: bool
    chain_id: U64  # `ChainConfig` is gone; only `chain_id` remains.
    schema_id: U16  # New public field containing the full schema ID.
```

Let's start with why `schema_id` was added to `StatelessValidationResult`.

A while ago, we removed `protocol_fork: ProtocolFork` from `ChainConfig`. The rationale was that the two-byte `SCHEMA_ID`—that is, the private input is encoded as `SCHEMA_ID || SSZ(StatelessInput)`—already identifies the protocol fork in its first byte. This is needed to select the correct `StatelessInput` shape before SSZ decoding, since fields such as `execution_payload` change across forks.

So technically, `SCHEMA_ID` already mandates which fork and input schema are being used. Keeping `ProtocolFork` in `ChainConfig` would therefore be redundant and could lead to inconsistent values or weird coherence checks.

But... `SCHEMA_ID` is a private input and, until this PR, it was not exposed as a public value.

For forks that share the same `execution_payload` shape—for example, Osaka and the subsequent BPO forks—the proof verifier otherwise has no explicit public value telling it which fork rules the guest used to validate the block. Inputs for those forks can have the same SSZ shape, so the shape alone is not enough for the verifier to distinguish whether the block was validated using Osaka, BPO1, BPO2, and so on.

This PR therefore makes the full `schema_id` part of the public result. The first byte identifies the protocol fork, while the second byte identifies the schema revision/encoding. Returning the full ID, rather than only the fork byte, also pins the exact encoding that the guest decoded.

The proof verifier can now explicitly check which fork rules and schema revision were used to validate the block.

Note that this is intentionally not part of `ChainConfig`. We want to avoid reintroducing a redundant `ProtocolFork` field there when `SCHEMA_ID` already defines both the fork and the input schema.

Okay, so hopefully the above makes sense—it is just being absolutely clear about which schema the guest decoded and which fork rules it considered active during block execution, period.

---

Another discussion was whether `ForkActivation` inside the chain config makes sense. `ForkActivation` contains the block number or timestamp at which the fork activates. The conclusion seems to be that it doesn't make sense for this information to be provided by the host.

In the same way that we removed `blob_schedule` from `ChainConfig` a while ago, expecting the guest program to have something like `map[chain_id][fork][blob_schedule]`, we can argue that it can also have `map[chain_id][fork][fork_activation_info]`.

The fork activation information is still needed by the guest program—for example, to detect whether a block is at a fork boundary and must apply additional logic such as deploying a system contract, or simply to check that the execution payload timestamp is compatible with the selected fork.

The point is that we don't need this information as private input. Removing it from the private input means less prover-controlled configuration, fewer coherence checks, and more trusted configuration baked directly into the guest program.

Said differently: given a `chain_id` and a fork identified by `schema_id`, things such as fork activation information and blob schedules should be completely defined by the guest, not by the host.

After removing `ForkActivation`, `ChainConfig` was left containing only `chain_id`. I therefore removed `ChainConfig` entirely and flattened its usages to carry `chain_id` directly.

So, indirectly, things became quite a bit simpler.


### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
