### PR TITLE
chore(8297): Temporarily add more test vectors to isolated pbt tests

### DIFF
--- a/tests/binary_trie/vectors/README.md
+++ b/tests/binary_trie/vectors/README.md
@@ -42,6 +42,7 @@ exceed a JSON-safe integer is hex.
 | `embedding` | object | Tree keys derived for one fixed account. |
 | `chunkify_code` | array | `chunkify_code` inputs and outputs. |
 | `encode_basic_data` | array | Packed account header leaves. |
+| `pbt_state` | array | Whole states and the roots they commit to. |
 
 ### `trie_roots`
 
@@ -133,3 +134,69 @@ the 32-byte packed leaf, laid out big-endian throughout:
 
 The balance field is 16 bytes, so a balance must be less than `2**128`
 to be encodable.
+
+### `pbt_state`
+
+The other sections pin the trie and the embedding primitives
+separately. This one pins their composition: whole Ethereum state to
+root, which is where an embedding mistake actually shows up. The roots
+come from `src/ethereum/state_pbt.py`, the reference state provider
+built on that embedding.
+
+An array of `{name, accounts, root}`.
+
+- `accounts`: an object keyed by the account's 20-byte address, as
+  hex. Order is not significant; the root is a function of the account
+  set alone.
+- `root`: the 32-byte state root of exactly that set of accounts.
+
+Each account value:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `nonce` | number | Account nonce. |
+| `balance` | hex | Account balance, as a `0x` hex string since it can exceed a JSON-safe integer. |
+| `code` | hex | The account's bytecode; `0x` for an account with none. |
+| `code_hash` | hex | `keccak256(code)`, the value of the code-hash leaf. Derived, and repeated here because the overflow chunk keys are content-addressed by it. |
+| `storage` | object | Decimal-string slot number to the slot's 32-byte value. |
+
+Nonces are JSON numbers and every case keeps them at or below
+`2**53 - 1`, the largest integer a JSON number holds exactly. Storage
+slot numbers are object keys in full decimal expansion, matching
+`embedding`'s `storage_slot_keys`, because they range over the whole
+`2**256` space.
+
+Building the state is: for each account, write its basic data leaf
+(`encode_basic_data` over `len(code)`, `nonce`, `balance`), its
+code-hash leaf, one leaf per `chunkify_code` chunk, and one leaf per
+storage slot. Two rules decide what is *not* written, and cases below
+depend on both:
+
+- **Zero is absent.** A leaf whose 32-byte value is all zeros is not
+  stored; it reads back as the zero it stood for. This reaches a
+  storage slot written to zero, a code chunk of 31 zero bytes, and the
+  basic data of an account with no code, zero nonce and zero balance.
+  A `storage` entry with a zero value is therefore still listed in the
+  case, as part of the input a consumer must reproduce the root from,
+  even though no leaf results.
+- **Code is sized, not delimited.** Because a chunk can be absent, the
+  number of chunk leaves does not give the code's length; `code_size`
+  in the basic data leaf does.
+
+The thirteen cases and what each one covers:
+
+| Name | Covers |
+| --- | --- |
+| `empty_state` | No accounts at all. The root is `EMPTY_TRIE_ROOT`, 32 zero bytes, not the hash of anything. |
+| `single_eoa` | One EOA: exactly two leaves, basic data and code hash. |
+| `eoa_zero_nonce_and_balance` | An EOA whose basic data encodes to 32 zero bytes, so only its code-hash leaf exists; that leaf alone is what distinguishes it from an absent account. |
+| `header_code_only` | Code short enough to live entirely in header chunks, with a `PUSH32` spilling across a chunk boundary so a chunk's leading push-data count is non-zero. |
+| `overflow_code_and_boundary_storage` | 129 chunks of code, one past the header, plus storage on both sides of the header boundary. Its root is independently pinned by `tests/binary_trie/test_state_pbt.py::test_embedded_state_root_is_pinned`. |
+| `storage_across_the_header_boundary` | Slots 0, 1, 63 in the header and 64, 255, 256, `2**256 - 1` in the storage zone, each with a distinct value so a swap between any two leaves is detectable. |
+| `zero_storage_slot_is_absent` | Slots declared with a zero value beside a non-zero one; the root is that of the non-zero slot alone. |
+| `full_header_stem` | 128 chunks of code and slots 0-63: every header sub-index the embedding can ever populate, `{0, 1}` and `64`-`255`, and no overflow-zone leaf. |
+| `shared_bytecode_two_accounts` | Two accounts with identical 129-chunk code. Their header chunks are per-account and disjoint; the one overflowing chunk is content-addressed and must land on a single shared leaf, so the state has 261 leaves rather than 262. |
+| `delegation_designator` | An EIP-7702 designator, `0xef0100` followed by an address: 23 bytes, one header chunk, the only protocol-reachable code change on an existing account. |
+| `code_chunks_of_zero_bytes` | 62 zero bytes of code: both chunks are 32 zero bytes and are absent, so the account commits no chunk leaf at all while its `code_size` stays 62. |
+| `max_basic_data_fields` | A balance of `2**128 - 1`, the largest the 16-byte field holds, beside the largest JSON-safe nonce. A balance of `2**128` or more cannot be committed at all. |
+| `random_6_accounts_seed_8297` | Six pseudo-random accounts with mixed code lengths, scattered storage, and full-width balances, as a broad spread over the composition. |

