### PR TITLE
feat(test-benchmark): more worst case scenario

### DIFF
--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -157,6 +157,8 @@ def test_extcodecopy_warm(
     "opcode",
     [
         Op.BALANCE,
+        Op.EXTCODESIZE,
+        Op.EXTCODEHASH,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -83,19 +83,6 @@ from tests.benchmark.helper.numeric import (
             ),
         ),
         pytest.param(
-            # This has the cycle of 2, see above.
-            Op.DIV,
-            (
-                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
-                # We want the first divisor to be slightly bigger than
-                # 2**192: a four-word divisor falls past the one- and
-                # two-word fast paths onto the general long-division
-                # algorithm, which the 2**64 and 2**128 cases above do not
-                # reach.
-                0x1000000000000000000000000000000000000000000000033,
-            ),
-        ),
-        pytest.param(
             # Same as DIV-0
             # But the numerator made positive, and the divisor made negative.
             Op.SDIV,
@@ -112,15 +99,6 @@ from tests.benchmark.helper.numeric import (
             (
                 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
                 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFCD,
-            ),
-        ),
-        pytest.param(
-            # Same as the 2**192 DIV case above, with the numerator made
-            # positive and the divisor made negative.
-            Op.SDIV,
-            (
-                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
-                0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFCD,
             ),
         ),
         pytest.param(

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -83,6 +83,19 @@ from tests.benchmark.helper.numeric import (
             ),
         ),
         pytest.param(
+            # This has the cycle of 2, see above.
+            Op.DIV,
+            (
+                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
+                # We want the first divisor to be slightly bigger than
+                # 2**192: a four-word divisor falls past the one- and
+                # two-word fast paths onto the general long-division
+                # algorithm, which the 2**64 and 2**128 cases above do not
+                # reach.
+                0x1000000000000000000000000000000000000000000000033,
+            ),
+        ),
+        pytest.param(
             # Same as DIV-0
             # But the numerator made positive, and the divisor made negative.
             Op.SDIV,
@@ -99,6 +112,15 @@ from tests.benchmark.helper.numeric import (
             (
                 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
                 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFCD,
+            ),
+        ),
+        pytest.param(
+            # Same as the 2**192 DIV case above, with the numerator made
+            # positive and the divisor made negative.
+            Op.SDIV,
+            (
+                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
+                0xFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFCD,
             ),
         ),
         pytest.param(

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -177,13 +177,14 @@ def test_nested_frame_memory(
         Op.MSTORE8(mem_size - 1, 0xFF) if mem_size > 0 else Bytecode()
     )
 
-    descend = Op.MSTORE(0, Op.SUB(Op.CALLDATALOAD(0), 1)) + Op.POP(
-        Op.CALL(
+    descend = Op.MSTORE(0, Op.SUB(Op.CALLDATALOAD(0), 1)) + Conditional(
+        condition=Op.CALL(
             gas=Op.GAS,
             address=Op.ADDRESS,
             args_offset=0,
             args_size=32,
-        )
+        ),
+        if_false=Op.REVERT(0, 0),
     )
 
     entry_address = pre.deploy_contract(

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -11,13 +11,18 @@ Supported Opcodes:
 
 import pytest
 from execution_testing import (
+    Alloc,
     BenchmarkCodeGenerator,
     BenchmarkTestFiller,
     Bytecode,
+    Conditional,
     ExtCallGenerator,
     Fork,
+    Hash,
     JumpLoopGenerator,
     Op,
+    Transaction,
+    WhileGas,
 )
 
 
@@ -126,4 +131,75 @@ def test_mcopy(
         code_generator=JumpLoopGenerator(
             attack_block=attack_block, cleanup=mem_touch
         ),
+    )
+
+
+@pytest.mark.parametrize("mem_size", [0, 8 * 1024, 64 * 1024])
+def test_sibling_frame_memory(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    mem_size: int,
+) -> None:
+    """Benchmark sibling call frames that each expand their own memory."""
+    frame_code = Op.STOP if mem_size == 0 else Op.MSTORE8(mem_size - 1, 0)
+    frame_address = pre.deploy_contract(code=frame_code)
+
+    benchmark_test(
+        target_opcode=Op.CALL,
+        code_generator=JumpLoopGenerator(
+            attack_block=Op.POP(
+                Op.CALL(
+                    gas=Op.GAS,
+                    address=frame_address,
+                )
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize("depth", [1, 64, 256])
+@pytest.mark.parametrize("mem_size", [0, 8 * 1024, 64 * 1024])
+def test_nested_frame_memory(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    depth: int,
+    mem_size: int,
+) -> None:
+    """Benchmark a deep frame stack where every frame holds live memory."""
+    leaf_address = pre.deploy_contract(
+        code=WhileGas(body=Op.POP(Op.MLOAD(Op.PUSH0)), fork=fork)
+    )
+
+    # The frame's own memory is claimed before the descent, and must not
+    # overlap memory[0:32], which carries the depth to the next frame.
+    frame_memory = (
+        Op.MSTORE8(mem_size - 1, 0xFF) if mem_size > 0 else Bytecode()
+    )
+
+    descend = Op.MSTORE(0, Op.SUB(Op.CALLDATALOAD(0), 1)) + Op.POP(
+        Op.CALL(
+            gas=Op.GAS,
+            address=Op.ADDRESS,
+            args_offset=0,
+            args_size=32,
+        )
+    )
+
+    entry_address = pre.deploy_contract(
+        code=frame_memory
+        + Conditional(
+            condition=Op.ISZERO(Op.CALLDATALOAD(0)),
+            if_true=Op.POP(Op.CALL(gas=Op.GAS, address=leaf_address)),
+            if_false=descend,
+        )
+    )
+
+    benchmark_test(
+        tx=Transaction(
+            to=entry_address,
+            data=Hash(depth),
+            sender=pre.fund_eoa(),
+        ),
+        skip_gas_used_validation=True,
     )

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -594,7 +594,7 @@ def test_nested_frame_state_access(
         if_false=Op.REVERT(0, 0),
     )
     invoke_leaf = Op.CALL(
-        gas=Op.GAS, address=leaf_address, address_warm=True
+        gas=Op.GAS, address=leaf_address, address_warm=False
     ) + Conditional(
         condition=Op.RETURNDATASIZE, if_false=Op.REVERT(Op.PUSH0, Op.PUSH0)
     )
@@ -606,15 +606,13 @@ def test_nested_frame_state_access(
     )
     entry_address = pre.deploy_contract(code=frame_code)
 
-    frame_gas = frame_code.execution_cost(fork)
+    frame_gas = frame_code.gas_cost(fork)
     leaf_gas = leaf_code.gas_cost(fork)
     leaf_state_gas = leaf_code.state_cost(fork)
 
-    def deepest_frame(execution_gas: int, reservoir_gas: int) -> int:
+    def deepest_frame(execution_gas: int) -> int:
         """Return the deepest frame that can still afford the leaf call."""
-        leaf_call_gas = frame_gas + math.ceil(
-            (leaf_gas - reservoir_gas) * 64 / 63
-        )
+        leaf_call_gas = frame_gas + math.ceil(leaf_gas * 64 / 63)
         frames = 0
         while True:
             forwarded_gas = execution_gas - frame_gas
@@ -645,7 +643,7 @@ def test_nested_frame_state_access(
                 to=entry_address,
                 gas_limit=execution_gas + reservoir_gas,
                 data=Hash(
-                    deepest_frame(execution_gas - intrinsic_gas, reservoir_gas)
+                    deepest_frame(execution_gas - intrinsic_gas)
                     if depth is None
                     else depth
                 ),

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -17,6 +17,7 @@ from execution_testing import (
     BenchmarkTestFiller,
     Block,
     Bytecode,
+    Conditional,
     ExtCallGenerator,
     Fork,
     Hash,
@@ -27,6 +28,7 @@ from execution_testing import (
     TestPhaseManager,
     Transaction,
     While,
+    WhileGas,
     compute_create_address,
 )
 
@@ -520,4 +522,84 @@ def test_storage_access_warm_benchmark(
         if storage_action == StorageAction.READ
         else Op.SSTORE,
         code_generator=ExtCallGenerator(attack_block=attack_block),
+    )
+
+
+@pytest.mark.parametrize("revert", [True, False])
+@pytest.mark.parametrize("depth", [1, pytest.param(None, id="max")])
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.SLOAD,
+        Op.SSTORE,
+        Op.TLOAD,
+        Op.TSTORE,
+    ],
+)
+def test_nested_frame_state_access(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_gas_limit: int,
+    gas_benchmark_value: int,
+    depth: int | None,
+    opcode: Op,
+    revert: bool,
+) -> None:
+    """Benchmark warm state access from the bottom of a deep frame stack."""
+    match opcode:
+        case Op.SLOAD:
+            body = Op.POP(Op.SLOAD(Op.PUSH0))
+        case Op.SSTORE:
+            body = Op.SSTORE(Op.GAS, Op.GAS)
+        case Op.TLOAD:
+            body = Op.POP(Op.TLOAD(Op.GAS))
+        case Op.TSTORE:
+            body = Op.TSTORE(Op.GAS, Op.GAS)
+        case _:
+            raise ValueError(f"Unsupported opcode: {opcode}")
+
+    epilogue = Op.REVERT(0, 0) if revert else Bytecode()
+    leaf_code = (
+        WhileGas(body=body, fork=fork, extra_gas=epilogue.gas_cost(fork))
+        + epilogue
+    )
+    leaf_address = pre.deploy_contract(code=leaf_code)
+
+    descend = Op.MSTORE(0, Op.SUB(Op.CALLDATALOAD(0), 1)) + Op.POP(
+        Op.CALL(
+            gas=Op.GAS,
+            address=Op.ADDRESS,
+            args_offset=0,
+            args_size=32,
+            address_warm=True,
+        )
+    )
+
+    frame_code = Conditional(
+        condition=Op.ISZERO(Op.CALLDATALOAD(0)),
+        if_true=Op.POP(
+            Op.CALL(gas=Op.GAS, address=leaf_address, address_warm=True)
+        ),
+        if_false=descend,
+    )
+    entry_address = pre.deploy_contract(code=frame_code)
+
+    if depth is None:
+        frame_cost = frame_code.gas_cost(fork)
+        gas = min(tx_gas_limit, gas_benchmark_value)
+        depth = 0
+        while gas > frame_cost + leaf_code.gas_cost(fork):
+            gas -= frame_cost
+            gas -= gas // 64
+            depth += 1
+
+    benchmark_test(
+        target_opcode=opcode,
+        skip_gas_used_validation=True,
+        tx=Transaction(
+            to=entry_address,
+            data=Hash(depth),
+            sender=pre.fund_eoa(),
+        ),
     )

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -559,47 +559,103 @@ def test_nested_frame_state_access(
         case _:
             raise ValueError(f"Unsupported opcode: {opcode}")
 
-    epilogue = Op.REVERT(0, 0) if revert else Bytecode()
+    # A leaf that runs out of gas returns no data, unlike one that reverts.
+    epilogue = (
+        Op.REVERT(
+            0,
+            32,
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        if revert
+        else Op.RETURN(
+            0,
+            32,
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+    )
     leaf_code = (
         WhileGas(body=body, fork=fork, extra_gas=epilogue.gas_cost(fork))
         + epilogue
     )
     leaf_address = pre.deploy_contract(code=leaf_code)
 
-    descend = Op.MSTORE(0, Op.SUB(Op.CALLDATALOAD(0), 1)) + Op.POP(
-        Op.CALL(
+    descend = Op.MSTORE(0, Op.SUB(Op.CALLDATALOAD(0), 1)) + Conditional(
+        condition=Op.CALL(
             gas=Op.GAS,
             address=Op.ADDRESS,
             args_offset=0,
             args_size=32,
             address_warm=True,
-        )
+        ),
+        if_false=Op.REVERT(0, 0),
+    )
+    invoke_leaf = Op.CALL(
+        gas=Op.GAS, address=leaf_address, address_warm=True
+    ) + Conditional(
+        condition=Op.RETURNDATASIZE, if_false=Op.REVERT(Op.PUSH0, Op.PUSH0)
     )
 
     frame_code = Conditional(
-        condition=Op.ISZERO(Op.CALLDATALOAD(0)),
-        if_true=Op.POP(
-            Op.CALL(gas=Op.GAS, address=leaf_address, address_warm=True)
-        ),
-        if_false=descend,
+        condition=Op.CALLDATALOAD(0),
+        if_true=descend,
+        if_false=invoke_leaf,
     )
     entry_address = pre.deploy_contract(code=frame_code)
 
-    if depth is None:
-        frame_cost = frame_code.gas_cost(fork)
-        gas = min(tx_gas_limit, gas_benchmark_value)
-        depth = 0
-        while gas > frame_cost + leaf_code.gas_cost(fork):
-            gas -= frame_cost
-            gas -= gas // 64
-            depth += 1
+    frame_gas = frame_code.execution_cost(fork)
+    leaf_gas = leaf_code.gas_cost(fork)
+    leaf_state_gas = leaf_code.state_cost(fork)
+
+    def deepest_frame(execution_gas: int, reservoir_gas: int) -> int:
+        """Return the deepest frame that can still afford the leaf call."""
+        leaf_call_gas = frame_gas + math.ceil(
+            (leaf_gas - reservoir_gas) * 64 / 63
+        )
+        frames = 0
+        while True:
+            forwarded_gas = execution_gas - frame_gas
+            forwarded_gas -= forwarded_gas // 64
+            if forwarded_gas < leaf_call_gas:
+                return frames
+            execution_gas = forwarded_gas
+            frames += 1
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=b"\xff" * 32,
+        return_cost_deducted_prior_execution=True,
+    )
+
+    txs = []
+    remaining_gas = gas_benchmark_value
+    while remaining_gas > 0:
+        execution_gas = min(tx_gas_limit, remaining_gas)
+        remaining_gas -= execution_gas
+        reservoir_gas = (
+            leaf_state_gas
+            if fork.state_gas_reservoir_enabled()
+            and execution_gas == tx_gas_limit
+            else 0
+        )
+        txs.append(
+            Transaction(
+                to=entry_address,
+                gas_limit=execution_gas + reservoir_gas,
+                data=Hash(
+                    deepest_frame(execution_gas - intrinsic_gas, reservoir_gas)
+                    if depth is None
+                    else depth
+                ),
+                sender=pre.fund_eoa(),
+            )
+        )
 
     benchmark_test(
         target_opcode=opcode,
         skip_gas_used_validation=True,
-        tx=Transaction(
-            to=entry_address,
-            data=Hash(depth),
-            sender=pre.fund_eoa(),
-        ),
+        expected_receipt_status=1,
+        blocks=[Block(txs=txs)],
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -13,6 +13,7 @@ Supported Opcodes:
 - SELFDESTRUCT
 """
 
+import math
 from typing import Any
 
 import pytest
@@ -268,19 +269,39 @@ def test_nested_call_chain(
     gas_benchmark_value: int,
 ) -> None:
     """Benchmark nested call frames that each enter a different contract."""
-    gas = min(tx_gas_limit, gas_benchmark_value)
+    # Overwriting the slot keeps the tail cheaper than filling a fresh one.
+    tail = Op.SSTORE(0, 2, original_value=1, current_value=1, new_value=2)
+    tail_address = pre.deploy_contract(code=tail, storage={0: 1})
 
-    address = pre.deploy_contract(code=Op.STOP)
-    link = Op.POP(Op.CALL(gas=Op.GAS, address=address, address_warm=True))
-    while gas > link.gas_cost(fork):
-        gas -= link.gas_cost(fork)
-        gas -= gas // 64
+    # Every level is a distinct account, so the first traversal pays cold
+    # access all the way down.
+    address = tail_address
+    link = Op.POP(Op.CALL(gas=Op.GAS, address=address, address_warm=False))
+    tail_call_gas = link.gas_cost(fork) + math.ceil(
+        tail.gas_cost(fork) * 64 / 63
+    )
+
+    gas = min(tx_gas_limit, gas_benchmark_value)
+    gas -= fork.transaction_intrinsic_cost_calculator()(
+        return_cost_deducted_prior_execution=True
+    )
+    while True:
+        forwarded_gas = gas - link.gas_cost(fork)
+        forwarded_gas -= forwarded_gas // 64
+        if forwarded_gas < tail_call_gas:
+            break
+        gas = forwarded_gas
         address = pre.deploy_contract(code=link)
-        link = Op.POP(Op.CALL(gas=Op.GAS, address=address, address_warm=True))
+        link = Op.POP(Op.CALL(gas=Op.GAS, address=address, address_warm=False))
 
     benchmark_test(
         target_opcode=Op.CALL,
-        code_generator=JumpLoopGenerator(attack_block=link),
+        skip_gas_used_validation=True,
+        post={tail_address: Account(storage={0: 2})},
+        tx=Transaction(
+            to=pre.deploy_contract(code=WhileGas(body=link, fork=fork)),
+            sender=pre.fund_eoa(),
+        ),
     )
 
 
@@ -289,35 +310,57 @@ def test_nested_creates(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
+    tx_gas_limit: int,
+    gas_benchmark_value: int,
     out_of_gas: bool,
 ) -> None:
-    """
-    Benchmark chains of nested CREATE frames.
+    """Benchmark chains of nested CREATE frames."""
+    initcode_size = 32
 
-    The initcode copies itself into memory and hands that copy to CREATE,
-    so every frame it opens runs the same code and creates in turn, down
-    to the depth the 63/64 rule can still fund a CREATE at. Nothing is
-    returned, so the accounts are left empty and no code deposit is paid.
+    copy_self = Op.CODECOPY(
+        dest_offset=0,
+        offset=0,
+        size=Op.CODESIZE,
+        # gas accounting
+        data_size=initcode_size,
+        old_memory_size=0,
+        new_memory_size=initcode_size,
+    )
 
-    Under `out_of_gas` the descent runs until a frame cannot pay for its
-    CREATE, and the driver until the transaction is spent, so every
-    account the chain made is thrown away. Otherwise both stop one level
-    short of that and all of them are committed instead.
-    """
-    copy_self = Op.CODECOPY(dest_offset=0, offset=0, size=Op.CODESIZE)
-    create_self = Op.POP(Op.CREATE(value=0, offset=0, size=Op.CODESIZE))
+    create_self = Op.POP(
+        Op.CREATE(
+            value=0,
+            offset=0,
+            size=Op.CODESIZE,
+            # gas accounting
+            init_code_size=initcode_size,
+            old_memory_size=initcode_size,
+            new_memory_size=initcode_size,
+        )
+    )
 
     initcode = copy_self + create_self
     if not out_of_gas:
-        # Twice a level's cost leaves each frame enough to reach its own
-        # STOP after the CREATE it decides not to make.
         initcode = copy_self + Conditional(
             condition=Op.GT(Op.GAS, 2 * initcode.gas_cost(fork)),
             if_true=create_self,
         )
 
+    assert len(initcode) <= initcode_size, "initcode outgrew its padding"
+    initcode += Op.STOP * (initcode_size - len(initcode))
+
     setup = Om.MSTORE(bytes(initcode), 0)
-    launch = Op.POP(Op.CREATE(value=0, offset=0, size=len(initcode)))
+    launch = Op.POP(
+        Op.CREATE(
+            value=0,
+            offset=0,
+            size=initcode_size,
+            # gas accounting
+            init_code_size=initcode_size,
+            old_memory_size=initcode_size,
+            new_memory_size=initcode_size,
+        )
+    )
 
     if out_of_gas:
         benchmark_test(
@@ -325,15 +368,36 @@ def test_nested_creates(
             code_generator=JumpLoopGenerator(setup=setup, attack_block=launch),
         )
     else:
+        driver_address = pre.deploy_contract(
+            code=setup + WhileGas(body=launch, fork=fork)
+        )
+        # Every level spends fifteen times more state gas than execution
+        # gas, so a single transaction asking for the whole budget goes
+        # deeper than several could: the state gas the chain spends counts
+        # against the budget whether a reservoir or execution gas paid it.
+        gas_limit = min(tx_gas_limit, gas_benchmark_value)
+        if fork.state_gas_reservoir_enabled():
+            gas_limit = gas_benchmark_value
+
         benchmark_test(
             target_opcode=Op.CREATE,
             skip_gas_used_validation=True,
-            tx=Transaction(
-                to=pre.deploy_contract(
-                    code=setup + WhileGas(body=launch, fork=fork)
-                ),
-                sender=pre.fund_eoa(),
-            ),
+            post={
+                compute_create_address(
+                    address=driver_address, nonce=1
+                ): Account(nonce=2, code=b""),
+            },
+            blocks=[
+                Block(
+                    txs=[
+                        Transaction(
+                            to=driver_address,
+                            gas_limit=gas_limit,
+                            sender=pre.fund_eoa(),
+                        )
+                    ]
+                )
+            ],
         )
 
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -24,6 +24,7 @@ from execution_testing import (
     BenchmarkTestFiller,
     Block,
     Bytecode,
+    Conditional,
     Create2PreimageLayout,
     ExtCallGenerator,
     Fork,
@@ -32,10 +33,13 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
     TestPhaseManager,
+    Transaction,
     While,
+    WhileGas,
     compute_create2_address,
     compute_create_address,
 )
+from execution_testing import Macros as Om
 
 from tests.frontier.identity_precompile.spec import Spec as IdentitySpec
 
@@ -164,6 +168,34 @@ def test_contract_calling_many_addresses(
     )
 
 
+@pytest.mark.parametrize("opcode", [Op.DELEGATECALL, Op.STATICCALL])
+@pytest.mark.parametrize(
+    "warm_access",
+    [True, False],
+)
+def test_delegatecall_staticcall(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    warm_access: bool,
+) -> None:
+    """Benchmark a contract that STATICCALL/DELEGATECALL accounts."""
+    target = pre.deploy_contract(code=Op.STOP)
+    address = target if warm_access else Op.GAS
+
+    benchmark_test(
+        target_opcode=opcode,
+        code_generator=JumpLoopGenerator(
+            attack_block=Op.POP(
+                opcode(
+                    gas=Op.GAS,
+                    address=address,
+                )
+            ),
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "opcode,value",
     [
@@ -204,6 +236,105 @@ def test_call_opcodes_to_precompile(
             contract_balance=10**9 if value else 0,
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL],
+)
+def test_nested_calls(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    opcode: Op,
+) -> None:
+    """Benchmark chains of nested call frames."""
+    chain_address = pre.deploy_contract(
+        code=Op.POP(opcode(gas=Op.GAS, address=Op.ADDRESS))
+    )
+
+    benchmark_test(
+        target_opcode=opcode,
+        code_generator=JumpLoopGenerator(
+            attack_block=Op.POP(Op.CALL(gas=Op.GAS, address=chain_address))
+        ),
+    )
+
+
+def test_nested_call_chain(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_gas_limit: int,
+    gas_benchmark_value: int,
+) -> None:
+    """Benchmark nested call frames that each enter a different contract."""
+    gas = min(tx_gas_limit, gas_benchmark_value)
+
+    address = pre.deploy_contract(code=Op.STOP)
+    link = Op.POP(Op.CALL(gas=Op.GAS, address=address, address_warm=True))
+    while gas > link.gas_cost(fork):
+        gas -= link.gas_cost(fork)
+        gas -= gas // 64
+        address = pre.deploy_contract(code=link)
+        link = Op.POP(Op.CALL(gas=Op.GAS, address=address, address_warm=True))
+
+    benchmark_test(
+        target_opcode=Op.CALL,
+        code_generator=JumpLoopGenerator(attack_block=link),
+    )
+
+
+@pytest.mark.parametrize("out_of_gas", [True, False])
+def test_nested_creates(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    out_of_gas: bool,
+) -> None:
+    """
+    Benchmark chains of nested CREATE frames.
+
+    The initcode copies itself into memory and hands that copy to CREATE,
+    so every frame it opens runs the same code and creates in turn, down
+    to the depth the 63/64 rule can still fund a CREATE at. Nothing is
+    returned, so the accounts are left empty and no code deposit is paid.
+
+    Under `out_of_gas` the descent runs until a frame cannot pay for its
+    CREATE, and the driver until the transaction is spent, so every
+    account the chain made is thrown away. Otherwise both stop one level
+    short of that and all of them are committed instead.
+    """
+    copy_self = Op.CODECOPY(dest_offset=0, offset=0, size=Op.CODESIZE)
+    create_self = Op.POP(Op.CREATE(value=0, offset=0, size=Op.CODESIZE))
+
+    initcode = copy_self + create_self
+    if not out_of_gas:
+        # Twice a level's cost leaves each frame enough to reach its own
+        # STOP after the CREATE it decides not to make.
+        initcode = copy_self + Conditional(
+            condition=Op.GT(Op.GAS, 2 * initcode.gas_cost(fork)),
+            if_true=create_self,
+        )
+
+    setup = Om.MSTORE(bytes(initcode), 0)
+    launch = Op.POP(Op.CREATE(value=0, offset=0, size=len(initcode)))
+
+    if out_of_gas:
+        benchmark_test(
+            target_opcode=Op.CREATE,
+            code_generator=JumpLoopGenerator(setup=setup, attack_block=launch),
+        )
+    else:
+        benchmark_test(
+            target_opcode=Op.CREATE,
+            skip_gas_used_validation=True,
+            tx=Transaction(
+                to=pre.deploy_contract(
+                    code=setup + WhileGas(body=launch, fork=fork)
+                ),
+                sender=pre.fund_eoa(),
+            ),
+        )
 
 
 @pytest.mark.repricing(max_code_size_ratio=0)

--- a/tests/benchmark/compute/precompile/test_blake2f.py
+++ b/tests/benchmark/compute/precompile/test_blake2f.py
@@ -29,6 +29,11 @@ from tests.istanbul.eip152_blake2.spec import Spec as Blake2bSpec
             Blake2bInput(rounds=0xFFFF, f=True),
             id="blake2f",
         ),
+        pytest.param(
+            Blake2bSpec.BLAKE2_PRECOMPILE_ADDRESS,
+            Blake2bInput(rounds=0, f=True),
+            id="blake2f_zero_rounds",
+        ),
     ],
 )
 def test_blake2f(

--- a/tests/benchmark/compute/scenario/test_mix_operations.py
+++ b/tests/benchmark/compute/scenario/test_mix_operations.py
@@ -79,7 +79,9 @@ def test_jumpdest_analysis(
         + Op.CREATE(value=Op.PUSH0, offset=Op.PUSH0, size=Op.MSIZE)
     )
 
-    setup = code_prepare_initcode + Op.PUSH0
+    setup = code_prepare_initcode + Op.CREATE(
+        value=Op.PUSH0, offset=Op.PUSH0, size=Op.MSIZE
+    )
 
     benchmark_test(
         code_generator=JumpLoopGenerator(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add more benchmark cases to enhance the worst case coverage:
- `test_ext_account_query_cold`: add `EXTCODESIZE` and `EXTCODEHASH` operations.
- `test_arithmetic`: new parametrization for `DIV` and `SDIV`.
- `test_memory.py`: create worst case benchmark memory expansion scenario.
- `test_nested_frame_state_access`: doing state access from deep nested frames.
- `test_delegatecall_staticcall`: similar to `test_contract_calling_many_addresses` but for `STATICCALL`, `DELEGATECALL` version.
- `test_blake2f`: new input.
- `test_jumpdest_analysis`: Clients could cache the jumpdest analysis result given the current test implementation.
- `test_nested_calls`: stress testing `CALL*` -> `CALL*` -> `CALL*` -> ...

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
