### PR TITLE
perf(test-rpc, test-fill): fetch a block's receipts with single `eth_getBlockReceipts`

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -292,7 +292,9 @@ class ClientBackend:
         assert np_version is not None
         assert fcu_version is not None
 
-        receipts = self._fetch_receipts(txs)
+        receipts = self._fetch_receipts(
+            txs, get_payload_response.execution_payload.block_hash
+        )
         result = self._build_result(
             built_payload=get_payload_response.execution_payload,
             execution_requests=get_payload_response.execution_requests,
@@ -434,29 +436,50 @@ class ClientBackend:
         )
 
     def _fetch_receipts(
-        self, txs: List[Transaction]
+        self,
+        txs: List[Transaction],
+        block_hash: Optional[Hash] = None,
     ) -> List[TransactionReceipt]:
         """
-        Fetch receipts for every transaction in the block, batched.
+        Fetch a receipt for every transaction, in transaction order.
 
-        One request per transaction makes fill time latency-bound: a block
-        of 5,000 transactions costs 5,000 sequential round trips, which
-        against a non-local client dominates everything else the fill does
-        (the client executes such a block in ~150ms).
+        Given a `block_hash`, one `eth_getBlockReceipts` fetches the whole
+        block's receipts at once. Returned receipts are matched to
+        transactions by hash rather than byposition, so the block-level
+        response may arrive in any order. Any receipt it did not include is
+        fetched individually with a batched`eth_getTransactionReceipt`;
+        an error is raised only if a receipt is still missing after
+        that fallback.
         """
         if not txs:
             return []
