### PR TITLE
fix(tests): accept gas-used divergence in BAL omitted-slot-change test

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -138,6 +138,9 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_GAS_USED_ABOVE_LIMIT: (
             r"invalid gasUsed: have \d+, gasLimit \d+"
         ),
+        BlockException.INVALID_GAS_USED: (
+            r"invalid gas used \(remote: \d+ local: \d+\)"
+        ),
         BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
             r"invalid requests hash|failed to parse deposit logs"
         ),

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
@@ -2008,7 +2008,12 @@ def test_bal_invalid_omitted_slot_change_at_index(
         blocks=[
             Block(
                 txs=[tx1, tx2],
-                exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+                # Clients that execute against the declared BAL see gas
+                # diverge before the BAL comparison (e.g. geth, reth).
+                exception=[
+                    BlockException.INVALID_BLOCK_ACCESS_LIST,
+                    BlockException.INVALID_GAS_USED,
+                ],
                 expected_block_access_list=BlockAccessListExpectation(
                     account_expectations={
                         alice: BalAccountExpectation(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Clients that execute a block against its declared BAL (geth, reth) see gas diverge before their BAL comparison runs when the corrupted entry feeds a later transaction's reads, so they reject `test_bal_invalid_omitted_slot_change_at_index` with a gas used error instead of a BAL error. Check ordering is not consensus, so accept `INVALID_GAS_USED` as an alternate exception on this test rather than forcing clients to reorder their checks.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Unblocks ethereum/go-ethereum#35514

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A curious tabby cat](https://upload.wikimedia.org/wikipedia/commons/6/66/An_up-close_picture_of_a_curious_male_domestic_shorthair_tabby_cat.jpg)
