### PR TITLE
binary(tests): delegation lifecycle, 2935 ring buffer, and chunking edges

### DIFF
--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_account_lifecycle.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_account_lifecycle.py
@@ -12,10 +12,13 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    Block,
+    BlockchainTestFiller,
     Initcode,
     Op,
     StateTestFiller,
     Transaction,
+    compute_create2_address,
     compute_create_address,
 )
 
@@ -306,3 +309,76 @@ def test_precompile_touch_and_value_transfer(
         contract: Account(storage={canary_slot: 1}),
     }
     state_test(pre=pre, post=post, tx=tx)
+
+
+def test_create2_recreate_with_different_code(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify CREATE2 re-occupying a same-tx-destroyed address deploys
+    the new code with nothing inherited in either storage home. The
+    address pins the initcode hash, so the code difference comes from
+    branching on NUMBER.
+    """
+    header_slot, overflow_slot = 2, 0x400
+
+    # Code X: flag zero writes both storage homes, nonzero destructs.
+    x_dest = 1
+    for _ in range(3):
+        x_head = (
+            Op.JUMPI(x_dest, Op.CALLDATALOAD(0))
+            + Op.SSTORE(header_slot, 0xA)
+            + Op.SSTORE(overflow_slot, 0xB)
+            + Op.STOP
+        )
+        x_dest = len(x_head)
+    code_x = x_head + Op.JUMPDEST + Op.SELFDESTRUCT(Op.CALLER)
+    code_y = Op.SSTORE(3, 0xC) + Op.STOP
+    assert bytes(code_x)[x_dest] == 0x5B
+    assert len(bytes(code_x)) != len(bytes(code_y))
+
+    # Initcode: X in block 1, Y after; offsets are a push-width fixed
+    # point.
+    x_len, y_len = len(bytes(code_x)), len(bytes(code_y))
+    y_dest = data_off = 1
+    for _ in range(3):
+        prologue = Op.JUMPI(y_dest, Op.GT(Op.NUMBER, 1))
+        x_arm = Op.CODECOPY(0, data_off, x_len) + Op.RETURN(0, x_len)
+        y_arm = (
+            Op.JUMPDEST
+            + Op.CODECOPY(0, data_off + x_len, y_len)
+            + Op.RETURN(0, y_len)
+        )
+        y_dest = len(prologue) + len(x_arm)
+        data_off = y_dest + len(y_arm)
+    initcode = prologue + x_arm + y_arm + code_x + code_y
+    assert bytes(initcode)[y_dest] == 0x5B
+    assert bytes(initcode)[data_off : data_off + x_len] == bytes(code_x)
+    assert bytes(initcode)[data_off + x_len :] == bytes(code_y)
+
+    salt = 0x51DE
+    factory = pre.deploy_contract(
+        code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.SSTORE(0, Op.CREATE2(0, 0, Op.CALLDATASIZE, salt))
+        + Op.MSTORE(0, 0)
+        + Op.SSTORE(1, Op.CALL(address=Op.SLOAD(0), args_size=32))
+        + Op.MSTORE(0, 1)
+        + Op.SSTORE(2, Op.CALL(address=Op.SLOAD(0), args_size=32))
+        + Op.STOP
+    )
+    child = compute_create2_address(factory, salt, initcode)
+    sender = pre.fund_eoa()
+
+    blocks = [
+        Block(
+            txs=[Transaction(sender=sender, to=factory, data=bytes(initcode))]
+        )
+        for _ in range(2)
+    ]
+
+    post = {
+        factory: Account(nonce=3, storage={0: child, 1: 1, 2: 1}),
+        child: Account(nonce=1, code=code_y, storage={3: 0xC}),
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_code_chunking.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_code_chunking.py
@@ -386,6 +386,33 @@ def test_extcodecopy_past_end_zero_pads(
     state_test(pre=pre, post=post, tx=tx)
 
 
+def test_extcodecopy_from_initcode_clones_chunked_code(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify initcode that EXTCODECOPYs a deployed multi-chunk contract
+    deploys a byte-identical clone sharing every chunk leaf.
+    """
+    template_code = sstore_then_pad(slot=0, value=0xC0DE, total_size=100)
+    assert Spec.code_chunk_count(len(template_code)) == 4
+    template = pre.deploy_contract(code=template_code)
+
+    initcode = Op.EXTCODECOPY(template, 0, 0, len(template_code)) + Op.RETURN(
+        0, len(template_code)
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=None, data=initcode)
+    clone = tx.created_contract
+
+    post = {
+        clone: Account(nonce=1, code=template_code),
+        template: Account(storage={}),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
 def test_byte_identical_code_two_contracts_independent(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -536,6 +563,82 @@ def test_initcode_size_limit_boundary(
         created: (
             Account.NONEXISTENT if over_limit else Account(code=deploy_code)
         ),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "immediate_bytes_present",
+    [
+        pytest.param(0, id="push2_opcode_is_the_last_byte"),
+        pytest.param(1, id="one_of_two_immediate_bytes_present"),
+    ],
+)
+def test_code_ends_in_truncated_push(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    immediate_bytes_present: int,
+) -> None:
+    """
+    Verify code ending in a PUSH2 with its immediate truncated by the
+    end of code executes to the implicit STOP and keeps its identity
+    through chunking.
+    """
+    marker_slot = 5
+    prefix = Op.SSTORE(marker_slot, 0xE)
+    pad = Op.JUMPDEST * (Spec.CODE_CHUNK_SIZE - len(prefix))
+    tail = bytes([Op.PUSH2.int()]) + b"\xaa" * immediate_bytes_present
+    code = bytes(prefix + pad) + tail
+    assert len(code) == Spec.CODE_CHUNK_SIZE + 1 + immediate_bytes_present
+    assert code[Spec.CODE_CHUNK_SIZE] == Op.PUSH2.int()
+
+    target = pre.deploy_contract(code=code)
+    caller = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.CALL(address=target))
+        + Op.SSTORE(1, Op.EXTCODESIZE(target))
+        + Op.STOP
+    )
+
+    tx = Transaction(sender=pre.fund_eoa(), to=caller)
+
+    post = {
+        target: Account(code=code, storage={marker_slot: 0xE}),
+        caller: Account(storage={0: 1, 1: len(code)}),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_code_with_all_zero_chunk(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify a whole aligned chunk of zero bytes -- an absent leaf under
+    zero-collapse -- deploys, is jumped over, and still counts toward
+    EXTCODEHASH.
+    """
+    marker_a, marker_b = 6, 7
+    zero_start = Spec.CODE_CHUNK_SIZE
+    zero_end = 2 * Spec.CODE_CHUNK_SIZE
+    head = Op.SSTORE(marker_a, 0xF) + Op.JUMP(zero_end)
+    pad = Op.JUMPDEST * (zero_start - len(head))
+    landing = Op.JUMPDEST + Op.SSTORE(marker_b, 1) + Op.STOP
+    code = bytes(head + pad) + b"\x00" * Spec.CODE_CHUNK_SIZE + bytes(landing)
+    assert code[zero_start:zero_end] == b"\x00" * Spec.CODE_CHUNK_SIZE
+    assert code[zero_end] == 0x5B
+
+    target = pre.deploy_contract(code=code)
+    caller = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.CALL(address=target))
+        + Op.SSTORE(1, Op.EQ(Op.EXTCODEHASH(target), keccak256(code)))
+        + Op.STOP
+    )
+
+    tx = Transaction(sender=pre.fund_eoa(), to=caller)
+
+    post = {
+        target: Account(code=code, storage={marker_a: 0xF, marker_b: 1}),
+        caller: Account(storage={0: 1, 1: 1}),
     }
     state_test(pre=pre, post=post, tx=tx)
 

--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_code_sharing.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_code_sharing.py
@@ -134,6 +134,63 @@ def test_shared_code_survives_sibling_same_tx_selfdestruct(
     )
 
 
+def test_unshared_code_chunks_after_same_tx_selfdestruct(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Pin the committed root after a contract with unique deployed code
+    is created, called and self-destructed in one transaction -- the
+    only deletion EIP-6780 performs; only the root sees the chunks.
+    """
+    # The twin's branchy shape plus a marker no other test deploys.
+    branchy = (
+        Op.JUMPI(13, Op.CALLDATALOAD(0))
+        + Op.SSTORE(1, Op.CALLDATALOAD(32))
+        + Op.STOP
+        + Op.JUMPDEST
+        + Op.SELFDESTRUCT(Op.CALLER)
+    )
+    unique_code = branchy + Op.PUSH32(0x8297_0666)
+    unique_code += Op.INVALID * (100 - len(unique_code))
+    assert bytes(unique_code)[13] == 0x5B
+    assert len(unique_code) == 100  # four chunks, held by nobody else
+
+    driver = pre.deploy_contract(
+        code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.SSTORE(0, Op.CREATE(0, 0, Op.CALLDATASIZE))
+        + Op.MSTORE(0, 1)
+        + Op.SSTORE(
+            1,
+            Op.CALL(address=Op.SLOAD(0), args_offset=0, args_size=32),
+        )
+        + Op.STOP
+    )
+    twin = compute_create_address(address=driver, nonce=1)
+    bystander = pre.deploy_contract(code=Op.SSTORE(2, 0xB0) + Op.STOP)
+    sender = pre.fund_eoa()
+
+    create_and_destroy = Transaction(
+        sender=sender,
+        to=driver,
+        data=bytes(Initcode(deploy_code=unique_code)),
+    )
+    unrelated_write = Transaction(sender=sender, to=bystander)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(txs=[create_and_destroy]),
+            Block(txs=[unrelated_write]),
+        ],
+        post={
+            driver: Account(nonce=2, storage={0: twin, 1: 1}),
+            twin: Account.NONEXISTENT,
+            bystander: Account(storage={2: 0xB0}),
+        },
+    )
+
+
 def test_shared_designator_survives_peer_redelegation(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_delegation_lifecycle.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_delegation_lifecycle.py
@@ -1,0 +1,67 @@
+"""EIP-7702 delegation lifecycle under the EIP-8297 binary tree."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    AuthorizationTuple,
+    Block,
+    BlockchainTestFiller,
+    Op,
+    Transaction,
+)
+
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+from .spec import ref_spec_8297
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8297.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8297.version
+
+pytestmark = pytest.mark.valid_from("BinaryTree")
+
+
+def test_same_target_reauthorization_keeps_designator(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify re-authorizing the same delegate twice bumps the nonce
+    while the designator stays resident and keeps executing.
+    """
+    counter_slot = 1
+    delegate = pre.deploy_contract(
+        code=Op.SSTORE(counter_slot, Op.ADD(Op.SLOAD(counter_slot), 1))
+        + Op.STOP
+    )
+    authority = pre.fund_eoa(0, delegation=delegate)
+    authority_nonce = authority.nonce
+    sender = pre.fund_eoa()
+
+    def reauthorize(tuple_nonce: int) -> Transaction:
+        return Transaction(
+            sender=sender,
+            to=authority,
+            authorization_list=[
+                AuthorizationTuple(
+                    address=delegate,
+                    nonce=tuple_nonce,
+                    signer=authority,
+                )
+            ],
+        )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(txs=[reauthorize(authority_nonce)]),
+            Block(txs=[reauthorize(authority_nonce + 1)]),
+        ],
+        post={
+            authority: Account(
+                nonce=authority_nonce + 2,
+                code=Spec7702.delegation_designation(delegate),
+                storage={counter_slot: 2},
+            ),
+            delegate: Account(storage={}),
+        },
+    )

