### PR TITLE
feat(tests): add EIP-2780 coverage gap tests

### DIFF
--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
@@ -5,6 +5,7 @@ from enum import Enum, auto
 
 from execution_testing import (
     EOA,
+    AccessList,
     Account,
     Address,
     Alloc,
@@ -16,7 +17,7 @@ from execution_testing import (
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
 
-EOA_INITIAL_BALANCE = 100
+EOA_INITIAL_BALANCE = 1
 NULL_ADDRESS = Address(0)
 
 RECIPIENT_TYPES_NON_CREATE = [
@@ -186,7 +187,10 @@ def build_authorization(
 
 
 def authorization_transaction_cost(
-    fork: Fork, authorization_list: list[AuthorizationTuple]
+    fork: Fork,
+    authorization_list: list[AuthorizationTuple],
+    *,
+    access_list: list[AccessList] | None = None,
 ) -> int:
     """
     Return the exact gas a value-free type-4 transaction to a plain
@@ -199,6 +203,7 @@ def authorization_transaction_cost(
     ``writes_delegation`` / ``first_write`` annotations.
     """
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
         recipient_type=RecipientType.CONTRACT,
         authorization_list_or_count=authorization_list,
         return_cost_deducted_prior_execution=True,

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
@@ -7,6 +7,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Fork,
+    Op,
     RecipientType,
     StateTestFiller,
     Transaction,
@@ -18,7 +19,11 @@ from execution_testing import (
 from ...prague.eip7623_increase_calldata_cost.helpers import (
     find_floor_cost_threshold,
 )
-from .helpers import EOA_INITIAL_BALANCE
+from .helpers import (
+    EOA_INITIAL_BALANCE,
+    AuthorizationAction,
+    build_authorization,
+)
 from .spec import ref_spec_2780
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
@@ -320,6 +325,116 @@ def test_calldata_floor_contract_creation(
         post = {
             sender: Account(nonce=1),
             created: Account(nonce=1, balance=value, code=b""),
+        }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        pytest.param("floor_binds", id="floor_binds"),
+        pytest.param(
+            "below_floor",
+            id="below_floor_rejected",
+            marks=pytest.mark.exception_test,
+        ),
+    ],
+)
+def test_calldata_floor_with_authorizations(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    outcome: str,
+) -> None:
+    """
+    A data-heavy type-4 transaction whose calldata floor exceeds the
+    full authorization total: the intrinsic plus the authorization's
+    top-frame execution and state charges.
+
+    Authorization tuples add no floor tokens, so the floor must be
+    grown past the total by calldata alone.
+
+    - ``floor_binds``: ``gas_used`` pins to the floor. The
+      authorization's ``ACCOUNT_WRITE`` execution gas and ``AUTH_BASE``
+      state gas are masked by the binding floor while the delegation
+      still lands on the authority.
+    - ``below_floor``: a gas limit one short of the floor still covers
+      the intrinsic, so the rejection is pinned to the floor check,
+      before ``set_delegation`` runs; the authority is untouched.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.deploy_contract(code=Op.STOP)
+    scenario = build_authorization(
+        pre, AuthorizationAction.SETS_NEW_DELEGATION
+    )
+    authorization_list = [scenario.authorization]
+
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    floor_calc = fork.transaction_data_floor_cost_calculator()
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        recipient_type=RecipientType.CONTRACT,
+        authorizations=authorization_list,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.CONTRACT,
+        authorizations=authorization_list,
+    )
+
+    def total(byte_count: int) -> int:
+        return (
+            intrinsic_calc(
+                calldata=b"\x00" * byte_count,
+                recipient_type=RecipientType.CONTRACT,
+                authorization_list_or_count=authorization_list,
+                return_cost_deducted_prior_execution=True,
+            )
+            + top_frame_gas
+            + top_frame_state_gas
+        )
+
+    def floor(byte_count: int) -> int:
+        return floor_calc(
+            data=b"\x00" * byte_count,
+            recipient_type=RecipientType.CONTRACT,
+        )
+
+    threshold = find_floor_cost_threshold(
+        floor_data_gas_cost_calculator=floor,
+        intrinsic_gas_cost_calculator=total,
+    )
+    byte_count = threshold + 1
+    calldata = Bytes(b"\x00" * byte_count)
+    calldata_floor = floor(byte_count)
+    assert calldata_floor > total(byte_count), (
+        "the calldata floor must dominate the full authorization total"
+    )
+
+    post: dict[Address, Account | None]
+    if outcome == "below_floor":
+        tx = Transaction(
+            sender=sender,
+            to=recipient,
+            data=calldata,
+            authorization_list=authorization_list,
+            gas_limit=calldata_floor - 1,
+            error=TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+        )
+        post = {scenario.authority: scenario.original_account}
+    else:
+        tx = Transaction(
+            sender=sender,
+            to=recipient,
+            data=calldata,
+            authorization_list=authorization_list,
+            gas_limit=calldata_floor,
+            expected_receipt=TransactionReceipt(
+                cumulative_gas_used=calldata_floor,
+            ),
+        )
+        post = {
+            sender: Account(nonce=1),
+            scenario.authority: scenario.applied_account,
         }
 
     state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
@@ -1,0 +1,172 @@
+"""
+Mainnet-marked tests for
+[EIP-2780: Resource-based intrinsic transaction gas](https://eips.ethereum.org/EIPS/eip-2780).
+
+One case per row of the EIP's transaction reference table. This EIP only
+reprices, so the pinned ``cumulative_gas_used`` is the sole observable
+that catches a client still charging the legacy intrinsic.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Address,
+    Alloc,
+    Fork,
+    Initcode,
+    Op,
+    RecipientType,
+    StateTestFiller,
+    Transaction,
+    TransactionReceipt,
+    compute_create_address,
+)
+from execution_testing.checklists import EIPChecklist
+
+from .helpers import (
+    EOA_INITIAL_BALANCE,
+    RECIPIENT_TYPES_NON_CREATE,
+    AuthorizationAction,
+    authorization_transaction_cost,
+    build_authorization,
+    setup_target,
+)
+from .spec import ref_spec_2780
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
+REFERENCE_SPEC_VERSION = ref_spec_2780.version
+
+pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.parametrize("recipient_type", RECIPIENT_TYPES_NON_CREATE)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_transaction_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    recipient_type: RecipientType,
+    value: int,
+) -> None:
+    """Gas for a non-create transaction, per recipient type and value."""
+    sender = pre.fund_eoa()
+    target = setup_target(pre, recipient_type, sender)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=bool(value),
+        recipient_type=recipient_type,
+    )
+    gas_used = intrinsic_gas + top_frame_gas + top_frame_state_gas
+
+    tx = Transaction(
+        to=target,
+        value=value,
+        gas_limit=gas_used,
+        sender=sender,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
+
+    post: dict[Address, Account | None] = {sender: Account(nonce=1)}
+    if recipient_type != RecipientType.SELF:
+        target_initial_balance = (
+            EOA_INITIAL_BALANCE if recipient_type == RecipientType.EOA else 0
+        )
+        if recipient_type == RecipientType.EMPTY_ACCOUNT and value == 0:
+            post[target] = None
+        else:
+            post[target] = Account(balance=target_initial_balance + value)
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0, id="zero_value"),
+        pytest.param(1, id="non-zero_value"),
+    ],
+)
+def test_contract_creation_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    value: int,
+) -> None:
+    """Gas for a contract-creation transaction, per value."""
+    sender = pre.fund_eoa()
+    deploy_code = Op.STOP
+    init_code = Initcode(deploy_code=deploy_code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=init_code,
+        contract_creation=True,
+        sends_value=bool(value),
+        return_cost_deducted_prior_execution=True,
+    )
+    new_account_state_gas = fork.transaction_top_frame_state_gas(
+        contract_creation=True,
+    )
+    gas_used = intrinsic_gas + new_account_state_gas + init_code.gas_cost(fork)
+
+    tx = Transaction(
+        to=None,
+        value=value,
+        data=init_code,
+        gas_limit=gas_used,
+        sender=sender,
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
+
+    created = compute_create_address(address=sender, nonce=0)
+    post = {created: Account(balance=value, code=deploy_code)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.parametrize(
+    "action",
+    [
+        pytest.param(AuthorizationAction.CREATES_ACCOUNT, id="new_authority"),
+        pytest.param(
+            AuthorizationAction.SETS_NEW_DELEGATION, id="existing_authority"
+        ),
+    ],
+)
+def test_authorization_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    action: AuthorizationAction,
+) -> None:
+    """Gas for one EIP-7702 authorization, per authority pre-state."""
+    scenario = build_authorization(pre, action)
+    authorization_list = [scenario.authorization]
+    gas_used = authorization_transaction_cost(fork, authorization_list)
+
+    tx = Transaction(
+        to=pre.deploy_contract(code=Op.STOP),
+        authorization_list=authorization_list,
+        gas_limit=gas_used,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_used),
+    )
+
+    post = {scenario.authority: scenario.applied_account}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py
@@ -27,15 +27,18 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    AuthorizationTuple,
     Block,
     BlockchainTestFiller,
     Op,
     RecipientType,
     Transaction,
