### PR TITLE
feat(zkevm): replace SszList with ProgressiveList for state, codes, and public keys

### DIFF
--- a/src/ethereum/forks/amsterdam/stateless_ssz.py
+++ b/src/ethereum/forks/amsterdam/stateless_ssz.py
@@ -44,20 +44,6 @@ from .stateless import (
 
 MAX_EXTRA_DATA_BYTES = 32
 
-# Stateless witness resource bounds.  These are local limits chosen for this
-# schema, not consensus-spec SSZ constants.
-
-# BAL permits block_gas_limit // 2_000 items. At 500M gas, that is
-# 250_000 account accesses; budgeting 16 witness nodes per account gives
-# 4_000_000 nodes, rounded up to 2**22. This targets an account-heavy
-# witness, since deep storage tries are harder to construct. Depth of
-# 16 is around double the depth of mainnet account trie.
-MAX_WITNESS_NODES = 2**22
-
-# Enough room for one pre-state bytecode read per BAL item at 500M gas:
-# 500_000_000 // 2_000 = 250_000, rounded up to 2**18.
-MAX_WITNESS_CODES = 2**18
-
 # Execution only exposes the previous 256 block hashes.
 MAX_WITNESS_HEADERS = 256
 # As defined in EIP-7954.
@@ -68,10 +54,6 @@ MAX_BYTES_PER_HEADER = 2**10
 # 2**10 is the next power of two, with almost twice the needed capacity.
 MAX_BYTES_PER_WITNESS_NODE = 2**10
 
-# One public key is supplied per transaction. Every valid transaction consumes
-# at least 21_000 gas, so a 500M gas block can contain at most
-# 500_000_000 // 21_000 = 23_809 transactions, rounded up to next power of 2.
-MAX_PUBLIC_KEYS = 2**15
 PUBLIC_KEY_BYTES = 65
 
 # Stateless guest input bytes are schema-prefixed:
@@ -194,8 +176,8 @@ class SszNewPayloadRequest(Container):
 class SszExecutionWitness(Container):
     """SSZ container mirroring ``ExecutionWitness``."""
 
-    state: SszList[ByteList[MAX_BYTES_PER_WITNESS_NODE], MAX_WITNESS_NODES]
-    codes: SszList[ByteList[MAX_BYTES_PER_CODE], MAX_WITNESS_CODES]
+    state: ProgressiveList[ByteList[MAX_BYTES_PER_WITNESS_NODE]]
+    codes: ProgressiveList[ByteList[MAX_BYTES_PER_CODE]]
     headers: SszList[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS]
 
 
@@ -205,7 +187,7 @@ class SszStatelessInput(Container):
     new_payload_request: SszNewPayloadRequest
     witness: SszExecutionWitness
     chain_id: uint64
-    public_keys: SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
+    public_keys: ProgressiveList[ByteVector[PUBLIC_KEY_BYTES]]
 
 
 class SszStatelessValidationResult(Container):
@@ -485,10 +467,10 @@ def _witness_to_ssz(
 ) -> SszExecutionWitness:
     """Convert an ExecutionWitness to its SSZ form."""
     return SszExecutionWitness(
-        state=SszList[ByteList[MAX_BYTES_PER_WITNESS_NODE], MAX_WITNESS_NODES](
+        state=ProgressiveList[ByteList[MAX_BYTES_PER_WITNESS_NODE]](
             ByteList[MAX_BYTES_PER_WITNESS_NODE](bytes(s)) for s in w.state
         ),
-        codes=SszList[ByteList[MAX_BYTES_PER_CODE], MAX_WITNESS_CODES](
+        codes=ProgressiveList[ByteList[MAX_BYTES_PER_CODE]](
             ByteList[MAX_BYTES_PER_CODE](bytes(c)) for c in w.codes
         ),
         headers=SszList[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS](
@@ -524,7 +506,7 @@ def stateless_input_to_ssz(
         ),
         witness=_witness_to_ssz(si.witness),
         chain_id=uint64(int(si.chain_id)),
-        public_keys=SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS](
+        public_keys=ProgressiveList[ByteVector[PUBLIC_KEY_BYTES]](
             ByteVector[PUBLIC_KEY_BYTES](bytes(pk)) for pk in si.public_keys
         ),
     )

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -7,8 +7,6 @@ import pytest
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes8, Bytes32, Bytes48, Bytes96
 from ethereum_types.numeric import U16, U64, U256, Uint
-from remerkleable.complex import List as SszList
-from remerkleable.progressive import ProgressiveList
 
 from ethereum.crypto.hash import Hash32
 from ethereum.forks.amsterdam.block_access_lists import BlockAccessList
@@ -50,13 +48,10 @@ from ethereum.forks.amsterdam.stateless_ssz import (
     MAX_BYTES_PER_HEADER,
     MAX_BYTES_PER_WITNESS_NODE,
     MAX_WITNESS_HEADERS,
-    PUBLIC_KEY_BYTES,
     STATELESS_INPUT_SCHEMA_FORK_INDEX,
     STATELESS_INPUT_SCHEMA_ID,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
     STATELESS_INPUT_SCHEMA_REVISION,
-    SszExecutionWitness,
-    SszStatelessInput,
     stateless_input_to_ssz,
 )
 from ethereum.forks.amsterdam.transactions import LegacyTransaction

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -7,6 +7,8 @@ import pytest
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes8, Bytes32, Bytes48, Bytes96
 from ethereum_types.numeric import U16, U64, U256, Uint
+from remerkleable.complex import List as SszList
+from remerkleable.progressive import ProgressiveList
 
 from ethereum.crypto.hash import Hash32
 from ethereum.forks.amsterdam.block_access_lists import BlockAccessList
@@ -44,10 +46,17 @@ from ethereum.forks.amsterdam.stateless_host import (
     serialize_stateless_input,
 )
 from ethereum.forks.amsterdam.stateless_ssz import (
+    MAX_BYTES_PER_CODE,
+    MAX_BYTES_PER_HEADER,
+    MAX_BYTES_PER_WITNESS_NODE,
+    MAX_WITNESS_HEADERS,
+    PUBLIC_KEY_BYTES,
     STATELESS_INPUT_SCHEMA_FORK_INDEX,
     STATELESS_INPUT_SCHEMA_ID,
     STATELESS_INPUT_SCHEMA_ID_BYTES,
     STATELESS_INPUT_SCHEMA_REVISION,
+    SszExecutionWitness,
+    SszStatelessInput,
     stateless_input_to_ssz,
 )
 from ethereum.forks.amsterdam.transactions import LegacyTransaction
@@ -365,6 +374,68 @@ class TestSerializeStatelessInput:
         )
 
         with pytest.raises(ValueError):
+            serialize_stateless_input(invalid)
+
+    @pytest.mark.parametrize(
+        "witness",
+        [
+            pytest.param(
+                ExecutionWitness(
+                    state=(Bytes(b"\0" * (MAX_BYTES_PER_WITNESS_NODE + 1)),),
+                    codes=(),
+                    headers=(),
+                ),
+                id="state-node",
+            ),
+            pytest.param(
+                ExecutionWitness(
+                    state=(),
+                    codes=(Bytes(b"\0" * (MAX_BYTES_PER_CODE + 1)),),
+                    headers=(),
+                ),
+                id="code",
+            ),
+            pytest.param(
+                ExecutionWitness(
+                    state=(),
+                    codes=(),
+                    headers=(Bytes(b"\0" * (MAX_BYTES_PER_HEADER + 1)),),
+                ),
+                id="header",
+            ),
+        ],
+    )
+    def test_rejects_oversized_witness_item(
+        self,
+        witness: ExecutionWitness,
+    ) -> None:
+        """Retain the structural byte limit for each witness item."""
+        original = _make_stateless_input()
+        invalid = StatelessInput(
+            new_payload_request=original.new_payload_request,
+            witness=witness,
+            chain_id=original.chain_id,
+            public_keys=original.public_keys,
+        )
+
+        with pytest.raises(Exception, match="cannot be more than limit"):
+            serialize_stateless_input(invalid)
+
+    def test_rejects_more_than_256_headers(self) -> None:
+        """Retain the protocol-backed witness header count limit."""
+        original = _make_stateless_input()
+        invalid = StatelessInput(
+            new_payload_request=original.new_payload_request,
+            witness=ExecutionWitness(
+                state=(),
+                codes=(),
+                headers=tuple(Bytes() for _ in range(MAX_WITNESS_HEADERS + 1)),
+            ),
+            chain_id=original.chain_id,
+            public_keys=original.public_keys,
+        )
+
+        with pytest.raises(Exception, match="too many list inputs: 257"):
             serialize_stateless_input(invalid)
 
 


### PR DESCRIPTION
### Description
Follow-up to #3248, which aligned Amsterdam's payload-related SSZ types with progressive SSZ.

This PR replaces the locally bounded SSZ lists for:

- `ExecutionWitness.state`
- `ExecutionWitness.codes`
- `StatelessInput.public_keys`

with `ProgressiveList`.

The removed limits were derived from an assumed 500M block gas limit rather than protocol-level SSZ constraints. Keeping them in the schema could unnecessarily reject valid stateless inputs as operational limits evolve.

Protocol and structural constraints remain unchanged:

- Witness headers remain bounded to 256, matching the `BLOCKHASH` history window.
- Per-node, code, and header byte limits remain bounded.
- Public keys remain fixed at 65 bytes.
- The surrounding structures remain regular SSZ `Container` types.

Progressive lists preserve the existing SSZ byte encoding, so Amsterdam schema ID `0x1501` remains unchanged and existing `statelessInputBytes` do not require refilling. Merkleization changes for the affected collections, but neither the witness root nor the complete stateless-input root is externally committed; `new_payload_request_root` is unaffected.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
