### PR TITLE
ci: pass composite action inputs via env before shell

### DIFF
--- a/.github/actions/cache-docker-images/action.yaml
+++ b/.github/actions/cache-docker-images/action.yaml
@@ -28,9 +28,11 @@ runs:
 
     - name: Pull and save Docker images
       shell: bash
+      env:
+        IMAGES: ${{ inputs.images }}
       run: |
         mkdir -p /tmp/docker-images
-        for image in ${{ inputs.images }}; do
+        for image in ${IMAGES}; do
           # Create a safe filename from image name
           filename=$(echo "$image" | sed 's/[\/:]/-/g').tar.gz
           if [ ! -f "/tmp/docker-images/$filename" ]; then

--- a/.github/actions/fetch-binary/action.yaml
+++ b/.github/actions/fetch-binary/action.yaml
@@ -24,8 +24,15 @@ runs:
   steps:
     - name: Download binary
       shell: bash
+      env:
+        REPO_OWNER: ${{ inputs.repo_owner }}
+        REPO_NAME: ${{ inputs.repo_name }}
+        VERSION: ${{ inputs.version }}
+        REMOTE_NAME: ${{ inputs.remote_name }}
+        BINARY_NAME: ${{ inputs.binary_name }}
+        EXPECTED_SHA256: ${{ inputs.expected_sha256 }}
       run: |
-        curl -sSL "https://github.com/${{ inputs.repo_owner }}/${{ inputs.repo_name }}/releases/download/${{ inputs.version }}/${{ inputs.remote_name }}" -o ./${{ inputs.binary_name }}
-        echo "${{ inputs.expected_sha256 }}  ${{ inputs.binary_name }}" | sha256sum -c -
-        sudo mv ./${{ inputs.binary_name }} /usr/local/bin/${{ inputs.binary_name }}
-        sudo chmod +x /usr/local/bin/${{ inputs.binary_name }}
+        curl -sSL "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${VERSION}/${REMOTE_NAME}" -o "./${BINARY_NAME}"
+        echo "${EXPECTED_SHA256}  ${BINARY_NAME}" | sha256sum -c -
+        sudo mv "./${BINARY_NAME}" "/usr/local/bin/${BINARY_NAME}"
+        sudo chmod +x "/usr/local/bin/${BINARY_NAME}"


### PR DESCRIPTION
## Summary
`fetch-binary` interpolated repo/version/filename/checksum inputs directly into `curl`/`mv`/`chmod` in a `run:` script. `cache-docker-images` interpolated `inputs.images` into a `for` loop. Move those values into `env:` and expand shell variables instead.

## Test plan
- [ ] Workflows using `fetch-binary` still download, checksum, and install the binary
- [ ] Docker image cache warm/cold paths still pull/save listed images


Made with [Cursor](https://cursor.com)