### PR TITLE
fix(test-execute): register per-test hive test cases with the shared client

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -295,14 +295,16 @@ def test_case_description(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(autouse=True)
-def per_test_hive_test(hive_test: HiveTest) -> None:
+def per_test_hive_test(client: Client, hive_test: HiveTest) -> None:
     """
     Report each pytest test as an individual hive test case.
 
-    The client runs under the session-scoped base hive test; this
-    per-test entry only propagates the individual test result to hive.
+    The client runs under the session-scoped base hive test; register
+    it with each per-test entry so hive attaches the client and its
+    log segment to the individual test case and marks the base test
+    as the multi-test lifecycle owner.
     """
-    del hive_test
+    hive_test.register_multi_test_client(client)
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -430,6 +432,11 @@ def client(
         users += 1
         with open(users_file, "w") as f:
             json.dump(users, f)
+
+    # Set on every worker (the client object is shared across xdist
+    # workers via JSON serialization) so that per-test hive test cases
+    # can register with the client.
+    client.multi_test = True
 
     yield client
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -309,7 +309,6 @@ def per_test_hive_test(client: Client, hive_test: HiveTest) -> None:
 
 @pytest.fixture(autouse=True, scope="session")
 def base_hive_test(
-    request: pytest.FixtureRequest,
     test_suite: HiveTestSuite,
     session_temp_folder: Path,
 ) -> Generator[HiveTest, None, None]:
@@ -349,11 +348,17 @@ def base_hive_test(
 
     yield test
 
-    test_pass = True
-    test_details = "All tests have completed"
-    if request.session.testsfailed > 0:
+    # Individual results are reported by the per-test hive test cases,
+    # and hive marks this test as the multi-test lifecycle owner, so it
+    # always passes unless the client failed to start (the client
+    # fixture leaves its error file behind on startup failure).
+    client_error_file = session_temp_folder / "hive_client.err"
+    if client_error_file.exists():
         test_pass = False
-        test_details = "One or more tests have failed"
+        test_details = "Failed to start the client."
+    else:
+        test_pass = True
+        test_details = "Multi-test client context completed."
 
     with FileLock(users_lock_file):
         with open(users_file, "r") as f:


### PR DESCRIPTION
### Description

Follow-up to #3287, which made `execute hive` report each pytest test as an individual hive test case, but left out the client-registration step that `consume enginex` performs. This PR:

- **Adds client association**: each per-test entry now shows the shared client it ran against (previously no client was attached).
- **Adds per-test client log segments**: each entry links to only its own byte range of the shared client's log (previously no client log link at all).
- **Fixes double-reported failures**: the "Base Hive Test" entry no longer duplicates every failure as an extra failing entry at the end of the run.

Implementation, mirroring the enginex pattern (`_per_test_reporting` / `resolved_client.multi_test = True`):

- Set `multi_test = True` on the session-scoped shared client. It is set unconditionally on every xdist worker, so the flag also holds on workers that deserialize the client from the session temp folder rather than starting it.
- Register the client with every per-test hive test case via `hive_test.register_multi_test_client(client)`. Hive then copies the client info into each test case with its own log byte range (`logOffsets`) and marks the base test as the multi-test lifecycle owner (`multiTestContext`), so hiveview and [hive-ui](https://github.com/ethpandaops/hive-ui/pull/76) show the client and a scoped client-log link on each individual test entry.
- End the base test `pass=True` ("Multi-test client context completed."), matching enginex's `multi_test_hive_test`, unless the client failed to start (detected via the client fixture's error file), in which case it ends `pass=False`. This removes the double-reported failure; the previous `request.session.testsfailed` check was also unreliable under xdist, since only the last worker to finish ended the test, using its own per-worker failure count.

Notes:

- **Hive version**: this breaks `execute hive` against hive versions from before ethereum/hive#1402 (on `master` since 2026-03-17; CI checks out `master`) — registration fails loudly during every test's setup. This was deemed reasonable: enginex has the same requirement with no fallback, and the failure clearly points at the missing `/register/` endpoint ("update your hive").
- **Log segments are approximate under xdist**: `execute hive` runs all tests concurrently against one shared client across `-n` workers, so a test's log byte range contains interleaved output from tests running in parallel on other workers (unlike enginex, where a pre-alloc group's tests run serially on one worker). Client association in the UI is the main win.
- **Non-hive execute modes are unaffected**: only `pytest-execute-hive.ini` loads the `rpc.hive` plugin; `rpc.remote` imports nothing from it, and `fill_stateful` imports only pure builder functions from this module, none of which are touched.

Verified against local `./hive --dev` (hive master) with go-ethereum and nethermind, including with `-n 2`: every per-test case in the resulting suite JSON carries `clientInfo` with its own `logOffsets` range, the base test is `multiTestContext: true` and passes while failing tests are counted exactly once, and the `multi_test` flag survives the client-sharing round trip between xdist workers.

### Related Issues or PRs

Follow-up to #3287. Related: ethereum/hive#1402 (multi-test client registration), ethpandaops/hive-ui#76 (per-test client log sections in the UI).

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A cat guarding its log segments](https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Cat_on_wood.jpg/960px-Cat_on_wood.jpg)
