### PR TITLE
fix(benchmark): split benchmark gas evenly: every tx can pay data floor

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -481,15 +481,50 @@ class BenchmarkTest(BaseTest):
             return [tx]
 
         num_splits = math.ceil(self.gas_benchmark_value / gas_limit_cap)
-        remaining_gas = self.gas_benchmark_value
+
+        # Spread the gas evenly rather than giving every split the cap and the
+        # last one whatever remains.
+        #
+        # Every split is a copy carrying the *same* calldata, so each one has
+        # an irreducible minimum: it must cover that calldata's floor data
+        # cost. A remainder tail is unrelated to that minimum and can land
+        # below it, producing a transaction no client will accept. With the
+        # EIP-7825 cap of 2**24, a 220M benchmark left its final transaction
+        # 1,896,192 gas while its 36,864-byte calldata cost 2,374,296 at the
+        # floor, and geth rejected the block build outright:
+        #
+        #   insufficient gas for floor data gas cost: have 1896192,
+        #   want 2374296
+        #
+        # That was reachable only after EIP-7976 raised the floor from 40 to
+        # 64 gas per calldata byte; under the previous floor the same tail
+        # cost 1,245,840 and fit. An even split's smallest share is
+        # gas_benchmark_value // num_splits, i.e. at least half the cap.
+        #
+        # The total is deliberately unchanged, because benchmark gas
+        # validation asserts the block consumes exactly gas_benchmark_value
+        # (`BaseTest.validate_gas_used`). Dropping the short tail instead
+        # would trade a rejected transaction for a failed assertion.
+        base_gas, extra = divmod(self.gas_benchmark_value, num_splits)
+
+        fork = self.fork.fork_at(block_number=0, timestamp=0)
+        minimum_gas = max(
+            fork.transaction_intrinsic_cost_calculator()(calldata=tx.data),
+            fork.transaction_data_floor_cost_calculator()(data=tx.data),
+        )
+        if base_gas < minimum_gas:
+            raise ValueError(
+                f"cannot split {self.gas_benchmark_value} gas across "
+                f"{num_splits} transactions: each would receive {base_gas} "
+                f"gas, but the {len(tx.data)}-byte calldata costs "
+                f"{minimum_gas} at minimum. The test's own gas guard should "
+                f"have skipped this configuration."
+            )
 
         split_transactions = []
         for i in range(num_splits):
             split_tx = tx.model_copy()
-            split_tx.gas_limit = HexNumber(
-                remaining_gas if i == num_splits - 1 else gas_limit_cap
-            )
-            remaining_gas -= gas_limit_cap
+            split_tx.gas_limit = HexNumber(base_gas + (1 if i < extra else 0))
             split_tx.nonce = HexNumber(tx.nonce + i)
             split_transactions.append(split_tx)
 

--- a/packages/testing/src/execution_testing/specs/tests/test_benchmark.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_benchmark.py
@@ -5,8 +5,8 @@ transaction splitting functionality.
 
 import pytest
 
-from execution_testing.base_types import HexNumber
-from execution_testing.forks import Osaka
+from execution_testing.base_types import Bytes, HexNumber
+from execution_testing.forks import Amsterdam, Osaka
 from execution_testing.specs.benchmark import BenchmarkTest
 from execution_testing.test_types import Alloc, Environment, Transaction
 
@@ -65,28 +65,84 @@ def test_split_transaction(
             f"Transaction {i} gas limit {tx_gas_limit} "
             f"exceeds cap {gas_limit_cap}"
         )
-        # Verify gas distribution
-        if i < len(split_txs) - 1:  # All but last should be at cap
-            assert tx_gas_limit == gas_limit_cap, (
-                f"Transaction {i} should have gas limit {gas_limit_cap}, "
-                f"got {tx_gas_limit}"
-            )
-        else:
-            # Last transaction should have the remainder
-            if expected_splits > 1:
-                expected_last_gas = gas_benchmark_value - (
-                    gas_limit_cap * (expected_splits - 1)
-                )
-                assert tx_gas_limit == expected_last_gas, (
-                    f"Last transaction should have {expected_last_gas} gas, "
-                    f"got {tx_gas_limit}"
-                )
         # Verify nonces increment correctly
         assert tx.nonce == i, f"Transaction {i} has incorrect nonce {tx.nonce}"
