### PR TITLE
chore: Temporarily add PBT conformance tests

### DIFF
--- a/.github/workflows/binary-trie-vectors.yaml
+++ b/.github/workflows/binary-trie-vectors.yaml
@@ -1,0 +1,73 @@
+name: Binary Trie Vectors
+
+# Keeps `tests/binary_trie/vectors/binary_trie_vectors.json` in step with
+# the implementation it is derived from, so a pull request that changes
+# the tree or the embedding does not have to regenerate it by hand.
+#
+# Runs only on the project branch, and only when something the vectors
+# depend on moved. The generator's output is a pure function of the
+# implementation, so a run that finds no change commits nothing — and the
+# commit it does make touches only the JSON, which is not in the paths
+# filter below, so it cannot retrigger this workflow.
+
+on:
+  push:
+    branches:
+      - "projects/binary-trie"
+    paths:
+      - "src/ethereum/binary_trie/**"
+      - "tests/binary_trie/vectors/dump_vectors.py"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/setup-uv
+
+      - name: Regenerate vectors
+        run: uv run python tests/binary_trie/vectors/dump_vectors.py
+
+      - name: Commit if the vectors changed
+        env:
+          VECTORS: tests/binary_trie/vectors/binary_trie_vectors.json
+        run: |
+          # `source_commit` is a stamp, not a vector: it changes on every
+          # run because HEAD moved. Compare the substance without it, so
+          # a push that did not alter behaviour commits nothing.
+          if git cat-file -e "HEAD:$VECTORS" 2>/dev/null; then
+            git show "HEAD:$VECTORS" > /tmp/vectors-before.json
+          else
+            # Not committed yet: nothing to compare against, so the
+            # freshly generated file is always a change worth committing.
+            echo '{}' > /tmp/vectors-before.json
+          fi
+          strip() { python3 -c "
+          import json, sys
+          d = json.load(open(sys.argv[1]))
+          d.pop('source_commit', None)
+          json.dump(d, sys.stdout, indent=2, sort_keys=True)
+          " "$1"; }
+          if [ "$(strip /tmp/vectors-before.json)" = "$(strip "$VECTORS")" ]
+          then
+            echo "Vectors unchanged; discarding the new stamp."
+            git checkout -- "$VECTORS"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$VECTORS"
+          git commit -m "chore(binary-trie): regenerate conformance vectors"
+          git push

--- a/tests/binary_trie/vectors/README.md
+++ b/tests/binary_trie/vectors/README.md
@@ -1,0 +1,135 @@
+# Binary Trie Conformance Vectors
+
+Cross-client conformance vectors for the [EIP-8297] binary trie and its
+state embedding, generated from the reference implementation in
+`src/ethereum/binary_trie/`.
+
+While things are moving quickly, client implementations vendor
+`binary_trie_vectors.json` and check against it. This mainly makes
+debugging quicker, since you don't need to run through the whole
+STF to debug an issue.
+
+[EIP-8297]: https://eips.ethereum.org/EIPS/eip-8297
+
+## Important Files
+
+- `binary_trie_vectors.json`: the file clients vendor. Not committed by
+  hand — the `Binary Trie Vectors` workflow generates it on
+  `projects/binary-trie` and commits it there.
+- `dump_vectors.py`: the generator that produces it.
+
+## Regenerating
+
+To run it by hand, from the repository root:
+
+```console
+uv run python tests/binary_trie/vectors/dump_vectors.py
+```
+
+## Schema
+
+Every byte string is a `0x`-prefixed lowercase hex string. Numbers that
+fit comfortably in a JSON integer are JSON numbers; anything that could
+exceed a JSON-safe integer is hex.
+
+### Top level
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `source` | string | The repository and branch the vectors originate from. |
+| `source_commit` | string | Commit of the implementation these values were generated from. |
+| `trie_roots` | array | Tree roots for a spread of key shapes. |
+| `embedding` | object | Tree keys derived for one fixed account. |
+| `chunkify_code` | array | `chunkify_code` inputs and outputs. |
+| `encode_basic_data` | array | Packed account header leaves. |
+
+### `trie_roots`
+
+An array of `{name, entries, root}`.
+
+- `entries`: an **ordered** array of `{key, value}` objects. The order
+  is significant and duplicate keys are legal: writes are applied in
+  sequence and the last write to a key wins. The
+  `overwrite_takes_last_value` case depends on this, so a consumer must
+  replay the entries in order rather than loading them into an
+  unordered map.
+- `key`: a variable-length tree key.
+- `value`: 32 bytes.
+- `root`: the 32-byte root after all entries have been applied in
+  order.
+
+The nine cases and the structural property each one covers:
+
+| Name | Covers |
+| --- | --- |
+| `empty` | The root of a tree with no entries. |
+| `single_leaf` | One 34-byte (account-zone length) key. |
+| `single_leaf_one_byte_key` | A key far shorter than a real zone key, exercising short-key handling. |
+| `two_leaves_diverge_first_bit` | Divergence at the very first bit, so the split happens at the root. |
+| `two_leaves_diverge_last_bit` | Divergence at the very last bit, the deepest split the keys allow. |
+| `three_leaves_shared_prefix` | Two keys sharing a prefix alongside a third that does not, exercising internal-node reuse. |
+| `mixed_key_lengths_34_and_66` | The two real key lengths together: 34 bytes for account/code-zone keys, 66 for storage-zone keys. |
+| `overwrite_takes_last_value` | The same key written twice; the second value must win. |
+| `random_50_keys_seed_8297` | 50 distinct pseudo-random 34-byte keys, listed in insertion order, as a broad spread over the key space. |
+
+### `embedding`
+
+All keys in this section belong to a single test account.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `address20` | hex | The legacy 20-byte test address. |
+| `address32` | hex | Its 32-byte tree form. |
+| `basic_data_key` | hex | Tree key of the account's basic-data header leaf. |
+| `code_hash_key` | hex | Tree key of the account's code-hash header leaf. |
+| `header_sub_index_255_key` | hex | Tree key at header sub-index 255, the last sub-index of the header stem. |
+| `storage_slot_keys` | object | Decimal-string slot number to tree key. |
+| `code_chunk_keys` | object | Decimal-string chunk index to tree key. |
+| `code_hash` | hex | Keccak hash of the test account's bytecode; the content address the overflow chunk keys derive from. |
+
+`storage_slot_keys` carries slots 0, 1, 63, 64, 255, 256, 511, 512, and
+`2**200`. Slots below 64 live in the account header, so the 63/64 pair
+straddles the boundary between the header and the storage zone; the
+remaining values walk across successive overflow stems, and `2**200`
+exercises the `U256` arithmetic on a slot number no fixture can reach by
+counting. Note that the object key for the large slot is its full
+decimal expansion, not an exponent.
+
+`code_chunk_keys` carries chunk indices 0, 1, 127, 128, 129, 383 and
+384. Chunks below 128 live in the account header, so the 127/128 pair
+straddles the boundary between the header and the code zone, and the
+383/384 pair crosses from one overflow stem to the next.
+
+Overflow code is content-addressed, so the chunk keys past the header
+are derived from `code_hash` rather than from the address
+alone. A consumer reproducing these keys must feed in that same hash.
+
+### `chunkify_code`
+
+An array of `{name, code, chunks}`, where `code` is the input bytecode
+and `chunks` is the resulting list of 32-byte chunks.
+
+Each chunk is one leading byte followed by 31 bytes of code, zero-padded
+if the code runs out. The leading byte counts how many of the chunk's
+31 payload bytes are push data continuing from a push instruction that
+began in an earlier chunk, capped at 31. That count is what lets a chunk
+be interpreted without fetching its predecessors.
+
+### `encode_basic_data`
+
+An array of `{code_size, nonce, balance, encoded}`.
+
+`code_size` and `nonce` are JSON numbers; `balance` is a `0x` hex string
+because its values exceed what a JSON integer holds safely. `encoded` is
+the 32-byte packed leaf, laid out big-endian throughout:
+
+| Offset | Length | Field |
+| --- | --- | --- |
+| 0 | 1 | Version byte, currently zero. |
+| 1 | 3 | Reserved, zero. |
+| 4 | 4 | Code size. |
+| 8 | 8 | Nonce. |
+| 16 | 16 | Balance. |
+
+The balance field is 16 bytes, so a balance must be less than `2**128`
+to be encodable.

--- a/tests/binary_trie/vectors/__init__.py
+++ b/tests/binary_trie/vectors/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-client conformance vectors for the binary trie."""

--- a/tests/binary_trie/vectors/dump_vectors.py
+++ b/tests/binary_trie/vectors/dump_vectors.py
@@ -1,0 +1,287 @@
+"""
+
+TODO: This will be deleted before merging into forks/I*
+TODO: It is here so that clients can quickly test only the trie and
+TODO: embedding logic in isolation to the STF.
+
+Generate the cross-client conformance vectors for the EIP-8297 binary
+tree and its state embedding.
+
+The vectors pin the observable outputs of `ethereum.binary_trie`: tree
+roots for a spread of key shapes, the tree keys the embedding derives
+for headers, storage slots and code chunks, `chunkify_code` output, and
+the packed `encode_basic_data` leaf. Client implementations for now should
+vendor the emitted JSON as a fixture rather than re-running this
+script.
+
+A pull request does not need to run this. The `Binary Trie Vectors`
+workflow regenerates the JSON on `projects/binary-trie` whenever the
+tree, the embedding, or this generator changes, and commits the result.
+
+To run it by hand:
+
+    uv run python tests/binary_trie/vectors/dump_vectors.py
+
+which rewrites `binary_trie_vectors.json` in place. Apart from the
+`source_commit` stamp, the output is a pure function of the
+implementation (seeded RNG, no timestamps), so a behavior-preserving
+change leaves every vector value untouched; the workflow compares with
+the stamp removed and commits only when the values actually moved.
+"""
+
+import json
+import random
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
+
+from ethereum_types.bytes import Bytes, Bytes20, Bytes32
+from ethereum_types.numeric import U32, U64, U256, Uint
+
+from ethereum.binary_trie.embedding import (
+    address20_to_address32,
+    chunkify_code,
+    encode_basic_data,
+    get_tree_key_for_basic_data,
+    get_tree_key_for_code_chunk,
+    get_tree_key_for_code_hash,
+    get_tree_key_for_header,
+    get_tree_key_for_storage_slot,
+)
+from ethereum.binary_trie.trie import BinaryTrie, root, trie_set
+from ethereum.crypto.hash import keccak256
+
+VECTORS_PATH = Path(__file__).parent / "binary_trie_vectors.json"
+
+SOURCE = "ethereum/execution-specs projects/binary-trie"
+
+V1 = bytes.fromhex("01" * 32)
+V2 = bytes.fromhex("02" * 32)
+V3 = bytes.fromhex("03" * 32)
+
+ADDRESS20 = bytes.fromhex("00112233445566778899aabbccddeeff00112233")
+
+PUSH4 = bytes([0x63])
+PUSH32 = bytes([0x7F])
+
+
+def hx(b: bytes) -> str:
+    """Render `b` as a `0x`-prefixed lowercase hex string."""
+    return "0x" + bytes(b).hex()
+
+
+def trie_root_case(
+    name: str, entries: Sequence[Tuple[bytes, bytes]]
+) -> Dict[str, Any]:
+    """
+    Build one tree-root case from an ordered list of `(key, value)`
+    pairs, applied in order with `trie_set`.
+
+    Duplicates are preserved in the serialized output so consumers can
+    replay overwrites in the same order.
+    """
+    t = BinaryTrie()
+    for k, v in entries:
+        trie_set(t, Bytes(k), Bytes32(v))
+    return {
+        "name": name,
+        "entries": [{"key": hx(k), "value": hx(v)} for k, v in entries],
+        "root": hx(root(t)),
+    }
+
+
+def trie_root_cases() -> List[Dict[str, Any]]:
+    """
+    Build the tree-root cases: hand-picked key shapes (divergence at the
+    first and last bit, shared prefixes, mixed key lengths, an
+    overwrite) plus a deterministic pseudo-random spread.
+    """
+    cases = [
+        trie_root_case("empty", []),
+        trie_root_case("single_leaf", [(b"\x00" * 34, V1)]),
+        trie_root_case("single_leaf_one_byte_key", [(b"\xab", V1)]),
+        trie_root_case(
+            "two_leaves_diverge_first_bit",
+            [(b"\x00" + b"\x11" * 33, V1), (b"\x80" + b"\x11" * 33, V2)],
+        ),
+        trie_root_case(
+            "two_leaves_diverge_last_bit",
+            [(b"\x22" * 33 + b"\x00", V1), (b"\x22" * 33 + b"\x01", V2)],
+        ),
+        trie_root_case(
+            "three_leaves_shared_prefix",
+            [
+                (b"\xf0" + b"\x00" * 33, V1),
+                (b"\xf1" + b"\x00" * 33, V2),
+                (b"\x0f" + b"\x00" * 33, V3),
+            ],
+        ),
+        trie_root_case(
+            "mixed_key_lengths_34_and_66",
+            [
+                (b"\x00" + b"\xaa" * 32 + b"\x05", V1),
+                (b"\xff" + b"\xbb" * 64 + b"\x07", V2),
+            ],
+        ),
+        trie_root_case(
+            "overwrite_takes_last_value",
+            # same key written twice: the second trie_set overwrites
+            [(b"\x42" * 34, V1), (b"\x42" * 34, V2)],
+        ),
+    ]
+
+    # Deterministic pseudo-random case: 50 distinct 34-byte keys, listed
+    # in generation (insertion) order.
+    rng = random.Random(8297)
+    rand_entries: Dict[bytes, bytes] = {}
+    while len(rand_entries) < 50:
+        k = bytes(rng.randrange(256) for _ in range(34))
+        v = bytes(rng.randrange(256) for _ in range(32))
+        rand_entries[k] = v
+    cases.append(
+        trie_root_case("random_50_keys_seed_8297", list(rand_entries.items()))
+    )
+
+    return cases
+
+
+def embedding_cases() -> Dict[str, Any]:
+    """
+    Build the embedding cases: the tree keys one fixed account derives
+    for its header leaves, storage slots and code chunks.
+
+    The storage slot and code chunk indices straddle the header/overflow
+    boundaries, so a client that mis-splits either zone disagrees here.
+    """
+    address32 = address20_to_address32(Bytes20(ADDRESS20))
+    code_hash = keccak256(b"\xfe")  # hash of some 1-byte code
+    return {
+        "address20": hx(ADDRESS20),
+        "address32": hx(address32),
+        "basic_data_key": hx(get_tree_key_for_basic_data(address32)),
+        "code_hash_key": hx(get_tree_key_for_code_hash(address32)),
+        "header_sub_index_255_key": hx(
+            get_tree_key_for_header(address32, Uint(255))
+        ),
+        "storage_slot_keys": {
+            str(slot): hx(get_tree_key_for_storage_slot(address32, U256(slot)))
+            for slot in [0, 1, 63, 64, 255, 256, 511, 512, 2**200]
+        },
+        "code_chunk_keys": {
+            str(cid): hx(
+                get_tree_key_for_code_chunk(
+                    address32, Bytes32(code_hash), Uint(cid)
+                )
+            )
+            for cid in [0, 1, 127, 128, 129, 383, 384]
+        },
+        "code_hash": hx(code_hash),
+    }
+
+
+def chunkify_cases() -> List[Dict[str, Any]]:
+    """
+    Build the `chunkify_code` cases, covering the empty program, padding
+    of a short one, and PUSH data spilling across a chunk boundary.
+    """
+
+    def case(name: str, code: bytes) -> Dict[str, Any]:
+        return {
+            "name": name,
+            "code": hx(code),
+            "chunks": [hx(c) for c in chunkify_code(Bytes(code))],
+        }
+
+    # PUSH4 at position 29: its 4 data bytes spill 2 into chunk 1
+    push4_boundary = b"\x01" * 29 + PUSH4 + b"\xaa\xbb\xcc\xdd" + b"\x01" * 10
+    push32_spill = b"\x01" * 30 + PUSH32 + bytes(range(32)) + b"\x01" * 5
+
+    return [
+        {"name": "empty", "code": hx(b""), "chunks": []},
+        case("stop_padded", b"\x00"),
+        case("eip_example_push4_boundary", push4_boundary),
+        case("push32_at_chunk_end_spills_31", push32_spill),
+    ]
+
+
+def basic_data_cases() -> List[Dict[str, Any]]:
+    """
+    Build the `encode_basic_data` cases, from an all-zero account up to
+    each packed field at its maximum.
+    """
+    return [
+        {
+            "code_size": 0,
+            "nonce": 0,
+            "balance": "0x0",
+            "encoded": hx(encode_basic_data(U32(0), U64(0), U256(0))),
+        },
+        {
+            "code_size": 1234,
+            "nonce": 42,
+            "balance": hex(10**18),
+            "encoded": hx(encode_basic_data(U32(1234), U64(42), U256(10**18))),
+        },
+        {
+            "code_size": 2**32 - 1,
+            "nonce": 2**64 - 1,
+            "balance": hex(2**128 - 1),
+            "encoded": hx(
+                encode_basic_data(
+                    U32(2**32 - 1), U64(2**64 - 1), U256(2**128 - 1)
+                )
+            ),
+        },
+    ]
+
+
+def build_vectors() -> Dict[str, Any]:
+    """
+    Build the full vector set, without the `source_commit` stamp.
+
+    Deterministic and free of process state: everything here is derived
+    from the implementation alone.
+    """
+    return {
+        "source": SOURCE,
+        "trie_roots": trie_root_cases(),
+        "embedding": embedding_cases(),
+        "chunkify_code": chunkify_cases(),
+        "encode_basic_data": basic_data_cases(),
+    }
+
+
+def head_commit() -> str:
+    """Return this checkout's HEAD commit."""
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(__file__).parent,
+        text=True,
+    ).strip()
+
+
+def main() -> None:
+    """
+    Write the vectors, stamped with this checkout's HEAD.
+
+    The stamp records which revision of the implementation the values
+    correspond to, for the benefit of repositories that vendor the file.
+    It is not part of the vectors: the workflow that regenerates them
+    compares content with `source_commit` removed, so a run that changes
+    nothing does not commit a new stamp.
+    """
+    vectors = build_vectors()
+    stamped = {
+        "source": vectors["source"],
+        "source_commit": head_commit(),
+        **{k: v for k, v in vectors.items() if k != "source"},
+    }
+    VECTORS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with VECTORS_PATH.open("w") as f:
+        json.dump(stamped, f, indent=2)
+        f.write("\n")
+    print(f"wrote {VECTORS_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description

When bootstrapping a new state trie, it is convenient to be able to test the state trie in isolation of the STF since a divergence only implies that there could be a problem in the state trie, but its not guaranteed.

Output: On each commit to `projects/binary-trie`, a .json file will be generated with trie test vectors if something has changed.

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
