### PR TITLE
refactor(testing): capitalize SSZ in class names

### DIFF
--- a/packages/testing/src/execution_testing/base_types/ssz.py
+++ b/packages/testing/src/execution_testing/base_types/ssz.py
@@ -1,7 +1,7 @@
 """
 Native SSZ serialization for base_types models.
 
-Declare a container once as a pydantic SszModel, in the ordinary base types,
+Declare a container once as a pydantic SSZModel, in the ordinary base types,
 and get SSZ encoding, hash_tree_root, and defaults for them.
 
 Each field's SSZ type is derived from its Python type, so the model stays the
@@ -10,20 +10,20 @@ single source of truth:
 * fixed byte types self-describe by byte_length
   (Hash -> ByteVector[32], Address -> ByteVector[20]);
 * the width ints defined here carry it (Uint64 -> uint64);
-* bool -> boolean; a nested SszModel -> Container;
+* bool -> boolean; a nested SSZModel -> Container;
 * the only facts a Python type cannot express -- list / vector / bytelist / bit
   caps -- ride as Annotated markers (ssz_list(N), ssz_vector(N), byte_list(N),
   bitvector(N), bitlist(N)). Element types are derived from the annotation, so
   a marker carries only the cap/length, never a duplicated element spec.
 
-Each field's SSZ type is described by an SszType value (SszUint, SszByteList,
-SszList, SszContainer, ...). The engine turns that into a remerkleable type
+Each field's SSZ type is described by an SSZType value (SSZUint, SSZByteList,
+SSZList, SSZContainer, ...). The engine turns that into a remerkleable type
 on demand (build_ssz_type) and delegates the actual encoding, merkleization,
 and default (zero) values to it.
 
 Fork-scoped models: one model can serve every fork. Future-fork fields are
 declared T | None (None == absent in older forks, omitted from JSON), and a
-__ssz_schema__ = SszForkSchema(...) table beside the fields says which fork
+__ssz_schema__ = SSZForkSchema(...) table beside the fields says which fork
 introduces what, in canonical SSZ order (the class body's order stays free
 for JSON). Such models require fork= on encode / hash_tree_root / decode /
 ssz_default / describe_schema / build_ssz_type
@@ -82,97 +82,97 @@ _UINTS = {
 }
 
 
-class SszType:
+class SSZType:
     """A description of a field's SSZ type."""
 
 
 @dataclass(frozen=True)
-class SszUint(SszType):
+class SSZUint(SSZType):
     """An unsigned integer of bits width (8/16/32/64/128/256)."""
 
     bits: int
 
 
 @dataclass(frozen=True)
-class SszByteVector(SszType):
+class SSZByteVector(SSZType):
     """A fixed-length byte vector of length bytes."""
 
     length: int
 
 
 @dataclass(frozen=True)
-class SszByteList(SszType):
+class SSZByteList(SSZType):
     """A variable byte list capped at limit bytes."""
 
     limit: int
 
 
 @dataclass(frozen=True)
-class SszList(SszType):
+class SSZList(SSZType):
     """A list of element capped at limit items."""
 
-    element: SszType
+    element: SSZType
     limit: int
 
 
 @dataclass(frozen=True)
-class SszVector(SszType):
+class SSZVector(SSZType):
     """A fixed-length vector of exactly length element items."""
 
-    element: SszType
+    element: SSZType
     length: int
 
 
 @dataclass(frozen=True)
-class SszBitvector(SszType):
+class SSZBitvector(SSZType):
     """A fixed-length bit vector of length bits."""
 
     length: int
 
 
 @dataclass(frozen=True)
-class SszBitlist(SszType):
+class SSZBitlist(SSZType):
     """A variable bit list capped at limit bits."""
 
     limit: int
 
 
 @dataclass(frozen=True)
-class SszBool(SszType):
+class SSZBool(SSZType):
     """The SSZ boolean type."""
 
 
 @dataclass(frozen=True)
-class SszContainer(SszType):
+class SSZContainer(SSZType):
     """A nested container backed by pydantic model."""
 
-    model: Type["SszModel"]
+    model: Type["SSZModel"]
 
 
 @dataclass(frozen=True)
-class SszProgressiveList(SszType):
+class SSZProgressiveList(SSZType):
     """An uncapped progressive list of element (EIP-7916)."""
 
-    element: SszType
+    element: SSZType
 
 
 @dataclass(frozen=True)
-class SszProgressiveBitlist(SszType):
+class SSZProgressiveBitlist(SSZType):
     """An uncapped progressive bit list."""
 
 
 @dataclass(frozen=True)
-class SszProgressiveContainer(SszType):
+class SSZProgressiveContainer(SSZType):
     """A forward-compatible progressive container backed by model."""
 
-    model: Type["SszModel"]
+    model: Type["SSZModel"]
 
 
-_M = TypeVar("_M", bound="SszModel")
+_M = TypeVar("_M", bound="SSZModel")
 
 
 @dataclass(frozen=True, eq=False)
-class SszForkSchema:
+class SSZForkSchema:
     """
     Fork-scoped field sets for a fork-evolving container.
 
@@ -225,18 +225,18 @@ def _unwrap_optional(annotation: Any) -> Tuple[Any, bool]:
     return annotation, False
 
 
-def _is_fork_optional(model_cls: Type["SszModel"], name: str) -> bool:
+def _is_fork_optional(model_cls: Type["SSZModel"], name: str) -> bool:
     ann = model_cls.model_fields[name].annotation
     return _unwrap_optional(ann)[1]
 
 
-def _is_ssz_excluded(model_cls: Type["SszModel"], name: str) -> bool:
+def _is_ssz_excluded(model_cls: Type["SSZModel"], name: str) -> bool:
     """Whether name carries the ssz_exclude() marker (JSON-only)."""
     metadata = model_cls.model_fields[name].metadata
-    return any(isinstance(m, _SszExclude) for m in metadata)
+    return any(isinstance(m, _SSZExclude) for m in metadata)
 
 
-def _included_fields(model_cls: Type["SszModel"]) -> Tuple[str, ...]:
+def _included_fields(model_cls: Type["SSZModel"]) -> Tuple[str, ...]:
     """Every SSZ-participating field, in declaration order."""
     return tuple(
         name
@@ -245,7 +245,7 @@ def _included_fields(model_cls: Type["SszModel"]) -> Tuple[str, ...]:
     )
 
 
-def _check_fork_schema(model_cls: Type["SszModel"]) -> None:
+def _check_fork_schema(model_cls: Type["SSZModel"]) -> None:
     """
     Validate a model's __ssz_schema__ against its fields, at class
     definition.