+    TransactionReceipt,
     TransitionFork,
     compute_create_address,
 )
 
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
 from .helpers import EOA_INITIAL_BALANCE
 from .spec import ref_spec_2780
 
@@ -267,5 +270,118 @@ def test_creation_tx_intrinsic_across_amsterdam_transition(
             balance=sender_initial_balance - value - total_gas * gas_price,
         )
         post[created] = Account(nonce=1, balance=value, code=b"")
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+def test_setcode_tx_across_amsterdam_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: TransitionFork,
+) -> None:
+    """
+    Pin the EIP-2780 authorization repricing across the Amsterdam
+    boundary.
+
+    The same set-code transaction shape -- one authorization whose
+    empty authority delegates to a ``STOP`` contract, sent to a
+    ``STOP`` contract recipient -- is sent in a pre-fork and a
+    post-fork block from fresh senders and authorities. Pre-fork the
+    whole authorization cost is intrinsic: ``AUTH_PER_EMPTY_ACCOUNT``
+    on top of the flat ``TX_BASE``. Post-fork only the
+    state-independent ``REGULAR_PER_AUTH_BASE_COST`` stays intrinsic
+    (plus the recipient's ``COLD_ACCOUNT_ACCESS``), while the
+    state-dependent remainder moves to the top frame as
+    ``ACCOUNT_WRITE`` execution gas plus ``NEW_ACCOUNT`` and
+    ``AUTH_BASE`` state gas.
+
+    The per-fork totals returned by the calculators are also checked
+    against a hand-derived decomposition built from each fork's gas
+    constants, so a calculator regression fails here with a clear
+    message rather than only as a downstream balance mismatch.
+    """
+    gas_price = 1_000_000_000
+
+    pre_costs = fork.fork_at(timestamp=PRE_FORK_TIMESTAMP).gas_costs()
+    post_costs = fork.fork_at(timestamp=POST_FORK_TIMESTAMP).gas_costs()
+
+    # Pre-fork: EIP-7702 charges the full per-authorization cost in the
+    # intrinsic; an empty authority earns no existing-authority refund.
+    expected_pre = pre_costs.TX_BASE + pre_costs.AUTH_PER_EMPTY_ACCOUNT
+    # Post-fork: EIP-2780 decomposition across the three charge layers.
+    expected_post = (
+        post_costs.TX_BASE
+        + post_costs.COLD_ACCOUNT_ACCESS
+        + post_costs.REGULAR_PER_AUTH_BASE_COST
+        + post_costs.ACCOUNT_WRITE
+        + post_costs.NEW_ACCOUNT
+        + post_costs.AUTH_BASE
+    )
+
+    timestamps = [PRE_FORK_TIMESTAMP, POST_FORK_TIMESTAMP]
+    expected_totals = [expected_pre, expected_post]
+    blocks = []
+    post: dict[Address, Account] = {}
+
+    for timestamp, expected_total in zip(
+        timestamps, expected_totals, strict=True
+    ):
+        sub_fork = fork.fork_at(timestamp=timestamp)
+        recipient = pre.deploy_contract(code=Op.STOP)
+        delegate_to = pre.deploy_contract(code=Op.STOP)
+        authority = pre.fund_eoa(amount=0)
+        authorization = AuthorizationTuple(
+            address=delegate_to,
+            nonce=0,
+            signer=authority,
+            creates_account=True,
+        )
+
+        intrinsic_gas = sub_fork.transaction_intrinsic_cost_calculator()(
+            recipient_type=RecipientType.CONTRACT,
+            authorization_list_or_count=[authorization],
+            return_cost_deducted_prior_execution=True,
+        )
+        top_frame_gas = sub_fork.transaction_top_frame_gas_calculator()(
+            recipient_type=RecipientType.CONTRACT,
+            authorizations=[authorization],
+        )
+        top_frame_state_gas = sub_fork.transaction_top_frame_state_gas(
+            recipient_type=RecipientType.CONTRACT,
+            authorizations=[authorization],
+        )
+        total_gas = intrinsic_gas + top_frame_gas + top_frame_state_gas
+        assert total_gas == expected_total, (
+            f"set-code total at timestamp {timestamp} ({sub_fork}) is "
+            f"{total_gas}, expected {expected_total}"
+        )
+
+        sender_initial_balance = 10**18
+        sender = pre.fund_eoa(sender_initial_balance)
+
+        # Both recipient and delegate run ``STOP`` (no execution gas),
+        # so the receipt pins the intrinsic and top-frame layers alone.
+        tx = Transaction(
+            sender=sender,
+            to=recipient,
+            authorization_list=[authorization],
+            gas_limit=total_gas,
+            max_fee_per_gas=gas_price,
+            max_priority_fee_per_gas=gas_price,
+            expected_receipt=TransactionReceipt(
+                cumulative_gas_used=total_gas,
+            ),
+        )
+        blocks.append(Block(timestamp=timestamp, txs=[tx]))
+
+        post[sender] = Account(
+            nonce=1,
+            balance=sender_initial_balance - total_gas * gas_price,
+        )
+        post[authority] = Account(
+            nonce=1,
+            balance=0,
+            code=Spec7702.delegation_designation(delegate_to),
+        )
 
     blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_intrinsic_gas_boundary.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_intrinsic_gas_boundary.py
