### PR TITLE
test(evm_tools): revive the opcode-count test against in-repo inputs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -215,7 +215,6 @@ spec-tools *args: (_tmp "spec-tools")
     uv run pytest \
         -n {{ xdist_workers }} \
         --basetemp="{{ output_dir }}/spec-tools/tmp" \
-        --ignore=tests/evm_tools/test_count_opcodes.py \
         "$@" \
         tests/evm_tools
 

--- a/tests/evm_tools/test_count_opcodes.py
+++ b/tests/evm_tools/test_count_opcodes.py
@@ -6,7 +6,6 @@ using the T8N tool.
 import json
 from io import StringIO
 from pathlib import Path
-from typing import Callable
 
 import pytest
 
@@ -16,25 +15,27 @@ from ethereum_spec_tools.evm_tools.t8n.cli import run_t8n_cli
 
 parser = create_parser()
 
+# Fixture 3 is the only client_clis alloc with code, so the only one
+# that runs opcodes.
+FIXTURE = Path(__file__).parents[2] / (
+    "packages/testing/src/execution_testing/client_clis/tests/fixtures/3"
+)
+
 
 @pytest.mark.evm_tools
-def test_count_opcodes(root_relative: Callable[[str | Path], Path]) -> None:
+def test_count_opcodes() -> None:
     """Test counting opcodes in a transaction execution using the T8N tool."""
-    base_path = root_relative(
-        "fixtures/evm_tools_testdata/t8n/fixtures/testdata/2"
-    )
-
     options = parser.parse_args(
         [
             "t8n",
-            f"--input.env={base_path / 'env.json'}",
-            f"--input.alloc={base_path / 'alloc.json'}",
-            f"--input.txs={base_path / 'txs.json'}",
+            f"--input.env={FIXTURE / 'env.json'}",
+            f"--input.alloc={FIXTURE / 'alloc.json'}",
+            f"--input.txs={FIXTURE / 'txs.json'}",
             "--output.result=stdout",
             "--output.body=stdout",
             "--output.alloc=stdout",
             "--opcode.count=stdout",
-            "--state-test",
+            "--state.fork=Frontier",
         ]
     )
 
@@ -47,10 +48,5 @@ def test_count_opcodes(root_relative: Callable[[str | Path], Path]) -> None:
 
     results = json.loads(out_file.getvalue())
 
-    assert results["opcodeCount"] == {
-        "PUSH1": 5,
-        "MSTORE8": 1,
-        "CREATE": 1,
-        "ADD": 1,
-        "SELFDESTRUCT": 1,
-    }
+    # 0x600140 is PUSH1 then BLOCKHASH.
+    assert results["opcodeCount"] == {"PUSH1": 1, "BLOCKHASH": 1}


### PR DESCRIPTION
Closes #3326, taking the second option there: rewrite rather than delete, so the
opcode-count tracer gets its first coverage.

The test asked for `root_relative`, defined in a sibling tree, and pointed at
`fixtures/evm_tools_testdata`, which no download step provides. It now uses the
client_clis transition inputs. Fixture 3 is the only alloc there with code, `0x600140`,
so the call runs PUSH1 then BLOCKHASH. Those inputs are a plain transition rather than a
state test, so the run names the fork instead of passing `--state-test`.

The `--ignore` in the `spec-tools` target goes with it. Only one target carries it on
`forks/amsterdam`; the issue mentions two, which holds on another branch.

One thing I did not decide: `test_execution_specs.py` imports `Berlin` while this names
Frontier. The count is the same either way, but say if Berlin is the intended fork.

## Testing

`uv run pytest -n 4 tests/evm_tools`: 42 passed, with the file collected for the first
time. I restored the pre-change file from git and confirmed it still errors with
`fixture 'root_relative' not found`, and flipping the expected count to `PUSH1: 2` fails,
so the assertion really reads the tracer.

Static analysis: `ruff check`, `ruff format --check`, `codespell`, `vulture`,
`ethereum-spec-lint` and `mypy` all pass.

Claude Code was used for implementation assistance, covering the test rewrite and this
description. All changes have been reviewed, understood and manually tested by me.