@@ -337,13 +337,13 @@ class _ProgressiveListMark(_Marker):
 
 
 @dataclass(frozen=True)
-class _SszExclude(_Marker):
+class _SSZExclude(_Marker):
     pass
 
 
-def byte_list(limit: int) -> SszByteList:
+def byte_list(limit: int) -> SSZByteList:
     """Annotate a Bytes field as a capped SSZ byte list."""
-    return SszByteList(limit)
+    return SSZByteList(limit)
 
 
 def ssz_list(limit: int) -> _ListCap:
@@ -356,14 +356,14 @@ def ssz_vector(length: int) -> _VectorLen:
     return _VectorLen(length)
 
 
-def bitvector(length: int) -> SszBitvector:
+def bitvector(length: int) -> SSZBitvector:
     """Annotate a list[bool] field as a fixed SSZ bit vector."""
-    return SszBitvector(length)
+    return SSZBitvector(length)
 
 
-def bitlist(limit: int) -> SszBitlist:
+def bitlist(limit: int) -> SSZBitlist:
     """Annotate a list[bool] field as a capped SSZ bit list."""
-    return SszBitlist(limit)
+    return SSZBitlist(limit)
 
 
 def progressive_list() -> _ProgressiveListMark:
@@ -371,31 +371,31 @@ def progressive_list() -> _ProgressiveListMark:
     return _ProgressiveListMark()
 
 
-def progressive_bitlist() -> SszProgressiveBitlist:
+def progressive_bitlist() -> SSZProgressiveBitlist:
     """Annotate a list[bool] field as an uncapped progressive bit list."""
-    return SszProgressiveBitlist()
+    return SSZProgressiveBitlist()
 
 
-def ssz_exclude() -> _SszExclude:
+def ssz_exclude() -> _SSZExclude:
     """
     Annotate a field as JSON-only: SSZ ignores it entirely.
 
     Such a field must carry a default: decode never sees it on the wire
     and so cannot reconstruct it.
     """
-    return _SszExclude()
+    return _SSZExclude()
 
 
-class SszModel(CamelModel):
+class SSZModel(CamelModel):
     """
     A pydantic model whose fields carry SSZ types.
 
-    Every field must resolve to an SszType, or be excluded from SSZ with
+    Every field must resolve to an SSZType, or be excluded from SSZ with
     an ssz_exclude() marker (JSON-only fields); each Annotated marker
     must be consistent with the field's Python type.
     """
 
-    __ssz_schema__: ClassVar[Optional[SszForkSchema]] = None
+    __ssz_schema__: ClassVar[Optional[SSZForkSchema]] = None
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
@@ -413,7 +413,7 @@ class SszModel(CamelModel):
         _check_fork_schema(cls)
 
 
-class ProgressiveModel(SszModel):
+class ProgressiveModel(SSZModel):
     """
     A forward-compatible progressive container.
 
@@ -442,28 +442,28 @@ class ProgressiveModel(SszModel):
 def _marker_in(metadata: Any) -> Any:
     """The first SSZ marker in metadata."""
     return next(
-        (m for m in metadata if isinstance(m, (SszType, _Marker))), None
+        (m for m in metadata if isinstance(m, (SSZType, _Marker))), None
     )
 
 
-def _spec_for_type_bare(annotation: Any) -> SszType:
+def _spec_for_type_bare(annotation: Any) -> SSZType:
     """Derive the SSZ type of a plain Python type."""
     ssz = getattr(annotation, "__ssz__", None)
-    if isinstance(ssz, SszType):
+    if isinstance(ssz, SSZType):
         return ssz
     if isinstance(annotation, type):
         if issubclass(annotation, FixedSizeBytes):
-            return SszByteVector(annotation.byte_length)
+            return SSZByteVector(annotation.byte_length)
         if issubclass(annotation, ProgressiveModel):
-            return SszProgressiveContainer(annotation)
-        if issubclass(annotation, SszModel):
-            return SszContainer(annotation)
+            return SSZProgressiveContainer(annotation)
+        if issubclass(annotation, SSZModel):
+            return SSZContainer(annotation)
         if annotation is bool:
-            return SszBool()
+            return SSZBool()
     raise TypeError(f"no SSZ type for {annotation!r}")
 
 
-def _spec_for_type(annotation: Any) -> SszType:
+def _spec_for_type(annotation: Any) -> SSZType:
     """Resolve an SSZ type, honoring an inner Annotated marker if present."""
     meta = getattr(annotation, "__metadata__", None)
     if meta is not None:
@@ -471,7 +471,7 @@ def _spec_for_type(annotation: Any) -> SszType:
     return _spec_for_type_bare(annotation)
 
 
-def _element_of(annotation: Any, ctx: str) -> SszType:
+def _element_of(annotation: Any, ctx: str) -> SSZType:
     """Resolve the element SSZ type of a list[...] annotation."""
     if get_origin(annotation) not in (list, List):
         raise TypeError(f"{ctx} requires a list[...] field: {annotation!r}")
@@ -481,7 +481,7 @@ def _element_of(annotation: Any, ctx: str) -> SszType:
     return _spec_for_type(args[0])
 
 
-def _resolve(marker: Any, annotation: Any) -> SszType:
+def _resolve(marker: Any, annotation: Any) -> SSZType:
     """
     Resolve a field/element into an SSZ type.
 
@@ -493,12 +493,12 @@ def _resolve(marker: Any, annotation: Any) -> SszType:
     if marker is None:
         return _spec_for_type(annotation)
     if isinstance(marker, _ListCap):
-        return SszList(_element_of(annotation, "ssz_list"), marker.limit)
+        return SSZList(_element_of(annotation, "ssz_list"), marker.limit)
     if isinstance(marker, _VectorLen):
