### PR TITLE
fix(binary_trie): raise typed errors from state-root computation

### DIFF
--- a/src/ethereum/binary_trie/embedding.py
+++ b/src/ethereum/binary_trie/embedding.py
@@ -50,6 +50,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes32
 from ethereum_types.numeric import U8, U32, U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import BalanceOverflowError
 from ethereum.utils.byte import left_pad_zero_bytes, right_pad_zero_bytes
 
 from .trie import (
@@ -476,16 +477,22 @@ def encode_basic_data(code_size: U32, nonce: U64, balance: U256) -> Bytes32:
     The code size and nonce parameters are typed at their field
     widths; the nonce cannot exceed eight bytes by [EIP-2681].
     Balances are protocol-level `U256` values, so the parameter
-    keeps that type and the sixteen-byte field bound is asserted
-    here instead.
+    keeps that type; a balance too large for the sixteen-byte
+    field cannot be committed and raises [`BalanceOverflowError`],
+    invalidating the block whose state would hold it.
 
     TODO: `code_size` is four bytes at offset four here, one
     byte wider than EIP-7864's three-byte field at offset five.
 
     [`BASIC_DATA_LEAF_KEY`]: ref:ethereum.binary_trie.embedding.BASIC_DATA_LEAF_KEY
+    [`BalanceOverflowError`]: ref:ethereum.exceptions.BalanceOverflowError
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """  # noqa: E501
-    assert balance < U256(2) ** U256(128)  # U128 doesn't exist
+    if balance >= U256(2) ** U256(128):  # U128 doesn't exist
+        raise BalanceOverflowError(
+            f"balance {balance} does not fit the sixteen-byte "
+            f"basic data balance field"
+        )
     return Bytes32(
         bytes([int(BASIC_DATA_VERSION)])
         # Reserved bytes: headroom for future header fields.

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -73,3 +73,22 @@ class NonceOverflowError(InvalidTransaction):
     """
     Thrown when a transaction's nonce is greater than `2**64 - 2`.
     """
+
+
+class BalanceOverflowError(InvalidBlock):
+    """
+    Thrown when an account's balance is too large to fit the sixteen-byte
+    balance field of the binary tree's basic data leaf.
+    """
+
+
+class UnknownCodeHashError(EthereumException):
+    """
+    Thrown when a code hash has no bytecode stored for it in the state's
+    code store.
+
+    Indicates a malformed pre-state rather than an invalid block, so this
+    is deliberately not an [`InvalidBlock`].
+
+    [`InvalidBlock`]: ref:ethereum.exceptions.InvalidBlock
+    """

--- a/src/ethereum/state.py
+++ b/src/ethereum/state.py
@@ -115,8 +115,12 @@ class PreState(Protocol):
         """
         Get the bytecode for a given code hash.
 
-        Return ``b""`` for ``EMPTY_CODE_HASH``.
-        """
+        Return ``b""`` for ``EMPTY_CODE_HASH``. A code hash with no
+        stored bytecode is a malformed pre-state; providers raise
+        [`UnknownCodeHashError`] rather than a raw lookup error.
+
+        [`UnknownCodeHashError`]: ref:ethereum.exceptions.UnknownCodeHashError
+        """  # noqa: E501
         ...
 
     def account_has_storage(self, address: Address) -> bool:
@@ -140,6 +144,13 @@ class PreState(Protocol):
         new bytecode is not yet in the provider's code store when the
         root is computed.
 
+        A commitment whose encoding bounds a field more tightly than
+        the protocol types — such as the binary tree's sixteen-byte
+        balance field — raises [`InvalidBlock`] when the diffed state
+        cannot be committed.
+
         Return the new state root.
+
+        [`InvalidBlock`]: ref:ethereum.exceptions.InvalidBlock
         """
         ...

--- a/src/ethereum/state_mpt.py
+++ b/src/ethereum/state_mpt.py
@@ -18,6 +18,7 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import UnknownCodeHashError
 from ethereum.merkle_patricia_trie import (
     EMPTY_TRIE_ROOT,
     Trie,
@@ -50,11 +51,20 @@ class State:
         """
         Get the bytecode for a given code hash.
 
-        Return ``b""`` for ``EMPTY_CODE_HASH``.
-        """
+        Return ``b""`` for ``EMPTY_CODE_HASH``. Any other hash with no
+        stored bytecode raises [`UnknownCodeHashError`]: an account
+        referencing such a hash is a malformed pre-state.
+
+        [`UnknownCodeHashError`]: ref:ethereum.exceptions.UnknownCodeHashError
+        """  # noqa: E501
         if code_hash == EMPTY_CODE_HASH:
             return b""
-        return self._code_store[code_hash]
+        code = self._code_store.get(code_hash)
+        if code is None:
+            raise UnknownCodeHashError(
+                f"no bytecode stored for code hash 0x{code_hash.hex()}"
+            )
+        return code
 
     def get_account_optional(self, address: Address) -> Optional[Account]:
         """

--- a/src/ethereum/state_pbt.py
+++ b/src/ethereum/state_pbt.py
@@ -52,6 +52,7 @@ from ethereum.binary_trie.embedding import (
 from ethereum.binary_trie.trie import BinaryTrie
 from ethereum.binary_trie.trie import root as binary_tree_root
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import UnknownCodeHashError
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, BlockDiff, Root
 
 
@@ -121,11 +122,20 @@ class State:
         """
         Get the bytecode for a given code hash.
 
-        Return ``b""`` for ``EMPTY_CODE_HASH``.
-        """
+        Return ``b""`` for ``EMPTY_CODE_HASH``. Any other hash with no
+        stored bytecode raises [`UnknownCodeHashError`]: an account
+        referencing such a hash is a malformed pre-state.
+
+        [`UnknownCodeHashError`]: ref:ethereum.exceptions.UnknownCodeHashError
+        """  # noqa: E501
         if code_hash == EMPTY_CODE_HASH:
             return b""
-        return self._code_store[code_hash]
+        code = self._code_store.get(code_hash)
+        if code is None:
+            raise UnknownCodeHashError(
+                f"no bytecode stored for code hash 0x{code_hash.hex()}"
+            )
+        return code
 
     def get_account_optional(self, address: Address) -> Optional[Account]:
         """

--- a/src/ethereum_spec_tools/evm_tools/t8n/result.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/result.py
@@ -11,7 +11,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from ethereum_rlp import rlp
 
 from ethereum.crypto.hash import keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum.merkle_patricia_trie import root, trie_get
+from ethereum.state import BlockDiff
 
 if TYPE_CHECKING:
     from execution_testing.client_clis.cli_types import (
@@ -79,7 +81,16 @@ def build_result(
     from execution_testing.client_clis.cli_types import Result as TestingResult
 
     diff = t8n.fork.extract_block_diff(t8n._block_state)
-    state_root = t8n.alloc.compute_state_root(diff)
+    try:
+        state_root = t8n.alloc.compute_state_root(diff)
+    except InvalidBlock as e:
+        # The executed block produced state that cannot be committed
+        # (e.g. a balance past the sixteen-byte basic data field). Such
+        # a block is rejected and leaves the chain state unchanged, so
+        # report the pre-state root.
+        if block_exception is None:
+            block_exception = f"{e}"
+        state_root = t8n.alloc.compute_state_root(BlockDiff())
 
     arguments: Dict[str, Any] = {
         "state_root": state_root,

--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_basic_data_values.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_basic_data_values.py
@@ -44,8 +44,9 @@ def test_account_at_max_balance_field_transacts(
     a value-transferring transaction successfully, with exact post
     balances on both ends.
 
-    `2**128` and above overflow the field with no protocol-level cap;
-    that gap is pinned as a unit test, not exercised here.
+    `2**128` and above cannot be committed: root computation rejects
+    the block with `BalanceOverflowError`; that bound is pinned by
+    unit tests, not exercised here.
     """
     max_balance = 2**128 - 1
     value = 12345

--- a/tests/binary_trie/test_differential_mpt.py
+++ b/tests/binary_trie/test_differential_mpt.py
@@ -318,9 +318,10 @@ def _random_account(rng: random.Random, code_hash: Hash32) -> Account:
     Build an `Account` with `code_hash`, a random nonce below `2**64`,
     and a random balance below `2**128`.
 
-    The cap is not cosmetic: `encode_basic_data` asserts balance fits
-    its sixteen-byte field, so `2**128` or more would crash root
-    computation rather than merely being unrealistic.
+    The cap is not cosmetic: `encode_basic_data` rejects balances
+    past its sixteen-byte field with `BalanceOverflowError`, so
+    `2**128` or more would invalidate root computation rather than
+    merely being unrealistic.
     """
     return Account(
         nonce=Uint(rng.randrange(0, 2**64)),

--- a/tests/binary_trie/test_embedding.py
+++ b/tests/binary_trie/test_embedding.py
@@ -34,6 +34,7 @@ from ethereum.binary_trie.embedding import (
     remove_storage_slot,
 )
 from ethereum.binary_trie.trie import BinaryTrie, root, trie_set
+from ethereum.exceptions import BalanceOverflowError, InvalidBlock
 from ethereum.state import EMPTY_CODE_HASH as MPT_STATE_EMPTY_CODE_HASH
 
 ADDRESS = Address32(b"\x00" * 12 + b"\xaa" * 20)
@@ -752,10 +753,12 @@ def test_encode_basic_data_layout() -> None:
 
 def test_encode_basic_data_rejects_balance_past_sixteen_bytes() -> None:
     """
-    A balance that does not fit the sixteen-byte field is rejected,
-    rather than silently truncated by `to_bytes`.
+    A balance that does not fit the sixteen-byte field raises
+    `BalanceOverflowError` -- an `InvalidBlock` -- rather than being
+    silently truncated by `to_bytes`.
     """
-    with pytest.raises(AssertionError):
+    assert issubclass(BalanceOverflowError, InvalidBlock)
+    with pytest.raises(BalanceOverflowError):
         encode_basic_data(
             code_size=U32(0),
             nonce=U64(0),

--- a/tests/binary_trie/test_state_pbt.py
+++ b/tests/binary_trie/test_state_pbt.py
@@ -71,6 +71,11 @@ from ethereum.binary_trie.trie import (
     trie_set,
 )
 from ethereum.crypto.hash import keccak256
+from ethereum.exceptions import (
+    BalanceOverflowError,
+    InvalidBlock,
+    UnknownCodeHashError,
+)
 from ethereum.state import EMPTY_CODE_HASH, Account, BlockDiff
 from ethereum.state_mpt import State as MptState
 from ethereum.state_mpt import set_account as mpt_set_account
@@ -1184,19 +1189,17 @@ def test_basic_data_leaf_bytes_carry_code_size_nonce_and_balance() -> None:
     assert leaf[16:32] == (12345).to_bytes(16, "big")  # balance
 
 
-def test_balance_at_or_above_the_sixteen_byte_field_fails_at_root_time() -> (
+def test_balance_at_or_above_the_sixteen_byte_field_rejects_at_root_time() -> (
     None
 ):
     """
-    A balance of exactly `2**128` crashes `state_root` with an
-    `AssertionError` instead of being rejected when it is set.
+    A balance of exactly `2**128` is rejected when the root is
+    computed, not when it is set.
 
-    `Account.balance` is a full `U256`; nothing between `set_account`
-    and `encode_basic_data`'s own bounds assertion enforces the
-    sixteen-byte field EIP-8297 packs it into. There is no
-    protocol-level cap on balance today, so an over-cap value crashes
-    root computation rather than invalidating the block at the point
-    it was set, a known spec gap being pinned here, not endorsed.
+    `Account.balance` is a full `U256` and `set_account` stays
+    unbounded, so the sixteen-byte field EIP-8297 packs it into is
+    enforced at commitment time, as `BalanceOverflowError` -- an
+    `InvalidBlock` -- rather than a raw `AssertionError`.
     """
     state = State()
     set_account(
@@ -1209,8 +1212,41 @@ def test_balance_at_or_above_the_sixteen_byte_field_fails_at_root_time() -> (
         ),
     )
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(BalanceOverflowError):
         state_root(state)
+
+
+def test_block_diff_minting_over_cap_balance_rejects_the_block() -> None:
+    """
+    A diff that raises an account's balance to `2**128` makes
+    `compute_state_root` raise `BalanceOverflowError`: the block
+    minting the balance is invalid, and the pre-state, whose balance
+    still fits the field, embeds cleanly afterwards.
+    """
+    state = State()
+    set_account(
+        state,
+        ADDRESS_A,
+        Account(
+            nonce=Uint(0),
+            balance=U256(2) ** U256(128) - U256(1),
+            code_hash=EMPTY_CODE_HASH,
+        ),
+    )
+    diff = BlockDiff(
+        account_changes={
+            ADDRESS_A: Account(
+                nonce=Uint(0),
+                balance=U256(2) ** U256(128),
+                code_hash=EMPTY_CODE_HASH,
+            )
+        }
+    )
+
+    with pytest.raises(BalanceOverflowError):
+        state.compute_state_root(diff)
+
+    assert state.compute_state_root(BlockDiff()) == state_root(state)
 
 
 def test_empty_code_contract_embeds_like_an_eoa() -> None:
@@ -1287,13 +1323,17 @@ def test_delegation_designator_account_embedding() -> None:
 
 def test_get_code_raises_for_an_unknown_code_hash() -> None:
     """
-    An account whose `code_hash` was never stored raises `KeyError`
-    when the root is computed, because `embed_flat_state` resolves
-    every account's code through `get_code` to size it.
+    An account whose `code_hash` was never stored raises
+    `UnknownCodeHashError` when the root is computed, because
+    `embed_flat_state` resolves every account's code through
+    `get_code` to size it.
 
-    Only `EMPTY_CODE_HASH` needs no store entry; any other unstored
-    hash is missing from `_code_store` and `get_code` raises directly.
+    Only `EMPTY_CODE_HASH` needs no store entry. An unstored hash is
+    a malformed pre-state, not an invalid block, so the error is an
+    `EthereumException` but deliberately not an `InvalidBlock`.
     """
+    assert not issubclass(UnknownCodeHashError, InvalidBlock)
+
     state = State()
     unknown_hash = keccak256(b"never stored")
     set_account(
@@ -1303,9 +1343,9 @@ def test_get_code_raises_for_an_unknown_code_hash() -> None:
     )
 
     assert state.get_code(EMPTY_CODE_HASH) == b""
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownCodeHashError):
         state.get_code(unknown_hash)
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownCodeHashError):
         state_root(state)
 
 


### PR DESCRIPTION
### Description

Computing a PBT state root could crash the transition tool with raw Python exceptions instead of failing through the protocol's own error path:

- `encode_basic_data` enforced the sixteen-byte balance field with a bare `assert`, so a block minting a balance at or above `2**128` died with `AssertionError`. It now raises `BalanceOverflowError`, an `InvalidBlock`: the block whose state cannot be committed is rejected, on the same path as a state-root mismatch. The `2**128 - 1` boundary still encodes (pinned by `test_encode_basic_data_maximum_fields`).
- `State.get_code` raised `KeyError` for a hash absent from the code store — reachable during PBT root computation because code chunk leaves commit code contents. It now raises `UnknownCodeHashError`, an `EthereumException` but deliberately **not** an `InvalidBlock`: no block content can cause it (`apply_diff_to_trie` consults `diff.code_changes` first), only a malformed pre-state. `state_mpt.get_code` gets the identical edit so both providers honor the same `PreState` contract.
- t8n's `build_result` computed the state root outside any exception handler, so even a typed `InvalidBlock` would have escaped as a crash. It now catches `InvalidBlock`, records the block exception, and reports the pre-state root — `Result.state_root` is required and non-Optional, and a rejected block leaves the chain state unchanged. `UnknownCodeHashError` is intentionally not caught there: malformed input should fail the run loudly, now with a readable message.

Unit tests pinning the old crashes were updated to pin the typed rejections, and a new test covers the block-diff path (`compute_state_root` on a diff minting an over-cap balance rejects the block while the pre-state still embeds cleanly).
After an invalid block, t8n `run()` still applies the diff to its alloc unconditionally (pre-existing behavior); a later block building on an over-cap alloc would hit the fallback recompute and raise uncaught. No current test reaches this.

### Related Issues or PRs

Fixes #3255.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
