### PR TITLE
feat(stateful-filler): add flag to not rollback chain on stateful filler

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -148,6 +148,22 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
     group.addoption(
+        "--keep-chain-head",
+        action="store_true",
+        dest="keep_chain_head",
+        default=False,
+        help=(
+            "Do not rewind the client to start_block after each test, so "
+            "the chain keeps whatever head the fill produced. Use when the "
+            "fixtures being filled CONSTRUCT state that later fixtures "
+            "depend on (deploy targets, then authorise delegations onto "
+            "them): each subsequent fill anchors on the new head, because "
+            "--snapshot-block defaults to `latest`. Leave unset for "
+            "benchmark fixtures, which must all start from an identical "
+            "prestate."
+        ),
+    )
+    group.addoption(
         "--verify-full-accounts",
         action="store_true",
         dest="verify_full_accounts",
@@ -767,6 +783,7 @@ def t8n(
 
 @pytest.fixture(autouse=True, scope="function")
 def _reset_chain_between_tests(
+    request: pytest.FixtureRequest,
     client_backend: ClientBackend,
     debug_rpc: DebugRPC,
     eth_rpc: "ChainBuilderEthRPC",
@@ -779,8 +796,17 @@ def _reset_chain_between_tests(
     so the client reorgs onto it even without a debug rewind. Afterwards we
     verify the block at the start_block number matches and fail loudly if it
     drifted (e.g. a live reorg).
+
+    Skipped entirely under ``--keep-chain-head``, where the fills build a
+    prestate incrementally and each one must see the previous one's result.
     """
     yield
+    if request.config.getoption("keep_chain_head", default=False):
+        logger.info(
+            "--keep-chain-head: leaving the chain at the head this fill "
+            "produced; the next fill will anchor on it"
+        )
+        return
     if client_backend.start_block is None:
         return
     start_hex = client_backend.start_block["number"]


### PR DESCRIPTION
### Description
If you want to deploy prestate using benchmarks, rolling back the chain to the snapshot height is not wanted. This flag allows one to use the EELS framework to drive the chain forward, for instance to fill blocks with specific prestate.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
