### PR TITLE
fix(tests): accept gas allowance error at EIP-7778 admission gate

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -614,7 +614,10 @@ def test_extra_tx_admission_uses_pre_refund_gas(
         blocks=[
             Block(
                 txs=[refund_tx, extra_tx],
-                exception=BlockException.GAS_USED_OVERFLOW,
+                exception=[
+                    BlockException.GAS_USED_OVERFLOW,
+                    TransactionException.GAS_ALLOWANCE_EXCEEDED,
+                ],
                 gas_limit=environment_gas_limit,
             )
         ],


### PR DESCRIPTION
- the last transaction requests 30,000 gas while there is only 29,999 gas left available in the gas pool
- transaction gets rejected at admission with `GAS_ALLOWANCE_EXCEEDED`