### PR TITLE
feat(forks): let development forks inherit exact-fork validity

### DIFF
--- a/docs/filling_tests/filling_tests_dev_fork.md
+++ b/docs/filling_tests/filling_tests_dev_fork.md
@@ -42,7 +42,7 @@ just binary-trie-fork [paths]
 
 A bare invocation fills only the scoped `tests/binary_tree` suite; `just binary-trie-fork tests` instead reinterprets the entire `tests/` tree against `BinaryTree`.
 
-When porting existing tests: `valid_from(...)` markers select `BinaryTree` (it subclasses `Amsterdam`), but `valid_at(...)` silently does not, so a handful of `valid_at`-pinned tests are invisible to the port with no warning at collection time.
+When porting existing tests: `valid_from(...)` markers select `BinaryTree` (it subclasses `Amsterdam`), and `valid_at(...)` markers naming `Amsterdam` — or an EIP that resolves to it — select it too, because the fork is declared with `inherits_exact_fork_validity=True` (it keeps Amsterdam's execution semantics). Tests pinned to earlier forks (e.g. `valid_at("Prague")`) remain excluded, as do `valid_at_transition_to(...)` tests: no transition fork to `BinaryTree` exists.
 
 ## Further Help
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -1092,6 +1092,34 @@ class ValidBefore(ValidityMarker, mutually_exclusive=[ValidUntil]):
         return resulting_set
 
 
+def expand_forks_with_inherited_validity(
+    forks: Set[Fork | TransitionFork],
+) -> Set[Fork | TransitionFork]:
+    """
+    Add every fork that declares `inherits_exact_fork_validity` and
+    whose parent is in `forks` (transitively, so a chain of such forks
+    is followed).
+
+    This lets a development fork that keeps its parent's semantics,
+    such as `BinaryTree` over `Amsterdam`, run tests pinned to the
+    parent with `valid_at`, without naming the development fork in
+    every marker.
+    """
+    expanded = set(forks)
+    changed = True
+    while changed:
+        changed = False
+        for fork in ALL_FORKS:
+            if fork in expanded:
+                continue
+            if not fork.inherits_exact_fork_validity():
+                continue
+            if fork.parent() in expanded:
+                expanded.add(fork)
+                changed = True
+    return expanded
+
+
 class ValidAt(ValidityMarker):
     """
     Marker to specify each fork individually for which the test is valid.
@@ -1111,13 +1139,20 @@ class ValidAt(ValidityMarker):
 
     In this example, the test will only be filled for the London and Cancun
     forks.
+
+    A development fork declared with `inherits_exact_fork_validity=True`
+    is additionally selected wherever its parent fork is: `BinaryTree`
+    keeps Amsterdam's execution semantics, so `valid_at("Amsterdam")`
+    (or an EIP name resolving to Amsterdam) also selects `BinaryTree`.
     """
 
     def _process_with_marker_args(
         self, *fork_args: str
     ) -> Set[Fork | TransitionFork]:
         """Process the fork arguments."""
-        return self.process_fork_arguments(*fork_args)
+        return expand_forks_with_inherited_validity(
+            self.process_fork_arguments(*fork_args)
+        )
 
 
 class ValidAtTransitionTo(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -82,6 +82,46 @@ def test_case(state_test):
         ),
         pytest.param(
             generate_test(
+                valid_at='"London", "Cancun"',
+            ),
+            [],
+            {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_at",
+        ),
+        pytest.param(
+            generate_test(
+                valid_at='"Amsterdam"',
+            ),
+            ["--fork=BinaryTree"],
+            # BinaryTree is declared with
+            # `inherits_exact_fork_validity=True`, so a test pinned to
+            # its parent Amsterdam also fills for it.
+            {"passed": 1, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_at_dev_fork_inherits_validity",
+        ),
+        pytest.param(
+            generate_test(
+                valid_at='"EIP7981"',
+            ),
+            ["--fork=BinaryTree"],
+            # The EIP name resolves to Amsterdam, which BinaryTree
+            # inherits exact-fork validity from.
+            {"passed": 1, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_at_eip_dev_fork_inherits_validity",
+        ),
+        pytest.param(
+            generate_test(
+                valid_at='"Cancun"',
+            ),
+            ["--fork=BinaryTree"],
+            # Inheritance follows the parent link only: BinaryTree's
+            # parent is Amsterdam, so a test pinned to an older fork
+            # stays excluded.
+            {"passed": 0, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_at_dev_fork_older_fork_excluded",
+        ),
+        pytest.param(
+            generate_test(
                 valid_from='"EIP3675"',
                 valid_until='"EIP4844"',
             ),

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -343,6 +343,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     _fork_by_timestamp: ClassVar[bool] = False
     _blob_constants: ClassVar[Dict[str, int]] = {}
     _deployed: ClassVar[bool] = True
+    _inherits_exact_fork_validity: ClassVar[bool] = False
     _enabled_eips: ClassVar[Set[int]] = set()
     _enabling_forks: ClassVar[Set[Type["BaseFork"]]] = set()
 
@@ -362,6 +363,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         ruleset_name: Optional[str] = None,
         fork_by_timestamp: Optional[bool] = None,
         deployed: Optional[bool] = None,
+        inherits_exact_fork_validity: bool = False,
         update_blob_constants: Optional[Dict[str, int]] = None,
         engine_new_payload_version_bump: Optional[bool] = None,
         engine_forkchoice_updated_version_bump: Optional[bool] = None,
@@ -376,6 +378,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         cls._solc_name = solc_name
         cls._ignore = ignore
         cls._bpo_fork = bpo_fork
+        cls._inherits_exact_fork_validity = inherits_exact_fork_validity
         cls._ruleset_name = ruleset_name
         cls._children = set()
         if fork_by_timestamp is None:
@@ -1323,6 +1326,18 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     def ignore(cls) -> bool:
         """Return whether the fork should be ignored during test generation."""
         return cls._ignore
+
+    @classmethod
+    def inherits_exact_fork_validity(cls) -> bool:
+        """
+        Return whether markers that name this fork's parent exactly
+        (`valid_at`) also select this fork.
+
+        Declared per fork with the `inherits_exact_fork_validity` class
+        argument; meant for development forks that keep their parent's
+        semantics, so tests pinned to the parent remain meaningful.
+        """
+        return cls._inherits_exact_fork_validity
 
     @classmethod
     def bpo_fork(cls) -> bool:

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1654,12 +1654,17 @@ class Amsterdam(
 class BinaryTree(
     Amsterdam,
     deployed=False,
+    inherits_exact_fork_validity=True,
 ):
     """
     Experimental EIP-8297 fork: state is committed through the
     Partitioned Binary Tree instead of the Merkle Patricia Trie.
     For testing purposes only. The commitment scheme is selected by
     the spec fork's own imports; the transition tool reflects it.
+
+    The fork keeps Amsterdam's execution semantics, so it inherits
+    exact-fork validity: tests pinned to Amsterdam with `valid_at`
+    also run here.
     """
 
     pass


### PR DESCRIPTION
### Description

Filling against a development fork silently dropped every test pinned with `valid_at`: the marker resolves to literally the named forks, so `BinaryTree` — which subclasses `Amsterdam` and is selected by `valid_from` — never intersected, and the tests were simply not parametrized. This PR makes those tests **fill** rather than merely reporting them as dropped (an earlier revision of this PR implemented reporting only; it was reverted in favor of inclusion).

- A fork can now be declared with `inherits_exact_fork_validity=True` (new `BaseFork.__init_subclass__` class argument + accessor), meaning it keeps its parent's execution semantics, so tests pinned to the parent remain meaningful for it.
- `ValidAt` expands each fork it resolves — named directly or via an EIP name — onto declaring subclass forks, transitively (`expand_forks_with_inherited_validity`).
- `BinaryTree` declares it, so the 14 Amsterdam-pinned `valid_at` usages fill under `--fork BinaryTree` with **zero test-file edits**, and the next development fork is a one-line declaration.

The expansion is deliberately **opt-in per fork** rather than automatic subclass widening (the issue's option 3): unconditional widening would silently pull BPO forks into every `valid_at("Osaka")`-family fill, conflicting with the deliberate `valid_for_bpo_forks` opt-in. Tests pinned to non-ancestor forks (e.g. `valid_at("Prague")`) and `valid_at_transition_to(...)` tests remain excluded — no transition fork to `BinaryTree` exists.

Verified end-to-end: `just binary-trie-fork tests/amsterdam/eip7981_increase_access_list_cost` now fills 357 fixtures including the previously-dropped `valid_at` tests (e.g. `test_access_list_token_calculation[fork_BinaryTree-...]`); before this change the directory filled only its `valid_from` tests.

Tests: adds the first pytester coverage for plain `valid_at` (it previously had none — every `valid_at*` case was `valid_at_transition_to`), covering the positive case, parent inheritance, EIP-name resolution onto the inheriting fork, and non-ancestor exclusion.

### Related Issues or PRs

Fixes #3260.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