@@ -12,16 +12,21 @@ from execution_testing import (
     Alloc,
     AuthorizationTuple,
     Fork,
+    Hash,
     Op,
     RecipientType,
     StateTestFiller,
     Transaction,
     TransactionException,
+    add_kzg_version,
 )
 
+from ...cancun.eip4844_blobs.spec import Spec as EIP4844_Spec
 from .helpers import (
     EOA_INITIAL_BALANCE,
     RECIPIENT_TYPES_NON_CREATE,
+    AuthorizationAction,
+    build_authorization,
     setup_target,
 )
 from .spec import ref_spec_2780
@@ -173,6 +178,61 @@ def test_intrinsic_gas_floor_boundary_with_authorizations(
         gas_limit=intrinsic_gas - 1,
         max_fee_per_gas=1_000_000_000,
         max_priority_fee_per_gas=1_000_000_000,
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+    )
+
+    state_test(pre=pre, tx=tx, post=pre)
+
+
+@pytest.mark.exception_test
+@pytest.mark.with_all_tx_types
+def test_intrinsic_gas_floor_boundary_all_tx_types(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    tx_type: int,
+) -> None:
+    """
+    Reject every transaction type when ``gas_limit = intrinsic_gas - 1``.
+
+    Each type layers its own intrinsic components on the shared
+    value-transfer shape -- ``REGULAR_PER_AUTH_BASE_COST`` for type 4 --
+    and the pre-execution check must reject one gas below the per-type
+    total. Blob gas is priced in its own dimension, so a type-3
+    transaction's execution-gas boundary is identical to type 2.
+    """
+    value = 1
+    sender = pre.fund_eoa()
+    target = pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+
+    scenario = (
+        build_authorization(pre, AuthorizationAction.SETS_NEW_DELEGATION)
+        if tx_type == 4
+        else None
+    )
+    authorizations = [scenario.authorization] if scenario else []
+
+    blob_versioned_hashes = (
+        add_kzg_version([Hash(1)], EIP4844_Spec.BLOB_COMMITMENT_VERSION_KZG)
+        if tx_type == 3
+        else None
+    )
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorization_list_or_count=authorizations,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=target,
+        value=value,
+        authorization_list=authorizations or None,
+        blob_versioned_hashes=blob_versioned_hashes,
+        gas_limit=intrinsic_gas - 1,
         error=TransactionException.INTRINSIC_GAS_TOO_LOW,
     )
 

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
@@ -13,23 +13,30 @@ Test gas costs with EIP-2780 for value-moving transactions to:
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Address,
     Alloc,
     Fork,
