### PR TITLE
chore(tooling): add runner-selection guidance to the edit-workflow skill

### DIFF
--- a/.claude/commands/edit-workflow.md
+++ b/.claude/commands/edit-workflow.md
@@ -13,6 +13,23 @@ uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 - Never use version tags alone (`@v4` is wrong)
 - Local actions (`./.github/actions/*`) are exempt from pinning
 
+## Runner Selection
+
+Self-hosted runners (`[self-hosted-ghr, size-*-x64]`) are a shared EF devops
+pool — reserve them for jobs that need the capacity. Non-critical or low-load
+jobs belong on GitHub-hosted runners (`ubuntu-latest`), which also avoids a
+provisioning wait (~2.5 min) if the self-hosted warm pool is exhausted.
+
+- **Pattern**: lightweight job (short runtime, no heavy parallelism) →
+  `ubuntu-latest` (e.g. `spec-tools` in #3177).
+- **Anti-pattern**: defaulting a quick gate, lint, or cache-restore job to
+  `size-xl-x64` "to be safe".
+- **Exception**: a job may need self-hosted for reasons other than load, e.g.
+  Docker Hub pulls from GHR egress IPs to dodge per-IP rate limits (#3185
+  keeps push runs self-hosted while PR runs use `ubuntu-latest`).
+
+If unsure which runner a job needs, flag it and ask instead of guessing.
+
 ## Validation
 
 Run `just lint-actions` before committing to validate YAML syntax and structure.


### PR DESCRIPTION
### Description

Adds a "Runner Selection" section to the `/edit-workflow` agent skill so workflow changes default non-critical, low-load jobs to GitHub-hosted runners (`ubuntu-latest`) instead of the shared EF devops self-hosted pool (`[self-hosted-ghr, size-*-x64]`), avoiding unnecessary throttling of the self-hosted runners.

Codifies the pattern from two recent right-sizing PRs:
- #3177 — `spec-tools` moved to `ubuntu-latest`, `test-tests-pypy` downsized to `size-l-x64`
- #3185 — the PR docker-image cache gate moved to `ubuntu-latest`, with push/dispatch runs kept self-hosted for the GHR-egress-IP exception (Docker Hub per-IP rate limits)

The skill also instructs the agent to flag and ask rather than guess when the right runner for a job is unclear.

### Related Issues or PRs

Follows up on #3177 and #3185.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![429 Too Many Requests](https://http.cat/429)