-        receipt_data_list = self.eth_rpc.get_transaction_receipts(
-            [tx.hash for tx in txs]
-        )
-        receipts: List[TransactionReceipt] = []
-        for tx, receipt_data in zip(txs, receipt_data_list, strict=True):
-            if receipt_data is None:
-                raise RuntimeError(
-                    f"No receipt found for transaction {tx.hash}"
-                )
-            receipts.append(TransactionReceipt.model_validate(receipt_data))
-        return receipts
+        receipt_data_by_hash: Dict[Hash, Any] = {}
+        if block_hash is not None:
+            block_receipts = self.eth_rpc.get_block_receipts(block_hash)
+            for receipt_data in block_receipts or []:
+                tx_hash = receipt_data.get("transactionHash")
+                if tx_hash is not None:
+                    receipt_data_by_hash[Hash(tx_hash)] = receipt_data
+        missing = [
+            tx.hash for tx in txs if tx.hash not in receipt_data_by_hash
+        ]
+        if missing:
+            fetched = self.eth_rpc.get_transaction_receipts(missing)
+            for tx_hash, fetched_data in zip(missing, fetched, strict=True):
+                if fetched_data is not None:
+                    receipt_data_by_hash[tx_hash] = fetched_data
+        still_missing = [
+            tx.hash for tx in txs if tx.hash not in receipt_data_by_hash
+        ]
+        if still_missing:
+            raise RuntimeError(
+                f"No receipt found for {len(still_missing)} of {len(txs)} "
+                f"transactions, first missing: {still_missing[0]}"
+            )
+        return [
+            TransactionReceipt.model_validate(receipt_data_by_hash[tx.hash])
+            for tx in txs
+        ]
 
     def _build_result(
         self,

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -438,44 +438,48 @@ class ClientBackend:
     def _fetch_receipts(
         self,
         txs: List[Transaction],
-        block_hash: Optional[Hash] = None,
+        block_hash: Hash,
     ) -> List[TransactionReceipt]:
         """
-        Fetch a receipt for every transaction, in transaction order.
+        Fetch all transaction receipts in order.
 
-        Given a `block_hash`, one `eth_getBlockReceipts` fetches the whole
-        block's receipts at once. Returned receipts are matched to
-        transactions by hash rather than byposition, so the block-level
-        response may arrive in any order. Any receipt it did not include is
-        fetched individually with a batched`eth_getTransactionReceipt`;
-        an error is raised only if a receipt is still missing after
-        that fallback.
+        Use `eth_getBlockReceipts` for the block, then fetch any receipt it
+        did not return with a batched `eth_getTransactionReceipt` fallback.
+        Raise an error if any receipt remains missing.
         """
         if not txs:
             return []
-        receipt_data_by_hash: Dict[Hash, Any] = {}
-        if block_hash is not None:
-            block_receipts = self.eth_rpc.get_block_receipts(block_hash)
-            for receipt_data in block_receipts or []:
-                tx_hash = receipt_data.get("transactionHash")
-                if tx_hash is not None:
-                    receipt_data_by_hash[Hash(tx_hash)] = receipt_data
+        block_receipts: List[dict[str, Any]] = []
+        try:
+            block_receipts = self.eth_rpc.get_block_receipts(block_hash) or []
+        except JSONRPCError as error:
+            logger.warning(
+                f"eth_getBlockReceipts failed for block {block_hash}: {error}"
+            )
+
+        receipt_data_by_hash: Dict[Hash, dict[str, Any]] = {}
+        for receipt_data in block_receipts:
+            tx_hash = receipt_data.get("transactionHash")
+            if tx_hash is not None:
+                receipt_data_by_hash[Hash(tx_hash)] = receipt_data
+
         missing = [
             tx.hash for tx in txs if tx.hash not in receipt_data_by_hash
         ]
         if missing:
+            logger.warning(
+                f"Block receipts covered {len(txs) - len(missing)} of "
+                f"{len(txs)} transactions; fetching the remaining "
+                f"{len(missing)} in a batched fallback"
+            )
             fetched = self.eth_rpc.get_transaction_receipts(missing)
             for tx_hash, fetched_data in zip(missing, fetched, strict=True):
-                if fetched_data is not None:
-                    receipt_data_by_hash[tx_hash] = fetched_data
-        still_missing = [
-            tx.hash for tx in txs if tx.hash not in receipt_data_by_hash
-        ]
-        if still_missing:
-            raise RuntimeError(
-                f"No receipt found for {len(still_missing)} of {len(txs)} "
-                f"transactions, first missing: {still_missing[0]}"
-            )
+                if fetched_data is None:
+                    raise RuntimeError(
+                        f"No receipt found for transaction {tx_hash}"
+                    )
+                receipt_data_by_hash[tx_hash] = fetched_data
+
         return [
             TransactionReceipt.model_validate(receipt_data_by_hash[tx.hash])
             for tx in txs

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -598,16 +598,14 @@ class EthRPC(BaseRPC):
         ).result_or_raise()
 
     def get_block_receipts(
-        self, block: BlockNumberType | Hash = "latest"
+        self, block_hash: Hash
     ) -> List[dict[str, Any]] | None:
-        """
-        `eth_getBlockReceipts`: every receipt in a block, in one call.
-        Returns receipts in transaction order, or None if the block is unknown.
-        """
-        identifier = hex(block) if isinstance(block, int) else str(block)
-        logger.info(f"Requesting all receipts for block {identifier}..")
+        """`eth_getBlockReceipts`: Returns every receipt in a block."""
+        logger.info(f"Requesting all receipts for block {block_hash}..")
         return self.post_request(
-            request=RPCCall(method="getBlockReceipts", params=[identifier])
+            request=RPCCall(
+                method="getBlockReceipts", params=[f"{block_hash}"]
+            )
         ).result_or_raise()
 
     def get_block_by_hash(

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -597,6 +597,19 @@ class EthRPC(BaseRPC):
             request=RPCCall(method="getBlockByNumber", params=params)
         ).result_or_raise()
 
+    def get_block_receipts(
+        self, block: BlockNumberType | Hash = "latest"
+    ) -> List[dict[str, Any]] | None:
+        """
+        `eth_getBlockReceipts`: every receipt in a block, in one call.
+        Returns receipts in transaction order, or None if the block is unknown.
+        """
+        identifier = hex(block) if isinstance(block, int) else str(block)
+        logger.info(f"Requesting all receipts for block {identifier}..")
+        return self.post_request(
+            request=RPCCall(method="getBlockReceipts", params=[identifier])
+        ).result_or_raise()
+
     def get_block_by_hash(
         self, block_hash: Hash, full_txs: bool = True
     ) -> Any | None:


### PR DESCRIPTION
Note: written with LLM

Per-transaction receipt lookup is quadratic in a block's transaction count. A client resolves a single receipt by loading the block's whole receipt list and returning one entry from it, so N lookups do N x O(N) work. Batching the requests removes the round trips but not that cost -- the batch is one request, and the client still does the work N times.

Measured against ethpandaops/geth:glamsterdam-devnet-7 on a block of plain transfers, timing each phase separately:

    transactions   per-tx batch   getBlockReceipts
           1,000          0.47s              0.02s
           2,000          1.66s              0.05s
           4,000          5.43s              0.08s
           8,000         19.94s              0.17s

The per-tx path scales at ~n^1.7 (8x the transactions costs 42x the time) while this one is linear. Everything else in the fill -- building the block, executing it, forkchoice -- is linear and fast by comparison (0.82s, 0.34s, 0.03s at N=8,000).

At the 16,000-transaction blocks the stateful benchmarks build, that extrapolates to ~80s of receipt fetching per fixture against well under a second, roughly half the wall clock of a fill run. Observed on a real fill: 16,000-tx fixtures took ~170s each while geth logged elapsed=423ms for the block import.

eth_getBlockReceipts returns receipts in transaction order, but the previous path matched them to transactions by hash; keep that guarantee explicitly rather than trusting ordering silently, and check the count.

Drops the now-unused batched get_transaction_receipts helper, which this branch had added for this call site and nothing else uses.

### Description
Switches to `eth_getBlockReceipts` instead of batch-query of each receipt in the block.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