+    Hash,
     Initcode,
     Op,
     RecipientType,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
+    add_kzg_version,
     compute_create_address,
 )
 
+from ...cancun.eip4844_blobs.spec import Spec as EIP4844_Spec
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
 from ..eip7708_eth_transfer_logs.spec import transfer_log
 from .helpers import (
     EOA_INITIAL_BALANCE,
     RECIPIENT_TYPES_NON_CREATE,
+    AuthorizationAction,
+    build_authorization,
     setup_target,
 )
 from .spec import ref_spec_2780
@@ -124,6 +131,142 @@ def test_value_moving_transactions(
             post[target] = None
         else:
             post[target] = Account(balance=target_initial_balance + value)
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "delegation_warm",
+    [
+        pytest.param(False, id="cold_delegation_target"),
+        pytest.param(True, id="warm_delegation_target"),
+    ],
+)
+def test_self_transfer_with_delegated_sender(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    delegation_warm: bool,
+) -> None:
+    """
+    Gas for a self-transfer whose sender already holds a delegation.
+
+    The EIP's prose skips the delegation-target access for a
+    self-transfer; its reference-case row charges it.
+    """
+    value = 1
+    delegated_to = pre.deploy_contract(code=Op.STOP)
+    sender = pre.fund_eoa(delegation=delegated_to)
+
+    access_list = (
+        [AccessList(address=delegated_to, storage_keys=[])]
+        if delegation_warm
+        else []
+    )
+
+    intrinsic_recipient_type = RecipientType.SELF
+    top_frame_recipient_type = RecipientType.DELEGATION_7702
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        sends_value=True,
+        recipient_type=intrinsic_recipient_type,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=True,
+        recipient_type=top_frame_recipient_type,
+        delegation_warm=delegation_warm,
+    )
+    total_gas_cost = intrinsic_gas + top_frame_gas
+
+    tx = Transaction(
+        sender=sender,
+        to=sender,
+        value=value,
+        access_list=access_list,
+        gas_limit=total_gas_cost,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=total_gas_cost, logs=[]
+        ),
+    )
+
+    post = {
+        sender: Account(
+            nonce=2, code=Spec7702.delegation_designation(delegated_to)
+        ),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.with_all_tx_types
+def test_intrinsic_decomposition_across_tx_types(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+    tx_type: int,
+) -> None:
+    """
+    The decomposed intrinsic keys on the transaction's fields, not its
+    type: every type pays the same recipient and value primitives, with
+    type-specific costs riding on top.
+    """
+    value = 1
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=EOA_INITIAL_BALANCE)
+
+    scenario = (
+        build_authorization(pre, AuthorizationAction.SETS_NEW_DELEGATION)
+        if tx_type == 4
+        else None
+    )
+    authorizations = [scenario.authorization] if scenario else []
+
+    blob_versioned_hashes = (
+        add_kzg_version([Hash(1)], EIP4844_Spec.BLOB_COMMITMENT_VERSION_KZG)
+        if tx_type == 3
+        else None
+    )
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorization_list_or_count=authorizations,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorizations=authorizations,
+    )
+    top_frame_state_gas = fork.transaction_top_frame_state_gas(
+        sends_value=True,
+        recipient_type=RecipientType.EOA,
+        authorizations=authorizations,
+    )
+    total_gas_cost = intrinsic_gas + top_frame_gas + top_frame_state_gas
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=recipient,
+        value=value,
+        authorization_list=authorizations or None,
+        blob_versioned_hashes=blob_versioned_hashes,
+        gas_limit=total_gas_cost,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=total_gas_cost,
+            logs=[transfer_log(sender, recipient, value)],
+        ),
+    )
+
+    post: dict[Address, Account] = {
+        sender: Account(nonce=1),
+        recipient: Account(balance=EOA_INITIAL_BALANCE + value),
+    }
+    if scenario:
+        post[scenario.authority] = scenario.applied_account
 
     state_test(pre=pre, tx=tx, post=post)
 

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -8,7 +8,8 @@ differently:
   intrinsic phase, without reading state, so it is *always cold*:
   listing ``tx.to`` in the access list pays the access-list cost but
   does not waive it, and the protocol-warmed coinbase is still charged
