### PR TITLE
feat(spec-specs,tests): apply revised EIP-8038 gas values

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8038.py
@@ -42,7 +42,7 @@ class EIP8038(BaseFork):
 
         warm_access = 100
         cold_account_access = 3_000
-        cold_storage_access = 3_000
+        cold_storage_access = 2_100
         storage_write = 10_000
         # The framework models the SSTORE write via the compound
         # COLD_STORAGE_WRITE (access + write), so preserve the invariant
@@ -50,8 +50,8 @@ class EIP8038(BaseFork):
         cold_storage_write = cold_storage_access + storage_write
         # Surcharge for the first write to an account leaf, introduced as a
         # standalone parameter by this repricing.
-        account_write = 8_000
-        create_access = 11_000
+        account_write = 9_000
+        create_access = account_write + cold_account_access
         # ecRecover stays PRECOMPILE_ECRECOVER (3000) until EIP-7904 lands.
         execution_per_auth_base_cost = (
             1_616 + 3_000 + cold_account_access + 2 * warm_access
@@ -66,7 +66,7 @@ class EIP8038(BaseFork):
             COLD_STORAGE_WRITE=cold_storage_write,
             ACCOUNT_WRITE=account_write,
             CALL_VALUE=account_write + 2_300,  # ACCOUNT_WRITE + CALL_STIPEND
-            REFUND_STORAGE_CLEAR=12_480,
+            REFUND_STORAGE_CLEAR=11_616,
             TX_ACCESS_LIST_ADDRESS=cold_account_access - warm_access,
             TX_ACCESS_LIST_STORAGE_KEY=cold_storage_access - warm_access,
             BLOCK_ACCESS_LIST_ITEM=2000,

--- a/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_iterating_bytecode.py
@@ -433,7 +433,20 @@ def test_state_reservoir_lets_tx_gas_exceed_execution_gas_limit_cap() -> None:
     fork = CustomAmsterdam.with_tx_gas_limit_cap(cap)
     bytecode = IteratingBytecode(iterating=Op.SSTORE(0, 1))
 
-    total_iterations = (cap // Op.SSTORE(0, 1).execution_cost(fork=fork)) - 1
+    # Largest iteration count the tx splitter accepts for a single tx:
+    # execution gas plus the subcall reserve must fit the cap, derived
+    # from the helper's own (linear) cost model.
+    cost_one = bytecode.tx_execution_gas_cost_by_iteration_count(
+        fork=fork, iteration_count=1
+    )
+    per_iteration = (
+        bytecode.tx_execution_gas_cost_by_iteration_count(
+            fork=fork, iteration_count=2
+        )
+        - cost_one
+    )
+    reserve = bytecode.iterating_subcall_reserve(fork=fork)
+    total_iterations = 1 + (cap - reserve - cost_one) // per_iteration
     counts = list(
         bytecode.tx_iterations_by_total_iteration_count(
             fork=fork, total_iterations=total_iterations

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -80,20 +80,20 @@ class GasCosts:
     # Access
     WARM_ACCESS: Final[Uint] = Uint(100)
     COLD_ACCOUNT_ACCESS: Final[Uint] = Uint(3000)
-    COLD_STORAGE_ACCESS: Final[Uint] = Uint(3000)
+    COLD_STORAGE_ACCESS: Final[Uint] = Uint(2100)
 
     # Storage
     STORAGE_WRITE: Final[Uint] = Uint(10000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(10300)  # ACCOUNT_WRITE + CALL_STIPEND
+    CALL_VALUE: Final[Uint] = Uint(11300)  # ACCOUNT_WRITE + CALL_STIPEND
     CALL_STIPEND: Final[Uint] = Uint(2300)
-    ACCOUNT_WRITE: Final[Uint] = Uint(8000)
+    ACCOUNT_WRITE: Final[Uint] = Uint(9000)
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: Final[Uint] = Uint(200)
     CODE_INIT_PER_WORD: Final[Uint] = Uint(2)
-    CREATE_ACCESS: Final[Uint] = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
+    CREATE_ACCESS: Final[Uint] = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS
 
     # Utility
     ZERO: Final[Uint] = Uint(0)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/spec.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/spec.py
@@ -13,5 +13,5 @@ class ReferenceSpec:
 
 ref_spec_2780 = ReferenceSpec(
     git_path="EIPS/eip-2780.md",
-    version="04dd54c2e7ec1f408cf4a150d5c1aa43573bd025",
+    version="36c409e70e4117fc708f02da7d58cd7e5d075f7c",
 )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -114,18 +114,23 @@ def test_bal_sstore_and_oog(
     """
     Test BAL recording with SSTORE at various OOG boundaries and success.
 
-    The slot read is recorded in the BAL only once the cold access cost
-    is covered. Post-repricing that cost (COLD_STORAGE_ACCESS) exceeds the
-    EIP-2200 stipend, so clearing the stipend sentry alone no longer
-    records the read. The stipend + 1 case pins the old sentry boundary
-    against regressions to sentry-gated recording.
+    ``SSTORE`` clears two gates before the write cost: the EIP-2200
+    stipend sentry (``gas_left`` must exceed ``CALL_STIPEND``) and the
+    cold access charge (``COLD_STORAGE_ACCESS``). The slot read is
+    recorded in the BAL only once both are cleared, so the recording
+    gate is the higher of the two — which one dominates depends on the
+    fork's schedule, and the expectations below are derived from that
+    relation rather than assuming it.
 
-    1. OOG at the stipend, below the access cost -> no BAL changes
-    2. OOG above the stipend but below access cost (probed at
-       stipend + 1 and access cost - 1) -> no BAL changes
-    3. OOG at the access cost, write unaffordable -> storage read in BAL
-    4. OOG at exact gas minus 1 -> storage read in BAL
-    5. exact gas (success) -> storage write in BAL
+    1. OOG at the stipend -> sentry fires, no BAL changes
+    2. OOG at stipend + 1 -> sentry cleared by one; the read is
+       recorded only if this also covers the access cost
+    3. OOG at access cost - 1 -> below one of the two gates, no BAL
+       changes
+    4. OOG at the recording gate, write unaffordable -> storage read in
+       BAL
+    5. OOG at exact gas minus 1 -> storage read in BAL
+    6. exact gas (success) -> storage write in BAL
     """
     alice = pre.fund_eoa()
 
@@ -145,26 +150,29 @@ def test_bal_sstore_and_oog(
     push_code = Op.PUSH1(0x42) + Op.PUSH1(0x01)
     push_cost = push_code.gas_cost(fork)
 
-    # CALL_STIPEND is a threshold check, not a gas cost. The cold access
-    # cost gates the read into the BAL and now exceeds the stipend.
+    # CALL_STIPEND is a threshold check, not a gas cost. The read is
+    # recorded once the sentry is cleared and the access cost is
+    # affordable, so the recording gate is the higher of the two.
     stipend = fork.gas_costs().CALL_STIPEND
     cold_access = fork.gas_costs().COLD_STORAGE_ACCESS
+    read_gate = max(cold_access, stipend + 1)
 
     if out_of_gas_at == OutOfGasAt.EIP_2200_STIPEND:
-        # gas_left == stipend: fails the check, below the access cost.
+        # gas_left == stipend: fails the sentry check outright.
         tx_gas_limit = intrinsic_gas_cost + push_cost + stipend
     elif out_of_gas_at == OutOfGasAt.EIP_2200_STIPEND_PLUS_1:
-        # gas_left == stipend + 1: clears the stipend sentry by one but
-        # cannot afford the access, so OOG before the read.
+        # gas_left == stipend + 1: clears the stipend sentry by one;
+        # whether the access is then affordable depends on the schedule.
         tx_gas_limit = intrinsic_gas_cost + push_cost + stipend + 1
     elif out_of_gas_at == OutOfGasAt.ABOVE_STIPEND_BELOW_ACCESS:
-        # gas_left == access cost - 1: clears the stipend sentry but
-        # cannot afford the access, so OOG before the read.
+        # gas_left == access cost - 1: cannot afford the access (when
+        # the stipend dominates, the sentry fires first instead), so
+        # OOG before the read either way.
         tx_gas_limit = intrinsic_gas_cost + push_cost + cold_access - 1
     elif out_of_gas_at == OutOfGasAt.ACCESS_COVERED_OOG_ON_WRITE:
-        # gas_left == access cost: access affordable (read recorded),
-        # then OOG on the write cost.
-        tx_gas_limit = intrinsic_gas_cost + push_cost + cold_access
+        # gas_left == read gate: sentry cleared and access affordable
+        # (read recorded), then OOG on the write cost.
+        tx_gas_limit = intrinsic_gas_cost + push_cost + read_gate
     elif out_of_gas_at == OutOfGasAt.EXACT_GAS_MINUS_1:
         # fail at the final charge at exact gas - 1 (boundary condition).
         tx_gas_limit = intrinsic_gas_cost + full_cost - 1
@@ -178,11 +186,14 @@ def test_bal_sstore_and_oog(
         gas_limit=tx_gas_limit,
     )
 
-    # The read is recorded only once the access cost is covered: the
+    # The read is recorded only once the recording gate is covered: the
     # frame reaches the implicit SLOAD before any later OOG.
     expect_storage_read = out_of_gas_at in (
         OutOfGasAt.ACCESS_COVERED_OOG_ON_WRITE,
         OutOfGasAt.EXACT_GAS_MINUS_1,
+    ) or (
+        out_of_gas_at == OutOfGasAt.EIP_2200_STIPEND_PLUS_1
+        and stipend + 1 >= cold_access
     )
     expect_storage_write = out_of_gas_at is None
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -51,6 +51,6 @@ class Spec:
     # EIP-8038 then repriced them.
     EXECUTION_GAS_CREATE = 12000
     # Total execution intrinsic per EIP-7702 authorization:
-    # ACCOUNT_WRITE (9000) + EXECUTION_PER_AUTH_BASE_COST (7816).
+    # ACCOUNT_WRITE + EXECUTION_PER_AUTH_BASE_COST.
     PER_AUTH_BASE_COST = 16816
     GAS_COLD_STORAGE_WRITE = 12100

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -49,8 +49,8 @@ class Spec:
 
     # Execution gas constants. EIP-8037 separated state from execution gas;
     # EIP-8038 then repriced them.
-    EXECUTION_GAS_CREATE = 11000
+    EXECUTION_GAS_CREATE = 12000
     # Total execution intrinsic per EIP-7702 authorization:
-    # ACCOUNT_WRITE (8000) + EXECUTION_PER_AUTH_BASE_COST (7816).
-    PER_AUTH_BASE_COST = 15816
-    GAS_COLD_STORAGE_WRITE = 13000
+    # ACCOUNT_WRITE (9000) + EXECUTION_PER_AUTH_BASE_COST (7816).
+    PER_AUTH_BASE_COST = 16816
+    GAS_COLD_STORAGE_WRITE = 12100

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/spec.py
@@ -12,5 +12,5 @@ class ReferenceSpec:
 
 
 ref_spec_8038 = ReferenceSpec(
-    "EIPS/eip-8038.md", "a8862ae6653a12a2989b64a50eca5334cfe8b3cb"
+    "EIPS/eip-8038.md", "fc2322854d047ba1fd6e3ae9e61fb7a915535cb7"
 )

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_call_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_call_gas.py
@@ -8,7 +8,7 @@ dimension:
 - account access costs ``COLD_ACCOUNT_ACCESS`` (3,000) cold or
   ``WARM_ACCESS`` (100) warm;
 - a positive value transfer adds ``CALL_VALUE`` (``ACCOUNT_WRITE`` +
-  ``CALL_STIPEND`` = 10,300), charged only by ``CALL``/``CALLCODE``;
+  ``CALL_STIPEND`` = 11,300), charged only by ``CALL``/``CALLCODE``;
 - a value transfer to a *new* account additionally creates the account,
   whose ``GAS_NEW_ACCOUNT`` charge is the EIP-8037 *state* dimension and
   is asserted via the block header ``max(execution, state)`` accounting,
@@ -127,7 +127,7 @@ def test_call_value_alive_target_gas(
     """
     Measure call cost with value transfer to an already-alive target.
 
-    ``CALL``/``CALLCODE`` add ``CALL_VALUE`` (10,300) on top of the
+    ``CALL``/``CALLCODE`` add ``CALL_VALUE`` (11,300) on top of the
     access cost, where ``CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND``.
     ``DELEGATECALL``/``STATICCALL`` never transfer value, so they pay
     only the access cost regardless of any value argument. No new

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_call_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_call_gas.py
@@ -5,10 +5,10 @@ Tests for the EIP-8038 [State Access Gas Cost Increase](https://eips.ethereum.or
 Under EIP-8038 the call opcodes are repriced in their *execution* gas
 dimension:
 
-- account access costs ``COLD_ACCOUNT_ACCESS`` (3,000) cold or
-  ``WARM_ACCESS`` (100) warm;
+- account access costs ``COLD_ACCOUNT_ACCESS`` cold or
+  ``WARM_ACCESS`` warm;
 - a positive value transfer adds ``CALL_VALUE`` (``ACCOUNT_WRITE`` +
-  ``CALL_STIPEND`` = 11,300), charged only by ``CALL``/``CALLCODE``;
+  ``CALL_STIPEND``), charged only by ``CALL``/``CALLCODE``;
 - a value transfer to a *new* account additionally creates the account,
   whose ``GAS_NEW_ACCOUNT`` charge is the EIP-8037 *state* dimension and
   is asserted via the block header ``max(execution, state)`` accounting,
@@ -86,8 +86,8 @@ def test_call_access_gas(
     """
     Measure the access cost of every call opcode with no value transfer.
 
-    EIP-8038 charges ``COLD_ACCOUNT_ACCESS`` (3,000) cold and
-    ``WARM_ACCESS`` (100) warm for all four call opcodes.
+    EIP-8038 charges ``COLD_ACCOUNT_ACCESS`` cold and ``WARM_ACCESS``
+    warm for all four call opcodes.
     """
     target = pre.deploy_contract(Op.STOP)
 
@@ -127,13 +127,13 @@ def test_call_value_alive_target_gas(
     """
     Measure call cost with value transfer to an already-alive target.
 
-    ``CALL``/``CALLCODE`` add ``CALL_VALUE`` (11,300) on top of the
+    ``CALL``/``CALLCODE`` add ``CALL_VALUE`` on top of the
     access cost, where ``CALL_VALUE = ACCOUNT_WRITE + CALL_STIPEND``.
     ``DELEGATECALL``/``STATICCALL`` never transfer value, so they pay
     only the access cost regardless of any value argument. No new
     account is created (the target is alive), so no state gas is charged.
 
-    The ``CALL_STIPEND`` (2,300) is forwarded to the callee; with a
+    The ``CALL_STIPEND`` is forwarded to the callee; with a
     ``STOP`` callee it is unused and returned, so the gas *consumed* by
     the caller is ``access + ACCOUNT_WRITE`` while the *charged* schedule
     is ``access + CALL_VALUE``. Both are asserted.
@@ -212,7 +212,8 @@ def test_callcode_value_to_nonexistent_no_new_account(
     ``CALLCODE`` runs the callee's code in the caller's own context, so
     the value never leaves the caller and no beneficiary account is
     created. The block ``gas_used`` therefore equals the execution tx
-    cost with ``CALL_VALUE`` but with no 183,600 state-gas component.
+    cost with ``CALL_VALUE`` but with no ``GAS_NEW_ACCOUNT`` state-gas
+    component.
     """
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
 
@@ -270,10 +271,9 @@ def test_call_value_to_new_account_seam(
     Verify the CALL value-to-new-account execution/state seam.
 
     The EIP-8038 *execution* dimension is ``COLD_ACCOUNT_ACCESS`` +
-    ``CALL_VALUE`` = 13,300; the account creation charge
-    ``GAS_NEW_ACCOUNT`` (183,600) lands in the EIP-8037 *state*
-    dimension. The block header reflects ``max(execution, state)``, which
-    is dominated by the state charge.
+    ``CALL_VALUE``; the account creation charge ``GAS_NEW_ACCOUNT``
+    lands in the EIP-8037 *state* dimension. The block header reflects
+    ``max(execution, state)``, which is dominated by the state charge.
     """
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
 
@@ -344,8 +344,8 @@ def test_call_to_delegated_target_double_access(
     The spec applies the delegation surcharge to every call opcode
     (``CALL``/``CALLCODE``/``DELEGATECALL``/``STATICCALL``), so each
     reads two account leaves: the target's leaf and the delegation's
-    leaf. Each is charged independently as ``WARM_ACCESS`` (100) or
-    ``COLD_ACCOUNT_ACCESS`` (3,000) by warmth. ``DELEGATECALL`` and
+    leaf. Each is charged independently as ``WARM_ACCESS`` or
+    ``COLD_ACCOUNT_ACCESS`` by warmth. ``DELEGATECALL`` and
     ``STATICCALL`` carry no value but still pay the delegation
     surcharge.
     """
@@ -440,7 +440,7 @@ def test_call_self_is_warm(
     Verify a self-call is warm: the executing account is pre-warmed.
 
     The current target is in the accessed-addresses set on message
-    entry, so a call to ``ADDRESS`` pays only ``WARM_ACCESS`` (100).
+    entry, so a call to ``ADDRESS`` pays only ``WARM_ACCESS``.
     """
     # `Op.ADDRESS` is the call's address argument, embedded inside the
     # runnable call; the self address is in the accessed set on entry, so
@@ -474,7 +474,7 @@ def test_call_forwarded_gas_63_64(
     cold access charge.
 
     A wrapper performs a cold, zero-value ``CALL`` requesting maximum
-    gas. The spec charges the repriced ``COLD_ACCOUNT_ACCESS`` (3,000)
+    gas. The spec charges the repriced ``COLD_ACCOUNT_ACCESS``
     up front and only then forwards ``floor(63/64 * gas_left)`` to the
     child. The wrapper is handed an exact budget so that, net of the
     access charge, ``gas_left`` equals ``child_execution * 64 // 63``;
@@ -549,7 +549,7 @@ def test_account_warmth_reverts_on_subcall_revert(
     ``DELEGATECALL`` (so the warmed address belongs to the shared
     accessed-addresses set) then ``REVERT``s. Back in the outer frame,
     that same address's first ``BALANCE`` is cold again and is charged
-    ``COLD_ACCOUNT_ACCESS`` (3,000), proving the warm-address set is
+    ``COLD_ACCOUNT_ACCESS``, proving the warm-address set is
     rolled back on revert (mirrors the ``SLOAD`` warmth-revert case for
     the account dimension).
     """
@@ -601,7 +601,7 @@ def test_call_to_double_delegated_target_single_hop(
     an EOA delegated to ``final`` (C), a code-bearing account. A cold
     ``CALL`` to ``target`` reads exactly two account leaves -- the
     target's and its delegation's -- and is charged
-    ``2 * COLD_ACCOUNT_ACCESS`` (6,000). The chain is not followed a
+    ``2 * COLD_ACCOUNT_ACCESS``. The chain is not followed a
     second hop, so ``final``'s leaf is not charged. Both the framework
     opcode model and a runtime ``CodeGasMeasure`` confirm the value.
     """
@@ -647,7 +647,7 @@ def test_call_precompile_is_warm(
     Verify a call to a precompile is warm from the start.
 
     Precompiles are part of the accessed-addresses set from the start of
-    every transaction, so a call to one pays only ``WARM_ACCESS`` (100).
+    every transaction, so a call to one pays only ``WARM_ACCESS``.
     The identity precompile (address 4) is used as the target.
     """
     identity_precompile = Address(4)
@@ -676,18 +676,19 @@ def test_call_value_stipend_is_usable(
     value: int,
 ) -> None:
     """
-    The ``CALL`` value-transfer stipend (``CALL_STIPEND`` = 2,300) is
+    The ``CALL`` value-transfer stipend ``CALL_STIPEND`` is
     forwarded to the callee and usable for execution.
 
     The caller forwards ``gas=0``, so the callee receives only the stipend
-    (2,300) when a positive value is sent, and nothing otherwise. The
-    callee runs a small amount of work (well under 2,300 gas) then stops:
+    when a positive value is sent, and nothing otherwise. The
+    callee runs a small amount of work (well under the stipend) then
+    stops:
     with the stipend the call succeeds (returns 1); without value (no
     stipend, zero forwarded gas) the work runs out of gas and the call
     fails (returns 0). This proves the stipend is not merely returned but
     is spendable by the callee.
     """
-    # ~250 gas of cheap work: comfortably within the 2,300 stipend, far
+    # ~250 gas of cheap work: comfortably within the stipend, far
     # above the zero gas forwarded when no value (so no stipend) is sent.
     work = (Op.PUSH1(0) + Op.POP) * 50 + Op.STOP
     callee = pre.deploy_contract(code=work)

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_create_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_create_gas.py
@@ -4,7 +4,7 @@ Tests for the EIP-8038 [State Access Gas Cost Increase](https://eips.ethereum.or
 
 Under EIP-8038 the contract-creation opcodes are repriced in their
 *execution* gas dimension to ``CREATE_ACCESS`` (``ACCOUNT_WRITE`` +
-``COLD_STORAGE_ACCESS`` = 11,000), on top of which the EIP-3860 init
+``COLD_ACCOUNT_ACCESS`` = 12,000), on top of which the EIP-3860 init
 code word cost (2 per word) and, for ``CREATE2`` only, an additional
 keccak word cost (6 per word) are charged. The new-account creation
 and per-byte code deposit charges are the EIP-8037 *state* dimension,
@@ -68,7 +68,7 @@ def test_create_execution_gas(
     """
     Measure the execution gas of CREATE/CREATE2 and assert the schedule.
 
-    The EIP-8038 *execution* dimension is ``CREATE_ACCESS`` (11,000) plus
+    The EIP-8038 *execution* dimension is ``CREATE_ACCESS`` (12,000) plus
     the EIP-3860 init code word cost (2 per word) plus, for ``CREATE2``
     only, an additional keccak word cost (6 per word). The EIP-8037
     account-creation state gas is excluded by subtracting

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_create_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_create_gas.py
@@ -4,9 +4,9 @@ Tests for the EIP-8038 [State Access Gas Cost Increase](https://eips.ethereum.or
 
 Under EIP-8038 the contract-creation opcodes are repriced in their
 *execution* gas dimension to ``CREATE_ACCESS`` (``ACCOUNT_WRITE`` +
-``COLD_ACCOUNT_ACCESS`` = 12,000), on top of which the EIP-3860 init
-code word cost (2 per word) and, for ``CREATE2`` only, an additional
-keccak word cost (6 per word) are charged. The new-account creation
+``COLD_ACCOUNT_ACCESS``), on top of which the EIP-3860 init code
+word cost and, for ``CREATE2`` only, an additional keccak word cost
+are charged. The new-account creation
 and per-byte code deposit charges are the EIP-8037 *state* dimension,
 covered in
 ``eip8037_state_creation_gas_cost_increase/test_state_gas_create.py``.
@@ -68,9 +68,9 @@ def test_create_execution_gas(
     """
     Measure the execution gas of CREATE/CREATE2 and assert the schedule.
 
-    The EIP-8038 *execution* dimension is ``CREATE_ACCESS`` (12,000) plus
-    the EIP-3860 init code word cost (2 per word) plus, for ``CREATE2``
-    only, an additional keccak word cost (6 per word). The EIP-8037
+    The EIP-8038 *execution* dimension is ``CREATE_ACCESS`` plus the
+    EIP-3860 init code word cost plus, for ``CREATE2`` only, an
+    additional keccak word cost. The EIP-8037
     account-creation state gas is excluded by subtracting
     ``create_state_gas(0)``.
     """
@@ -393,7 +393,7 @@ def test_aborted_create_does_not_warm_address(
     balance for the endowment, or nonce overflow), the would-be address
     is never added to the accessed-addresses set. A subsequent
     ``BALANCE`` of that address is therefore charged the full
-    ``COLD_ACCOUNT_ACCESS`` (3,000), not ``WARM_ACCESS`` (100).
+    ``COLD_ACCOUNT_ACCESS``, not ``WARM_ACCESS``.
     """
     init_code = Op.STOP
     init_code_bytes = bytes(init_code)

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_exact_balance_no_fallback.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_exact_balance_no_fallback.py
@@ -83,7 +83,7 @@ def test_access_list_no_fallback(
     below the Amsterdam intrinsic.
 
     EIP-8038 raises ``TX_ACCESS_LIST_ADDRESS`` (2400 -> 2900) and
-    ``TX_ACCESS_LIST_STORAGE_KEY`` (1900 -> 2900). A client reusing the
+    ``TX_ACCESS_LIST_STORAGE_KEY`` (1900 -> 2000). A client reusing the
     old per-address/per-key constants would compute an intrinsic smaller
     by ``num_addresses * addr_delta + num_keys * key_delta``; with the
     sender funded to the wei, that fallback must not slip through.

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_exact_balance_no_fallback.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_exact_balance_no_fallback.py
@@ -82,8 +82,8 @@ def test_access_list_no_fallback(
     Reject an access-list transaction whose ``gas_limit`` is one gas
     below the Amsterdam intrinsic.
 
-    EIP-8038 raises ``TX_ACCESS_LIST_ADDRESS`` (2400 -> 2900) and
-    ``TX_ACCESS_LIST_STORAGE_KEY`` (1900 -> 2000). A client reusing the
+    EIP-8038 raises ``TX_ACCESS_LIST_ADDRESS`` and
+    ``TX_ACCESS_LIST_STORAGE_KEY``. A client reusing the
     old per-address/per-key constants would compute an intrinsic smaller
     by ``num_addresses * addr_delta + num_keys * key_delta``; with the
     sender funded to the wei, that fallback must not slip through.
@@ -218,7 +218,7 @@ def test_cold_account_access_no_fallback(
 
     Under EIP-2780 every non-create, non-self transaction pays one
     ``COLD_ACCOUNT_ACCESS`` in its intrinsic for touching the recipient;
-    EIP-8038 raises that constant (2600 -> 3000). A client reusing the
+    EIP-8038 raises that constant. A client reusing the
     old ``COLD_ACCOUNT_ACCESS`` would compute an intrinsic smaller by the
     per-access delta, and with the sender funded to the wei that fallback
     must not execute.

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_fork_transition.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_fork_transition.py
@@ -218,7 +218,7 @@ def test_call_value_cost_at_transition(
     fork: Fork,
 ) -> None:
     """
-    ``CALL_VALUE`` rises across the boundary (9000 -> 10300 on mainnet,
+    ``CALL_VALUE`` rises across the boundary (9000 -> 11300 on mainnet,
     becoming ``ACCOUNT_WRITE + CALL_STIPEND``). The constant transition
     is asserted from the derived schedules while a value-bearing ``CALL``
     is exercised in both blocks to prove it still succeeds in each
@@ -262,8 +262,8 @@ def test_create_base_cost_at_transition(
 ) -> None:
     """
     The ``CREATE`` execution base cost changes across the boundary
-    (``OPCODE_CREATE_BASE``: 32000 -> 11000 on mainnet, redefined as
-    ``ACCOUNT_WRITE + COLD_STORAGE_ACCESS``). The constant transition is
+    (``OPCODE_CREATE_BASE``: 32000 -> 12000 on mainnet, redefined as
+    ``ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS``). The constant transition is
     asserted from the derived schedules and a ``CREATE`` is exercised in
     both blocks to prove it still deploys.
     """
@@ -312,7 +312,7 @@ def test_selfdestruct_account_write_at_transition(
     """
     ``SELFDESTRUCT`` gains an ``ACCOUNT_WRITE`` charge when it sends a
     positive balance to an empty account, which is a new EIP-8038
-    parameter (0 -> 8000 on mainnet). The constant transition is
+    parameter (0 -> 9000 on mainnet). The constant transition is
     asserted from the derived schedules and a value-bearing
     ``SELFDESTRUCT`` to a fresh beneficiary is exercised in both blocks
     to prove it still runs.

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_fork_transition.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_fork_transition.py
@@ -121,7 +121,7 @@ def test_cold_account_access_at_transition(
 ) -> None:
     """
     ``BALANCE`` of a cold account costs ``COLD_ACCOUNT_ACCESS``, which
-    rises across the Amsterdam boundary (2600 -> 3000 on mainnet). The
+    rises across the Amsterdam boundary. The
     same opcode is measured before and after; each block asserts its
     regime's derived cost.
     """
@@ -167,9 +167,9 @@ def test_ext_code_surcharge_at_transition(
     """
     The EIP-8038 ``EXT*`` code-read surcharge appears at the fork. The
     surcharge equals ``EXTCODESIZE`` minus ``BALANCE`` at equal warmth:
-    it is zero before the fork and one ``WARM_ACCESS`` (100) after. That
+    it is zero before the fork and one ``WARM_ACCESS`` after. That
     comparison is computed from the opcode model. On-chain, each block
-    measures only a cold ``EXTCODESIZE`` (2600 before, 3100 after): its
+    measures only a cold ``EXTCODESIZE``: its
     rise reflects the surcharge on top of the cold-access repricing, and
     ``BALANCE`` is never executed.
     """
@@ -218,8 +218,8 @@ def test_call_value_cost_at_transition(
     fork: Fork,
 ) -> None:
     """
-    ``CALL_VALUE`` rises across the boundary (9000 -> 11300 on mainnet,
-    becoming ``ACCOUNT_WRITE + CALL_STIPEND``). The constant transition
+    ``CALL_VALUE`` rises across the boundary, becoming
+    ``ACCOUNT_WRITE + CALL_STIPEND``. The constant transition
     is asserted from the derived schedules while a value-bearing ``CALL``
     is exercised in both blocks to prove it still succeeds in each
     regime.
@@ -262,7 +262,7 @@ def test_create_base_cost_at_transition(
 ) -> None:
     """
     The ``CREATE`` execution base cost changes across the boundary
-    (``OPCODE_CREATE_BASE``: 32000 -> 12000 on mainnet, redefined as
+    (``OPCODE_CREATE_BASE`` is redefined as
     ``ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS``). The constant transition is
     asserted from the derived schedules and a ``CREATE`` is exercised in
     both blocks to prove it still deploys.
@@ -312,7 +312,7 @@ def test_selfdestruct_account_write_at_transition(
     """
     ``SELFDESTRUCT`` gains an ``ACCOUNT_WRITE`` charge when it sends a
     positive balance to an empty account, which is a new EIP-8038
-    parameter (0 -> 9000 on mainnet). The constant transition is
+    parameter. The constant transition is
     asserted from the derived schedules and a value-bearing
     ``SELFDESTRUCT`` to a fresh beneficiary is exercised in both blocks
     to prove it still runs.

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py
@@ -5,19 +5,18 @@ Tests for the EIP-8038 [State Access Gas Cost Increase](https://eips.ethereum.or
 Under EIP-8038 ``SELFDESTRUCT`` is charged, in its *execution* gas
 dimension:
 
-- ``OPCODE_SELFDESTRUCT_BASE`` (5,000);
-- a ``COLD_ACCOUNT_ACCESS`` (3,000) surcharge when the beneficiary is
+- ``OPCODE_SELFDESTRUCT_BASE``;
+- a ``COLD_ACCOUNT_ACCESS`` surcharge when the beneficiary is
   cold (a warm beneficiary adds nothing — SELFDESTRUCT has no
   ``WARM_ACCESS`` surcharge);
-- a net-new ``ACCOUNT_WRITE`` (9,000) when a positive balance is sent to
-  an empty (or non-existent) beneficiary, replacing the legacy combined
-  25,000 execution account-creation cost.
+- a net-new ``ACCOUNT_WRITE`` when a positive balance is sent to
+  an empty (or non-existent) beneficiary, replacing the legacy
+  combined execution account-creation cost.
 
-So ``execution = 5,000 + (3,000 if cold) + (9,000 if creating)``: 14,000
-warm / 17,000 cold when a new beneficiary is created, 5,000 warm / 8,000
-cold otherwise.
+So ``execution = OPCODE_SELFDESTRUCT_BASE + (COLD_ACCOUNT_ACCESS if
+cold) + (ACCOUNT_WRITE if creating)``.
 
-The beneficiary account-creation charge ``GAS_NEW_ACCOUNT`` (183,600) is
+The beneficiary account-creation charge ``GAS_NEW_ACCOUNT`` is
 the EIP-8037 *state* dimension (`charge_state_gas` in the spec), covered
 in ``eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py``.
 
@@ -31,7 +30,7 @@ The framework opcode-gas model splits the two dimensions for
 ``SELFDESTRUCT`` exactly as the spec does: ``ACCOUNT_WRITE`` is charged
 as execution gas and ``GAS_NEW_ACCOUNT`` as state gas, so
 ``Op.SELFDESTRUCT(account_new=True).execution_cost(fork)`` is the execution
-charge (17,000 cold / 14,000 warm) and ``.state_cost(fork)`` is
+charge and ``.state_cost(fork)`` is
 ``GAS_NEW_ACCOUNT``. These tests assert the execution dimension and verify
 account-creation via balances; the state dimension is owned by
 ``eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py``.
@@ -94,7 +93,7 @@ def test_selfdestruct_new_beneficiary_execution_gas(
 
     The destructor has a non-zero balance and targets an empty,
     non-existent beneficiary, so the net-new ``ACCOUNT_WRITE`` applies:
-    ``execution = 5,000 + access + 9,000`` (14,000 warm, 17,000 cold). The
+    ``execution = OPCODE_SELFDESTRUCT_BASE + access + ACCOUNT_WRITE``. The
     creation gas ``GAS_NEW_ACCOUNT`` is charged on the state axis (the
     EIP-8037 suite asserts it); here it is funded from the reservoir and
     the value transfer to the new beneficiary confirms the path.
@@ -145,8 +144,9 @@ def test_selfdestruct_alive_beneficiary_no_account_write(
     SELFDESTRUCT to an already-alive beneficiary charges no ACCOUNT_WRITE.
 
     The beneficiary already exists, so no account is created: execution =
-    ``5,000 + (3,000 if cold)`` (5,000 warm, 8,000 cold) and no state gas is
-    charged. The block header reflects the pure execution consumption.
+    ``OPCODE_SELFDESTRUCT_BASE + (COLD_ACCOUNT_ACCESS if cold)`` and no
+    state gas is charged. The block header reflects the pure execution
+    consumption.
     """
     beneficiary = pre.fund_eoa(amount=1)  # alive
 
@@ -212,8 +212,9 @@ def test_selfdestruct_codebearing_zero_balance_beneficiary_no_account_write(
     The beneficiary is alive because it has code, not balance: it holds a
     zero balance but a non-empty code (``Op.STOP``), so EIP-161 emptiness
     does not apply and no account is created when a positive balance is
-    sent to it. Execution = ``5,000 + (3,000 if cold)`` (5,000 warm, 8,000
-    cold) with no ACCOUNT_WRITE and no state gas — distinct from the
+    sent to it. Execution = ``OPCODE_SELFDESTRUCT_BASE +
+    (COLD_ACCOUNT_ACCESS if cold)`` with no ACCOUNT_WRITE and no state
+    gas — distinct from the
     alive-via-balance case, which exercises the same path through a
     different liveness source.
     """
@@ -280,7 +281,8 @@ def test_selfdestruct_zero_balance_no_account_write(
     SELFDESTRUCT with a zero-balance destructor charges no ACCOUNT_WRITE.
 
     No value is transferred, so even a non-existent beneficiary is not
-    created: execution = ``5,000 + access`` and no state gas is charged.
+    created: execution = ``OPCODE_SELFDESTRUCT_BASE + access`` and no
+    state gas is charged.
     """
     beneficiary = Address(0xDEAD)  # non-existent, but no value sent
 
@@ -345,8 +347,8 @@ def test_selfdestruct_self_or_precompile_beneficiary(
 
     The executing account is in the accessed set on entry (self), and
     precompiles are pre-warmed from the start, so neither pays a cold
-    surcharge: execution = ``5,000`` (warm base, no ``WARM_ACCESS``) with no
-    state gas.
+    surcharge: execution = ``OPCODE_SELFDESTRUCT_BASE`` (warm base, no
+    ``WARM_ACCESS``) with no state gas.
 
     The destructor balance is chosen so no account creation occurs: self
     is alive (sending to itself never creates), and the precompile case
@@ -418,10 +420,11 @@ def test_selfdestruct_oog_boundary(
     gas and one short.
 
     The destructor sends value to an empty beneficiary, charging
-    ``5,000 + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`` (17,000) in execution gas
-    and ``GAS_NEW_ACCOUNT`` in state gas. The child CALL frame has no state
-    reservoir of its own, so the state gas spills into the forwarded
-    execution gas and the frame needs its full ``gas_cost`` total. Forwarding
+    ``OPCODE_SELFDESTRUCT_BASE + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE``
+    in execution gas and ``GAS_NEW_ACCOUNT`` in state gas. The child
+    CALL frame has no state reservoir of its own, so the state gas
+    spills into the forwarded execution gas and the frame needs its
+    full ``gas_cost`` total. Forwarding
     exactly that total lets the SELFDESTRUCT succeed (CALL returns 1); one
     gas short OOGs (CALL returns 0) before the value transfer, so the
     beneficiary is never created.
@@ -483,7 +486,8 @@ def test_same_tx_created_selfdestruct_self_burn(
     to ITSELF: the originator is created in this transaction so it is
     deleted, and because a same-tx-created contract holding balance is
     alive, ``account_new`` is false for the self-beneficiary —
-    ``execution = 5,000`` (warm self, no ``ACCOUNT_WRITE``) and no
+    ``execution = OPCODE_SELFDESTRUCT_BASE`` (warm self, no
+    ``ACCOUNT_WRITE``) and no
     SELFDESTRUCT state gas.
 
     EIP-8246 removes the SELFDESTRUCT burn, so the self-send is a no-op:
@@ -562,8 +566,9 @@ def test_same_tx_created_selfdestruct_to_fresh_beneficiary(
     A creation transaction whose initcode SELFDESTRUCTs the new contract
     to a fresh ``Address(0xDEAD)``: the fresh, non-existent beneficiary
     receives a positive balance, so ``account_new`` is true —
-    ``execution = 5,000 + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`` (17,000
-    cold) plus a beneficiary ``NEW_ACCOUNT`` on the state axis. The
+    ``execution = OPCODE_SELFDESTRUCT_BASE + COLD_ACCOUNT_ACCESS +
+    ACCOUNT_WRITE`` plus a beneficiary ``NEW_ACCOUNT`` on the state
+    axis. The
     beneficiary creation charge keys on the beneficiary, while the
     originator (created in this transaction) is still deleted: a
     ``Transfer`` log is emitted (not a ``Burn``).

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py
@@ -9,12 +9,12 @@ dimension:
 - a ``COLD_ACCOUNT_ACCESS`` (3,000) surcharge when the beneficiary is
   cold (a warm beneficiary adds nothing — SELFDESTRUCT has no
   ``WARM_ACCESS`` surcharge);
-- a net-new ``ACCOUNT_WRITE`` (8,000) when a positive balance is sent to
+- a net-new ``ACCOUNT_WRITE`` (9,000) when a positive balance is sent to
   an empty (or non-existent) beneficiary, replacing the legacy combined
   25,000 execution account-creation cost.
 
-So ``execution = 5,000 + (3,000 if cold) + (8,000 if creating)``: 13,000
-warm / 16,000 cold when a new beneficiary is created, 5,000 warm / 8,000
+So ``execution = 5,000 + (3,000 if cold) + (9,000 if creating)``: 14,000
+warm / 17,000 cold when a new beneficiary is created, 5,000 warm / 8,000
 cold otherwise.
 
 The beneficiary account-creation charge ``GAS_NEW_ACCOUNT`` (183,600) is
@@ -31,7 +31,7 @@ The framework opcode-gas model splits the two dimensions for
 ``SELFDESTRUCT`` exactly as the spec does: ``ACCOUNT_WRITE`` is charged
 as execution gas and ``GAS_NEW_ACCOUNT`` as state gas, so
 ``Op.SELFDESTRUCT(account_new=True).execution_cost(fork)`` is the execution
-charge (16,000 cold / 13,000 warm) and ``.state_cost(fork)`` is
+charge (17,000 cold / 14,000 warm) and ``.state_cost(fork)`` is
 ``GAS_NEW_ACCOUNT``. These tests assert the execution dimension and verify
 account-creation via balances; the state dimension is owned by
 ``eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py``.
@@ -94,7 +94,7 @@ def test_selfdestruct_new_beneficiary_execution_gas(
 
     The destructor has a non-zero balance and targets an empty,
     non-existent beneficiary, so the net-new ``ACCOUNT_WRITE`` applies:
-    ``execution = 5,000 + access + 8,000`` (13,000 warm, 16,000 cold). The
+    ``execution = 5,000 + access + 9,000`` (14,000 warm, 17,000 cold). The
     creation gas ``GAS_NEW_ACCOUNT`` is charged on the state axis (the
     EIP-8037 suite asserts it); here it is funded from the reservoir and
     the value transfer to the new beneficiary confirms the path.
@@ -418,7 +418,7 @@ def test_selfdestruct_oog_boundary(
     gas and one short.
 
     The destructor sends value to an empty beneficiary, charging
-    ``5,000 + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`` (16,000) in execution gas
+    ``5,000 + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`` (17,000) in execution gas
     and ``GAS_NEW_ACCOUNT`` in state gas. The child CALL frame has no state
     reservoir of its own, so the state gas spills into the forwarded
     execution gas and the frame needs its full ``gas_cost`` total. Forwarding
@@ -562,7 +562,7 @@ def test_same_tx_created_selfdestruct_to_fresh_beneficiary(
     A creation transaction whose initcode SELFDESTRUCTs the new contract
     to a fresh ``Address(0xDEAD)``: the fresh, non-existent beneficiary
     receives a positive balance, so ``account_new`` is true —
-    ``execution = 5,000 + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`` (16,000
+    ``execution = 5,000 + COLD_ACCOUNT_ACCESS + ACCOUNT_WRITE`` (17,000
     cold) plus a beneficiary ``NEW_ACCOUNT`` on the state axis. The
     beneficiary creation charge keys on the beneficiary, while the
     originator (created in this transaction) is still deleted: a

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sload_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sload_gas.py
@@ -2,7 +2,7 @@
 Tests for [EIP-8038: State Access Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-8038).
 
 Covers the EIP-8038 ``SLOAD`` repricing: a cold storage slot read costs
-``COLD_STORAGE_ACCESS`` (3000) and a warm read costs ``WARM_SLOAD`` (100).
+``COLD_STORAGE_ACCESS`` (2100) and a warm read costs ``WARM_SLOAD`` (100).
 A slot is warmed either by listing it in the transaction access list or by
 a prior in-frame access; warmth acquired inside a sub-call that REVERTs is
 discarded, so a subsequent read in the outer frame is cold again.
@@ -65,7 +65,7 @@ def test_sload_gas(
     Measure the gas of a ``SLOAD`` on a slot that is either cold or
     pre-warmed via the transaction access list.
 
-    A cold read must cost ``COLD_STORAGE_ACCESS`` (3000); a warm read
+    A cold read must cost ``COLD_STORAGE_ACCESS`` (2100); a warm read
     must cost ``WARM_SLOAD`` (100).
     """
     slot = 0x42
@@ -155,7 +155,7 @@ def test_sload_warmth_reverts_on_subcall_revert(
     warmed ``(address, slot)`` pair belongs to the outer account) then
     ``REVERT``s. Back in the outer frame, that same slot's first
     ``SLOAD`` is cold again and is charged ``COLD_STORAGE_ACCESS``
-    (3000), proving the warm-slot set is rolled back on revert.
+    (2100), proving the warm-slot set is rolled back on revert.
     """
     slot = 0x42
     cold_gas = Op.SLOAD(key_warm=False).gas_cost(fork)

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sload_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sload_gas.py
@@ -2,7 +2,7 @@
 Tests for [EIP-8038: State Access Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-8038).
 
 Covers the EIP-8038 ``SLOAD`` repricing: a cold storage slot read costs
-``COLD_STORAGE_ACCESS`` (2100) and a warm read costs ``WARM_SLOAD`` (100).
+``COLD_STORAGE_ACCESS`` and a warm read costs ``WARM_SLOAD``.
 A slot is warmed either by listing it in the transaction access list or by
 a prior in-frame access; warmth acquired inside a sub-call that REVERTs is
 discarded, so a subsequent read in the outer frame is cold again.
@@ -65,8 +65,8 @@ def test_sload_gas(
     Measure the gas of a ``SLOAD`` on a slot that is either cold or
     pre-warmed via the transaction access list.
 
-    A cold read must cost ``COLD_STORAGE_ACCESS`` (2100); a warm read
-    must cost ``WARM_SLOAD`` (100).
+    A cold read must cost ``COLD_STORAGE_ACCESS``; a warm read must
+    cost ``WARM_SLOAD``.
     """
     slot = 0x42
     expected_gas = Op.SLOAD(key_warm=warm).gas_cost(fork)
@@ -103,7 +103,7 @@ def test_sload_warm_after_prior_touch(
 ) -> None:
     """
     A first ``SLOAD`` on a cold slot warms it; the second in-frame
-    ``SLOAD`` of the same slot is charged ``WARM_SLOAD`` (100).
+    ``SLOAD`` of the same slot is charged ``WARM_SLOAD``.
 
     Slot 0 records the cold first read and slot 1 the warm second read.
     """
@@ -154,8 +154,8 @@ def test_sload_warmth_reverts_on_subcall_revert(
     An inner contract ``SLOAD``s the slot via ``DELEGATECALL`` (so the
     warmed ``(address, slot)`` pair belongs to the outer account) then
     ``REVERT``s. Back in the outer frame, that same slot's first
-    ``SLOAD`` is cold again and is charged ``COLD_STORAGE_ACCESS``
-    (2100), proving the warm-slot set is rolled back on revert.
+    ``SLOAD`` is cold again and is charged ``COLD_STORAGE_ACCESS``,
+    proving the warm-slot set is rolled back on revert.
     """
     slot = 0x42
     cold_gas = Op.SLOAD(key_warm=False).gas_cost(fork)

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_gas.py
@@ -151,13 +151,13 @@ def test_sstore_cold_then_warm_same_slot(
 ) -> None:
     """
     A first ``SSTORE`` on a cold slot warms it; the second in-frame
-    ``SSTORE`` of the same slot is charged only ``WARM_SLOAD`` (100).
+    ``SSTORE`` of the same slot is charged only ``WARM_SLOAD``.
 
     The slot starts non-zero (original 1) and is left unlisted, so the
     first write is cold and is its first change (original == current !=
-    new), costing ``COLD_STORAGE_ACCESS + STORAGE_WRITE`` (2100 + 10000).
+    new), costing ``COLD_STORAGE_ACCESS + STORAGE_WRITE``.
     That write warms the slot, so the second write -- which moves the slot
-    again without being a first change -- costs only ``WARM_SLOAD`` (100),
+    again without being a first change -- costs only ``WARM_SLOAD``,
     with no further ``STORAGE_WRITE``. Slot 0 records the cold first write
     and slot 1 the warm second write; the data slot keeps its final value.
     """

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_gas.py
@@ -155,7 +155,7 @@ def test_sstore_cold_then_warm_same_slot(
 
     The slot starts non-zero (original 1) and is left unlisted, so the
     first write is cold and is its first change (original == current !=
-    new), costing ``COLD_STORAGE_ACCESS + STORAGE_WRITE`` (3000 + 10000).
+    new), costing ``COLD_STORAGE_ACCESS + STORAGE_WRITE`` (2100 + 10000).
     That write warms the slot, so the second write -- which moves the slot
     again without being a first change -- costs only ``WARM_SLOAD`` (100),
     with no further ``STORAGE_WRITE``. Slot 0 records the cold first write

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_refunds.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_refunds.py
@@ -15,14 +15,14 @@ This module covers the EIP-8038 *execution* ``SSTORE`` refund schedule via
 the transaction receipt's ``cumulative_gas_used``:
 
 * Clearing a slot whose original value is non-zero grants
-  ``REFUND_STORAGE_CLEAR`` (11616) to ``refund_counter`` (no EIP-8037
+  ``REFUND_STORAGE_CLEAR`` to ``refund_counter`` (no EIP-8037
   state refund, since no state was created).
 * Clearing then re-setting the same non-zero-original slot nets a zero
   refund: the clear grant is reversed (``refund -= REFUND_STORAGE_CLEAR``)
   exactly when ``original != 0 and current == 0`` and a non-zero value is
   written back.
 * Restoring a non-zero-original slot to its original value refunds the
-  write cost ``STORAGE_WRITE`` (10000).
+  write cost ``STORAGE_WRITE``.
 * The applied refund is capped at ``gas_used // 5`` (EIP-3529 quotient).
 
 All refunds use a non-zero original so the state-creation refund owned by
@@ -80,7 +80,7 @@ def test_sstore_clear_grants_refund(
     Clearing a non-zero-original slot grants ``REFUND_STORAGE_CLEAR``.
 
     Enough unrelated gas is burned so the EIP-3529 quotient cap
-    (``gas_used // 5``) does not bind, letting the full 11616 refund be
+    (``gas_used // 5``) does not bind, letting the full clear refund be
     observed in ``cumulative_gas_used``. The non-zero original means no
     EIP-8037 state refund participates.
     """
@@ -174,7 +174,7 @@ def test_sstore_restore_nonzero_refunds_write(
     Restoring a non-zero-original slot refunds the write cost.
 
     The slot is changed (charging ``STORAGE_WRITE``) then restored to its
-    original non-zero value, refunding ``STORAGE_WRITE`` (10000). Gas is
+    original non-zero value, refunding ``STORAGE_WRITE``. Gas is
     burned so the quotient cap does not bind and the full refund is
     observable.
     """

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_refunds.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_sstore_refunds.py
@@ -15,7 +15,7 @@ This module covers the EIP-8038 *execution* ``SSTORE`` refund schedule via
 the transaction receipt's ``cumulative_gas_used``:
 
 * Clearing a slot whose original value is non-zero grants
-  ``REFUND_STORAGE_CLEAR`` (12480) to ``refund_counter`` (no EIP-8037
+  ``REFUND_STORAGE_CLEAR`` (11616) to ``refund_counter`` (no EIP-8037
   state refund, since no state was created).
 * Clearing then re-setting the same non-zero-original slot nets a zero
   refund: the clear grant is reversed (``refund -= REFUND_STORAGE_CLEAR``)
@@ -80,7 +80,7 @@ def test_sstore_clear_grants_refund(
     Clearing a non-zero-original slot grants ``REFUND_STORAGE_CLEAR``.
 
     Enough unrelated gas is burned so the EIP-3529 quotient cap
-    (``gas_used // 5``) does not bind, letting the full 12480 refund be
+    (``gas_used // 5``) does not bind, letting the full 11616 refund be
     observed in ``cumulative_gas_used``. The non-zero original means no
     EIP-8037 state refund participates.
     """


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Applies the revised EIP-8038 values from ethereum/EIPs#12083:
> `COLD_STORAGE_ACCESS` returns to 2,100 (unchanged from Osaka) and `ACCOUNT_WRITE` rises to 9,000. The derived parameters follow: `CALL_VALUE` 11,300, `CREATE_ACCESS` 12,000, `REFUND_STORAGE_CLEAR` 11,616, `TX_ACCESS_LIST_STORAGE_KEY` 2,000 (`TX_ACCESS_LIST_ADDRESS` stays 2,900).

Also fixes a missed spec bug where the `CREATE_ACCESS` derivation to `ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS` per the EIP (it summed `COLD_STORAGE_ACCESS`, hidden as both cold costs were 3,000).

Updates the framework gas model in lockstep, drops hardcoded gas values from the test docstrings (constant names only, so prose cannot go stale on future repricings), and bumps the EIP-8038/EIP-2780 ref-spec pins.


### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
ethereum/EIPs#12083

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.giphy.com%2Fmedia%2FZdlSqZuzzMB1JT3nwT%2Fgiphy.gif&f=1&nofb=1&ipt=b9fefd1450157fae745c3bdecc71e4a0afc35084d6e07ce183a4502ada65d215)