-        return SszVector(_element_of(annotation, "ssz_vector"), marker.length)
+        return SSZVector(_element_of(annotation, "ssz_vector"), marker.length)
     if isinstance(marker, _ProgressiveListMark):
-        return SszProgressiveList(_element_of(annotation, "progressive_list"))
-    if isinstance(marker, SszByteList):
+        return SSZProgressiveList(_element_of(annotation, "progressive_list"))
+    if isinstance(marker, SSZByteList):
         is_bytes = isinstance(annotation, type) and issubclass(
             annotation, Bytes
         )
@@ -507,17 +507,17 @@ def _resolve(marker: Any, annotation: Any) -> SszType:
                 f"byte_list requires a Bytes field/element: {annotation!r}"
             )
         return marker
-    if isinstance(marker, (SszBitvector, SszBitlist, SszProgressiveBitlist)):
-        if not isinstance(_element_of(annotation, "bit markers"), SszBool):
+    if isinstance(marker, (SSZBitvector, SSZBitlist, SSZProgressiveBitlist)):
+        if not isinstance(_element_of(annotation, "bit markers"), SSZBool):
             raise TypeError(
                 f"bit markers require a list[bool] field: {annotation!r}"
             )
         return marker
-    if isinstance(marker, _SszExclude):
+    if isinstance(marker, _SSZExclude):
         raise TypeError(
             f"field is ssz_exclude()d; it has no SSZ type: {annotation!r}"
         )