-  cold when it is the recipient.
+  cold when it is the recipient. The same holds for the authority
+  access folded into ``REGULAR_PER_AUTH_BASE_COST``.
 - A delegated recipient's delegation-target access is a *top-frame*
   charge that reads state, so it follows normal warm/cold accounting:
   ``WARM_ACCESS`` when the target is already warm -- the sender, the
@@ -38,6 +39,11 @@ from execution_testing import (
 )
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .helpers import (
+    AuthorizationAction,
+    authorization_transaction_cost,
+    build_authorization,
+)
 from .spec import ref_spec_2780
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_2780.git_path
@@ -157,6 +163,49 @@ def test_intrinsic_charges_recipient_is_coinbase(
 
     post = {
         sender: Account(nonce=1, balance=sender_final_balance),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+def test_intrinsic_charges_authority_in_access_list(
+    fork: Fork,
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    Authority is listed in the access list. The intrinsic charge still
+    includes the full ``REGULAR_PER_AUTH_BASE_COST``, whose folded-in
+    authority access is charged at the cold rate.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.deploy_contract(code=Op.STOP)
+
+    scenario = build_authorization(
+        pre, AuthorizationAction.SETS_NEW_DELEGATION
+    )
+    authorization_list = [scenario.authorization]
+    access_list = [AccessList(address=scenario.authority, storage_keys=[])]
+
+    total_gas_cost = authorization_transaction_cost(
+        fork, authorization_list, access_list=access_list
+    )
+
+    tx = Transaction(
+        ty=4,
+        sender=sender,
+        to=recipient,
+        value=0,
+        access_list=access_list,
+        authorization_list=authorization_list,
+        gas_limit=total_gas_cost,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=total_gas_cost,
+        ),
+    )
+
+    post = {
+        scenario.authority: scenario.applied_account,
     }
 
     state_test(pre=pre, tx=tx, post=post)


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Stacked on #3266 (first commit is that PR's head). Adds three EIP-2780 coverage gaps, all filled green:

- `test_intrinsic_gas_floor_boundary_all_tx_types`: the `intrinsic - 1` rejection boundary for every transaction type (previously only types 0 and 4 had one).
- `test_setcode_tx_across_amsterdam_transition`: a type-4 transaction straddling the fork boundary, pinning the per-authorization cost migrating from the pre-fork intrinsic (`AUTH_PER_EMPTY_ACCOUNT`) into the decomposed intrinsic plus top-frame charges, cross-checked against a hand-derived per-fork decomposition.
- `test_calldata_floor_with_authorizations`: a binding calldata floor on a type-4 transaction, pinning that authorization tuples add no floor tokens while the masked delegation still lands, and that one gas below the floor rejects.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Stacked on #3266; part of the EIP-2780 coverage item in #3217.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fm%2F780hBQx52PAAAAAC%2Fcute-alligator.gif&f=1&nofb=1&ipt=3070bc22e0fcee09fb29024bd85057ec23536dfb567b991c6d9d0d890ccbabbd)
