### PR TITLE
feat(spec-specs): add EIP-8131 unified transaction content floor

### DIFF
--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -16,6 +16,7 @@ deterministic ``CREATE2`` factory predeploy.
 - [EIP-8024: Stack Access Instructions][EIP-8024]
 - [EIP-8037: State Creation Gas Cost Increase][EIP-8037]
 - [EIP-8038: State Access Gas Cost Increase][EIP-8038]
+- [EIP-8131: Unified Transaction Content Floor][EIP-8131]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
 - [EIP-8282: Builder Execution Requests][EIP-8282]
 
@@ -34,6 +35,7 @@ deterministic ``CREATE2`` factory predeploy.
 [EIP-8024]: https://eips.ethereum.org/EIPS/eip-8024
 [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 [EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
+[EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
 [EIP-8282]: https://eips.ethereum.org/EIPS/eip-8282
 """

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -619,7 +619,7 @@ def check_transaction(
         effective_gas_price=effective_gas_price,
         execution_gas_grant=allocation.execution_gas,
         state_gas_reservoir=allocation.state_gas_reservoir,
-        calldata_floor=intrinsic.calldata_floor,
+        content_floor=intrinsic.content_floor,
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
         accounts_with_paid_writes=accounts_with_paid_writes,
@@ -765,7 +765,7 @@ def process_unchecked_system_transaction(
         state_gas_reservoir=StateGas(
             StateGasCosts.STORAGE_SET * SYSTEM_MAX_SSTORES_PER_CALL
         ),
-        calldata_floor=Uint(0),
+        content_floor=Uint(0),
         access_list_addresses=set(),
         access_list_storage_keys=set(),
         # A system transaction charges no gas, so no write is paid for.
@@ -1062,7 +1062,7 @@ def process_transaction(
 
     settlement = settle_transaction_gas(
         tx_env.gas_limit,
-        tx_env.calldata_floor,
+        tx_env.content_floor,
         tx_output.gas_left,
         tx_output.state_gas_left,
         tx_output.refund_counter,

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -45,11 +45,12 @@ class IntrinsicGasCost:
     execution: ExecutionGas
     """Execution gas (calldata, base cost, access list, etc.)."""
 
-    calldata_floor: ExecutionGas
+    content_floor: ExecutionGas
     """
-    Minimum gas cost based on calldata size per [EIP-7623].
+    Minimum gas cost based on the transaction's content bytes per
+    [EIP-8131].
 
-    [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+    [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
     """
 
 
@@ -65,20 +66,27 @@ VERSIONED_HASH_VERSION_KZG = b"\x01"
 Version byte that every blob versioned hash must start with.
 """
 
-ACCESS_LIST_ADDRESS_FLOOR_TOKENS = Uint(80)
+ACCESS_LIST_ADDRESS_BYTES = Uint(20)
 """
-Floor data tokens contributed by a single access list address per
-[EIP-7981].
-
-[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+Content bytes contributed by a single access list address.
 """
 
-ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS = Uint(128)
+ACCESS_LIST_STORAGE_KEY_BYTES = Uint(32)
 """
-Floor data tokens contributed by a single access list storage key per
-[EIP-7981].
+Content bytes contributed by a single access list storage key.
+"""
 
-[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+AUTHORIZATION_BYTES = Uint(108)
+"""
+Content bytes contributed by a single [EIP-7702] authorization, taken
+as the largest it can encode to.
+
+[EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+"""
+
+BLOB_VERSIONED_HASH_BYTES = Uint(32)
+"""
+Content bytes contributed by a single blob versioned hash.
 """
 
 
@@ -604,8 +612,9 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     This function takes a transaction and gas_limit as parameters and
     returns the intrinsic gas costs for the transaction after validation.
     It throws an `InsufficientTransactionGasError` exception if the
-    transaction does not provide enough gas to cover the intrinsic cost,
-    and a `NonceOverflowError` exception if the nonce overflows.
+    transaction does not provide enough gas to cover the intrinsic cost
+    or the content floor ([EIP-8131]), and a `NonceOverflowError`
+    exception if the nonce overflows.
     It also raises an `InitCodeTooLargeError` if the code
     size of a contract creation transaction exceeds the maximum allowed
     size, and a `PriorityFeeGreaterThanMaxFeeError` if the maximum
@@ -613,7 +622,7 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
-    [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+    [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
@@ -655,15 +664,15 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     intrinsic_gas = Uint(intrinsic.execution)
     if intrinsic_gas > tx.gas:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
-    if intrinsic.calldata_floor > tx.gas:
-        raise InsufficientTransactionGasError("Insufficient calldata floor")
+    if intrinsic.content_floor > tx.gas:
+        raise InsufficientTransactionGasError("Insufficient content floor")
     if intrinsic.execution > TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
             "Intrinsic execution gas exceeds TX_MAX_GAS_LIMIT"
         )
-    if intrinsic.calldata_floor > TX_MAX_GAS_LIMIT:
+    if intrinsic.content_floor > TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
-            "Intrinsic calldata floor exceeds TX_MAX_GAS_LIMIT"
+            "Intrinsic content floor exceeds TX_MAX_GAS_LIMIT"
         )
 
     return intrinsic
@@ -704,9 +713,12 @@ def calculate_intrinsic_cost(
 
     This function takes a transaction and its sender as parameters and
     returns the intrinsic execution gas cost and the minimum (floor)
-    gas cost based on the calldata size. The floor is anchored on the
-    execution-gas portion of items 1 to 3 above rather than `TX_BASE`
-    alone, so it never undercuts the transaction's own intrinsic base.
+    gas cost, which charges every [content byte][cb] at
+    `FLOOR_PER_BYTE`. The floor is anchored on the execution-gas
+    portion of items 1 to 3 above rather than `TX_BASE` alone, so it
+    never undercuts the transaction's own intrinsic base.
+
+    [cb]: ref:ethereum.forks.amsterdam.transactions.count_content_bytes
     """
     from .vm.gas import GasCosts, init_code_cost
 
@@ -728,20 +740,12 @@ def calculate_intrinsic_cost(
             recipient_execution_gas += GasCosts.TX_VALUE_COST
 
     access_list_cost = Uint(0)
-    tokens_in_access_list = Uint(0)
     if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GasCosts.TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
                 ulen(access.slots) * GasCosts.TX_ACCESS_LIST_STORAGE_KEY
             )
-            tokens_in_access_list += ACCESS_LIST_ADDRESS_FLOOR_TOKENS
-            tokens_in_access_list += (
-                ulen(access.slots) * ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS
-            )
-
-    # Data token floor cost for access list bytes.
-    access_list_cost += tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR
 
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
@@ -749,19 +753,13 @@ def calculate_intrinsic_cost(
             tx.authorizations
         )
 
-    # EIP-7976 floor tokens: all calldata bytes count uniformly.
-    floor_tokens_in_calldata = ulen(tx.data) * GasCosts.TX_DATA_TOKEN_STANDARD
-
-    # Total floor tokens.
-    total_floor_tokens = floor_tokens_in_calldata + tokens_in_access_list
-
     # Decomposed execution-gas intrinsic base (EIP-2780), which also
-    # anchors the calldata floor.
+    # anchors the content floor.
     base_execution_gas = GasCosts.TX_BASE + recipient_execution_gas
 
-    # Floor gas cost (EIP-7623: minimum gas for data-heavy transactions).
-    data_floor_gas_cost = (
-        total_floor_tokens * GasCosts.TX_DATA_TOKEN_FLOOR + base_execution_gas
+    # Floor gas cost (EIP-8131: every content byte at `FLOOR_PER_BYTE`).
+    content_floor_gas_cost = (
+        count_content_bytes(tx) * GasCosts.FLOOR_PER_BYTE + base_execution_gas
     )
 
     return IntrinsicGasCost(
@@ -772,8 +770,34 @@ def calculate_intrinsic_cost(
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor=ExecutionGas(data_floor_gas_cost),
+        content_floor=ExecutionGas(content_floor_gas_cost),
     )
+
+
+def count_content_bytes(tx: Transaction) -> Uint:
+    """
+    Count the user-controlled content bytes of a transaction.
+
+    Calldata, access list entries, authorizations, and blob versioned
+    hashes each contribute their size. A field the transaction type does
+    not carry contributes nothing.
+    """
+    content_bytes = ulen(tx.data)
+
+    if has_access_list(tx):
+        for access in tx.access_list:
+            content_bytes += ACCESS_LIST_ADDRESS_BYTES
+            content_bytes += ulen(access.slots) * ACCESS_LIST_STORAGE_KEY_BYTES
+
+    if isinstance(tx, SetCodeTransaction):
+        content_bytes += ulen(tx.authorizations) * AUTHORIZATION_BYTES
+
+    if isinstance(tx, BlobTransaction):
+        content_bytes += (
+            ulen(tx.blob_versioned_hashes) * BLOB_VERSIONED_HASH_BYTES
+        )
+
+    return content_bytes
 
 
 def count_tokens_in_data(data: bytes) -> Uint:

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -136,7 +136,7 @@ class TransactionEnvironment:
     effective_gas_price: Uint
     execution_gas_grant: ExecutionGas
     state_gas_reservoir: StateGas
-    calldata_floor: Uint
+    content_floor: Uint
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     accounts_with_paid_writes: Set[Address]

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -156,7 +156,7 @@ class GasCosts:
     TX_CREATE: Final[ExecutionGas] = ExecutionGas(Uint(32000))
     TX_VALUE_COST: Final[ExecutionGas] = ExecutionGas(Uint(6000))
     TX_DATA_TOKEN_STANDARD: Final[ExecutionGas] = ExecutionGas(Uint(4))
-    TX_DATA_TOKEN_FLOOR: Final[ExecutionGas] = ExecutionGas(Uint(16))
+    FLOOR_PER_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(64))
     TX_ACCESS_LIST_ADDRESS: Final[ExecutionGas] = (
         COLD_ACCOUNT_ACCESS - WARM_ACCESS
     )
@@ -167,7 +167,8 @@ class GasCosts:
     # Authorization
     AUTH_TUPLE_BYTES: Final[Uint] = Uint(101)
     EXECUTION_PER_AUTH_BASE_COST: Final[ExecutionGas] = ExecutionGas(
-        AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
+        # The tuple's bytes at the non-zero calldata rate.
+        AUTH_TUPLE_BYTES * Uint(4) * TX_DATA_TOKEN_STANDARD
         + PRECOMPILE_ECRECOVER
         + COLD_ACCOUNT_ACCESS
         + Uint(2) * WARM_ACCESS
@@ -1138,7 +1139,7 @@ class TransactionGasSettlement:
 
 def settle_transaction_gas(
     tx_gas: Uint,
-    calldata_floor: Uint,
+    content_floor: Uint,
     gas_left: ExecutionGas,
     state_gas_left: StateGas,
     refund_counter: U256,
@@ -1153,7 +1154,7 @@ def settle_transaction_gas(
       execution gas and reservoir the top frame returned;
     - the refund, capped at one fifth of that pre-refund usage;
     - the gas used, taken as the larger of the post-refund usage and the
-      calldata floor, so a transaction never pays below the floor; and
+      content floor, so a transaction never pays below the floor; and
     - the per-dimension block amounts: the state gas used (clamped to
       zero, since refunds can drive it negative) and the execution gas
       used, which carries the floor because the floor binds the
@@ -1165,8 +1166,8 @@ def settle_transaction_gas(
     ----------
     tx_gas :
         The transaction's gas limit.
-    calldata_floor :
-        The transaction's calldata floor gas.
+    content_floor :
+        The transaction's content floor gas.
     gas_left :
         Execution gas the top frame returned.
     state_gas_left :
@@ -1187,13 +1188,13 @@ def settle_transaction_gas(
     gas_used_before_refund = tx_gas - gas_left - state_gas_left
     gas_refund = min(gas_used_before_refund // Uint(5), Uint(refund_counter))
     gas_used_after_refund = gas_used_before_refund - gas_refund
-    gas_used = max(gas_used_after_refund, calldata_floor)
+    gas_used = max(gas_used_after_refund, content_floor)
 
     settled_state_gas_used = StateGas(Uint(max(0, state_gas_used)))
     execution_gas_used = ExecutionGas(
         max(
             gas_used_before_refund - settled_state_gas_used,
-            calldata_floor,
+            content_floor,
         )
     )
     return TransactionGasSettlement(


### PR DESCRIPTION
### Description

Implement EIP-8131 in the Amsterdam fork. One floor rule replaces the EIP-7976 calldata floor and the EIP-7981 access list surcharge: every user-controlled content byte pays 64 gas at the floor.

### Related Issues or PRs

N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.