### PR TITLE
fix(test-execute): report each test as an individual hive test case

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -282,6 +282,24 @@ def test_suite_description() -> str:
     return "Execute EEST tests using hive endpoint."
 
 
+@pytest.fixture(scope="function")
+def test_case_description(request: pytest.FixtureRequest) -> str:
+    """Return the test docstring as the hive test-case description."""
+    description = getattr(request.node.function, "__doc__", None)
+    return description or ""
+
+
+@pytest.fixture(autouse=True)
+def per_test_hive_test(hive_test: HiveTest) -> None:
+    """
+    Report each pytest test as an individual hive test case.
+
+    The client runs under the session-scoped base hive test; this
+    per-test entry only propagates the individual test result to hive.
+    """
+    del hive_test
+
+
 @pytest.fixture(autouse=True, scope="session")
 def base_hive_test(
     request: pytest.FixtureRequest,


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Execute's hive mode only registered the session-scoped base hive test, so an entire run appeared as a single test case per client in the hive UI. Register each pytest test as an individual hive test case via the existing `hive_test` fixture (plus the `test_case_description` fixture it requires), matching the consume simulators. The client still runs under the base hive test.

Verified against `./hive --dev`: a 16-test run now produces 16 per-test entries instead of 1.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fm%2F780hBQx52PAAAAAC%2Fcute-alligator.gif&f=1&nofb=1&ipt=3070bc22e0fcee09fb29024bd85057ec23536dfb567b991c6d9d0d890ccbabbd)