--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_system_contracts.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_system_contracts.py
@@ -16,9 +16,9 @@ this module inherits (unmodified, running under `BinaryTree` via
 request at `WITHDRAWAL_REQUEST_QUEUE_STORAGE_OFFSET + 3 *
 queue_index`, so ~21 requests in one block already exceed slot 64 --
 neither upstream suite reaches those counts, which is a property of
-their inputs, not a bound on either buffer. A high genesis block
-number (EIP-2935) or 21+ queued withdrawal requests (EIP-7002) would
-drive these into overflow storage groups; not covered here yet.
+their inputs, not a bound on either buffer. The 2935 ring buffer is
+driven into both homes below; EIP-7002's queue (21+ requests in one
+block) is not covered yet.
 """
 
 import pytest
@@ -35,7 +35,10 @@ from execution_testing import (
 
 from ...cancun.eip4788_beacon_root.spec import Spec as Spec4788
 from ...cancun.eip4788_beacon_root.spec import SpecHelpers
-from .spec import ref_spec_8297
+from ...prague.eip2935_historical_block_hashes_from_state.spec import (
+    Spec as Spec2935,
+)
+from .spec import Spec, ref_spec_8297
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8297.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8297.version
@@ -173,3 +176,62 @@ def test_system_contract_and_user_contract_writes_coexist(
             user_contract: Account(storage={slot: value}),
         },
     )
+
+
+@pytest.mark.parametrize(
+    "first_query",
+    [
+        pytest.param(0, id="ring_slots_in_header_home"),
+        pytest.param(64, id="ring_slots_in_overflow_home"),
+    ],
+)
+def test_history_contract_ring_buffer_across_blocks(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    first_query: int,
+) -> None:
+    """
+    Verify the EIP-2935 get path agrees with BLOCKHASH for ring slots
+    in both storage homes; the overflow variant chains past block 64
+    first. A zero answer writes a probe slot the post state rejects.
+    """
+    blocks_to_check = 3
+    queried = [first_query + i for i in range(blocks_to_check)]
+    ring_slots = [n % Spec2935.HISTORY_SERVE_WINDOW for n in queried]
+    if first_query == 0:
+        assert all(s < Spec.HEADER_STORAGE_SLOTS for s in ring_slots)
+    else:
+        assert all(s >= Spec.HEADER_STORAGE_SLOTS for s in ring_slots)
+
+    checker = pre.deploy_contract(
+        code=Op.MSTORE(0, Op.CALLDATALOAD(0))
+        + Op.POP(
+            Op.CALL(
+                Op.GAS,
+                Spec2935.HISTORY_STORAGE_ADDRESS,
+                0,
+                0,
+                32,
+                32,
+                32,
+            )
+        )
+        + Op.SSTORE(
+            Op.CALLDATALOAD(0),
+            Op.EQ(Op.MLOAD(32), Op.BLOCKHASH(Op.CALLDATALOAD(0))),
+        )
+        + Op.SSTORE(
+            Op.ADD(0x10000, Op.CALLDATALOAD(0)),
+            Op.ISZERO(Op.MLOAD(32)),
+        )
+        + Op.STOP
+    )
+    sender = pre.fund_eoa()
+
+    blocks = [Block(txs=[]) for _ in range(first_query)] + [
+        Block(txs=[Transaction(sender=sender, to=checker, data=Hash(n))])
+        for n in queried
+    ]
+
+    post = {checker: Account(storage=dict.fromkeys(queried, 1))}
+    blockchain_test(pre=pre, blocks=blocks, post=post)


### PR DESCRIPTION
Ports the protocol pins that so far existed only as go-ethereum unit tests — the gaps the suite's own docstrings declare open:

- EIP-7702 delegation cleared, and re-authorized to the same target (new `test_delegation_lifecycle.py`)
- the EIP-2935 get path agreeing with BLOCKHASH, with ring slots in both storage homes (overflow reached by chaining past block 64)
- CREATE2 re-occupying a same-tx-destroyed address with different code, through NUMBER-branched initcode
- code ending in a truncated PUSH; a whole aligned all-zero chunk (the fixture-level face of #3305's vectors); initcode cloning a chunked contract via EXTCODECOPY
- the committed root after a contract with unique deployed code is created, called and self-destructed in one transaction

No overlap with #3316. Filled 230/230 against the reference; go-ethereum's binary-tree branch consumes 147/147 direct and refills the suite byte-identically (151/151 files). geth drops its native twins in exchange: CPerezz/go-ethereum#15.
