### PR TITLE
feat(spec-specs): add EIP-8279 block access list byte floo

### DIFF
--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -16,6 +16,7 @@ deterministic ``CREATE2`` factory predeploy.
 - [EIP-8024: Stack Access Instructions][EIP-8024]
 - [EIP-8037: State Creation Gas Cost Increase][EIP-8037]
 - [EIP-8038: State Access Gas Cost Increase][EIP-8038]
+- [EIP-8131: Unified Transaction Content Floor][EIP-8131]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
 - [EIP-8282: Builder Execution Requests][EIP-8282]
 
@@ -34,6 +35,7 @@ deterministic ``CREATE2`` factory predeploy.
 [EIP-8024]: https://eips.ethereum.org/EIPS/eip-8024
 [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 [EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
+[EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
 [EIP-8282]: https://eips.ethereum.org/EIPS/eip-8282
 """

--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -18,6 +18,7 @@ deterministic ``CREATE2`` factory predeploy.
 - [EIP-8038: State Access Gas Cost Increase][EIP-8038]
 - [EIP-8131: Unified Transaction Content Floor][EIP-8131]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
+- [EIP-8279: Block Access List Byte Floor][EIP-8279]
 - [EIP-8282: Builder Execution Requests][EIP-8282]
 
 ### Releases
@@ -37,6 +38,7 @@ deterministic ``CREATE2`` factory predeploy.
 [EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
 [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246
+[EIP-8279]: https://eips.ethereum.org/EIPS/eip-8279
 [EIP-8282]: https://eips.ethereum.org/EIPS/eip-8282
 """
 

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -27,6 +27,32 @@ from .exceptions import BlockAccessListGasLimitExceededError
 from .fork_types import BlockAccessIndex
 from .state_tracker import BlockState, TransactionState, get_code
 
+BAL_BYTES_PER_ADDRESS = Uint(20)
+"""
+Bytes an account address contributes to the block access list.
+"""
+
+BAL_BYTES_PER_STORAGE_KEY = Uint(32)
+"""
+Bytes a storage slot key contributes to the block access list.
+"""
+
+BAL_BYTES_PER_STORAGE_VALUE = Uint(32)
+"""
+Bytes a changed storage slot's post value contributes to the block
+access list.
+"""
+
+BAL_BYTES_PER_BALANCE = Uint(32)
+"""
+Bytes an account's post balance contributes to the block access list.
+"""
+
+BAL_BYTES_PER_NONCE = Uint(8)
+"""
+Bytes an account's post nonce contributes to the block access list.
+"""
+
 
 @final
 @slotted_freezable

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -619,7 +619,7 @@ def check_transaction(
         effective_gas_price=effective_gas_price,
         execution_gas_grant=allocation.execution_gas,
         state_gas_reservoir=allocation.state_gas_reservoir,
-        calldata_floor=intrinsic.calldata_floor,
+        content_floor=intrinsic.content_floor,
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
         accounts_with_paid_writes=accounts_with_paid_writes,
@@ -765,7 +765,7 @@ def process_unchecked_system_transaction(
         state_gas_reservoir=StateGas(
             StateGasCosts.STORAGE_SET * SYSTEM_MAX_SSTORES_PER_CALL
         ),
-        calldata_floor=Uint(0),
+        content_floor=Uint(0),
         access_list_addresses=set(),
         access_list_storage_keys=set(),
         # A system transaction charges no gas, so no write is paid for.
@@ -1062,7 +1062,7 @@ def process_transaction(
 
     settlement = settle_transaction_gas(
         tx_env.gas_limit,
-        tx_env.calldata_floor,
+        tx_env.content_floor,
         tx_output.gas_left,
         tx_output.state_gas_left,
         tx_output.refund_counter,

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -101,6 +101,7 @@ from .vm.gas import (
     check_block_gas_capacity,
     check_max_fee_per_blob_gas,
     settle_transaction_gas,
+    transaction_floor_gas,
 )
 from .vm.interpreter import TransactionOutput, process_top_level
 
@@ -619,7 +620,9 @@ def check_transaction(
         effective_gas_price=effective_gas_price,
         execution_gas_grant=allocation.execution_gas,
         state_gas_reservoir=allocation.state_gas_reservoir,
-        content_floor=intrinsic.content_floor,
+        static_floor=intrinsic.static_floor,
+        bal_data_bytes=Uint(0),
+        metered_storage_values=set(),
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
         accounts_with_paid_writes=accounts_with_paid_writes,
@@ -765,7 +768,11 @@ def process_unchecked_system_transaction(
         state_gas_reservoir=StateGas(
             StateGasCosts.STORAGE_SET * SYSTEM_MAX_SSTORES_PER_CALL
         ),
-        content_floor=Uint(0),
+        # A system transaction has no floor to settle against, and with
+        # no static floor the bytes it meters can never make one bind.
+        static_floor=Uint(0),
+        bal_data_bytes=Uint(0),
+        metered_storage_values=set(),
         access_list_addresses=set(),
         access_list_storage_keys=set(),
         # A system transaction charges no gas, so no write is paid for.
@@ -1062,7 +1069,7 @@ def process_transaction(
 
     settlement = settle_transaction_gas(
         tx_env.gas_limit,
-        tx_env.content_floor,
+        transaction_floor_gas(tx_env),
         tx_output.gas_left,
         tx_output.state_gas_left,
         tx_output.refund_counter,

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -45,11 +45,12 @@ class IntrinsicGasCost:
     execution: ExecutionGas
     """Execution gas (calldata, base cost, access list, etc.)."""
 
-    calldata_floor: ExecutionGas
+    content_floor: ExecutionGas
     """
-    Minimum gas cost based on calldata size per [EIP-7623].
+    Minimum gas cost based on the transaction's content bytes per
+    [EIP-8131].
 
-    [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+    [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
     """
 
 
@@ -65,20 +66,27 @@ VERSIONED_HASH_VERSION_KZG = b"\x01"
 Version byte that every blob versioned hash must start with.
 """
 
-ACCESS_LIST_ADDRESS_FLOOR_TOKENS = Uint(80)
+ACCESS_LIST_ADDRESS_BYTES = Uint(20)
 """
-Floor data tokens contributed by a single access list address per
-[EIP-7981].
-
-[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+Content bytes contributed by a single access list address.
 """
 
-ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS = Uint(128)
+ACCESS_LIST_STORAGE_KEY_BYTES = Uint(32)
 """
-Floor data tokens contributed by a single access list storage key per
-[EIP-7981].
+Content bytes contributed by a single access list storage key.
+"""
 
-[EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
+AUTHORIZATION_BYTES = Uint(108)
+"""
+Content bytes contributed by a single [EIP-7702] authorization, taken
+as the largest it can encode to.
+
+[EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
+"""
+
+BLOB_VERSIONED_HASH_BYTES = Uint(32)
+"""
+Content bytes contributed by a single blob versioned hash.
 """
 
 
@@ -604,8 +612,9 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     This function takes a transaction and gas_limit as parameters and
     returns the intrinsic gas costs for the transaction after validation.
     It throws an `InsufficientTransactionGasError` exception if the
-    transaction does not provide enough gas to cover the intrinsic cost,
-    and a `NonceOverflowError` exception if the nonce overflows.
+    transaction does not provide enough gas to cover the intrinsic cost
+    or the content floor ([EIP-8131]), and a `NonceOverflowError`
+    exception if the nonce overflows.
     It also raises an `InitCodeTooLargeError` if the code
     size of a contract creation transaction exceeds the maximum allowed
     size, and a `PriorityFeeGreaterThanMaxFeeError` if the maximum
@@ -613,7 +622,7 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     fee per gas.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
-    [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+    [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
@@ -655,15 +664,15 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     intrinsic_gas = Uint(intrinsic.execution)
     if intrinsic_gas > tx.gas:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
-    if intrinsic.calldata_floor > tx.gas:
-        raise InsufficientTransactionGasError("Insufficient calldata floor")
+    if intrinsic.content_floor > tx.gas:
+        raise InsufficientTransactionGasError("Insufficient content floor")
     if intrinsic.execution > TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
             "Intrinsic execution gas exceeds TX_MAX_GAS_LIMIT"
         )
-    if intrinsic.calldata_floor > TX_MAX_GAS_LIMIT:
+    if intrinsic.content_floor > TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
-            "Intrinsic calldata floor exceeds TX_MAX_GAS_LIMIT"
+            "Intrinsic content floor exceeds TX_MAX_GAS_LIMIT"
         )
 
     return intrinsic
@@ -704,9 +713,12 @@ def calculate_intrinsic_cost(
 
     This function takes a transaction and its sender as parameters and
     returns the intrinsic execution gas cost and the minimum (floor)
-    gas cost based on the calldata size. The floor is anchored on the
-    execution-gas portion of items 1 to 3 above rather than `TX_BASE`
-    alone, so it never undercuts the transaction's own intrinsic base.
+    gas cost, which charges every [content byte][cb] at
+    `FLOOR_PER_BYTE`. The floor is anchored on the execution-gas
+    portion of items 1 to 3 above rather than `TX_BASE` alone, so it
+    never undercuts the transaction's own intrinsic base.
+
+    [cb]: ref:ethereum.forks.amsterdam.transactions.count_content_bytes
     """
     from .vm.gas import GasCosts, init_code_cost
 
@@ -728,20 +740,12 @@ def calculate_intrinsic_cost(
             recipient_execution_gas += GasCosts.TX_VALUE_COST
 
     access_list_cost = Uint(0)
-    tokens_in_access_list = Uint(0)
     if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GasCosts.TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
                 ulen(access.slots) * GasCosts.TX_ACCESS_LIST_STORAGE_KEY
             )
-            tokens_in_access_list += ACCESS_LIST_ADDRESS_FLOOR_TOKENS
-            tokens_in_access_list += (
-                ulen(access.slots) * ACCESS_LIST_STORAGE_KEY_FLOOR_TOKENS
-            )
-
-    # Data token floor cost for access list bytes.
-    access_list_cost += tokens_in_access_list * GasCosts.TX_DATA_TOKEN_FLOOR
 
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
@@ -749,19 +753,13 @@ def calculate_intrinsic_cost(
             tx.authorizations
         )
 
-    # EIP-7976 floor tokens: all calldata bytes count uniformly.
-    floor_tokens_in_calldata = ulen(tx.data) * GasCosts.TX_DATA_TOKEN_STANDARD
-
-    # Total floor tokens.
-    total_floor_tokens = floor_tokens_in_calldata + tokens_in_access_list
-
     # Decomposed execution-gas intrinsic base (EIP-2780), which also
-    # anchors the calldata floor.
+    # anchors the content floor.
     base_execution_gas = GasCosts.TX_BASE + recipient_execution_gas
 
-    # Floor gas cost (EIP-7623: minimum gas for data-heavy transactions).
-    data_floor_gas_cost = (
-        total_floor_tokens * GasCosts.TX_DATA_TOKEN_FLOOR + base_execution_gas
+    # Floor gas cost (EIP-8131: every content byte at `FLOOR_PER_BYTE`).
+    content_floor_gas_cost = (
+        count_content_bytes(tx) * GasCosts.FLOOR_PER_BYTE + base_execution_gas
     )
 
     return IntrinsicGasCost(
@@ -772,8 +770,34 @@ def calculate_intrinsic_cost(
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor=ExecutionGas(data_floor_gas_cost),
+        content_floor=ExecutionGas(content_floor_gas_cost),
     )
+
+
+def count_content_bytes(tx: Transaction) -> Uint:
+    """
+    Count the user-controlled content bytes of a transaction.
+
+    Calldata, access list entries, authorizations, and blob versioned
+    hashes each contribute their size. A field the transaction type does
+    not carry contributes nothing.
+    """
+    content_bytes = ulen(tx.data)
+
+    if has_access_list(tx):
+        for access in tx.access_list:
+            content_bytes += ACCESS_LIST_ADDRESS_BYTES
+            content_bytes += ulen(access.slots) * ACCESS_LIST_STORAGE_KEY_BYTES
+
+    if isinstance(tx, SetCodeTransaction):
+        content_bytes += ulen(tx.authorizations) * AUTHORIZATION_BYTES
+
+    if isinstance(tx, BlobTransaction):
+        content_bytes += (
+            ulen(tx.blob_versioned_hashes) * BLOB_VERSIONED_HASH_BYTES
+        )
+
+    return content_bytes
 
 
 def count_tokens_in_data(data: bytes) -> Uint:

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -23,6 +23,7 @@ from ethereum.exceptions import (
 )
 from ethereum.state import Address
 
+from .block_access_lists import BAL_BYTES_PER_ADDRESS, BAL_BYTES_PER_NONCE
 from .exceptions import (
     BlobCountExceededError,
     EmptyAuthorizationListError,
@@ -45,12 +46,15 @@ class IntrinsicGasCost:
     execution: ExecutionGas
     """Execution gas (calldata, base cost, access list, etc.)."""
 
-    content_floor: ExecutionGas
+    static_floor: ExecutionGas
     """
-    Minimum gas cost based on the transaction's content bytes per
-    [EIP-8131].
+    Minimum gas cost fixed by the transaction itself: its content bytes
+    per [EIP-8131], and the block access list bytes its authorizations
+    contribute per [EIP-8279]. Execution extends it with the block
+    access list bytes it meters.
 
     [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
+    [EIP-8279]: https://eips.ethereum.org/EIPS/eip-8279
     """
 
 
@@ -613,8 +617,8 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     returns the intrinsic gas costs for the transaction after validation.
     It throws an `InsufficientTransactionGasError` exception if the
     transaction does not provide enough gas to cover the intrinsic cost
-    or the content floor ([EIP-8131]), and a `NonceOverflowError`
-    exception if the nonce overflows.
+    or the static floor ([EIP-8131], [EIP-8279]), and a
+    `NonceOverflowError` exception if the nonce overflows.
     It also raises an `InitCodeTooLargeError` if the code
     size of a contract creation transaction exceeds the maximum allowed
     size, and a `PriorityFeeGreaterThanMaxFeeError` if the maximum
@@ -623,6 +627,7 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-8131]: https://eips.ethereum.org/EIPS/eip-8131
+    [EIP-8279]: https://eips.ethereum.org/EIPS/eip-8279
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
@@ -664,15 +669,15 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     intrinsic_gas = Uint(intrinsic.execution)
     if intrinsic_gas > tx.gas:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
-    if intrinsic.content_floor > tx.gas:
-        raise InsufficientTransactionGasError("Insufficient content floor")
+    if intrinsic.static_floor > tx.gas:
+        raise InsufficientTransactionGasError("Insufficient static floor")
     if intrinsic.execution > TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
             "Intrinsic execution gas exceeds TX_MAX_GAS_LIMIT"
         )
-    if intrinsic.content_floor > TX_MAX_GAS_LIMIT:
+    if intrinsic.static_floor > TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
-            "Intrinsic content floor exceeds TX_MAX_GAS_LIMIT"
+            "Intrinsic static floor exceeds TX_MAX_GAS_LIMIT"
         )
 
     return intrinsic
@@ -713,7 +718,8 @@ def calculate_intrinsic_cost(
 
     This function takes a transaction and its sender as parameters and
     returns the intrinsic execution gas cost and the minimum (floor)
-    gas cost, which charges every [content byte][cb] at
+    gas cost, which charges every [content byte][cb] and every block
+    access list byte the authorizations contribute, at
     `FLOOR_PER_BYTE`. The floor is anchored on the execution-gas
     portion of items 1 to 3 above rather than `TX_BASE` alone, so it
     never undercuts the transaction's own intrinsic base.
@@ -754,12 +760,15 @@ def calculate_intrinsic_cost(
         )
 
     # Decomposed execution-gas intrinsic base (EIP-2780), which also
-    # anchors the content floor.
+    # anchors the static floor.
     base_execution_gas = GasCosts.TX_BASE + recipient_execution_gas
 
-    # Floor gas cost (EIP-8131: every content byte at `FLOOR_PER_BYTE`).
-    content_floor_gas_cost = (
-        count_content_bytes(tx) * GasCosts.FLOOR_PER_BYTE + base_execution_gas
+    # Floor gas cost: every content byte (EIP-8131) and every block
+    # access list byte the authorizations contribute (EIP-8279), at
+    # `FLOOR_PER_BYTE`.
+    floor_bytes = count_content_bytes(tx) + count_authorization_bal_bytes(tx)
+    static_floor_gas_cost = (
+        floor_bytes * GasCosts.FLOOR_PER_BYTE + base_execution_gas
     )
 
     return IntrinsicGasCost(
@@ -770,7 +779,7 @@ def calculate_intrinsic_cost(
             + access_list_cost
             + auth_cost
         ),
-        content_floor=ExecutionGas(content_floor_gas_cost),
+        static_floor=ExecutionGas(static_floor_gas_cost),
     )
 
 
@@ -798,6 +807,30 @@ def count_content_bytes(tx: Transaction) -> Uint:
         )
 
     return content_bytes
+
+
+def count_authorization_bal_bytes(tx: Transaction) -> Uint:
+    """
+    Count the block access list bytes the transaction's authorizations
+    contribute: each authority's address, delegation indicator, and
+    nonce.
+
+    Counted up front, so that applying the authorizations in
+    [`set_delegation`][sd] never meters at runtime.
+
+    [sd]: ref:ethereum.forks.amsterdam.vm.eoa_delegation.set_delegation
+    """
+    from .vm.eoa_delegation import EOA_DELEGATED_CODE_LENGTH
+
+    if not isinstance(tx, SetCodeTransaction):
+        return Uint(0)
+
+    bytes_per_authorization = (
+        BAL_BYTES_PER_ADDRESS
+        + Uint(EOA_DELEGATED_CODE_LENGTH)
+        + BAL_BYTES_PER_NONCE
+    )
+    return ulen(tx.authorizations) * bytes_per_authorization
 
 
 def count_tokens_in_data(data: bytes) -> Uint:

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -136,7 +136,7 @@ class TransactionEnvironment:
     effective_gas_price: Uint
     execution_gas_grant: ExecutionGas
     state_gas_reservoir: StateGas
-    calldata_floor: Uint
+    content_floor: Uint
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     accounts_with_paid_writes: Set[Address]

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -136,7 +136,12 @@ class TransactionEnvironment:
     effective_gas_price: Uint
     execution_gas_grant: ExecutionGas
     state_gas_reservoir: StateGas
-    content_floor: Uint
+    static_floor: Uint
+    # Block access list bytes metered during execution; they extend the
+    # floor above `static_floor`.
+    bal_data_bytes: Uint
+    # Storage slots whose post value is counted in `bal_data_bytes`.
+    metered_storage_values: Set[Tuple[Address, Bytes32]]
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     accounts_with_paid_writes: Set[Address]

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -156,7 +156,7 @@ class GasCosts:
     TX_CREATE: Final[ExecutionGas] = ExecutionGas(Uint(32000))
     TX_VALUE_COST: Final[ExecutionGas] = ExecutionGas(Uint(6000))
     TX_DATA_TOKEN_STANDARD: Final[ExecutionGas] = ExecutionGas(Uint(4))
-    TX_DATA_TOKEN_FLOOR: Final[ExecutionGas] = ExecutionGas(Uint(16))
+    FLOOR_PER_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(64))
     TX_ACCESS_LIST_ADDRESS: Final[ExecutionGas] = (
         COLD_ACCOUNT_ACCESS - WARM_ACCESS
     )
@@ -167,7 +167,8 @@ class GasCosts:
     # Authorization
     AUTH_TUPLE_BYTES: Final[Uint] = Uint(101)
     EXECUTION_PER_AUTH_BASE_COST: Final[ExecutionGas] = ExecutionGas(
-        AUTH_TUPLE_BYTES * TX_DATA_TOKEN_FLOOR
+        # The tuple's bytes at the non-zero calldata rate.
+        AUTH_TUPLE_BYTES * Uint(4) * TX_DATA_TOKEN_STANDARD
         + PRECOMPILE_ECRECOVER
         + COLD_ACCOUNT_ACCESS
         + Uint(2) * WARM_ACCESS
@@ -1138,7 +1139,7 @@ class TransactionGasSettlement:
 
 def settle_transaction_gas(
     tx_gas: Uint,
-    calldata_floor: Uint,
+    content_floor: Uint,
     gas_left: ExecutionGas,
     state_gas_left: StateGas,
     refund_counter: U256,
@@ -1153,7 +1154,7 @@ def settle_transaction_gas(
       execution gas and reservoir the top frame returned;
     - the refund, capped at one fifth of that pre-refund usage;
     - the gas used, taken as the larger of the post-refund usage and the
-      calldata floor, so a transaction never pays below the floor; and
+      content floor, so a transaction never pays below the floor; and
     - the per-dimension block amounts: the state gas used (clamped to
       zero, since refunds can drive it negative) and the execution gas
       used, which carries the floor because the floor binds the
@@ -1165,8 +1166,8 @@ def settle_transaction_gas(
     ----------
     tx_gas :
         The transaction's gas limit.
-    calldata_floor :
-        The transaction's calldata floor gas.
+    content_floor :
+        The transaction's content floor gas.
     gas_left :
         Execution gas the top frame returned.
     state_gas_left :
@@ -1187,13 +1188,13 @@ def settle_transaction_gas(
     gas_used_before_refund = tx_gas - gas_left - state_gas_left
     gas_refund = min(gas_used_before_refund // Uint(5), Uint(refund_counter))
     gas_used_after_refund = gas_used_before_refund - gas_refund
-    gas_used = max(gas_used_after_refund, calldata_floor)
+    gas_used = max(gas_used_after_refund, content_floor)
 
     settled_state_gas_used = StateGas(Uint(max(0, state_gas_used)))
     execution_gas_used = ExecutionGas(
         max(
             gas_used_before_refund - settled_state_gas_used,
-            calldata_floor,
+            content_floor,
         )
     )
     return TransactionGasSettlement(

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -41,7 +41,7 @@ from ..transactions import (
 from .exceptions import OutOfGasError
 
 if TYPE_CHECKING:
-    from . import BlockEnvironment, BlockOutput, Evm
+    from . import BlockEnvironment, BlockOutput, Evm, TransactionEnvironment
 
 
 # These may be patched at runtime by a future gas repricing utility to
@@ -1114,6 +1114,88 @@ def allocate_evm_gas(
     return EvmGasAllocation(execution_gas, state_gas_reservoir)
 
 
+def transaction_floor_gas(tx_env: "TransactionEnvironment") -> Uint:
+    """
+    Return the transaction's floor gas: the static floor its content
+    fixes before execution, extended by the block access list bytes
+    metered so far.
+
+    Parameters
+    ----------
+    tx_env :
+        The transaction's execution environment.
+
+    Returns
+    -------
+    floor_gas : `ethereum.base_types.Uint`
+        The floor the transaction's gas used cannot fall below.
+
+    """
+    return (
+        tx_env.static_floor + tx_env.bal_data_bytes * GasCosts.FLOOR_PER_BYTE
+    )
+
+
+def meter_bal_data(tx_env: "TransactionEnvironment", num_bytes: Uint) -> None:
+    """
+    Count `num_bytes` of block access list data toward the
+    transaction's floor.
+
+    Called before the operation adds the matching entry, so an
+    operation that cannot pay the floor its bytes extend aborts while
+    the block access list is still unchanged. The count is an upper
+    bound on what the transaction contributes: bytes metered inside a
+    frame that later reverts stay counted, since over-counting only
+    raises a floor that rarely binds.
+
+    The floor binds the execution dimension, of which a transaction
+    consumes at most [`TX_MAX_GAS_LIMIT`], so it is capped by that as
+    well as by the gas limit. `validate_transaction` holds the static
+    floor to the same two bounds.
+
+    Parameters
+    ----------
+    tx_env :
+        The transaction's execution environment.
+    num_bytes :
+        The bytes the operation is about to contribute.
+
+    Raises
+    ------
+    OutOfGasError :
+        If the extended floor exceeds either bound.
+
+    [`TX_MAX_GAS_LIMIT`]: ref:ethereum.forks.amsterdam.transactions.TX_MAX_GAS_LIMIT
+
+    """  # noqa: E501
+    floor_gas = (
+        tx_env.static_floor
+        + (tx_env.bal_data_bytes + num_bytes) * GasCosts.FLOOR_PER_BYTE
+    )
+    if floor_gas > min(tx_env.gas_limit, TX_MAX_GAS_LIMIT):
+        raise OutOfGasError
+    tx_env.bal_data_bytes += num_bytes
+
+
+def refund_bal_data(tx_env: "TransactionEnvironment", num_bytes: Uint) -> None:
+    """
+    Take `num_bytes` back off the transaction's metered count.
+
+    Only for bytes that provably leave the block access list, and only
+    where the caller metered them earlier in the transaction, so the
+    count never falls below what the transaction contributes.
+
+    Parameters
+    ----------
+    tx_env :
+        The transaction's execution environment.
+    num_bytes :
+        The bytes leaving the block access list.
+
+    """
+    tx_env.bal_data_bytes -= num_bytes
+
+
 @final
 @dataclass
 class TransactionGasSettlement:
@@ -1139,7 +1221,7 @@ class TransactionGasSettlement:
 
 def settle_transaction_gas(
     tx_gas: Uint,
-    content_floor: Uint,
+    floor_gas: Uint,
     gas_left: ExecutionGas,
     state_gas_left: StateGas,
     refund_counter: U256,
@@ -1154,7 +1236,7 @@ def settle_transaction_gas(
       execution gas and reservoir the top frame returned;
     - the refund, capped at one fifth of that pre-refund usage;
     - the gas used, taken as the larger of the post-refund usage and the
-      content floor, so a transaction never pays below the floor; and
+      floor, so a transaction never pays below the floor; and
     - the per-dimension block amounts: the state gas used (clamped to
       zero, since refunds can drive it negative) and the execution gas
       used, which carries the floor because the floor binds the
@@ -1166,8 +1248,8 @@ def settle_transaction_gas(
     ----------
     tx_gas :
         The transaction's gas limit.
-    content_floor :
-        The transaction's content floor gas.
+    floor_gas :
+        The transaction's floor gas.
     gas_left :
         Execution gas the top frame returned.
     state_gas_left :
@@ -1188,13 +1270,13 @@ def settle_transaction_gas(
     gas_used_before_refund = tx_gas - gas_left - state_gas_left
     gas_refund = min(gas_used_before_refund // Uint(5), Uint(refund_counter))
     gas_used_after_refund = gas_used_before_refund - gas_refund
-    gas_used = max(gas_used_after_refund, content_floor)
+    gas_used = max(gas_used_after_refund, floor_gas)
 
     settled_state_gas_used = StateGas(Uint(max(0, state_gas_used)))
     execution_gas_used = ExecutionGas(
         max(
             gas_used_before_refund - settled_state_gas_used,
-            content_floor,
+            floor_gas,
         )
     )
     return TransactionGasSettlement(

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -17,6 +17,7 @@ from ethereum_types.numeric import U256, Uint, ulen
 from ethereum.state import EMPTY_ACCOUNT
 from ethereum.utils.numeric import ceil32
 
+from ...block_access_lists import BAL_BYTES_PER_ADDRESS
 from ...fork_types import ExecutionGas
 from ...state_tracker import get_account, get_code
 from ...utils.address import to_address_masked
@@ -28,6 +29,7 @@ from ..gas import (
     calculate_blob_gas_price,
     calculate_gas_extend_memory,
     charge_gas,
+    meter_bal_data,
 )
 from ..stack import pop, push
 
@@ -74,6 +76,8 @@ def balance(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         charge_gas(evm, GasCosts.COLD_ACCOUNT_ACCESS)
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
@@ -346,6 +350,8 @@ def extcodesize(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
     access_gas_cost += GasCosts.WARM_ACCESS  # Code reading cost (EIP-8038)
     charge_gas(evm, access_gas_cost)
 
@@ -389,6 +395,8 @@ def extcodecopy(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
     access_gas_cost += GasCosts.WARM_ACCESS  # Code reading cost (EIP-8038)
 
     total_gas_cost = access_gas_cost + copy_gas_cost + extend_memory.cost
@@ -492,6 +500,8 @@ def extcodehash(evm: Evm) -> None:
     else:
         evm.accessed_addresses.add(address)
         access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     charge_gas(evm, access_gas_cost)
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -13,6 +13,10 @@ Implementations of the EVM storage related instructions.
 
 from ethereum_types.numeric import Uint
 
+from ...block_access_lists import (
+    BAL_BYTES_PER_STORAGE_KEY,
+    BAL_BYTES_PER_STORAGE_VALUE,
+)
 from ...fork_types import ExecutionGas, StateGas
 from ...state_tracker import (
     get_storage,
@@ -30,6 +34,8 @@ from ..gas import (
     charge_state_gas,
     check_gas,
     credit_state_gas_refund,
+    meter_bal_data,
+    refund_bal_data,
 )
 from ..stack import pop, push
 
@@ -54,6 +60,8 @@ def sload(evm: Evm) -> None:
     else:
         evm.accessed_storage_keys.add((evm.current_target, key))
         charge_gas(evm, GasCosts.COLD_STORAGE_ACCESS)
+        # The slot enters the block access list on this first access.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_STORAGE_KEY)
 
     # OPERATION
     tx_state = evm.tx_env.state
@@ -111,6 +119,8 @@ def sstore(evm: Evm) -> None:
     # transaction's refunds.
     if is_cold_access:
         evm.accessed_storage_keys.add((evm.current_target, key))
+        # The slot enters the block access list on this first access.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_STORAGE_KEY)
 
     tx_state = evm.tx_env.state
     original_value = get_storage_original(tx_state, evm.current_target, key)
@@ -148,6 +158,21 @@ def sstore(evm: Evm) -> None:
         if original_value == 0:
             # Slot set then cleared: refund the state gas charge.
             credit_state_gas_refund(evm.gas_meter, StateGasCosts.STORAGE_SET)
+
+    # BLOCK ACCESS LIST DATA
+    # The block access list holds one post value per changed slot, so
+    # the value bytes are counted while the slot differs from its
+    # pre-transaction value, and given back when a write restores it.
+    # Tracking which slots are counted keeps the count right when a
+    # frame that restored a slot reverts.
+    slot = (evm.current_target, key)
+    value_counted = slot in evm.tx_env.metered_storage_values
+    if new_value != original_value and not value_counted:
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_STORAGE_VALUE)
+        evm.tx_env.metered_storage_values.add(slot)
+    elif new_value == original_value and value_counted:
+        refund_bal_data(evm.tx_env, BAL_BYTES_PER_STORAGE_VALUE)
+        evm.tx_env.metered_storage_values.remove(slot)
 
     # Charge execution gas before state gas so that an execution-gas
     # OOG does not consume state gas that would inflate the parent's

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -20,6 +20,11 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
+from ...block_access_lists import (
+    BAL_BYTES_PER_ADDRESS,
+    BAL_BYTES_PER_BALANCE,
+    BAL_BYTES_PER_NONCE,
+)
 from ...fork_types import ExecutionGas, StateGas
 from ...state_tracker import (
     account_deployable,
@@ -56,6 +61,7 @@ from ..gas import (
     credit_state_gas_refund,
     drain_state_gas_reservoir,
     init_code_cost,
+    meter_bal_data,
     restore_child_gas,
     withhold_create_gas,
 )
@@ -109,7 +115,10 @@ def generic_create(
     # DESTINATION ACCESS
     # The account-creation charge is decided by existence alone,
     # independently of the collision outcome below.
-    evm.accessed_addresses.add(contract_address)
+    if contract_address not in evm.accessed_addresses:
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
+        evm.accessed_addresses.add(contract_address)
 
     new_account_charged = not is_account_alive(tx_state, contract_address)
     if new_account_charged:
@@ -128,6 +137,12 @@ def generic_create(
             credit_state_gas_refund(evm.gas_meter, StateGasCosts.NEW_ACCOUNT)
         push(evm.stack, U256(0))
         return
+
+    # The new contract's nonce, and its balance when it is endowed,
+    # join the block access list.
+    meter_bal_data(evm.tx_env, BAL_BYTES_PER_NONCE)
+    if endowment != 0:
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_BALANCE)
 
     # The whole state gas reservoir rides along (no 63/64 rule for
     # state gas) and is restored when the child returns.
@@ -524,6 +539,8 @@ def call(evm: Evm) -> None:
     tx_state = evm.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(to)
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     extra_gas = access_gas_cost + transfer_gas_cost
     (
@@ -538,6 +555,8 @@ def call(evm: Evm) -> None:
         check_gas(evm, extra_gas + extend_memory.cost)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
+            # The target enters the block access list on this touch.
+            meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
@@ -552,6 +571,11 @@ def call(evm: Evm) -> None:
     new_account_charged = has_value and not is_account_alive(tx_state, to)
     if new_account_charged:
         charge_state_gas(evm, StateGasCosts.NEW_ACCOUNT)
+
+    # A transfer to another account puts the recipient's post balance
+    # in the block access list.
+    if has_value and to != evm.current_target:
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_BALANCE)
 
     # CHILD GRANT
     # Computed after every charge above, so any state-gas spill has
@@ -650,6 +674,8 @@ def callcode(evm: Evm) -> None:
     tx_state = evm.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     extra_gas = access_gas_cost + transfer_gas_cost
     (
@@ -664,6 +690,8 @@ def callcode(evm: Evm) -> None:
         check_gas(evm, extra_gas + extend_memory.cost)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
+            # The target enters the block access list on this touch.
+            meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
@@ -745,6 +773,8 @@ def selfdestruct(evm: Evm) -> None:
     tx_state = evm.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     # STATE GAS
     # A sweep that will create the beneficiary pays the account write
@@ -768,6 +798,11 @@ def selfdestruct(evm: Evm) -> None:
     # OPERATION
     originator = evm.current_target
     originator_balance = get_account(tx_state, originator).balance
+
+    # A sweep to another account puts the beneficiary's post balance in
+    # the block access list.
+    if beneficiary != originator and originator_balance != 0:
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_BALANCE)
 
     # Transfer balance
     move_ether(tx_state, originator, beneficiary, originator_balance)
@@ -830,6 +865,8 @@ def delegatecall(evm: Evm) -> None:
     # with the child grant.
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     extra_gas = access_gas_cost
     (
@@ -844,6 +881,8 @@ def delegatecall(evm: Evm) -> None:
         check_gas(evm, extra_gas + extend_memory.cost)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
+            # The target enters the block access list on this touch.
+            meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     tx_state = evm.tx_env.state
     code_hash = get_account(tx_state, code_address).code_hash
@@ -933,6 +972,8 @@ def staticcall(evm: Evm) -> None:
     # with the child grant.
     if is_cold_access:
         evm.accessed_addresses.add(to)
+        # The account enters the block access list on this first touch.
+        meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     extra_gas = access_gas_cost
     (
@@ -947,6 +988,8 @@ def staticcall(evm: Evm) -> None:
         check_gas(evm, extra_gas + extend_memory.cost)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
+            # The target enters the block access list on this touch.
+            meter_bal_data(evm.tx_env, BAL_BYTES_PER_ADDRESS)
 
     tx_state = evm.tx_env.state
     code_hash = get_account(tx_state, code_address).code_hash

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -57,6 +57,7 @@ from ..vm.gas import (
     charge_state_gas_from_meter,
     commit_state_gas,
     forfeit_remaining_gas,
+    meter_bal_data,
     restore_state_gas,
     restore_state_gas_to_entry,
     tx_state_gas_used,
@@ -382,6 +383,8 @@ def process_create(evm: Evm) -> Evm:
                 ulen(contract_code) * StateGasCosts.COST_PER_STATE_BYTE
             )
             charge_state_gas(evm, code_deposit_state_gas)
+            # The deployed code joins the block access list.
+            meter_bal_data(evm.tx_env, ulen(contract_code))
         except ExceptionalHalt as error:
             restore_tx_state(tx_state, snapshot)
             # A create frame never applies authorizations, so its


### PR DESCRIPTION
### Description
Implement EIP-8279 in the Amsterdam fork. Built on #3350.

### Related Issues or PRs

Depends on https://github.com/ethereum/execution-specs/pull/3350

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.