-    # Raw SszType instances (SszUint, SszContainer, ...) as markers would
+    # Raw SSZType instances (SSZUint, SSZContainer, ...) as markers would
     # bypass the consistency checks above; only the marker helpers are
     # supported.
     raise TypeError(
@@ -527,14 +527,14 @@ def _resolve(marker: Any, annotation: Any) -> SszType:
 
 
 @lru_cache(maxsize=None)
-def spec_of(model_cls: Type["SszModel"], name: str) -> SszType:
+def spec_of(model_cls: Type["SSZModel"], name: str) -> SSZType:
     """
     The resolved SSZ type of a field.
 
     An Annotated marker takes precedence over the bare type; cap-only markers
     derive their element from the annotation, and every marker is checked for
     consistency with it. A T | None union resolves to T's SSZ type -- the
-    None arm means "absent in older forks" (see SszForkSchema), which is a
+    None arm means "absent in older forks" (see SSZForkSchema), which is a
     schema fact, not an SSZ type. Cached per (model_cls, name).
     """
     field = model_cls.model_fields[name]
@@ -547,40 +547,40 @@ def spec_of(model_cls: Type["SszModel"], name: str) -> SszType:
     return _resolve(_marker_in(field.metadata), annotation)
 
 
-def _rmk_type(spec: SszType, fork: Optional[str] = None) -> Type[View]:
-    if isinstance(spec, SszUint):
+def _rmk_type(spec: SSZType, fork: Optional[str] = None) -> Type[View]:
+    if isinstance(spec, SSZUint):
         return _UINTS[spec.bits]
-    if isinstance(spec, SszByteVector):
+    if isinstance(spec, SSZByteVector):
         return ByteVector[spec.length]
-    if isinstance(spec, SszByteList):
+    if isinstance(spec, SSZByteList):
         return ByteList[spec.limit]
-    if isinstance(spec, SszList):
+    if isinstance(spec, SSZList):
         return RmkList[_rmk_type(spec.element, fork), spec.limit]
-    if isinstance(spec, SszVector):
+    if isinstance(spec, SSZVector):
         return RmkVector[_rmk_type(spec.element, fork), spec.length]
-    if isinstance(spec, SszBitvector):
+    if isinstance(spec, SSZBitvector):
         return RmkBitvector[spec.length]
-    if isinstance(spec, SszBitlist):
+    if isinstance(spec, SSZBitlist):
         return RmkBitlist[spec.limit]
-    if isinstance(spec, SszProgressiveList):
+    if isinstance(spec, SSZProgressiveList):
         return RmkProgressiveList[_rmk_type(spec.element, fork)]
-    if isinstance(spec, SszProgressiveBitlist):
+    if isinstance(spec, SSZProgressiveBitlist):
         return RmkProgressiveBitlist
-    if isinstance(spec, (SszContainer, SszProgressiveContainer)):
+    if isinstance(spec, (SSZContainer, SSZProgressiveContainer)):
         return build_ssz_type(spec.model, _nested_fork(spec.model, fork))
-    if isinstance(spec, SszBool):
+    if isinstance(spec, SSZBool):
         return boolean
     raise TypeError(f"unhandled SSZ type {spec!r}")
 
 
-def _active_fields(model_cls: Type["SszModel"]) -> Sequence[int]:
+def _active_fields(model_cls: Type["SSZModel"]) -> Sequence[int]:
     """The active-field bitvector, defaulting to every SSZ field active."""
     declared = getattr(model_cls, "__active_fields__", ())
     return declared if declared else [1] * len(_included_fields(model_cls))
 
 
 def _nested_fork(
-    model_cls: Type["SszModel"], fork: Optional[str]
+    model_cls: Type["SSZModel"], fork: Optional[str]
 ) -> Optional[str]:
     """
     The fork a nested container is projected at.
@@ -594,7 +594,7 @@ def _nested_fork(
 
 
 def _schema_fields(
-    model_cls: Type["SszModel"], fork: Optional[str]
+    model_cls: Type["SSZModel"], fork: Optional[str]
 ) -> Tuple[str, ...]:
     """
     The SSZ field names of model_cls, in canonical order.
@@ -619,7 +619,7 @@ def _schema_fields(
 
 
 def ssz_fields(
-    model_cls: Type["SszModel"], fork: Optional[str] = None
+    model_cls: Type["SSZModel"], fork: Optional[str] = None
 ) -> Tuple[str, ...]:
     """
     The SSZ field names of model_cls, in canonical (wire) order.
@@ -632,7 +632,7 @@ def ssz_fields(
 
 
 def _check_populated(
-    model: "SszModel", names: Tuple[str, ...], fork: str
+    model: "SSZModel", names: Tuple[str, ...], fork: str
 ) -> None:
     """Raise unless the populated fields exactly match the fork schema."""
     missing = [n for n in names if getattr(model, n) is None]
@@ -650,7 +650,7 @@ def _check_populated(
 
 
 def build_ssz_type(
-    model_cls: Type["SszModel"], fork: Optional[str] = None
+    model_cls: Type["SSZModel"], fork: Optional[str] = None
 ) -> Type[Container]:
     """
     Build the remerkleable container type mirroring model_cls.
@@ -664,7 +664,7 @@ def build_ssz_type(
 
 @lru_cache(maxsize=None)
 def _build_ssz_type(
-    model_cls: Type["SszModel"], fork: Optional[str]
+    model_cls: Type["SSZModel"], fork: Optional[str]
 ) -> Type[Container]:
     names = _schema_fields(model_cls, fork)
     anns = {name: _rmk_type(spec_of(model_cls, name), fork) for name in names}
@@ -678,18 +678,18 @@ def _build_ssz_type(
     return type(cls_name, (base,), {"__annotations__": anns})
 
 
-def _to_rmk(spec: SszType, value: Any, fork: Optional[str] = None) -> Any:
-    if isinstance(spec, (SszContainer, SszProgressiveContainer)):
+def _to_rmk(spec: SSZType, value: Any, fork: Optional[str] = None) -> Any:
+    if isinstance(spec, (SSZContainer, SSZProgressiveContainer)):
         return _rmk_instance(value, _nested_fork(spec.model, fork))
-    if isinstance(spec, (SszList, SszVector, SszProgressiveList)):
+    if isinstance(spec, (SSZList, SSZVector, SSZProgressiveList)):
         return [_to_rmk(spec.element, v, fork) for v in value]
-    if isinstance(spec, (SszBitvector, SszBitlist, SszProgressiveBitlist)):
+    if isinstance(spec, (SSZBitvector, SSZBitlist, SSZProgressiveBitlist)):
         return list(value)
     return value  # scalar / byte-vector / byte-list: remerkleable coerces
 
 
-def _rmk_instance(model: "SszModel", fork: Optional[str] = None) -> Container:
-    model_cls: Type[SszModel] = type(model)
+def _rmk_instance(model: "SSZModel", fork: Optional[str] = None) -> Container:
+    model_cls: Type[SSZModel] = type(model)
     names = _schema_fields(model_cls, fork)
     if fork is not None:
         _check_populated(model, names, fork)
@@ -701,21 +701,21 @@ def _rmk_instance(model: "SszModel", fork: Optional[str] = None) -> Container:
     return container(**values)
 
 
-def _to_py(spec: SszType, value: Any, fork: Optional[str] = None) -> Any:
-    if isinstance(spec, (SszContainer, SszProgressiveContainer)):
+def _to_py(spec: SSZType, value: Any, fork: Optional[str] = None) -> Any:
+    if isinstance(spec, (SSZContainer, SSZProgressiveContainer)):
         nested = _nested_fork(spec.model, fork)
         return _view_to_model(
             spec.model, value, _schema_fields(spec.model, nested), nested
         )
-    if isinstance(spec, (SszList, SszVector, SszProgressiveList)):
+    if isinstance(spec, (SSZList, SSZVector, SSZProgressiveList)):
         return [_to_py(spec.element, v, fork) for v in value]
-    if isinstance(spec, (SszBitvector, SszBitlist, SszProgressiveBitlist)):
+    if isinstance(spec, (SSZBitvector, SSZBitlist, SSZProgressiveBitlist)):
         return [bool(b) for b in value]
-    if isinstance(spec, (SszByteVector, SszByteList)):
+    if isinstance(spec, (SSZByteVector, SSZByteList)):
         return bytes(value)
-    if isinstance(spec, SszUint):
+    if isinstance(spec, SSZUint):
         return int(value)
-    if isinstance(spec, SszBool):
+    if isinstance(spec, SSZBool):
         return bool(value)
     raise TypeError(f"unhandled SSZ type {spec!r}")
 
@@ -737,28 +737,28 @@ def _view_to_model(
     )
 
 
-def default_value(spec: SszType, fork: Optional[str] = None) -> Any:
+def default_value(spec: SSZType, fork: Optional[str] = None) -> Any:
     """Return the SSZ default (zero) value for spec as a pydantic value."""
-    if isinstance(spec, SszUint):
+    if isinstance(spec, SSZUint):
         return 0
-    if isinstance(spec, SszByteVector):
+    if isinstance(spec, SSZByteVector):
         return b"\x00" * spec.length
     if isinstance(
         spec,
-        (SszByteList, SszList, SszBitlist, SszProgressiveList),
+        (SSZByteList, SSZList, SSZBitlist, SSZProgressiveList),
     ):
         return []
-    if isinstance(spec, SszProgressiveBitlist):
+    if isinstance(spec, SSZProgressiveBitlist):
         return []
-    if isinstance(spec, SszVector):
+    if isinstance(spec, SSZVector):
         # A fresh value per slot: container defaults are mutable, so a shared
         # [x] * n would alias one instance across every position.
         return [default_value(spec.element, fork) for _ in range(spec.length)]
-    if isinstance(spec, SszBitvector):
+    if isinstance(spec, SSZBitvector):
         return [False] * spec.length
-    if isinstance(spec, (SszContainer, SszProgressiveContainer)):
+    if isinstance(spec, (SSZContainer, SSZProgressiveContainer)):
         return ssz_default(spec.model, _nested_fork(spec.model, fork))
-    if isinstance(spec, SszBool):
+    if isinstance(spec, SSZBool):
         return False
     raise TypeError(f"no default for SSZ type {spec!r}")
 
@@ -777,37 +777,37 @@ def ssz_default(model_cls: Type[_M], fork: Optional[str] = None) -> _M:
     )
 
 
-def describe_type(spec: SszType) -> str:
+def describe_type(spec: SSZType) -> str:
     """Render an SSZ type as text (uint64, List[T, N], ...)."""
-    if isinstance(spec, SszUint):
+    if isinstance(spec, SSZUint):
         return f"uint{spec.bits}"
-    if isinstance(spec, SszByteVector):
+    if isinstance(spec, SSZByteVector):
         return f"ByteVector[{spec.length}]"
-    if isinstance(spec, SszByteList):
+    if isinstance(spec, SSZByteList):
         return f"ByteList[{spec.limit}]"
-    if isinstance(spec, SszList):
+    if isinstance(spec, SSZList):
         return f"List[{describe_type(spec.element)}, {spec.limit}]"
-    if isinstance(spec, SszVector):
+    if isinstance(spec, SSZVector):
         return f"Vector[{describe_type(spec.element)}, {spec.length}]"
-    if isinstance(spec, SszBitvector):
+    if isinstance(spec, SSZBitvector):
         return f"Bitvector[{spec.length}]"
-    if isinstance(spec, SszBitlist):
+    if isinstance(spec, SSZBitlist):
         return f"Bitlist[{spec.limit}]"
-    if isinstance(spec, SszProgressiveList):
+    if isinstance(spec, SSZProgressiveList):
         return f"ProgressiveList[{describe_type(spec.element)}]"
-    if isinstance(spec, SszProgressiveBitlist):
+    if isinstance(spec, SSZProgressiveBitlist):
         return "ProgressiveBitlist"
-    if isinstance(spec, SszContainer):
+    if isinstance(spec, SSZContainer):
         return spec.model.__name__
-    if isinstance(spec, SszProgressiveContainer):
+    if isinstance(spec, SSZProgressiveContainer):
         return f"Progressive[{spec.model.__name__}]"
-    if isinstance(spec, SszBool):
+    if isinstance(spec, SSZBool):
         return "boolean"
     raise TypeError(f"unhandled SSZ type {spec!r}")
 
 
 def describe_schema(
-    model_cls: Type["SszModel"], fork: Optional[str] = None
+    model_cls: Type["SSZModel"], fork: Optional[str] = None
 ) -> str:
     """
     Render the resolved SSZ layout, one 'field: type' line per field.
@@ -821,7 +821,7 @@ def describe_schema(
     return "\n".join(lines)
 
 
-def encode(model: "SszModel", fork: Optional[str] = None) -> bytes:
+def encode(model: "SSZModel", fork: Optional[str] = None) -> bytes:
     """
     Return the SSZ wire bytes of model.
 
@@ -831,7 +831,7 @@ def encode(model: "SszModel", fork: Optional[str] = None) -> bytes:
     return _rmk_instance(model, fork).encode_bytes()
 
 
-def hash_tree_root(model: "SszModel", fork: Optional[str] = None) -> bytes:
+def hash_tree_root(model: "SSZModel", fork: Optional[str] = None) -> bytes:
     """
     Return the 32-byte SSZ hash_tree_root of model.
 
@@ -873,61 +873,61 @@ class Uint8(_SizedUint):
     """An 8-bit unsigned integer."""
 
     __bits__: ClassVar[int] = 8
-    __ssz__: ClassVar[SszType] = SszUint(8)
+    __ssz__: ClassVar[SSZType] = SSZUint(8)
 
 
 class Uint16(_SizedUint):
     """A 16-bit unsigned integer."""
 
     __bits__: ClassVar[int] = 16
-    __ssz__: ClassVar[SszType] = SszUint(16)
+    __ssz__: ClassVar[SSZType] = SSZUint(16)
 
 
 class Uint32(_SizedUint):
     """A 32-bit unsigned integer."""
 
     __bits__: ClassVar[int] = 32
-    __ssz__: ClassVar[SszType] = SszUint(32)
+    __ssz__: ClassVar[SSZType] = SSZUint(32)
 
 
 class Uint64(_SizedUint):
     """A 64-bit unsigned integer."""
 
     __bits__: ClassVar[int] = 64
-    __ssz__: ClassVar[SszType] = SszUint(64)
+    __ssz__: ClassVar[SSZType] = SSZUint(64)
 
 
 class Uint128(_SizedUint):
     """A 128-bit unsigned integer."""
 
     __bits__: ClassVar[int] = 128
-    __ssz__: ClassVar[SszType] = SszUint(128)
+    __ssz__: ClassVar[SSZType] = SSZUint(128)
 
 
 class Uint256(_SizedUint):
     """A 256-bit unsigned integer."""
 
     __bits__: ClassVar[int] = 256
-    __ssz__: ClassVar[SszType] = SszUint(256)
+    __ssz__: ClassVar[SSZType] = SSZUint(256)
 
 
 __all__ = [
     "ProgressiveModel",
-    "SszBitlist",
-    "SszBitvector",
-    "SszBool",
-    "SszByteList",
-    "SszByteVector",
-    "SszContainer",
-    "SszForkSchema",
-    "SszList",
-    "SszModel",
-    "SszProgressiveBitlist",
-    "SszProgressiveContainer",
-    "SszProgressiveList",
-    "SszType",
-    "SszUint",
-    "SszVector",
+    "SSZBitlist",
+    "SSZBitvector",
+    "SSZBool",
+    "SSZByteList",
+    "SSZByteVector",
+    "SSZContainer",
+    "SSZForkSchema",
+    "SSZList",
+    "SSZModel",
+    "SSZProgressiveBitlist",
+    "SSZProgressiveContainer",
+    "SSZProgressiveList",
+    "SSZType",
+    "SSZUint",
+    "SSZVector",
     "Uint128",
     "Uint16",
     "Uint256",

--- a/packages/testing/src/execution_testing/base_types/tests/test_ssz.py
+++ b/packages/testing/src/execution_testing/base_types/tests/test_ssz.py
@@ -22,9 +22,9 @@ from remerkleable.progressive import ProgressiveList as RmkProgressiveList
 from execution_testing.base_types import Address, Bloom, Bytes, Hash
 from execution_testing.base_types.ssz import (
     ProgressiveModel,
-    SszForkSchema,
-    SszModel,
-    SszUint,
+    SSZForkSchema,
+    SSZModel,
+    SSZUint,
     Uint8,
     Uint16,
     Uint32,
@@ -57,7 +57,7 @@ CELLS = 128
 BITS = [i % 3 == 0 for i in range(CELLS)]
 
 
-class Withdrawal(SszModel):
+class Withdrawal(SSZModel):
     """A pydantic model declared to check the SSZ machinery."""
 
     index: Uint64
@@ -66,7 +66,7 @@ class Withdrawal(SszModel):
     amount: Uint64
 
 
-class ExecutionPayload(SszModel):
+class ExecutionPayload(SSZModel):
     """An Amsterdam-shaped payload exercising every field kind."""
 
     parent_hash: Hash
@@ -83,21 +83,21 @@ class ExecutionPayload(SszModel):
     withdrawals: Annotated[List[Withdrawal], ssz_list(MAX_WITHDRAWALS)]
 
 
-class Status(SszModel):
+class Status(SSZModel):
     """A boolean and a fixed bit vector."""
 
     ok: bool
     columns: Annotated[List[bool], bitvector(CELLS)]
 
 
-class Committee(SszModel):
+class Committee(SSZModel):
     """A fixed Vector[uint64, N] and a variable Bitlist[N]."""
 
     seats: Annotated[List[Uint64], ssz_vector(3)]
     flags: Annotated[List[bool], bitlist(8)]
 
 
-class Ballot(SszModel):
+class Ballot(SSZModel):
     """An uncapped progressive bit list."""
 
     votes: Annotated[List[bool], progressive_bitlist()]
@@ -128,7 +128,7 @@ class MixedProg(ProgressiveModel):
     c: Uint64
 
 
-class ForkedPayload(SszModel):
+class ForkedPayload(SSZModel):
     """One model for every fork."""
 
     parent_hash: Hash
@@ -142,7 +142,7 @@ class ForkedPayload(SszModel):
         Annotated[List[Withdrawal], ssz_list(MAX_WITHDRAWALS)] | None
     ) = None
 
-    __ssz_schema__ = SszForkSchema(
+    __ssz_schema__ = SSZForkSchema(
         base_fork="Paris",
         base=("parent_hash", "block_number", "transactions"),
         appended={
@@ -152,7 +152,7 @@ class ForkedPayload(SszModel):
     )
 
 
-class Mixed(SszModel):
+class Mixed(SSZModel):
     """An SSZ container carrying a JSON-only (excluded) field."""
 
     a: Uint64
@@ -311,7 +311,7 @@ def _shanghai_payload() -> ForkedPayload:
 
 
 def assert_matches_reference(
-    model: SszModel, ref: Container, fork: Optional[str] = None
+    model: SSZModel, ref: Container, fork: Optional[str] = None
 ) -> None:
     """
     Compare the engine against a hand-written remerkleable twin.
@@ -337,7 +337,7 @@ def assert_matches_reference(
 TWIN_CASES: List[
     Tuple[
         str,
-        Callable[[], SszModel],
+        Callable[[], SSZModel],
         Callable[[], Container],
         Optional[str],
     ]
@@ -418,7 +418,7 @@ TWIN_CASES: List[
     [pytest.param(m, r, f, id=name) for name, m, r, f in TWIN_CASES],
 )
 def test_matches_remerkleable_reference(
-    make_model: Callable[[], SszModel],
+    make_model: Callable[[], SSZModel],
     make_ref: Callable[[], Container],
     fork: Optional[str],
 ) -> None:
@@ -471,10 +471,10 @@ def test_describe_schema_renders_every_field_kind() -> None:
 def test_default_vector_of_container_has_independent_slots() -> None:
     """A defaulted Vector-of-container has independent (non-aliased) slots."""
 
-    class Inner(SszModel):
+    class Inner(SSZModel):
         x: Uint64
 
-    class Outer(SszModel):
+    class Outer(SSZModel):
         items: Annotated[List[Inner], ssz_vector(3)]
 
     zero = ssz_default(Outer)
@@ -514,7 +514,7 @@ def test_fork_scoped_nested_in_complete_model_raises() -> None:
     test_fork_propagates_to_nested_containers.)
     """
 
-    class Wrapper(SszModel):
+    class Wrapper(SSZModel):
         payload: ForkedPayload
 
     wrapper = Wrapper(payload=_shanghai_payload())
@@ -531,11 +531,11 @@ def test_fork_propagates_to_nested_containers() -> None:
     the same chain fork. The outer fork= selects every nested projection.
     """
 
-    class Envelope(SszModel):
+    class Envelope(SSZModel):
         payload: ForkedPayload
         blob_count: Uint64 | None = None  # Shanghai-era envelope field
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris",
             base=("payload",),
             appended={"Shanghai": ("blob_count",)},
@@ -577,57 +577,57 @@ def test_forked_model_describe_schema_per_fork() -> None:
 
 
 def _bad_vector_marker_on_scalar() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         seats: Annotated[Uint64, ssz_vector(3)]  # not a list
 
 
 def _bad_byte_list_on_int() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         data: Annotated[Uint64, byte_list(8)]  # not Bytes
 
 
 def _bad_bit_marker_on_ints() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         flags: Annotated[List[Uint64], bitlist(8)]  # not list[bool]
 
 
 def _bad_raw_ssz_type_marker() -> None:
-    class Bad(SszModel):
-        x: Annotated[Uint64, SszUint(32)]  # raw SszType, not a helper
+    class Bad(SSZModel):
+        x: Annotated[Uint64, SSZUint(32)]  # raw SSZType, not a helper
 
 
 def _bad_unmapped_str() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         s: str  # no SSZ mapping and not excluded
 
 
 def _bad_bare_bytes() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         data: Bytes  # variable bytes need a byte_list cap
 
 
 def _bad_bare_list() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         items: List[Uint64]  # lists need a cap/length marker
 
 
 def _bad_multi_arm_union() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         x: Uint64 | Uint8 | None = None  # only T | None supported
 
 
 def _bad_optional_without_schema() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         b: Uint64 | None = None  # optional but no schema
 
 
 def _bad_schema_field_typo() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         b: Uint64 | None = None
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris",
             base=("a",),
             appended={"Shanghai": ("typo",)},
@@ -635,11 +635,11 @@ def _bad_schema_field_typo() -> None:
 
 
 def _bad_required_appended() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         b: Uint64  # appended but not optional
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris",
             base=("a",),
             appended={"Shanghai": ("b",)},
@@ -647,11 +647,11 @@ def _bad_required_appended() -> None:
 
 
 def _bad_optional_base() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         b: Uint64 | None = None  # optional but declared in base
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris",
             base=("a", "b"),
             appended={},
@@ -659,11 +659,11 @@ def _bad_optional_base() -> None:
 
 
 def _bad_appended_no_default() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         b: Uint64 | None  # optional type but NO None default
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris",
             base=("a",),
             appended={"Shanghai": ("b",)},
@@ -671,11 +671,11 @@ def _bad_appended_no_default() -> None:
 
 
 def _bad_duplicate_schema_names() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         b: Uint64 | None = None
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris",
             base=("a", "a"),
             appended={"Shanghai": ("b",)},
@@ -683,7 +683,7 @@ def _bad_duplicate_schema_names() -> None:
 
 
 def _bad_required_excluded() -> None:
-    class Bad(SszModel):
+    class Bad(SSZModel):
         a: Uint64
         note: Annotated[str, ssz_exclude()]  # excluded but required
 
@@ -692,7 +692,7 @@ def _bad_progressive_with_schema() -> None:
     class Bad(ProgressiveModel):
         a: Uint64
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Paris", base=("a",), appended={}
         )
 
@@ -837,7 +837,7 @@ def test_build_ssz_type_cache_identity() -> None:
     )
 
     def make_dup() -> type:
-        class Dup(SszModel):
+        class Dup(SSZModel):
             a: Uint64
 
         return Dup
@@ -895,12 +895,12 @@ def test_excluded_field_is_json_only() -> None:
 def test_excluded_field_on_fork_scoped_model() -> None:
     """Exclusion composes with __ssz_schema__ (schema skips the field)."""
 
-    class ForkedMixed(SszModel):
+    class ForkedMixed(SSZModel):
         a: Uint64
         b: Uint64 | None = None
         note: Annotated[str, ssz_exclude()] = "aux"
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="One",
             base=("a",),
             appended={"Two": ("b",)},
@@ -948,10 +948,10 @@ def test_spec_of_rejects_excluded_field() -> None:
 def test_single_fork_schema_works_end_to_end() -> None:
     """A schema with no appended forks is valid and encodable."""
 
-    class OnlyFork(SszModel):
+    class OnlyFork(SSZModel):
         a: Uint64
 
-        __ssz_schema__ = SszForkSchema(
+        __ssz_schema__ = SSZForkSchema(
             base_fork="Only", base=("a",), appended={}
         )
 

--- a/packages/testing/src/execution_testing/tools/ssz_vectors.py
+++ b/packages/testing/src/execution_testing/tools/ssz_vectors.py
@@ -31,20 +31,20 @@ from typing import (
 import yaml
 
 from execution_testing.base_types.ssz import (
-    SszBitlist,
-    SszBitvector,
-    SszBool,
-    SszByteList,
-    SszByteVector,
-    SszContainer,
-    SszList,
-    SszModel,
-    SszProgressiveBitlist,
-    SszProgressiveContainer,
-    SszProgressiveList,
-    SszType,
-    SszUint,
-    SszVector,
+    SSZBitlist,
+    SSZBitvector,
+    SSZBool,
+    SSZByteList,
+    SSZByteVector,
+    SSZContainer,
+    SSZList,
+    SSZModel,
+    SSZProgressiveBitlist,
+    SSZProgressiveContainer,
+    SSZProgressiveList,
+    SSZType,
+    SSZUint,
+    SSZVector,
     encode,
     hash_tree_root,
     spec_of,
@@ -56,7 +56,7 @@ MAX_BYTES_LENGTH = 1000
 
 RANDOM_CASE_COUNT = 30
 
-_M = TypeVar("_M", bound=SszModel)
+_M = TypeVar("_M", bound=SSZModel)
 
 _MODE_NAMES = (
     "random",
@@ -147,7 +147,7 @@ def _bitlist_length(
 
 def random_value(
     rng: random.Random,
-    spec: SszType,
+    spec: SSZType,
     mode: RandomizationMode,
     *,
     max_bytes_length: int = MAX_BYTES_LENGTH,
@@ -158,12 +158,12 @@ def random_value(
     Build a pydantic value of spec filled with random data per mode.
 
     A port of the consensus-specs get_random_ssz_object, branching on the
-    engine's SszType descriptors. With chaos, the mode is re-drawn at every
+    engine's SSZType descriptors. With chaos, the mode is re-drawn at every
     level of the value tree.
     """
     if chaos:
         mode = rng.choice(list(RandomizationMode))
-    if isinstance(spec, SszByteList):
+    if isinstance(spec, SSZByteList):
         if mode == RandomizationMode.mode_nil_count:
             return b""
         if mode == RandomizationMode.mode_max_count:
@@ -177,41 +177,41 @@ def random_value(
         return _random_bytes(
             rng, rng.randint(0, min(max_bytes_length, spec.limit))
         )
-    if isinstance(spec, SszByteVector):
+    if isinstance(spec, SSZByteVector):
         # Byte vectors are fixed length; no max-bytes cap applies.
         if mode == RandomizationMode.mode_zero:
             return b"\x00" * spec.length
         if mode == RandomizationMode.mode_max:
             return b"\xff" * spec.length
         return _random_bytes(rng, spec.length)
-    if isinstance(spec, SszUint):
+    if isinstance(spec, SSZUint):
         if mode == RandomizationMode.mode_zero:
             return 0
         if mode == RandomizationMode.mode_max:
             return (1 << spec.bits) - 1
         return rng.randint(0, (1 << spec.bits) - 1)
-    if isinstance(spec, SszBool):
+    if isinstance(spec, SSZBool):
         if mode == RandomizationMode.mode_zero:
             return False
         if mode == RandomizationMode.mode_max:
             return True
         return bool(rng.getrandbits(1))
-    if isinstance(spec, SszBitvector):
+    if isinstance(spec, SSZBitvector):
         # Bit vectors are fixed length; no cap applies.
         return _bits(rng, spec.length, mode)
-    if isinstance(spec, SszBitlist):
+    if isinstance(spec, SSZBitlist):
         # Consensus caps bit lists by the LIST cap, not the byte cap.
         cap = min(max_list_length, spec.limit)
         length = _bitlist_length(rng, cap, mode)
         return _bits(rng, length, mode)
-    if isinstance(spec, SszProgressiveBitlist):
+    if isinstance(spec, SSZProgressiveBitlist):
         # Progressive bit lists are uncapped; the list cap bounds them.
         length = _bitlist_length(rng, max_list_length, mode)
         return _bits(rng, length, mode)
-    if isinstance(spec, (SszList, SszProgressiveList)):
+    if isinstance(spec, (SSZList, SSZProgressiveList)):
         # Progressive lists are uncapped; the list cap bounds them.
         limit = max_list_length
-        if isinstance(spec, SszList) and spec.limit < limit:
+        if isinstance(spec, SSZList) and spec.limit < limit:
             limit = spec.limit
         length = rng.randint(0, limit)
         if mode == RandomizationMode.mode_one_count:
@@ -233,7 +233,7 @@ def random_value(
             )
             for _ in range(length)
         ]
-    if isinstance(spec, SszVector):
+    if isinstance(spec, SSZVector):
         return [
             random_value(
                 rng,
@@ -245,7 +245,7 @@ def random_value(
             )
             for _ in range(spec.length)
         ]
-    if isinstance(spec, (SszContainer, SszProgressiveContainer)):
+    if isinstance(spec, (SSZContainer, SSZProgressiveContainer)):
         return random_model(
             rng,
             spec.model,
@@ -288,7 +288,7 @@ def random_model(
     )
 
 
-def make_case(model: SszModel, fork: Optional[str] = None) -> VectorCase:
+def make_case(model: SSZModel, fork: Optional[str] = None) -> VectorCase:
     """Turn a model instance into its ssz_static case triple."""
     return VectorCase(
         value=model.model_dump(mode="json", exclude_none=True),
@@ -331,17 +331,17 @@ def suite_plan(
     return plan
 
 
-ModelSpec = Union[Type[SszModel], Tuple[Type[SszModel], str]]
+ModelSpec = Union[Type[SSZModel], Tuple[Type[SSZModel], str]]
 
 
 def _normalize_models(
     models: Sequence[ModelSpec],
-) -> List[Tuple[Type[SszModel], Optional[str]]]:
+) -> List[Tuple[Type[SSZModel], Optional[str]]]:
     """Normalize entries to (model, fork) and reject output collisions."""
-    entries: List[Tuple[Type[SszModel], Optional[str]]] = [
+    entries: List[Tuple[Type[SSZModel], Optional[str]]] = [
         m if isinstance(m, tuple) else (m, None) for m in models
     ]
-    seen: Dict[Tuple[str, Optional[str]], Type[SszModel]] = {}
+    seen: Dict[Tuple[str, Optional[str]], Type[SSZModel]] = {}
     for model_cls, fork in entries:
         key = (model_cls.__name__, fork)
         other = seen.setdefault(key, model_cls)

--- a/packages/testing/src/execution_testing/tools/tests/test_ssz_vectors.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_ssz_vectors.py
@@ -16,8 +16,8 @@ import yaml
 
 from execution_testing.base_types import Address, Bytes, Hash
 from execution_testing.base_types.ssz import (
-    SszForkSchema,
-    SszModel,
+    SSZForkSchema,
+    SSZModel,
     Uint64,
     Uint256,
     byte_list,
@@ -44,7 +44,7 @@ MAX_BYTES_PER_TX = 2**30
 MAX_WITHDRAWALS = 16
 
 
-class Withdrawal(SszModel):
+class Withdrawal(SSZModel):
     """A withdrawal container."""
 
     index: Uint64
@@ -53,7 +53,7 @@ class Withdrawal(SszModel):
     amount: Uint64
 
 
-class Payload(SszModel):
+class Payload(SSZModel):
     """A container with a byte-list, a capped list, and a nested list."""
 
     parent_hash: Hash
@@ -66,7 +66,7 @@ class Payload(SszModel):
     withdrawals: Annotated[List[Withdrawal], ssz_list(MAX_WITHDRAWALS)]
 
 
-class ForkedPayload(SszModel):
+class ForkedPayload(SSZModel):
     """A fork-scoped model, for the generator's fork axis."""
 
     parent_hash: Hash
@@ -75,14 +75,14 @@ class ForkedPayload(SszModel):
         Annotated[List[Withdrawal], ssz_list(MAX_WITHDRAWALS)] | None
     ) = None
 
-    __ssz_schema__ = SszForkSchema(
+    __ssz_schema__ = SSZForkSchema(
         base_fork="Paris",
         base=("parent_hash", "block_number"),
         appended={"Shanghai": ("withdrawals",)},
     )
 
 
-def assert_roundtrip(model: SszModel) -> None:
+def assert_roundtrip(model: SSZModel) -> None:
     """Reusable harness: encode -> decode reconstructs the SSZ value."""
     restored = decode(type(model), encode(model))
     assert encode(restored) == encode(model)
@@ -221,7 +221,7 @@ def test_chaos_redraws_modes() -> None:
 
 @pytest.mark.parametrize("name", list(Payload.model_fields))
 def test_random_value_covers_field_spec(name: str) -> None:
-    """random_value handles every SszType the test containers use."""
+    """random_value handles every SSZType the test containers use."""
     rng = random.Random(1)
     value = random_value(
         rng, spec_of(Payload, name), RandomizationMode.mode_random
@@ -287,7 +287,7 @@ def test_duplicate_vector_targets_rejected(tmp_path: Path) -> None:
     """Two distinct same-named models cannot share an output directory."""
 
     def make_dup() -> type:
-        class Withdrawal(SszModel):  # same __name__, different class
+        class Withdrawal(SSZModel):  # same __name__, different class
             a: Uint64
 
         return Withdrawal


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Small nit PR but it bothered me hard.

Mechanical rename of the `Ssz` prefixed class names to `SSZ` (`SSZModel`, `SSZList`, `SSZUnion`, `SSZContainer` and the rest), matching how the repo capitalizes acronyms elsewhere (`EngineRPC`, `EthRPC`, `RLP`).

Four files under `packages/testing` (`base_types/ssz.py`, `tools/ssz_vectors.py` and their tests). All names are internal to the package, none are exported through any `__init__`, so nothing outside these files changes.

Receipts: full mypy clean, all SSZ unit tests pass, `just static` clean.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fm%2FMilCTUavcqYAAAAC%2Fdolphin-man.gif&f=1&nofb=1&ipt=37deeeb1c09a807d7522f58ed91a1852cbd0abfc57e896423bb43de77e20e9ac)
