### PR TITLE
feat(test-rpc): add eth_getTransactionReceipt batching

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -430,10 +430,21 @@ class ClientBackend:
     def _fetch_receipts(
         self, txs: List[Transaction]
     ) -> List[TransactionReceipt]:
-        """Fetch receipts for each transaction. TODO: batch via JSON-RPC."""
+        """
+        Fetch receipts for every transaction in the block, batched.
+
+        One request per transaction makes fill time latency-bound: a block
+        of 5,000 transactions costs 5,000 sequential round trips, which
+        against a non-local client dominates everything else the fill does
+        (the client executes such a block in ~150ms).
+        """
+        if not txs:
+            return []
+        receipt_data_list = self.eth_rpc.get_transaction_receipts(
+            [tx.hash for tx in txs]
+        )
         receipts: List[TransactionReceipt] = []
-        for tx in txs:
-            receipt_data = self.eth_rpc.get_transaction_receipt(tx.hash)
+        for tx, receipt_data in zip(txs, receipt_data_list, strict=True):
             if receipt_data is None:
                 raise RuntimeError(
                     f"No receipt found for transaction {tx.hash}"

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -837,6 +837,43 @@ class EthRPC(BaseRPC):
             )
         ).result_or_raise()
 
+    def get_transaction_receipts(
+        self,
+        transaction_hashes: Sequence[Hash],
+        *,
+        chunk_size: int = 500,
+    ) -> List[dict[str, Any] | None]:
+        """
+        `eth_getTransactionReceipt` batch: receipts for many transactions.
+
+        Returns one entry per input hash, in the same order (see
+        `post_batch_request`, which maps responses back by request id).
+
+        Requests are chunked because clients cap batch size -- geth's
+        `--rpc.batchrequestlimit` defaults to 1000 -- and because a single
+        response carrying thousands of receipts is several megabytes.
+        """
+        if not transaction_hashes:
+            return []
+        logger.info(
+            f"Batch requesting {len(transaction_hashes)} tx receipts "
+            f"in chunks of {chunk_size}"
+        )
+        receipts: List[dict[str, Any] | None] = []
+        for start in range(0, len(transaction_hashes), chunk_size):
+            chunk = transaction_hashes[start : start + chunk_size]
+            responses = self.post_batch_request(
+                calls=[
+                    RPCCall(
+                        method="getTransactionReceipt",
+                        params=[f"{tx_hash}"],
+                    )
+                    for tx_hash in chunk
+                ]
+            )
+            receipts.extend(r.result_or_raise() for r in responses)
+        return receipts
+
     def get_storage_at(
         self,
         address: Address,


### PR DESCRIPTION
### Description
This PR adds using batch-JSON-RPCs on eth_getTransactionReceipt, this is especially for benchmarks/tests which send a lot of transactions which we all verify if those were included/mined.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