--- a/tests/binary_trie/vectors/dump_vectors.py
+++ b/tests/binary_trie/vectors/dump_vectors.py
@@ -10,9 +10,10 @@ tree and its state embedding.
 The vectors pin the observable outputs of `ethereum.binary_trie`: tree
 roots for a spread of key shapes, the tree keys the embedding derives
 for headers, storage slots and code chunks, `chunkify_code` output, and
-the packed `encode_basic_data` leaf. Client implementations for now should
-vendor the emitted JSON as a fixture rather than re-running this
-script.
+the packed `encode_basic_data` leaf. On top of those primitives they
+pin the composition, whole Ethereum state to root, through
+`ethereum.state_pbt`. Client implementations for now should vendor the
+emitted JSON as a fixture rather than re-running this script.
 
 A pull request does not need to run this. The `Binary Trie Vectors`
 workflow regenerates the JSON on `projects/binary-trie` whenever the
@@ -33,7 +34,7 @@ import json
 import random
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, NamedTuple, Sequence, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes20, Bytes32
 from ethereum_types.numeric import U32, U64, U256, Uint
@@ -50,6 +51,14 @@ from ethereum.binary_trie.embedding import (
 )
 from ethereum.binary_trie.trie import BinaryTrie, root, trie_set
 from ethereum.crypto.hash import keccak256
+from ethereum.state import Account, Address
+from ethereum.state_pbt import (
+    State,
+    set_account,
+    set_storage,
+    state_root,
+    store_code,
+)
 
 VECTORS_PATH = Path(__file__).parent / "binary_trie_vectors.json"
 
@@ -61,8 +70,30 @@ V3 = bytes.fromhex("03" * 32)
 
 ADDRESS20 = bytes.fromhex("00112233445566778899aabbccddeeff00112233")
 
+# Addresses of the `pbt_state` cases. A and B match the ones the
+# spec's own `tests/binary_trie/test_state_pbt.py` uses, so a case
+# lifted from there keeps its address.
+ADDRESS_A = b"\xaa" * 20
+ADDRESS_B = b"\xbb" * 20
+ADDRESS_C = b"\xcc" * 20
+
 PUSH4 = bytes([0x63])
 PUSH32 = bytes([0x7F])
+
+# Code sized to each side of the header/overflow boundary. The header
+# holds chunks 0-127, so 128 chunks is the largest code that stays in
+# it and 129 chunks the smallest that reaches the code zone.
+HEADER_ONLY_CODE = b"\x01" * (31 * 128)
+OVERFLOW_CODE = b"\x01" * (31 * 129)
+
+# PUSH32 at position 30, so its data spills across the first chunk
+# boundary and the second chunk opens with a non-zero push-data count.
+PUSH32_SPILL_CODE = b"\x01" * 30 + PUSH32 + bytes(range(32)) + b"\x01" * 5
+
+# Largest integer a JSON number holds exactly, used as a nonce that
+# stresses the packed field without leaving what a JSON parser can
+# represent.
+MAX_JSON_SAFE_INT = 2**53 - 1
 
 
 def hx(b: bytes) -> str:
@@ -235,6 +266,223 @@ def basic_data_cases() -> List[Dict[str, Any]]:
     ]
 
 
