### PR TITLE
chore(tests): derive blob tx gas from fork intrinsic cost

### DIFF
--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -49,9 +49,11 @@ def tx_value() -> int:
 
 
 @pytest.fixture
-def tx_gas() -> int:
+def tx_gas(fork: Fork, tx_value: int) -> int:
     """Gas allocated to transactions sent during test."""
-    return 21_000
+    return fork.transaction_intrinsic_cost_calculator()(
+        sends_value=tx_value > 0
+    )
 
 
 @pytest.fixture

--- a/tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py
+++ b/tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py
@@ -55,11 +55,25 @@ def blob_gas_price(fork: Fork | TransitionFork) -> int:
 
 
 @pytest.fixture
+def tx_gas(fork: Fork | TransitionFork) -> int:
+    """Intrinsic gas for the value-carrying blob transactions."""
+    return max(
+        fork.transitions_from().transaction_intrinsic_cost_calculator()(
+            sends_value=True
+        ),
+        fork.transitions_to().transaction_intrinsic_cost_calculator()(
+            sends_value=True
+        ),
+    )
+
+
+@pytest.fixture
 def tx(
     sender: Address,
     destination: Address,
     blob_gas_price: int,
     blob_count: int,
+    tx_gas: int,
 ) -> Transaction:
     """Blob transaction fixture."""
     return Transaction(
@@ -67,7 +81,7 @@ def tx(
         sender=sender,
         to=destination,
         value=1,
-        gas_limit=21_000,
+        gas_limit=tx_gas,
         max_fee_per_gas=10,
         max_priority_fee_per_gas=1,
         max_fee_per_blob_gas=blob_gas_price,


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Replace the two hardcoded `21_000` blob transaction gas limits in the PeerDAS tests with fork derived intrinsic costs, so they survive future intrinsic gas repricings. Spotted by Besu when running execute blobs for the sparse blob pool tests.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow up to #3344.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Baby hedgehog](https://media.tenor.com/0JppWq_FCoUAAAA1/kaden-bear.webp)