+
+    # Gas is spread evenly rather than cap-cap-...-remainder, so the shares
+    # differ by at most one wei of gas. The old scheme's tail could be
+    # arbitrarily small, which made it unable to pay the floor data cost of the
+    # calldata every split carries -- see
+    # test_split_transaction_tail_covers_data_floor.
+    gas_limits = [int(tx.gas_limit or 0) for tx in split_txs]
+    assert max(gas_limits) - min(gas_limits) <= 1, (
+        f"Gas should be spread evenly, got {gas_limits}"
+    )
     # Verify total gas equals the benchmark value
     assert total_gas == gas_benchmark_value, (
         f"Total gas {total_gas} doesn't match benchmark "
         f"value {gas_benchmark_value}"
+    )
+
+
+@pytest.mark.parametrize(
+    "gas_benchmark_value_millions",
+    [100, 120, 140, 160, 180, 200, 220, 240, 260, 280, 300],
+)
+def test_split_transaction_tail_covers_data_floor(
+    gas_benchmark_value_millions: int,
+) -> None:
+    """
+    Every split must be able to pay the floor data cost of its calldata.
+
+    Each split is a copy of the same transaction, so each carries identical
+    calldata and owes identical floor data gas. Splitting gas as
+    cap-cap-...-remainder left the final transaction with
+    ``gas_benchmark_value % cap``, which is unrelated to that floor and could
+    fall below it -- a 220M benchmark on Amsterdam gave its last transaction
+    1,896,192 gas against a 2,374,296 floor, and clients reject it with
+    "insufficient gas for floor data gas cost".
+
+    36,864 bytes is the worst-case BLS12_G2MSM k=128 calldata that surfaced
+    this.
+    """
+    gas_benchmark_value = gas_benchmark_value_millions * 1_000_000
+    calldata = Bytes(b"\xab" * 36_864)
+    fork = Amsterdam
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    minimum_gas = max(
+        fork.transaction_intrinsic_cost_calculator()(calldata=calldata),
+        fork.transaction_data_floor_cost_calculator()(data=calldata),
+    )
+
+    benchmark_test = BenchmarkTest(
+        fork=fork,
+        pre=Alloc(),
+        post=Alloc(),
+        tx=Transaction(
+            sender=HexNumber(0), to=HexNumber(0), nonce=0, data=calldata
+        ),
+        env=Environment(),
+        gas_benchmark_value=gas_benchmark_value,
+    )
+    assert benchmark_test.tx is not None
+    split_txs = benchmark_test.split_transaction(
+        benchmark_test.tx, gas_limit_cap
+    )
+
+    for i, tx in enumerate(split_txs):
+        assert tx.gas_limit is not None
+        assert int(tx.gas_limit) >= minimum_gas, (
+            f"Transaction {i} of {len(split_txs)} has gas limit "
+            f"{int(tx.gas_limit)}, below the {minimum_gas} minimum its "
+            f"{len(calldata)}-byte calldata requires"
+        )
+
+    # The total must stay exact: benchmark gas validation asserts the block
+    # consumes precisely gas_benchmark_value.
+    assert sum(int(tx.gas_limit or 0) for tx in split_txs) == (
+        gas_benchmark_value
     )
 
 

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -164,11 +164,17 @@ def test_bls12_g2_msm(
 
     calldata = _g2msm_worstcase_calldata(k)
 
-    intrinsic_gas_cost = fork.transaction_intrinsic_cost_calculator()(
-        calldata=calldata
+    # The floor data cost can exceed the standard intrinsic cost on this much
+    # calldata -- EIP-7976 charges 64 gas per byte -- so the minimum a
+    # transaction carrying it can be given is the larger of the two. The
+    # per-transaction minimum (this benchmark is split across several
+    # transactions) is enforced in BenchmarkTest.split_transaction.
+    minimum_gas_cost = max(
+        fork.transaction_intrinsic_cost_calculator()(calldata=calldata),
+        fork.transaction_data_floor_cost_calculator()(data=calldata),
     )
 
-    if intrinsic_gas_cost > gas_benchmark_value:
+    if minimum_gas_cost > gas_benchmark_value:
         pytest.skip("k configuration exceeds the gas limit")
 
     attack_block = Op.POP(


### PR DESCRIPTION
Note: written by LLM

**MERGING THIS WILL CHANGE THE BENCHMARK/TEST OUTPUT SIGNIFICANTLY DUE TO UPDATED TX SPLITTER LOGIC**

`split_transaction` gave each split the gas limit cap and the last one whatever remained. Every split is a `model_copy()` of the same transaction, so each carries identical calldata and owes identical floor data gas -- but a remainder tail is unrelated to that floor and can land below it, producing a transaction no client will accept.

Filling the compute benchmarks against Amsterdam hit exactly this. With the EIP-7825 cap of 2**24, a 220M benchmark splits into 14 transactions and the last receives 220,000,000 - 13 * 16,777,216 = 1,896,192 gas, while the 36,864-byte worst-case BLS12_G2MSM k=128 calldata costs 2,374,296 at the floor. geth rejected the build:

    insufficient gas for floor data gas cost: have 1896192, want 2374296

220M was the only value in 100..300M that failed, which is why this surfaced as a single mystifying case rather than a pattern.

It is also new. The floor is 15,000 + 16 * 4 * 36,864 = 2,374,296 under Amsterdam, where EIP-7976 charges 64 gas per calldata byte (zero and non-zero alike) and EIP-2780 lowers the base to 15,000. Under Osaka the same calldata's floor is 21,000 + 10 * 122,484 = 1,245,840, which fits in 1,896,192 -- so the test was correct until EIP-7976 raised the floor. Both figures match `transaction_data_floor_cost_calculator` exactly.

Spreading the gas evenly across the same number of splits raises the smallest share from "whatever remains" to `gas // num_splits`, at least half the cap -- 15,000,000 at worst across the benchmark gas values, against a 2,374,296 floor.

The total is deliberately preserved. Dropping the short tail instead would trade a rejected transaction for a failed assertion, because `BaseTest.validate_gas_used` requires the block to consume exactly `gas_benchmark_value`.

Also makes the BLS12_G2MSM skip guard floor-aware; it compared only the standard intrinsic cost, which is the smaller of the two on calldata this large.

The existing split tests asserted the cap-cap-remainder shape itself, so they now assert the invariants that matter: the split count, the cap ceiling, exact total, incrementing nonces, and an even spread. The new test fails on the old code at 220M with `assert 1896192 >= 2374296`.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
