### PR TITLE
fix(test-execute): fix execute for Amsterdam

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -141,6 +141,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         self,
         *,
         next_timestamp: int,
+        next_target_gas_limit: int,
         withdrawals: List[Withdrawal] | None = None,
     ) -> PayloadAttributes:
         """Build payload attributes for a block at ``next_timestamp``."""
@@ -148,6 +149,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         return PayloadAttributes.for_fork(
             next_fork,
             timestamp=next_timestamp,
+            target_gas_limit=next_target_gas_limit,
             withdrawals=withdrawals,
         )
 
@@ -217,9 +219,11 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             head_block_hash=head_block["hash"],
         )
         next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
+        next_gas_limit = int(HexNumber(head_block["gasLimit"]))
         next_fork = self.fork.fork_at(block_number=0, timestamp=next_timestamp)
         payload_attributes = self._payload_attributes(
-            next_timestamp=next_timestamp
+            next_timestamp=next_timestamp,
+            next_target_gas_limit=next_gas_limit,
         )
         forkchoice_updated_version = (
             next_fork.engine_forkchoice_updated_version()
@@ -293,8 +297,10 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             head_block = self.get_block_by_number("latest")
             assert head_block is not None
             next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
+            next_gas_limit = int(HexNumber(head_block["gasLimit"]))
             payload_attributes = self._payload_attributes(
                 next_timestamp=next_timestamp,
+                next_target_gas_limit=next_gas_limit,
             )
             new_payload = self.testing_rpc.build_block(
                 parent_block_hash=Hash(head_block["hash"]),
@@ -337,8 +343,10 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             head_block = self.get_block_by_number("latest")
             assert head_block is not None
             next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
+            next_gas_limit = int(HexNumber(head_block["gasLimit"]))
             payload_attributes = self._payload_attributes(
                 next_timestamp=next_timestamp,
+                next_target_gas_limit=next_gas_limit,
                 withdrawals=withdrawals,
             )
             # Explicit empty list, not ``None``: per spec, ``null`` lets

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -6,18 +6,21 @@ submitted.
 import time
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, List, Sequence, Tuple
+from typing import Any, List, Mapping, Sequence, Tuple
 from urllib.parse import urlparse
 
 from filelock import FileLock
+from pydantic import ValidationError
 
 from execution_testing.base_types import (
     Address,
     Bytes,
     Hash,
     HexNumber,
+    to_json,
 )
 from execution_testing.client_clis.cli_types import EnginePayloadMetadata
+from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.rpc import (
     DEFAULT_REQUEST_TIMEOUT,
@@ -34,6 +37,73 @@ from execution_testing.rpc.rpc_types import (
     TransactionProtocol,
 )
 from execution_testing.test_types import Withdrawal
+
+
+def _genesis_header_differences(
+    expected: FixtureHeader,
+    actual_block: Mapping[str, Any],
+) -> List[str]:
+    """
+    Return the per-field differences between the expected genesis header and
+    the genesis block returned by the client, using the header's own field
+    names.
+
+    Return an empty list when the client's block cannot be parsed as a
+    header, in which case the caller only reports the block hashes.
+    """
+    try:
+        actual_header = FixtureHeader.model_validate(actual_block)
+    except ValidationError:
+        return []
+    expected_json = to_json(expected)
+    actual_json = to_json(actual_header)
+    # A field can be missing from either side: the fork may require a header
+    # field we never set, or the client may not report one we do set.
+    fields = list(expected_json) + [
+        field for field in actual_json if field not in expected_json
+    ]
+    differences = [
+        f"{field}: expected {expected_json.get(field, '<unset>')}, "
+        f"got {actual_json.get(field, '<unset>')}"
+        # The block hash is reported separately by the caller.
+        for field in fields
+        if field != "hash"
+        and expected_json.get(field) != actual_json.get(field)
+    ]
+    if actual_header.block_hash != Hash(actual_block["hash"]):
+        differences.append(
+            "note: the client's header does not hash to the block hash it "
+            "reports when re-encoded locally, so the fields listed above may "
+            "be incomplete"
+        )
+    return differences
+
+
+class GenesisMismatchError(Exception):
+    """
+    The client's genesis block does not match the one built locally.
+    """
+
+    def __init__(
+        self,
+        expected: FixtureHeader,
+        actual_block: Mapping[str, Any],
+    ) -> None:
+        """Initialize the exception with both genesis headers."""
+        self.expected = expected
+        self.actual_block = actual_block
+        message = (
+            "the client's genesis block does not match the one built "
+            "locally:"
+            f"\n  expected block hash: {expected.block_hash}"
+            f"\n  client block hash:   {Hash(actual_block['hash'])}"
+        )
+        differences = _genesis_header_differences(expected, actual_block)
+        if differences:
+            message += "\n  differing header fields:"
+            for difference in differences:
+                message += f"\n    {difference}"
+        super().__init__(message)
 
 
 class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
@@ -62,6 +132,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         max_transactions_per_batch: int | None = None,
         request_timeout: TimeoutType = DEFAULT_REQUEST_TIMEOUT,
         testing_rpc: TestingRPC | None = None,
+        expected_genesis_header: FixtureHeader | None = None,
     ):
         """Initialize the Ethereum RPC client for the hive simulator."""
         super().__init__(
@@ -90,6 +161,8 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                     "Error occurred during initial forkchoice_updated"
                 )
             if not base_file.exists():
+                if expected_genesis_header is not None:
+                    self.verify_genesis_block(expected_genesis_header)
                 base_error_file.touch()  # Assume error
                 # Get the head block hash
                 head_block = self.get_block_by_number("latest")
@@ -125,6 +198,17 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                     raise Exception("Initial forkchoice_updated was invalid")
                 base_error_file.unlink()  # Success
                 base_file.touch()
+
+    def verify_genesis_block(self, expected: FixtureHeader) -> None:
+        """
+        Verify the client's genesis block matches the one built locally.
+        """
+        genesis_block = self.get_block_by_number(0)
+        assert genesis_block is not None, (
+            "client did not return its genesis block"
+        )
+        if Hash(genesis_block["hash"]) != expected.block_hash:
+            raise GenesisMismatchError(expected, genesis_block)
 
     @property
     def transaction_polling_context(self) -> AbstractContextManager:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -221,19 +221,49 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         """
         return self.block_building_lock
 
+    def _next_timestamp(self, head_block: Mapping[str, Any]) -> int:
+        """Return the timestamp of the block following ``head_block``."""
+        return int(HexNumber(head_block["timestamp"]) + 1)
+
+    def _next_fork(self, head_block: Mapping[str, Any]) -> Fork:
+        """Return the fork of the block following ``head_block``."""
+        return self.fork.fork_at(
+            block_number=0, timestamp=self._next_timestamp(head_block)
+        )
+
+    def _head_fork(self, head_block: Mapping[str, Any]) -> Fork:
+        """Return the fork of ``head_block`` itself."""
+        return self.fork.fork_at(
+            block_number=int(HexNumber(head_block["number"])),
+            timestamp=int(HexNumber(head_block["timestamp"])),
+        )
+
     def _payload_attributes(
         self,
+        head_block: Mapping[str, Any],
         *,
-        next_timestamp: int,
-        next_target_gas_limit: int,
         withdrawals: List[Withdrawal] | None = None,
     ) -> PayloadAttributes:
-        """Build payload attributes for a block at ``next_timestamp``."""
-        next_fork = self.fork.fork_at(block_number=0, timestamp=next_timestamp)
+        """
+        Build the payload attributes for the block following ``head_block``.
+        """
+        next_timestamp = self._next_timestamp(head_block)
+        next_fork = self._next_fork(head_block)
+        next_slot_number: int | None = None
+        if next_fork.engine_payload_attribute_slot_number():
+            if not self._head_fork(head_block).header_slot_number_required():
+                next_slot_number = 1
+            else:
+                assert "slotNumber" in head_block, (
+                    "fork requires a slot number in the block header but the "
+                    "client does not report one for its head block"
+                )
+                next_slot_number = int(HexNumber(head_block["slotNumber"]) + 1)
         return PayloadAttributes.for_fork(
             next_fork,
             timestamp=next_timestamp,
-            target_gas_limit=next_target_gas_limit,
+            target_gas_limit=int(HexNumber(head_block["gasLimit"])),
+            slot_number=next_slot_number,
             withdrawals=withdrawals,
         )
 
@@ -302,13 +332,8 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         forkchoice_state = ForkchoiceState(
             head_block_hash=head_block["hash"],
         )
-        next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
-        next_gas_limit = int(HexNumber(head_block["gasLimit"]))
-        next_fork = self.fork.fork_at(block_number=0, timestamp=next_timestamp)
-        payload_attributes = self._payload_attributes(
-            next_timestamp=next_timestamp,
-            next_target_gas_limit=next_gas_limit,
-        )
+        next_fork = self._next_fork(head_block)
+        payload_attributes = self._payload_attributes(head_block)
         forkchoice_updated_version = (
             next_fork.engine_forkchoice_updated_version()
         )
@@ -380,12 +405,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         with self.block_building_lock:
             head_block = self.get_block_by_number("latest")
             assert head_block is not None
-            next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
-            next_gas_limit = int(HexNumber(head_block["gasLimit"]))
-            payload_attributes = self._payload_attributes(
-                next_timestamp=next_timestamp,
-                next_target_gas_limit=next_gas_limit,
-            )
+            payload_attributes = self._payload_attributes(head_block)
             new_payload = self.testing_rpc.build_block(
                 parent_block_hash=Hash(head_block["hash"]),
                 payload_attributes=payload_attributes,
@@ -426,12 +446,8 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         with self.block_building_lock:
             head_block = self.get_block_by_number("latest")
             assert head_block is not None
-            next_timestamp = int(HexNumber(head_block["timestamp"]) + 1)
-            next_gas_limit = int(HexNumber(head_block["gasLimit"]))
             payload_attributes = self._payload_attributes(
-                next_timestamp=next_timestamp,
-                next_target_gas_limit=next_gas_limit,
-                withdrawals=withdrawals,
+                head_block, withdrawals=withdrawals
             )
             # Explicit empty list, not ``None``: per spec, ``null`` lets
             # the client pull from its mempool, but we want a

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -28,6 +28,7 @@ from execution_testing.test_types import (
     DETERMINISTIC_FACTORY_BYTECODE,
     EOA,
     Alloc,
+    BlockAccessList,
     ChainConfig,
     Environment,
     Requests,
@@ -182,9 +183,10 @@ def build_genesis_header(
         requests_hash=Requests()
         if genesis_fork.header_requests_required()
         else None,
-        block_access_list_hash=Hash(EmptyTrieRoot)
+        block_access_list_hash=BlockAccessList().rlp_hash
         if genesis_fork.header_bal_hash_required()
         else None,
+        slot_number=0 if genesis_fork.header_slot_number_required() else None,
     )
 
     return (pre_alloc, genesis)
@@ -458,6 +460,7 @@ def eth_rpc(
     session_temp_folder: Path,
     max_transactions_per_batch: int | None,
     use_testing_build_block: bool,
+    base_pre_genesis: Tuple[Alloc, FixtureHeader],
 ) -> EthRPC:
     """Initialize ethereum RPC client for the execution client under test."""
     get_payload_wait_time = request.config.getoption("get_payload_wait_time")
@@ -474,4 +477,5 @@ def eth_rpc(
         transaction_wait_timeout=tx_wait_timeout,
         max_transactions_per_batch=max_transactions_per_batch,
         testing_rpc=testing_rpc,
+        expected_genesis_header=base_pre_genesis[1],
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -10,7 +10,9 @@ from filelock import FileLock
 from pytest_metadata.plugin import metadata_key
 
 from execution_testing.base_types import Account, Address, Number, Wei
+from execution_testing.forks import Fork, TransitionFork
 from execution_testing.logging import get_logger
+from execution_testing.recipient_type import RecipientType
 from execution_testing.rpc import EthRPC
 from execution_testing.rpc.rpc_types import JSONRPCError
 from execution_testing.test_types import (
@@ -56,9 +58,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store",
         dest="sender_fund_refund_gas_limit",
         type=Wei,
-        default=200_000,
+        default=None,
         help=(
-            "Gas limit set for the funding transactions of each worker's sender key."  # noqa: E501
+            "Gas limit set for the funding transactions of each worker's "
+            "sender key. Default=None (derived from the fork's cost of a "
+            "value transfer that creates the recipient account)."
         ),
     )
 
@@ -97,9 +101,27 @@ def sender_funding_transactions_gas_price(
 
 
 @pytest.fixture(scope="session")
-def sender_fund_refund_gas_limit(request: pytest.FixtureRequest) -> int:
-    """Get the gas limit of the funding transactions."""
-    gas_limit = request.config.option.sender_fund_refund_gas_limit
+def sender_fund_refund_gas_limit(
+    request: pytest.FixtureRequest,
+    session_fork: Fork | TransitionFork,
+) -> int:
+    """
+    Get the gas limit of the funding and refund transactions.
+
+    A funding transaction creates the recipient account, which is charged
+    account-creation state gas on top of the intrinsic cost, so the default
+    is derived from the fork instead of being a fixed value.
+    """
+    gas_limit: int | None = request.config.option.sender_fund_refund_gas_limit
+    if gas_limit is None:
+        fork = session_fork.transitions_to()
+        gas_limit = fork.transaction_intrinsic_cost_calculator()(
+            sends_value=True,
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+        ) + fork.transaction_top_frame_state_gas(
+            sends_value=True,
+            recipient_type=RecipientType.EMPTY_ACCOUNT,
+        )
     logger.info(f"Using gas limit for funding transactions: {gas_limit}")
     return gas_limit
 

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -36,6 +36,7 @@ from execution_testing.rpc.rpc_types import (
 )
 from execution_testing.test_types import (
     Alloc,
+    Environment,
     Requests,
     Transaction,
     Withdrawal,
@@ -360,7 +361,7 @@ class ClientBackend:
 
     def _payload_attributes(
         self,
-        env: Any,
+        env: Environment,
         block_fork: Fork,
     ) -> PayloadAttributes:
         """Build ``PayloadAttributes`` from the test's environment."""
@@ -373,6 +374,7 @@ class ClientBackend:
         return PayloadAttributes.for_fork(
             block_fork,
             timestamp=int(env.timestamp),
+            target_gas_limit=int(env.gas_limit),
             prev_randao=Hash(env.prev_randao or 0),
             suggested_fee_recipient=env.fee_recipient,
             withdrawals=withdrawals,

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -371,6 +371,9 @@ class ClientBackend:
         parent_beacon_block_root: Hash | None = None
         if block_fork.header_beacon_root_required():
             parent_beacon_block_root = Hash(env.parent_beacon_block_root or 0)
+        slot_number: int | None = None
+        if env.slot_number is not None:
+            slot_number = int(env.slot_number)
         return PayloadAttributes.for_fork(
             block_fork,
             timestamp=int(env.timestamp),
@@ -379,6 +382,7 @@ class ClientBackend:
             suggested_fee_recipient=env.fee_recipient,
             withdrawals=withdrawals,
             parent_beacon_block_root=parent_beacon_block_root,
+            slot_number=slot_number,
         )
 
     def _finalize(

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -561,6 +561,7 @@ class FixtureEngineNewPayload(CamelModel):
             withdrawals=execution_payload.withdrawals,
             parent_beacon_block_root=parent_beacon_block_root,
             slot_number=execution_payload.slot_number,
+            target_gas_limit=execution_payload.gas_limit,
         )
 
     @staticmethod

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -1152,6 +1152,14 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         """
         pass
 
+    @classmethod
+    @abstractmethod
+    def engine_payload_attribute_target_gas_limit(cls) -> bool:
+        """
+        Return true if the payload attributes include the target gas limit.
+        """
+        pass
+
     # Engine API method versions
     @classmethod
     def engine_new_payload_version(cls) -> Optional[int]:

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1012,6 +1012,13 @@ class Frontier(BaseFork):
         return False
 
     @classmethod
+    def engine_payload_attribute_target_gas_limit(cls) -> bool:
+        """
+        At genesis, payload attributes do not include the target gas limit.
+        """
+        return False
+
+    @classmethod
     def get_reward(cls) -> int:
         """
         At Genesis the expected reward amount in wei is
@@ -1633,4 +1640,10 @@ class Amsterdam(
     #  related Amsterdam specs change over time, and before Amsterdam is
     #  live on mainnet.
 
-    pass
+    @classmethod
+    def engine_payload_attribute_target_gas_limit(cls) -> bool:
+        """
+        Starting from Amsterdam, payload attributes now include the target gas
+        limit.
+        """
+        return True

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -233,6 +233,7 @@ class PayloadAttributes(CamelModel):
         *,
         timestamp: int,
         target_gas_limit: int,
+        slot_number: int | None,
         prev_randao: Hash | None = None,
         suggested_fee_recipient: Address | None = None,
         withdrawals: List[Withdrawal] | None = None,
@@ -252,6 +253,11 @@ class PayloadAttributes(CamelModel):
             and fork.header_beacon_root_required()
         ):
             parent_beacon_block_root = Hash(0)
+        attributes_slot_number: HexNumber | None = None
+        if fork.engine_payload_attribute_slot_number():
+            attributes_slot_number = HexNumber(
+                1 if slot_number is None else slot_number
+            )
         return cls(
             timestamp=HexNumber(timestamp),
             prev_randao=prev_randao if prev_randao is not None else Hash(0),
@@ -272,11 +278,7 @@ class PayloadAttributes(CamelModel):
                 if fork.engine_payload_attribute_max_blobs_per_block()
                 else None
             ),
-            slot_number=(
-                HexNumber(0)
-                if fork.engine_payload_attribute_slot_number()
-                else None
-            ),
+            slot_number=attributes_slot_number,
             target_gas_limit=(
                 HexNumber(target_gas_limit)
                 if fork.engine_payload_attribute_target_gas_limit()

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -224,6 +224,7 @@ class PayloadAttributes(CamelModel):
     target_blobs_per_block: HexNumber | None = None
     max_blobs_per_block: HexNumber | None = None
     slot_number: HexNumber | None = None
+    target_gas_limit: HexNumber | None = None
 
     @classmethod
     def for_fork(
@@ -231,6 +232,7 @@ class PayloadAttributes(CamelModel):
         fork: Fork,
         *,
         timestamp: int,
+        target_gas_limit: int,
         prev_randao: Hash | None = None,
         suggested_fee_recipient: Address | None = None,
         withdrawals: List[Withdrawal] | None = None,
@@ -273,6 +275,11 @@ class PayloadAttributes(CamelModel):
             slot_number=(
                 HexNumber(0)
                 if fork.engine_payload_attribute_slot_number()
+                else None
+            ),
+            target_gas_limit=(
+                HexNumber(target_gas_limit)
+                if fork.engine_payload_attribute_target_gas_limit()
                 else None
             ),
         )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -132,6 +132,7 @@ def apply_new_parent(
     updated["parent_gas_used"] = new_parent.gas_used
     updated["parent_gas_limit"] = new_parent.gas_limit
     updated["parent_ommers_hash"] = new_parent.ommers_hash
+    updated["parent_slot_number"] = new_parent.slot_number
     block_hashes = env.block_hashes.copy()
     block_hashes[new_parent.number] = new_parent.block_hash
     updated["block_hashes"] = block_hashes

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -135,6 +135,7 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     )
     parent_blob_gas_used: ZeroPaddedHexNumber | None = Field(None)
     parent_excess_blob_gas: ZeroPaddedHexNumber | None = Field(None)
+    parent_slot_number: ZeroPaddedHexNumber | None = Field(None)
     parent_beacon_block_root: Hash | None = Field(None)
 
     block_hashes: Dict[ZeroPaddedHexNumber, Hash] = Field(default_factory=dict)
@@ -202,7 +203,11 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
             updated_values["parent_beacon_block_root"] = 0
 
         if fork.header_slot_number_required() and self.slot_number is None:
-            updated_values["slot_number"] = 0
+            updated_values["slot_number"] = (
+                int(self.parent_slot_number) + 1
+                if self.parent_slot_number is not None
+                else 0
+            )
 
         return self.copy(**updated_values)
 


### PR DESCRIPTION
### Description

`uv run execute hive --fork Amsterdam` could not run a single test. This fixes the four separate problems behind that, all of them Amsterdam-specific regressions in the live-client paths (`execute` and `fill-stateful`) that the `fill` path never exercised.

This was all found while trying to verify execute tests on #3266.

Verified end-to-end with `execute hive --fork Amsterdam tests/frontier/opcodes/test_dup.py` against reth and go-ethereum (`glamsterdam-devnet-7`), and against nethermind on the final state: 16/16 passing, from 0/16 before.

#### 1. `targetGasLimit` payload attribute (`fix: Add target gas limit`)

Amsterdam adds `targetGasLimit` to the engine payload attributes. Adds the `Fork.engine_payload_attribute_target_gas_limit()` predicate (`False` from Frontier, `True` from Amsterdam) and populates the field in `PayloadAttributes.for_fork`, so `ChainBuilderEthRPC` and `ClientBackend` both send it when the fork requires it.

#### 2. Funding transactions ran out of gas (`fix(test-execute): Sender funding tx gas limit`)

The worker/EOA funding transactions used a hardcoded 200,000 gas limit. Since Amsterdam charges account-creation state gas, a plain value transfer that creates its recipient now costs **204,600** gas (21,000 intrinsic + 183,600 state gas), so every funding transaction hit out-of-gas:

```
   Prague: intrinsic=21000 state_gas=0      total=21000
Amsterdam: intrinsic=21000 state_gas=183600 total=204600
```

The receipt showed `status: 0x0` with the full gas limit consumed, so the value was never transferred and the test transaction then failed with `insufficient funds for gas * price + value: have 0`, pointing away from the real cause.

`--sender-fund-refund-gas-limit` now defaults to `None` and the value is derived from the fork (intrinsic cost + top-frame state gas for a value transfer to an empty account), matching what `fill_stateful` already did. The flag still overrides.

#### 3. Amsterdam genesis header was wrong, and nothing checked it (`fix(test-pytest): Fix amsterdam genesis`)

Two bugs in the genesis header `execute`/`fill-stateful` build for hive:

- `blockAccessListHash` used `EmptyTrieRoot` (`keccak(rlp(b""))`). A block access list hash is the hash of the RLP-encoded list, not a trie root, so an empty one is `keccak(rlp([]))` — the form `FixtureHeader.genesis` already used via `BlockAccessList().rlp_hash`.
- `slotNumber` was never set, although Amsterdam requires it, so our header had one fewer RLP element than the client's.

Both were invisible because nothing compared our genesis against the client's: the clients derive the genesis state root from the pre-allocation and ignore the `stateRoot` we write, and the initial `forkchoiceUpdated` uses the head block hash the client itself reports — so it can never disagree with itself. Setting the genesis `stateRoot` to a garbage value did not fail a single test.

`ChainBuilderEthRPC.verify_genesis_block` now compares the client's block 0 against the locally built `FixtureHeader` before the initial forkchoice update, and raises `GenesisMismatchError` with both hashes plus a field-level diff. The diff is produced by parsing the client's block back into a `FixtureHeader` so both sides are named consistently, and it warns when the re-encoded header does not reproduce the hash the client reported (i.e. when the field list may be incomplete).

#### 4. Slot numbers never advanced (`fix(test-specs): Make slotnum increment automatically`)

`env.slot_number` was only ever `0`: it defaults to `None`, `set_fork_requirements` pinned it to `0`, and nothing derived it per block. On top of that, `PayloadAttributes.for_fork` hardcoded `HexNumber(0)`, so a test setting `Environment(slot_number=N)` — as the whole EIP-7843 suite does — had the client build its block at slot 0 while the test asserted `SLOTNUM == N`.

- `PayloadAttributes.for_fork` takes the slot number from the caller; `ClientBackend` passes `env.slot_number`.
- `ChainBuilderEthRPC._payload_attributes` now takes the head block and derives timestamp, target gas limit and slot number from it, so the three call sites share one policy. When the fork requires a slot number but the head block predates the header field (fork transition) the count starts at zero; when the head block *should* carry one and does not, it fails loudly rather than silently rewinding to zero.
- `apply_new_parent` records `parent_slot_number` and `set_fork_requirements` derives `parent + 1` from it, mirroring how `excess_blob_gas` and `blob_gas_used` already work. An explicit `Block(slot_number=...)` still wins.

Fixture impact is limited to multi-block Amsterdam tests, which now advance (`[0x00] * 19` → `[0x00, 0x01, ... 0x12]`) instead of sitting at slot 0. The EIP-7843 suite is byte-identical, and so is every single-block fixture: block 1 has no `parent_slot_number`, so it still starts at 0.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
