### PR TITLE
chore(tooling): add test-docstring guidance to the write-test skill

### DIFF
--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -75,6 +75,13 @@ Never hand-reconstruct a gas amount by summing `fork.gas_costs()` constants (`NE
 - Each EIP directory has `spec.py` with `ReferenceSpec(git_path=..., version=...)` and test files declaring `REFERENCE_SPEC_GIT_PATH` / `REFERENCE_SPEC_VERSION`
 - Use `conftest.py` for shared fixtures within an EIP directory
 
+## Test Docstrings
+
+- Keep the docstring to a short summary of the scenario and the rule it pins — a sentence or two.
+- Do not narrate the implementation: parametrized cases, gas decompositions, and case-by-case outcome walkthroughs are already expressed by the code. Prose restating them goes stale when the test changes and adds review burden.
+- State only what the code cannot show (e.g. why a boundary value is chosen). Prefer a short inline comment at the relevant line over growing the docstring.
+- Never hardcode numeric gas values in docstrings; name the constants instead.
+
 ## Parametrization
 
 - `@pytest.mark.parametrize("name", [pytest.param(val, id="label"), ...])` with descriptive `id=` strings


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Adds a "Test Docstrings" section to the write-test skill: keep test docstrings to a short summary of the rule under test, don't narrate what the code already expresses (parametrized cases, gas decompositions, case-by-case outcomes), prefer inline comments for anything the code can't show, and never hardcode numeric gas values.

Follows the review feedback on #3318.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![cat](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)
