### PR TITLE
fix(tests): account for value in EIP-8070 transaction gas

### DIFF
--- a/tests/amsterdam/eip8070_sparse_blobpool/conftest.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/conftest.py
@@ -27,9 +27,11 @@ def tx_value() -> int:
 
 
 @pytest.fixture
-def tx_gas(fork: Fork) -> int:
+def tx_gas(fork: Fork, tx_value: int) -> int:
     """Gas allocated to transactions sent during test."""
-    return fork.transaction_intrinsic_cost_calculator()(sends_value=True)
+    return fork.transaction_intrinsic_cost_calculator()(
+        sends_value=tx_value > 0
+    )
 
 
 @pytest.fixture

--- a/tests/amsterdam/eip8070_sparse_blobpool/conftest.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/conftest.py
@@ -29,7 +29,7 @@ def tx_value() -> int:
 @pytest.fixture
 def tx_gas(fork: Fork) -> int:
     """Gas allocated to transactions sent during test."""
-    return fork.transaction_intrinsic_cost_calculator()()
+    return fork.transaction_intrinsic_cost_calculator()(sends_value=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description

The shared EIP-8070 fixture sends transactions with `value=1`, but derives `tx_gas` without setting `sends_value`. Under Amsterdam, the intrinsic-cost calculator therefore returns 15,000 gas instead of the required 21,000 gas, and `eels/execute-blobs` clients correctly reject the transactions as intrinsically under-gassed.

Pass `sends_value=True` when deriving the fixture gas limit. This restores the intended sparse-blob tests instead of failing at `eth_sendRawTransaction` before any EIP-8070 behavior is exercised.

The public Glamsterdam Hive workflow currently consumes `devnets/glamsterdam/8`, where this causes 137 real failures plus the aggregate base-test failure. Please add the `backport devnets/glamsterdam/8` label so the correction reaches that scheduled run after merge.

### Related Issues or PRs

N/A.

### Testing

- `eels/execute-blobs` through Hive, sourcing this exact fork commit and using Nethermind `1.40.0-unstable+5f7fd1c3`: 171/171 passed
- Amsterdam gas smoke check: default 15,000; `sends_value=True` 21,000; fixture 21,000
- Repository-wide Ruff format/lint, codespell, vulture, execution-spec lint, and lock checks
- Targeted mypy check for `tests/amsterdam/eip8070_sparse_blobpool/conftest.py`
- Upstream CI: all 16 checks passed, including `static`, all fork fills, PyPy, JSON loader, framework tests, Codecov, and GitGuardian

The local Windows host could not run the `just static` wrapper verbatim because its `just` predates the branch's `[default]` syntax; the equivalent applicable checks passed locally, and the complete upstream Linux `static` job passed.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Long-eared jerboa](https://inaturalist-open-data.s3.amazonaws.com/photos/306676265/original.jpg)


