### PR TITLE
fix(spec-specs): validate the gas limit on the London fork block

### DIFF
--- a/src/ethereum/forks/london/fork.py
+++ b/src/ethereum/forks/london/fork.py
@@ -331,7 +331,17 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     assert isinstance(FORK_CRITERIA, ByBlockNumber)
 
     expected_base_fee_per_gas = INITIAL_BASE_FEE
-    if header.number != FORK_CRITERIA.block_number:
+    if header.number == FORK_CRITERIA.block_number:
+        # The fork block has no parent base fee to extrapolate from, so the
+        # base fee is fixed. The gas limit is still bounded, but relative to
+        # the parent's gas limit scaled by the elasticity multiplier, because
+        # the fork doubles the gas limit while holding the gas target
+        # constant.
+        if not check_gas_limit(
+            header.gas_limit, parent_header.gas_limit * ELASTICITY_MULTIPLIER
+        ):
+            raise InvalidBlock
+    else:
         # For every block except the first, calculate the base fee per gas
         # based on the parent block.
         expected_base_fee_per_gas = calculate_base_fee_per_gas(


### PR DESCRIPTION
### Description

`validate_header` does not check the gas limit on the London fork block.

**Context.** Every header must satisfy the gas-limit relation: the limit must lie
strictly within `parent_gas_limit +/- parent_gas_limit // 1024` and be at least
`LIMIT_MINIMUM`. `check_gas_limit` implements it. On the fork block EIP-1559
scales the comparison base — the gas limit doubles while the gas target is held
constant. EIP-1559's own reference implementation does exactly this:

```python
if INITIAL_FORK_BLOCK_NUMBER == block.number:
    parent_gas_target = self.parent(block).gas_limit
    parent_gas_limit = self.parent(block).gas_limit * ELASTICITY_MULTIPLIER
```

and then asserts `block.gas_limit < parent_gas_limit + parent_gas_limit // 1024`,
`> parent_gas_limit - parent_gas_limit // 1024`, and `>= 5000` against that
scaled value. The Yellow Paper specifies the same thing as
`P(H)_{H_l'} = P(H)_{H_l} * rho` with `rho = 2` (`Paper.tex:655`, `:673-686`,
`:710-713`), and states it in prose at `:688`: *"the value of the parent block
gas limit for the purpose of validating the current block's gas limit is
modified at the London fork block by multiplying it by the elasticity
multiplier."*

**Anomaly.** In `london/fork.py`, `check_gas_limit` has exactly one call site:
line 257, inside `calculate_base_fee_per_gas`. `validate_header` skips that call
on the fork block —

```python
if header.number != FORK_CRITERIA.block_number:
    expected_base_fee_per_gas = calculate_base_fee_per_gas(...)
```

— substituting `INITIAL_BASE_FEE` for the computed base fee. A mandated validity
conjunct is thereby implemented only as a side effect of an unrelated
computation, and on the one block where that computation is skipped, **none of
the three gas-limit clauses is enforced**:

```
H_l <  2*P_l + floor(2*P_l/1024)
H_l >  2*P_l - floor(2*P_l/1024)
H_l >= 5000
```

Separately, the fork-block scaling is constructed nowhere in the codebase;
`ELASTICITY_MULTIPLIER` feeds only `parent_gas_target`.

**Impact.** On block 12965000 a header with any gas limit whatsoever — including
`1` — passes `validate_header`. The bypass is unique to London: from Paris
onward `validate_header` always calls `calculate_base_fee_per_gas`, so the check
is always reached (verified in `paris`, `shanghai`, `cancun` and `prague`, none
of which special-case the fork block in `validate_header`). Because the
canonical mainnet block at that height is long final, the consequence is confined
to EELS as a reference implementation and to consumers relying on it to reject
malformed historical headers. Per `SECURITY.md` this is not a serious issue —
production clients implement the EIP-1559 fork-block rule correctly — so it is
filed normally rather than reported privately.

**Resolution.** Call `check_gas_limit` explicitly on the fork block against
`parent_header.gas_limit * ELASTICITY_MULTIPLIER` and raise `InvalidBlock` on
failure. The `else` branch is the previous code path verbatim. One file changed.

**Verification.** A header at number 12965000 with a Berlin parent
(`gas_limit = 15,000,000`) and `gas_limit = 1` is accepted before the change and
rejected after. Two controls rule out vacuity: an off-by-one `base_fee_per_gas`
on the same path does raise `InvalidBlock`, and the identical gas limit at
LONDON+1 is rejected through `validate_header -> calculate_base_fee_per_gas`.

The fix is then pinned against real mainnet data. Block 12965000 has
`gas_limit = 30,029,122`, with parent 12964999 at `15,029,237`. Scaled:
`15,029,237 * 2 = 30,058,474`, adjustment delta
`30,058,474 // 1024 = 29,353`, so the exclusive lower bound is
`30,058,474 - 29,353 = 30,029,121`. The real block sits **exactly one gas
above** that bound and is still accepted; the same header **fails** the unscaled
check outright. The scaling factor is therefore load-bearing and exactly right.
The boundary is exercised in both directions: `30,029,121` — the bound itself,
which `check_gas_limit` rejects since its comparison is `<=` — is rejected, and
`30,029,122` is accepted.

`fill --fork=London tests/london tests/berlin tests/frontier`: **2643 passed, 4
deselected** both before and after the change.

`just static` passes in full (exit 0) — `typecheck` (mypy clean across 4287
source files), `lint-spec`, `spellcheck`, `deadcode`, `lint-actions`,
`lock-check`, `format-check` and `lint`, each also confirmed individually.

Branch is rebased on `forks/amsterdam` at `f1aa97022`; all of the above was
re-run against that tip.

### Related Issues or PRs

N/A — no existing issue or PR reports this. The nearest neighbours, checked and
distinct:

- **#743** (*Refactor base fee calculation*, merged) corrects the fork-block
  **base-fee value** for Arrow Glacier and Gray Glacier — adjacent, but a
  different quantity, and it does not restore the gas-limit check.
- **#1411** (EIP-7782, closed) contains a contributor remark that
  `check_gas_limit` "needs custom logic for the fork block" — but that is about
  implementing a *new* fork's activation logic on their own branch, not a report
  that London's `validate_header` skips the check.
- **#2230** (*historically-accurate per-fork block gas limits*, open) concerns
  the gas limit used when **filling test fixtures** (`A-test-fill`), not header
  validation.
- **#3056** (*move priority-fee check to `validate_transaction`*, merged) is the
  most recent change to this file and touches an unrelated validation path.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

Suggested labels: `C-bug`, `A-spec-specs` — matching the title's `fix` type and
`spec-specs` area.

### Cute Animal Picture

<img width="1080" height="2340" alt="Screenshot_20260805_143721_Gallery" src="https://github.com/user-attachments/assets/4f65954f-ab3c-46bc-8753-62c460c5f13b" />
