### PR TITLE
fix(zkevm): preserve extra data in environment and update block artifact construction

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -843,7 +843,7 @@ test_module_execution_witness = textwrap.dedent(
         contract = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.STOP)
         state_test(env=Environment(),
                     pre=pre, post={contract: Account(storage={0: 1})},
-                    tx=Transaction(to=contract, gas_limit=100_000, sender=pre.fund_eoa()))
+                    tx=Transaction(to=contract, sender=pre.fund_eoa()))
     """
 )
 
@@ -868,7 +868,7 @@ test_module_execution_witness_skip_stateless = textwrap.dedent(
     ) -> None:
         contract = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.STOP)
         sender = pre.fund_eoa()
-        tx = Transaction(to=contract, gas_limit=100_000, sender=sender)
+        tx = Transaction(to=contract, sender=sender)
 
         blockchain_test(
             pre=pre,
@@ -1049,7 +1049,7 @@ test_module_execution_witness_rlp_modifier = textwrap.dedent(
     ) -> None:
         contract = pre.deploy_contract(code=Op.SSTORE(0, 1) + Op.STOP)
         sender = pre.fund_eoa()
-        tx = Transaction(to=contract, gas_limit=100_000, sender=sender)
+        tx = Transaction(to=contract, sender=sender)
 
         blockchain_test(
             pre=pre,

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -457,6 +457,9 @@ class Block(Header):
         new_env_values["gas_limit"] = (
             self.gas_limit or env.parent_gas_limit or Environment().gas_limit
         )
+        new_env_values["extra_data"] = (
+            self.extra_data if self.extra_data is not None else Bytes(b"")
+        )
         if not isinstance(self.base_fee_per_gas, Removable):
             new_env_values["base_fee_per_gas"] = self.base_fee_per_gas
         new_env_values["withdrawals"] = self.withdrawals
@@ -1027,9 +1030,7 @@ class BlockchainTest(BaseTest):
             ),
             blob_gas_used=blob_gas_used,
             transactions_trie=Transaction.list_root(txs),
-            extra_data=(
-                block.extra_data if block.extra_data is not None else b""
-            ),
+            extra_data=env.extra_data,
             slot_number=slot_number_value,
             fork=fork,
         )

--- a/packages/testing/src/execution_testing/specs/blockchain_stateless.py
+++ b/packages/testing/src/execution_testing/specs/blockchain_stateless.py
@@ -484,7 +484,9 @@ def execution_witness_implicit_codes_for_block(
     if not addresses:
         return []
 
-    effective_alloc = alloc.get() if isinstance(alloc, LazyAlloc) else alloc
+    effective_alloc = (
+        alloc.materialize() if isinstance(alloc, LazyAlloc) else alloc
+    )
 
     codes: List[Bytes] = []
     seen: set[Bytes] = set()

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -207,7 +207,7 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
         if fork.header_slot_number_required() and self.slot_number is None:
             updated_values["slot_number"] = 0
 
-        return self.copy(**updated_values)
+        return self.copy(extra_data=self.extra_data, **updated_values)
 
     def __hash__(self) -> int:
         """Hashes the environment object."""

--- a/packages/testing/src/execution_testing/test_types/tests/test_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_types.py
@@ -15,6 +15,7 @@ from execution_testing.base_types import (
     to_json,
 )
 from execution_testing.base_types.pydantic import CopyValidateModel
+from execution_testing.forks import Amsterdam
 
 from ..account_types import EOA, Alloc
 from ..block_types import (
@@ -951,6 +952,15 @@ def test_model_copy(model: CopyValidateModel) -> None:
     """Test that the copy method returns a correct copy of the model."""
     assert to_json(model.copy()) == to_json(model)
     assert model.copy().model_fields_set == model.model_fields_set
+
+
+def test_environment_fork_requirements_preserve_extra_data() -> None:
+    """Preserve extra data while applying fork requirements."""
+    env = Environment(extra_data=b"current block")
+
+    assert (
+        env.set_fork_requirements(Amsterdam).extra_data == env.extra_data
+    )
 
 
 @pytest.mark.parametrize(

--- a/packages/testing/src/execution_testing/test_types/tests/test_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_types.py
@@ -958,9 +958,7 @@ def test_environment_fork_requirements_preserve_extra_data() -> None:
     """Preserve extra data while applying fork requirements."""
     env = Environment(extra_data=b"current block")
 
-    assert (
-        env.set_fork_requirements(Amsterdam).extra_data == env.extra_data
-    )
+    assert env.set_fork_requirements(Amsterdam).extra_data == env.extra_data
 
 
 @pytest.mark.parametrize(

--- a/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py
@@ -15,6 +15,7 @@ from ethereum.state import Root
 from ..blocks import Block, Header
 from ..fork import EMPTY_OMMER_HASH
 from ..requests import compute_requests_hash
+from ..transactions import LegacyTransaction, decode_transaction
 from .requests import ExecutionRequests, encode_execution_requests
 from .types import ExecutionPayload
 
@@ -84,6 +85,18 @@ def _payload_header(
     )
 
 
+def _payload_transaction_to_block_transaction(
+    encoded_transaction: Bytes,
+) -> LegacyTransaction | Bytes:
+    """Return the canonical block representation of a payload transaction."""
+    if not encoded_transaction or encoded_transaction[0] < 0xC0:
+        return encoded_transaction
+
+    transaction = decode_transaction(encoded_transaction)
+    assert isinstance(transaction, LegacyTransaction)
+    return transaction
+
+
 def _payload_block(
     execution_payload: ExecutionPayload,
     parent_beacon_block_root: Root,
@@ -100,7 +113,10 @@ def _payload_block(
 
     return Block(
         header=header,
-        transactions=execution_payload.transactions,
+        transactions=tuple(
+            _payload_transaction_to_block_transaction(encoded_transaction)
+            for encoded_transaction in execution_payload.transactions
+        ),
         ommers=(),
         withdrawals=execution_payload.withdrawals,
     )

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -249,6 +249,12 @@ class ForkLoad:
         return self._module("blocks").Block
 
     @property
+    def block_rlp_size_limit(self) -> int | None:
+        """Return the maximum RLP-encoded block size, if defined."""
+        limit = getattr(self._module("fork"), "MAX_RLP_BLOCK_SIZE", None)
+        return int(limit) if limit is not None else None
+
+    @property
     def decode_receipt(self) -> Any:
         """decode_receipt function of the fork."""
         return self._module("blocks").decode_receipt

--- a/src/ethereum_spec_tools/evm_tools/t8n/result.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/result.py
@@ -166,7 +166,11 @@ def _build_stateless_artifacts(
         gas_limit=block_env.block_gas_limit,
         gas_used=Uint(result_arguments["gas_used"]),
         timestamp=block_env.time,
-        extra_data=Bytes(b""),
+        extra_data=Bytes(
+            t8n.env.extra_data
+            if "extra_data" in t8n.env.model_fields_set
+            else b""
+        ),
         prev_randao=block_env.prev_randao,
         nonce=Bytes8(b"\x00" * 8),
         base_fee_per_gas=block_env.base_fee_per_gas,
@@ -209,7 +213,18 @@ def _build_stateless_artifacts(
         stateless_output_bytes
     )
 
-    if t8n.rejected_transactions or block_exception is not None:
+    # The transition phase executes the block body before the finalized block
+    # exists, so block-level RLP validation is first observable here.
+    block_rlp_size_limit = t8n.fork.block_rlp_size_limit
+    block_rlp_limit_exceeded = (
+        block_rlp_size_limit is not None
+        and len(rlp.encode(block)) > block_rlp_size_limit
+    )
+    if (
+        t8n.rejected_transactions
+        or block_exception is not None
+        or block_rlp_limit_exceeded
+    ):
         assert not stateless_output.successful_validation
     else:
         assert stateless_output.successful_validation, (

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_public_keys.py
@@ -1,8 +1,13 @@
 """Stateless input transaction public-key tests."""
 
 import pytest
-from coincurve import ecdsa
-from coincurve.keys import PublicKey
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import (
+    Prehashed,
+    encode_dss_signature,
+)
 from execution_testing import (
     Account,
     Address,
@@ -15,6 +20,7 @@ from execution_testing import (
 from execution_testing.test_types.execution_witness.modifiers import (
     replace_public_key_at,
 )
+from spec256k1 import PublicKey
 
 pytestmark = pytest.mark.valid_from("Amsterdam")
 
@@ -146,7 +152,6 @@ def _recover_public_key(
     public_key = PublicKey.from_signature_and_message(
         signature,
         signing_hash,
-        hasher=None,
     )
     return Bytes(public_key.format(compressed=False))
 
@@ -194,14 +199,17 @@ def _signature_verifies(
     signing_hash: bytes,
 ) -> bool:
     """Return whether ``public_key`` verifies the transaction signature."""
-    compact_signature = int(tx.r).to_bytes(32, byteorder="big") + int(
-        tx.s
-    ).to_bytes(32, byteorder="big")
-    der_signature = ecdsa.cdata_to_der(
-        ecdsa.deserialize_compact(compact_signature)
+    der_signature = encode_dss_signature(int(tx.r), int(tx.s))
+    verifying_key = ec.EllipticCurvePublicKey.from_encoded_point(
+        ec.SECP256K1(),
+        bytes(public_key),
     )
-    return PublicKey(bytes(public_key)).verify(
-        der_signature,
-        signing_hash,
-        hasher=None,
-    )
+    try:
+        verifying_key.verify(
+            der_signature,
+            signing_hash,
+            ec.ECDSA(Prehashed(hashes.SHA256())),
+        )
+    except InvalidSignature:
+        return False
+    return True

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -21,6 +21,9 @@ from ethereum.forks.amsterdam.execution_engine.types import (
     ExecutionPayload,
     NewPayloadRequest,
 )
+from ethereum.forks.amsterdam.execution_engine.validation_helpers import (
+    _payload_block,
+)
 from ethereum.forks.amsterdam.fork_types import Bloom
 from ethereum.forks.amsterdam.stateless import (
     ExecutionWitness,
@@ -265,6 +268,55 @@ class TestBuildStatelessInput:
         payload = stateless_input.new_payload_request.execution_payload
         assert payload.transactions == (Bytes(rlp.encode(tx)),)
         assert stateless_input.public_keys == ()
+
+    def test_payload_round_trip_preserves_legacy_transaction_rlp(self) -> None:
+        """Preserve canonical legacy transaction RLP through the payload."""
+        tx = LegacyTransaction(
+            nonce=U256(0),
+            gas_price=Uint(1),
+            gas=Uint(21_000),
+            to=Address(b"\x00" * 20),
+            value=U256(0),
+            data=Bytes(b"\x00" * 200_000),
+            v=U256(27),
+            r=U256(0),
+            s=U256(1),
+        )
+        block = Block(
+            header=_make_header(),
+            transactions=(tx,),
+            ommers=(),
+            withdrawals=(),
+        )
+        execution_requests = ExecutionRequests(
+            deposits=(),
+            withdrawals=(),
+            consolidations=(),
+            builder_deposits=(),
+            builder_exits=(),
+        )
+        stateless_input = build_stateless_input(
+            block,
+            execution_witness=ExecutionWitness(
+                state=(),
+                codes=(),
+                headers=(),
+            ),
+            execution_requests=execution_requests,
+            block_access_list=[],
+            chain_id=U64(1),
+        )
+
+        rebuilt_block = _payload_block(
+            stateless_input.new_payload_request.execution_payload,
+            block.header.parent_beacon_block_root,
+            execution_requests,
+        )
+
+        assert rebuilt_block.transactions == (tx,)
+        assert rlp.encode(rebuilt_block.transactions) == rlp.encode(
+            block.transactions
+        )
 
 
 class TestSerializeStatelessInput:


### PR DESCRIPTION
### Description
Fix Amsterdam stateless fixture generation so the stateless guest validates the same block header—and therefore the same RLP-encoded block- as the blockchain fixture.

I discovered this while rebasing `projects/zkevm` onto the base commit shared with [**tests-glamsterdam-devnet@v8.0.0**](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v8.0.0) and `forks/amsterdam`.

In particular, `test_block_at_rlp_size_limit_boundary` exposed an inconsistency between the generated blockchain fixture and its embedded stateless input.

The fixture block contained the intended `extraData`, producing blocks at:

- `MAX_RLP_BLOCK_SIZE - 1`
- `MAX_RLP_BLOCK_SIZE`
- `MAX_RLP_BLOCK_SIZE + 1`

However, stateless artifact construction omitted `extraData`.

As a result, all three stateless inputs represented the same 8,388,596-byte block and returned `successful_validation=True`, including the `MAX_RLP_BLOCK_SIZE + 1` case that expects `RLP_BLOCK_LIMIT_EXCEEDED`.

Result:
| Boundary | Stateless block RLP size | `successful_validation` |
|---|---:|---:|
| Limit − 1 byte | 8,388,607 | `True` |
| Exact limit | 8,388,608 | `True` |
| Limit + 1 byte | 8,388,609 | `False` |

The existing test expectation remains unchanged: blocks at or below the limit validate successfully, while the block one byte above the limit fails stateless validation.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
