### PR TITLE
chore(test-client-clis): update geth BAL exception mappings

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -156,7 +156,10 @@ class GethExceptionMapper(ExceptionMapper):
         # EELS definition for `is_valid_deposit_event_data`:
         # https://github.com/ethereum/execution-specs/blob/5ddb904fa7ba27daeff423e78466744c51e8cb6a/src/ethereum/forks/prague/requests.py#L51
         # BAL Exceptions
-        BlockException.INVALID_BAL_HASH: (r"invalid block access list:"),
+        BlockException.INVALID_BAL_HASH: (
+            r"invalid block access list:|"
+            r"access list hash mismatch"
+        ),
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"difference between computed state diff and "
             r"BAL entry for account|"
@@ -165,11 +168,14 @@ class GethExceptionMapper(ExceptionMapper):
             r"which weren't reported in BAL|"
             r"BAL change not reported in computed|"
             r"additional mutations compared to BAL|"
+            r"access list hash mismatch|"
+            r"failed to decode BAL|"
             r"[bB][aA][lL] validation fail"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (r"invalid block access list:"),
         BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
-            r"block access list exceeds gas limit"
+            r"block access list exceeds gas limit|"
+            r"block access list exceeds size constraint"
         ),
         BlockException.GAS_USED_OVERFLOW: (r"gas limit reached"),
         TransactionException.INTRINSIC_GAS_TOO_LOW: (


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Map 3 geth BAL rejection messages seen on glamsterdam-devnet-8 hive runs ([latest geth run](https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786364721-7e8d93e52bc192c82e545e97bf2fdeff)).

Clean up of the mappers is a follow up.

The remaining 9 are geth-side: 6 reject for a different reason than expected (validation ordering), 3 miss the `-32602` pre-fork field check.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
