### PR TITLE
refactor(spec-specs): split _prepare_data out of _prepare_trie

### DIFF
--- a/src/ethereum/merkle_patricia_trie.py
+++ b/src/ethereum/merkle_patricia_trie.py
@@ -404,12 +404,13 @@ def bytes_to_nibble_list(bytes_: Bytes) -> Bytes:
     return Bytes(nibble_list)
 
 
-def _prepare_trie(
-    trie: Trie[K, V],
+def _prepare_data(
+    data: Mapping[K, V],
+    secured: bool,
     get_storage_root: Optional[Callable[[Address], Root]] = None,
 ) -> Mapping[Bytes, Bytes]:
     """
-    Convert a [`Trie`] into the nibble-keyed mapping consumed by
+    Convert trie data into the nibble-keyed mapping consumed by
     [`patricialize`].
 
     Each value is encoded with [`encode_node`]; if the value is an
@@ -417,7 +418,6 @@ def _prepare_trie(
     root. Keys are hashed with [`keccak256`] when the trie is secured, then
     expanded into nibble form via [`bytes_to_nibble_list`][bnl].
 
-    [`Trie`]: ref:ethereum.merkle_patricia_trie.Trie
     [`patricialize`]: ref:ethereum.merkle_patricia_trie.patricialize
     [`encode_node`]: ref:ethereum.merkle_patricia_trie.encode_node
     [`Account`]: ref:ethereum.state.Account
@@ -426,7 +426,7 @@ def _prepare_trie(
     """
     mapped: MutableMapping[Bytes, Bytes] = {}
 
-    for preimage, value in trie._data.items():
+    for preimage, value in data.items():
         if isinstance(value, Account):
             assert get_storage_root is not None
             address = Address(preimage)
@@ -438,7 +438,7 @@ def _prepare_trie(
         if encoded_value == b"":
             raise AssertionError
         key: Bytes
-        if trie.secured:
+        if secured:
             # "secure" tries hash keys once before construction
             key = keccak256(preimage)
         else:
@@ -446,6 +446,33 @@ def _prepare_trie(
         mapped[bytes_to_nibble_list(key)] = encoded_value
 
     return mapped
+
+
+def _prepare_trie(
+    trie: Trie[K, V],
+    get_storage_root: Optional[Callable[[Address], Root]] = None,
+) -> Mapping[Bytes, Bytes]:
+    """
+    Prepare the trie for root calculation.
+
+    Remove values that are empty, hash the keys (if
+    ``secured == True``) and encode all the nodes.
+
+    Parameters
+    ----------
+    trie :
+        The ``Trie`` to prepare.
+    get_storage_root :
+        Function to get the storage root of an account. Needed
+        to encode ``Account`` objects.
+
+    Returns
+    -------
+    out : `Mapping[ethereum.base_types.Bytes, Node]`
+        Object with keys mapped to nibble-byte form.
+
+    """
+    return _prepare_data(trie._data, trie.secured, get_storage_root)
 
 
 def root(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Splits `_prepare_data` out of `_prepare_trie` in the shared `merkle_patricia_trie.py`. The new function converts a plain mapping into the nibble-keyed form consumed by `patricialize`, and `_prepare_trie` becomes a thin wrapper that passes the trie's data and secured flag through. Pure extraction with zero behavior change.

Motivation: root calculation over a mapping that is not a whole `Trie` is needed by upcoming stateless work (incremental trie updates in `projects/zkevm` consume exactly this seam). The refactor stands alone as cleanup and shrinks that future diff. Fixtures fill byte for byte identically before and after the change.

Added @jsign as a co-author as its his work.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F0e%2F41%2Fd9%2F0e41d9a7db815e65861295bc41bd6903.jpg%3Fnii%3Dt&f=1&nofb=1&ipt=90dccb5ebf66fb159d1f66d115759d41e2880d80938dbc23a0227be654a20a8a)
