### PR TITLE
feat(test-types): Fork-based State Commitment Property in Alloc

### DIFF
--- a/packages/testing/src/execution_testing/base_types/__init__.py
+++ b/packages/testing/src/execution_testing/base_types/__init__.py
@@ -27,6 +27,7 @@ from .composite_types import (
     Alloc,
     BlobSchedule,
     ForkBlobSchedule,
+    StateCommitment,
     Storage,
     StorageRootType,
 )
@@ -77,6 +78,7 @@ __all__ = (
     "ReferenceSpec",
     "RLPSerializable",
     "SignableRLPSerializable",
+    "StateCommitment",
     "Storage",
     "StorageKey",
     "StorageRootType",

--- a/packages/testing/src/execution_testing/base_types/composite_types.py
+++ b/packages/testing/src/execution_testing/base_types/composite_types.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import (
     Any,
     ClassVar,
@@ -567,6 +568,17 @@ class Alloc(EthereumTestRootModel[Dict[Address, Account | None]]):
     root: Dict[Address, Account | None] = Field(
         default_factory=dict, validate_default=True
     )
+
+
+class StateCommitment(Enum):
+    """
+    The state-commitment scheme used to compute an allocation's state root.
+    """
+
+    MPT = auto()
+    """Merkle-Patricia trie (all forks up to the binary-tree transition)."""
+    BINARY = auto()
+    """Binary tree commitment."""
 
 
 class AccessList(CamelModel, RLPSerializable):

--- a/packages/testing/src/execution_testing/base_types/composite_types.py
+++ b/packages/testing/src/execution_testing/base_types/composite_types.py
@@ -576,9 +576,7 @@ class StateCommitment(Enum):
     """
 
     MPT = auto()
-    """Merkle-Patricia trie (all forks up to the binary-tree transition)."""
-    BINARY = auto()
-    """Binary tree commitment."""
+    """Merkle-Patricia trie."""
 
 
 class AccessList(CamelModel, RLPSerializable):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/execute_types.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/execute_types.py
@@ -358,6 +358,15 @@ class Genesis(CamelModel):
     base_fee_per_gas: HexNumber = HexNumber(10**9)
     number: HexNumber = HexNumber(0)
 
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Seed the alloc's commitment scheme from the genesis fork.
+        """
+        super().model_post_init(__context)
+        self.alloc.migrate_state_commitment(
+            self.config.fork().state_commitment()
+        )
+
     @cached_property
     def hash(self) -> Hash:
         """Calculate the genesis hash."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -1299,19 +1299,13 @@ def pre(
     request: pytest.FixtureRequest,
 ) -> Generator[Alloc, None, None]:
     """Return default pre allocation for all tests (Empty alloc)."""
-    # FIXME: Static tests don't have a fork so we need to get it from the node.
-    actual_fork = fork
-    if actual_fork is None:
-        assert hasattr(request.node, "fork")
-        actual_fork = request.node.fork
-
     # Prepare the pre-alloc
     logger.debug(
         f"Initializing pre-alloc for test {request.node.nodeid} "
-        f"(fork={actual_fork}, chain_id={chain_config.chain_id})"
+        f"(fork={fork}, chain_id={chain_config.chain_id})"
     )
     pre = Alloc(
-        fork=actual_fork,
+        fork=fork,
         flags=alloc_flags,
         stub_eoas=stub_eoas,
         sender=worker_key,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -150,6 +150,9 @@ def build_genesis_header(
         pre_alloc = Alloc.merge(pre_alloc, base_pre)
     if empty_accounts := pre_alloc.empty_accounts():
         raise Exception(f"Empty accounts in pre state: {empty_accounts}")
+    pre_alloc.migrate_state_commitment(
+        session_fork.transitions_from().state_commitment()
+    )
     state_root = pre_alloc.state_root()
     genesis = FixtureHeader(
         parent_hash=0,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute_remote.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute_remote.py
@@ -107,6 +107,7 @@ def _build_client_genesis(seed_keys: List[EOA]) -> dict:
     genesis_alloc = Alloc.merge(
         Alloc.model_validate(TEST_FORK.pre_allocation_blockchain()),
         Alloc(alloc_dict),
+        state_commitment=TEST_FORK.state_commitment(),
     )
     if empty_accounts := genesis_alloc.empty_accounts():
         raise Exception(f"Empty accounts in pre state: {empty_accounts}")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -73,7 +73,7 @@ class Alloc(SharedAlloc):
     def __init__(
         self,
         *args: Any,
-        fork: Fork,
+        fork: Fork | TransitionFork,
         flags: AllocFlags,
         stub_accounts: Dict[str, Account] | None = None,
         stub_eoas: Dict[str, EOA] | None = None,
@@ -495,21 +495,14 @@ def stub_eoas(
 @pytest.fixture(scope="function")
 def pre(
     alloc_flags: AllocFlags,
-    fork: Fork | None,
-    request: pytest.FixtureRequest,
+    fork: Fork | TransitionFork,
     stub_accounts: Dict[str, Account],
     stub_eoas: Dict[str, EOA],
 ) -> Alloc:
     """Return default pre allocation for all tests (Empty alloc)."""
-    # FIXME: Static tests don't have a fork so we need to get it from the node.
-    actual_fork = fork
-    if actual_fork is None:
-        assert hasattr(request.node, "fork")
-        actual_fork = request.node.fork
-
     return Alloc(
         flags=alloc_flags,
-        fork=actual_fork,
+        fork=fork,
         stub_accounts=stub_accounts,
         stub_eoas=stub_eoas,
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -435,7 +435,7 @@ ALL_FIXTURE_FORMAT_NAMES.sort(key=len, reverse=True)
 
 @pytest.fixture(scope="function")
 def node_id_for_entropy(
-    request: pytest.FixtureRequest, fork: Fork | None
+    request: pytest.FixtureRequest, fork: Fork | TransitionFork
 ) -> str:
     """
     Return the node id with the fixture format name and fork name stripped.
@@ -453,11 +453,6 @@ def node_id_for_entropy(
     # deterministic regardless of whether xdist is active.
     if "@" in node_id:
         node_id = node_id.rsplit("@", 1)[0]
-    if fork is None:
-        # FIXME: Static tests don't have a fork, so we need to get it from the
-        # node.
-        assert hasattr(request.node, "fork")
-        fork = request.node.fork
     for fixture_format_name in ALL_FIXTURE_FORMAT_NAMES:
         if fixture_format_name in node_id:
             parts = node_id.split("::")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
@@ -61,7 +61,7 @@ class Alloc(BaseAlloc):
     def __init__(
         self,
         *args: Any,
-        fork: Fork,
+        fork: Fork | TransitionFork,
         flags: AllocFlags,
         stub_eoas: Dict[str, EOA] | None = None,
         **kwargs: Any,
@@ -70,6 +70,7 @@ class Alloc(BaseAlloc):
         super().__init__(*args, **kwargs)
         self._fork = fork
         self._flags = flags
+        self._state_commitment = fork.transitions_from().state_commitment()
         if stub_eoas is not None:
             self._stub_eoas = stub_eoas
 

--- a/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Type
 import pytest
 from pydantic import TypeAdapter
 
-from execution_testing.base_types import to_json
+from execution_testing.base_types import StateCommitment, to_json
 from execution_testing.client_clis import (
     ExecutionSpecsTransitionTool,
     TransitionTool,
@@ -93,7 +93,9 @@ def test_calc_state_root(
     expected_hash: bytes,
 ) -> None:
     """Test calculation of the state root against expected hash."""
-    assert Alloc(alloc).state_root().startswith(expected_hash)
+    test_alloc = Alloc(alloc)
+    test_alloc.migrate_state_commitment(StateCommitment.MPT)
+    assert test_alloc.state_root().startswith(expected_hash)
 
 
 @pytest.mark.parametrize("evm_tool", [ExecutionSpecsTransitionTool])

--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
@@ -9,6 +9,7 @@ from typing import Any, Type
 import ijson  # type: ignore[import-untyped]
 import pytest
 
+from execution_testing.base_types import StateCommitment
 from execution_testing.client_clis import (
     CLINotFoundInPathError,
     EvmOneTransitionTool,
@@ -116,6 +117,7 @@ def test_unknown_binary_path() -> None:
 TEST_ALLOC = Alloc.model_validate(
     {0xA: {"balance": 1, "nonce": 2, "code": "0x00"}}
 )
+TEST_ALLOC.migrate_state_commitment(StateCommitment.MPT)
 TEST_ALLOC_STATE_ROOT = TEST_ALLOC.state_root()
 
 
@@ -165,6 +167,7 @@ def test_lazy_alloc_file_handles_mixed_entries(tmp_path: Path) -> None:
             0xC: {"balance": "0xff", "nonce": 0, "code": "0x"},
         }
     )
+    alloc.migrate_state_commitment(StateCommitment.MPT)
     state_root = alloc.state_root()
     alloc_path = tmp_path / "alloc.json"
     alloc_path.write_text(alloc.model_dump_json())

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -53,6 +53,15 @@ class PreAllocGroupBuilder(CamelModel):
     )
     pre: Alloc
 
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Seed the pre-alloc's commitment scheme from its genesis fork.
+        """
+        super().model_post_init(__context)
+        self.pre.migrate_state_commitment(
+            self.fork.transitions_from().state_commitment()
+        )
+
     def get_pre_account_count(self) -> int:
         """Return the amount of accounts the pre-allocation group holds."""
         return len(self.pre.root)
@@ -71,6 +80,7 @@ class PreAllocGroupBuilder(CamelModel):
 
     def add_test_alloc(self, test_id: str, new_pre: Alloc) -> None:
         """Adds a pre to this builder's pre."""
+        assert self.pre.state_commitment() == new_pre.state_commitment()
         self.pre = Alloc.merge(
             self.pre,
             new_pre,

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -25,6 +25,7 @@ from execution_testing.base_types import (
     AccessList,
     Address,
     BlobSchedule,
+    StateCommitment,
 )
 from execution_testing.base_types.conversions import BytesConvertible
 from execution_testing.vm import (
@@ -457,6 +458,11 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         else:
             if base_fork_class is not BaseFork:
                 cls._deployed = base_fork_class._deployed
+
+    @classmethod
+    def state_commitment(cls) -> StateCommitment:
+        """Return the state-commitment scheme for the state root."""
+        return StateCommitment.MPT
 
     # Header information abstract methods
     @classmethod

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -819,6 +819,10 @@ class BlockchainTest(BaseTest):
             )
         if empty_accounts := pre_alloc.empty_accounts():
             raise Exception(f"Empty accounts in pre state: {empty_accounts}")
+        if pre_alloc.state_commitment() is None:
+            pre_alloc.migrate_state_commitment(
+                self.fork.transitions_from().state_commitment()
+            )
         state_root = pre_alloc.state_root()
         genesis = FixtureHeader.genesis(
             self.fork.transitions_from(), env, state_root

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -123,10 +123,13 @@ class Alloc(BaseAlloc):
 
     _phase: _Phase = PrivateAttr(default=_Phase.CONSTRUCTION)
     _code_store: Dict[Hash32, Bytes] = PrivateAttr(default_factory=dict)
-    _state_commitment: StateCommitment = PrivateAttr(
-        default=StateCommitment.MPT
-    )
-    """Commitment scheme this allocation's state root is computed under."""
+    _state_commitment: StateCommitment | None = PrivateAttr(default=None)
+    """
+    Commitment scheme this allocation's state root is computed under.
+
+    Unset by default: it must be seeded from the accompanying fork before any
+    state-root computation.
+    """
 
     @dataclass(kw_only=True)
     class UnexpectedAccountError(Exception):
@@ -371,6 +374,11 @@ class Alloc(BaseAlloc):
         """
         Return the spec state module implementing `self._state_commitment`.
         """
+        if self._state_commitment is None:
+            raise ValueError(
+                "Alloc state commitment is unset; seed it from the "
+                "accompanying fork."
+            )
         if self._state_commitment is StateCommitment.MPT:
             return spec_state_mpt
         raise NotImplementedError("State commitment type not yet implemented.")
@@ -582,11 +590,16 @@ class Alloc(BaseAlloc):
         """Lock the allocation: no further mutations allowed."""
         self._phase = _Phase.FROZEN
 
-    def state_commitment(self) -> StateCommitment:
-        """Return the commitment scheme this allocation is committed under."""
+    def state_commitment(self) -> StateCommitment | None:
+        """
+        Return the commitment scheme this allocation is committed under, or
+        `None` if it has not been seeded from a fork yet.
+        """
         return self._state_commitment
 
-    def migrate_state_commitment(self, commitment: StateCommitment) -> None:
+    def migrate_state_commitment(
+        self, commitment: StateCommitment | None
+    ) -> None:
         """
         Switch the commitment scheme used to compute the state root.
         """

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -370,9 +370,6 @@ class Alloc(BaseAlloc):
     def _state_module(self) -> ModuleType:
         """
         Return the spec state module implementing `self._state_commitment`.
-
-        The MPT implementation is the only one currently available; a binary
-        allocation raises until the spec `state_bmt` module exists.
         """
         if self._state_commitment is StateCommitment.BINARY:
             raise NotImplementedError(
@@ -596,11 +593,6 @@ class Alloc(BaseAlloc):
     def migrate_state_commitment(self, commitment: StateCommitment) -> None:
         """
         Switch the commitment scheme used to compute the state root.
-
-        Called by blockchain fillers at a transition-fork boundary where the
-        target fork's commitment differs from the scheme this allocation was
-        built under. Account data is scheme-independent, so only the
-        root-computation strategy changes.
         """
         if self._phase is _Phase.FROZEN:
             raise RuntimeError(

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -391,9 +391,10 @@ class Alloc(BaseAlloc):
                 continue
             addr = Bytes20(address)
             code = bytes(account.code) if account.code else b""
-            code_hash = (
-                spec_keccak256(code) if code else spec_state.EMPTY_CODE_HASH
-            )
+            if code:
+                code_hash = mod.store_code(state, code)
+            else:
+                code_hash = spec_state.EMPTY_CODE_HASH
             mod.set_account(
                 state,
                 addr,
@@ -413,8 +414,6 @@ class Alloc(BaseAlloc):
                     Bytes32(int(key_hi).to_bytes(32, "big")),
                     U256(value_int),
                 )
-        for stored_code in self._code_store.values():
-            mod.store_code(state, stored_code)
         return state
 
     def get_account_optional(

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
+from types import ModuleType
 from typing import (
     Any,
     Dict,
@@ -30,6 +31,7 @@ from execution_testing.base_types import (
     Hash,
     HashInt,
     Number,
+    StateCommitment,
     Storage,
     StorageRootType,
 )
@@ -121,6 +123,10 @@ class Alloc(BaseAlloc):
 
     _phase: _Phase = PrivateAttr(default=_Phase.CONSTRUCTION)
     _code_store: Dict[Hash32, Bytes] = PrivateAttr(default_factory=dict)
+    _state_commitment: StateCommitment = PrivateAttr(
+        default=StateCommitment.MPT
+    )
+    """Commitment scheme this allocation's state root is computed under."""
 
     @dataclass(kw_only=True)
     class UnexpectedAccountError(Exception):
@@ -199,6 +205,7 @@ class Alloc(BaseAlloc):
         alloc_1: "Alloc",
         alloc_2: "Alloc",
         key_collision_mode: KeyCollisionMode = KeyCollisionMode.OVERWRITE,
+        state_commitment: StateCommitment | None = None,
     ) -> "Alloc":
         """Return merged allocation of two sources."""
         overlapping_keys = alloc_1.root.keys() & alloc_2.root.keys()
@@ -222,18 +229,21 @@ class Alloc(BaseAlloc):
                             account_1=account_1,
                             account_2=account_2,
                         )
-        merged = alloc_1.model_dump()
+        merged = alloc_1.model_copy(deep=True)
 
         for address, other_account in alloc_2.root.items():
-            merged_account = Account.merge(
-                merged.get(address, None), other_account
-            )
+            merged_account = Account.merge(merged.get(address), other_account)
             if merged_account:
                 merged[address] = merged_account
             elif address in merged:
-                merged.pop(address, None)
+                merged.root.pop(address, None)
 
-        return Alloc(merged)
+        if state_commitment is not None:
+            merged.migrate_state_commitment(state_commitment)
+        else:
+            # By default, state commitment of the second alloc takes precedence
+            merged.migrate_state_commitment(alloc_2.state_commitment())
+        return merged
 
     def __iter__(self) -> Iterator[Address]:  # type: ignore [override]
         """Return iterator over the allocation."""
@@ -300,7 +310,7 @@ class Alloc(BaseAlloc):
 
     def state_root(self) -> Hash:
         """Return state root of the allocation."""
-        return Hash(spec_state_mpt.state_root(self._materialize_state()))
+        return Hash(self._state_module().state_root(self._materialize_state()))
 
     def verify_post_alloc(self, got_alloc: "Alloc") -> None:
         """
@@ -357,16 +367,31 @@ class Alloc(BaseAlloc):
             self._build_cache()
             self._phase = _Phase.LIVE
 
-    def _materialize_state(self) -> spec_state_mpt.State:
+    def _state_module(self) -> ModuleType:
         """
-        Build an in-memory `ethereum.state_mpt.State` mirror of
-        `self.root`.
+        Return the spec state module implementing `self._state_commitment`.
+
+        The MPT implementation is the only one currently available; a binary
+        allocation raises until the spec `state_bmt` module exists.
+        """
+        if self._state_commitment is StateCommitment.BINARY:
+            raise NotImplementedError(
+                "Binary-tree state commitment is not yet available: no spec "
+                "state_bmt module exists."
+            )
+        return spec_state_mpt
+
+    def _materialize_state(self) -> spec_state.PreState:
+        """
+        Build a spec-side `PreState` mirror of `self.root` using the
+        implementation module for this allocation's commitment scheme.
 
         Used as the trie-backed delegate for `compute_state_root` (a
         cold, once-per-block call). The materialized state is not
         retained.
         """
-        state = spec_state_mpt.State()
+        mod = self._state_module()
+        state: spec_state.PreState = mod.State()
         for address, account in self.root.items():
             if account is None:
                 continue
@@ -375,7 +400,7 @@ class Alloc(BaseAlloc):
             code_hash = (
                 spec_keccak256(code) if code else spec_state.EMPTY_CODE_HASH
             )
-            spec_state_mpt.set_account(
+            mod.set_account(
                 state,
                 addr,
                 spec_state.Account(
@@ -388,13 +413,14 @@ class Alloc(BaseAlloc):
                 value_int = int(value_hi)
                 if value_int == 0:
                     continue
-                spec_state_mpt.set_storage(
+                mod.set_storage(
                     state,
                     addr,
                     Bytes32(int(key_hi).to_bytes(32, "big")),
                     U256(value_int),
                 )
-        state._code_store.update(self._code_store)
+        for stored_code in self._code_store.values():
+            mod.store_code(state, stored_code)
         return state
 
     def get_account_optional(
@@ -562,6 +588,25 @@ class Alloc(BaseAlloc):
     def freeze(self) -> None:
         """Lock the allocation: no further mutations allowed."""
         self._phase = _Phase.FROZEN
+
+    def state_commitment(self) -> StateCommitment:
+        """Return the commitment scheme this allocation is committed under."""
+        return self._state_commitment
+
+    def migrate_state_commitment(self, commitment: StateCommitment) -> None:
+        """
+        Switch the commitment scheme used to compute the state root.
+
+        Called by blockchain fillers at a transition-fork boundary where the
+        target fork's commitment differs from the scheme this allocation was
+        built under. Account data is scheme-independent, so only the
+        root-computation strategy changes.
+        """
+        if self._phase is _Phase.FROZEN:
+            raise RuntimeError(
+                "migrate_state_commitment not allowed: Alloc is FROZEN"
+            )
+        self._state_commitment = commitment
 
     def deterministic_deploy_contract(
         self,

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -371,12 +371,9 @@ class Alloc(BaseAlloc):
         """
         Return the spec state module implementing `self._state_commitment`.
         """
-        if self._state_commitment is StateCommitment.BINARY:
-            raise NotImplementedError(
-                "Binary-tree state commitment is not yet available: no spec "
-                "state_bmt module exists."
-            )
-        return spec_state_mpt
+        if self._state_commitment is StateCommitment.MPT:
+            return spec_state_mpt
+        raise NotImplementedError("State commitment type not yet implemented.")
 
     def _materialize_state(self) -> spec_state.PreState:
         """

--- a/packages/testing/src/execution_testing/test_types/tests/test_alloc_prestate.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_alloc_prestate.py
@@ -22,7 +22,7 @@ from ethereum.crypto.hash import keccak256
 from ethereum_types.bytes import Bytes20, Bytes32
 from ethereum_types.numeric import U256, Uint
 
-from execution_testing.base_types import Account
+from execution_testing.base_types import Account, StateCommitment
 from execution_testing.test_types import Alloc
 from execution_testing.test_types.account_types import _Phase
 
@@ -45,7 +45,7 @@ CODE = bytes.fromhex("60016002")  # PUSH1 1 PUSH1 2
 
 def _fixture_alloc() -> Alloc:
     """Build a small alloc with one EOA, one contract, and one empty acct."""
-    return Alloc.model_validate(
+    alloc = Alloc.model_validate(
         {
             ADDR_A: {"balance": 100, "nonce": 1},
             ADDR_B: {
@@ -57,6 +57,8 @@ def _fixture_alloc() -> Alloc:
             ADDR_C: {"balance": 0, "nonce": 0},
         }
     )
+    alloc.migrate_state_commitment(StateCommitment.MPT)
+    return alloc
 
 
 def _state_from_alloc(alloc: Alloc) -> spec_state_mpt.State:
@@ -235,6 +237,7 @@ def test_apply_diff_round_trip_matches_independent_post_state() -> None:
             },
         }
     )
+    alloc_post_expected.migrate_state_commitment(StateCommitment.MPT)
 
     # Build the diff that, applied to alloc_pre, should produce
     # alloc_post_expected.

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -224,6 +224,7 @@ class T8N(Load):
         if isinstance(input_alloc, LazyAlloc):
             input_alloc = input_alloc.materialize()
         self.alloc = input_alloc.model_copy(deep=True)
+        self.alloc.migrate_state_commitment(t8n_data.fork.state_commitment())
         self.env = t8n_data.env
         self.txs = list(t8n_data.txs)
         self.ommers = list(ommers)


### PR DESCRIPTION
### Description

Attempt to respond to concern in #3251: teach `Alloc` to know **which state-commitment scheme** its state root is computed under, and let the **fork** decide that scheme. Today every fork commits with a Merkle-Patricia Trie (MPT); this change lets a future fork switch to a binary tree without touching the allocation-handling code — the correct root algorithm is selected per fork instead of being hard-wired to `state_mpt`.

This is behaviorally a **no-op on mainnet forks**: every fork returns `StateCommitment.MPT`, so all state roots are computed exactly as before. It only adds the plumbing (and the seeding) needed for a binary-tree fork to drop in later (or in work branches).

**Core pieces**

- **`StateCommitment` enum** (`MPT` / `BINARY`) added to `base_types` — a spec-free vocabulary type so both `forks` and `test_types` can reference it without new import edges.
- **`Fork.state_commitment()`** classmethod on `BaseFork`, defaulting to `MPT`. A binary-transition fork overrides it to `BINARY`; no spec import enters the `forks` package.
- **`Alloc` carries its scheme.** A private `_state_commitment` field (default `MPT`), a public `state_commitment()` getter, and `migrate_state_commitment()` to switch it (rejected once the alloc is `FROZEN`). `state_root()` / `_materialize_state()` now dispatch through a new `_state_module()` that maps the scheme → the spec implementation module; `BINARY` raises `NotImplementedError` until a `state_bmt` module exists.
- **Backend-agnostic materialization.** `_materialize_state()` is now typed against `ethereum.state.PreState` (which both `state_mpt.State` and the future binary `State` satisfy) and only touches the state through public module functions (`State`, `set_account`, `set_storage`, `store_code`) — it no longer pins `state_mpt.State` or pokes the private `_code_store`.
- **`Alloc.merge` is commitment-aware.** It now propagates a scheme instead of minting a default-`MPT` allocation: an explicit `state_commitment=` argument wins, otherwise the second (right-hand) allocation's scheme takes precedence. It also switched to `model_copy(deep=True)`, which preserves the private scheme field.

**Seeding the scheme (private attributes are not serialized)**

Because `_state_commitment` is a private attribute, it is not restored by `model_validate`/`model_dump_json` and is dropped by JSON round-trips, so it must be (re)seeded from the fork wherever an allocation is constructed, loaded, or merged before a root is computed:

- `shared/pre_alloc.Alloc.__init__` — seed at construction from `fork.transitions_from().state_commitment()`.
- `pre_alloc_groups.PreAllocGroupBuilder.model_post_init` — seed on every load-from-file (covers `PreAllocGroup` and `GroupPreAlloc` via inheritance); `add_test_alloc` asserts both sides agree.
- `execute/rpc/hive.py` and `execute/tests/test_execute_remote.py` — seed the execute-path genesis allocation.
- `ethereum_spec_tools/evm_tools/t8n` — after the defensive `model_copy(deep=True)`, seed `self.alloc` from `t8n_data.fork` (which is always a concrete, non-transition fork here), covering the JSON CLI path where the scheme is otherwise lost to the MPT default.

**Enabling binary later** (once a spec `state_bmt` module lands) is three steps, none in `_materialize_state`:

1. Import the binary state module in `account_types.py`.
2. Return it from `_state_module()` for `StateCommitment.BINARY` instead of raising.
3. Override `Fork.state_commitment()` → `BINARY` on the transition fork.

The transition-block state-root semantics at a commitment boundary remain to be defined in a follow-up.

cc @CPerezz 

### Related Issues or PRs
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://content.nationalgeographic.com.es/medio/2024/05/31/macho-jin-xi-en-el-zoo-de-madrid_355544e5_240531135148_800x800.jpg)