+class AccountSpec(NamedTuple):
+    """
+    Flat description of one account of a `pbt_state` case.
+
+    `storage` is an ordered sequence of `(slot, value)` pairs rather
+    than a mapping, so the order of the emitted JSON object is fixed
+    by the case itself.
+    """
+
+    address: bytes
+    nonce: int = 0
+    balance: int = 0
+    code: bytes = b""
+    storage: Tuple[Tuple[int, int], ...] = ()
+
+
+def pbt_state_case(
+    name: str, accounts: Sequence[AccountSpec]
+) -> Dict[str, Any]:
+    """
+    Build one `pbt_state` case: the flat account description as given,
+    beside the root `ethereum.state_pbt` commits that state to.
+
+    The root comes from `state_pbt`'s own `state_root`, driven through
+    `store_code`, `set_account` and `set_storage`, so what the case
+    pins is the composition of embedding and tree rather than a
+    re-derivation of it here.
+
+    The description is emitted as written, not as the state ends up
+    holding it: a slot declared zero stays in the JSON even though
+    `set_storage` drops it, since a consumer must reach the same root
+    from the same input.
+    """
+    state = State()
+    for spec in accounts:
+        address = Address(spec.address)
+        code_hash = store_code(state, Bytes(spec.code))
+        set_account(
+            state,
+            address,
+            Account(
+                nonce=Uint(spec.nonce),
+                balance=U256(spec.balance),
+                code_hash=code_hash,
+            ),
+        )
+        for slot, value in spec.storage:
+            set_storage(
+                state,
+                address,
+                Bytes32(U256(slot).to_be_bytes32()),
+                U256(value),
+            )
+    return {
+        "name": name,
+        "accounts": {
+            hx(spec.address): {
+                "nonce": spec.nonce,
+                "balance": hex(spec.balance),
+                "code": hx(spec.code),
+                "code_hash": hx(keccak256(Bytes(spec.code))),
+                "storage": {
+                    str(slot): hx(U256(value).to_be_bytes32())
+                    for slot, value in spec.storage
+                },
+            }
+            for spec in accounts
+        },
+        "root": hx(state_root(state)),
+    }
+
+
+def random_state_accounts() -> List[AccountSpec]:
+    """
+    Build a deterministic pseudo-random spread of accounts: mixed code
+    lengths, storage scattered over the whole slot space, and balances
+    and nonces filling their packed fields.
+
+    Slots are deduplicated because they become JSON object keys, and
+    drawn from `1` upwards because a zero value is a deletion.
+    """
+    rng = random.Random(8297)
+    specs = []
+    for _ in range(6):
+        address = bytes(rng.randrange(256) for _ in range(20))
+        code_length = rng.choice([0, 1, 31, 32, 100])
+        code = bytes(rng.randrange(256) for _ in range(code_length))
+        storage: Dict[int, int] = {}
+        while len(storage) < rng.randrange(4):
+            storage[rng.randrange(2**256)] = rng.randrange(1, 2**256)
+        specs.append(
+            AccountSpec(
+                address=address,
+                nonce=rng.randrange(2**32),
+                balance=rng.randrange(2**128),
+                code=code,
+                storage=tuple(storage.items()),
+            )
+        )
+    return specs
+
+
+def pbt_state_cases() -> List[Dict[str, Any]]:
+    """
+    Build the whole-state cases: flat state descriptions and the roots
+    `ethereum.state_pbt` commits them to.
+
+    Between them they cover both sides of every boundary the embedding
+    draws, the two ways a leaf collapses to absence, and the sharing of
+    content-addressed overflow code.
+    """
+    boundary_slots = (0, 1, 63, 64, 255, 256, 2**256 - 1)
+    return [
+        pbt_state_case("empty_state", []),
+        pbt_state_case(
+            "single_eoa",
+            [AccountSpec(address=ADDRESS_A, nonce=3, balance=10**18)],
+        ),
+        pbt_state_case(
+            "eoa_zero_nonce_and_balance",
+            [AccountSpec(address=ADDRESS_A)],
+        ),
+        pbt_state_case(
+            "header_code_only",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=1,
+                    balance=2**64,
+                    code=PUSH32_SPILL_CODE,
+                )
+            ],
+        ),
+        pbt_state_case(
+            "overflow_code_and_boundary_storage",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=1,
+                    code=OVERFLOW_CODE,
+                    storage=((63, 1), (64, 2), (256, 3)),
+                )
+            ],
+        ),
+        pbt_state_case(
+            "storage_across_the_header_boundary",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=1,
+                    storage=tuple(
+                        (slot, index + 1)
+                        for index, slot in enumerate(boundary_slots)
+                    ),
+                )
+            ],
+        ),
+        pbt_state_case(
+            "zero_storage_slot_is_absent",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=1,
+                    storage=((7, 0), (8, 9), (300, 0)),
+                )
+            ],
+        ),
+        pbt_state_case(
+            "full_header_stem",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=1,
+                    code=HEADER_ONLY_CODE,
+                    storage=tuple((slot, slot + 1) for slot in range(64)),
+                )
+            ],
+        ),
+        pbt_state_case(
+            "shared_bytecode_two_accounts",
+            [
+                AccountSpec(
+                    address=ADDRESS_A, nonce=1, balance=1, code=OVERFLOW_CODE
+                ),
+                AccountSpec(
+                    address=ADDRESS_B, nonce=2, balance=2, code=OVERFLOW_CODE
+                ),
+            ],
+        ),
+        pbt_state_case(
+            "delegation_designator",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=1,
+                    code=b"\xef\x01\x00" + ADDRESS_C,
+                )
+            ],
+        ),
+        pbt_state_case(
+            "code_chunks_of_zero_bytes",
+            [AccountSpec(address=ADDRESS_A, nonce=1, code=b"\x00" * 62)],
+        ),
+        pbt_state_case(
+            "max_basic_data_fields",
+            [
+                AccountSpec(
+                    address=ADDRESS_A,
+                    nonce=MAX_JSON_SAFE_INT,
+                    balance=2**128 - 1,
+                )
+            ],
+        ),
+        pbt_state_case("random_6_accounts_seed_8297", random_state_accounts()),
+    ]
+
+
 def build_vectors() -> Dict[str, Any]:
     """
     Build the full vector set, without the `source_commit` stamp.
@@ -248,6 +496,7 @@ def build_vectors() -> Dict[str, Any]:
         "embedding": embedding_cases(),
         "chunkify_code": chunkify_cases(),
         "encode_basic_data": basic_data_cases(),
+        "pbt_state": pbt_state_cases(),
     }
 
 


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
