### PR TITLE
fix(tests): use well-formed versioned hashes in getBlobs negative tests

### DIFF
--- a/tests/amsterdam/eip8070_sparse_blobpool/spec.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_8070 = ReferenceSpec(
-    "EIPS/eip-8070.md", "64d1b463e1c75884c995f81d8ffab40401acbcaa"
+    "EIPS/eip-8070.md", "43c7af020f1641924bed60565fde86f6ad3469df"
 )
 
 
@@ -22,6 +22,9 @@ class Spec:
     Parameters from the EIP-8070 specification as defined at
     https://eips.ethereum.org/EIPS/eip-8070.
     """
+
+    BLOB_COMMITMENT_VERSION_KZG = 1
+    """Version byte of a KZG blob versioned hash (EIP-4844)."""
 
     CELLS_PER_EXT_BLOB = 128
     """Number of cells an extended blob is split into for `getBlobsV4`."""

--- a/tests/amsterdam/eip8070_sparse_blobpool/test_get_cells.py
+++ b/tests/amsterdam/eip8070_sparse_blobpool/test_get_cells.py
@@ -22,6 +22,7 @@ from execution_testing import (
     Hash,
     NetworkWrappedTransaction,
     Transaction,
+    add_kzg_version,
 )
 
 from .spec import Spec, ref_spec_8070
@@ -109,6 +110,14 @@ def generate_blob_layouts(fork: Fork) -> List:
     ]
 
 
+def generate_nonexisting_blob_hashes(count: int) -> List[Hash]:
+    """Return well-formed versioned hashes that match no pooled blob."""
+    return add_kzg_version(
+        [sha256(str(i).encode()).digest() for i in range(count)],
+        Spec.BLOB_COMMITMENT_VERSION_KZG,
+    )
+
+
 def generate_single_blob_layout(fork: Fork) -> List:
     """Return a single-blob transaction layout."""
     return [
@@ -187,9 +196,7 @@ def test_get_cells_partial_and_missing(
     Test that `getBlobsV4` returns a partial response: existing blobs yield a
     cell matrix while non-existing versioned hashes yield `null` entries.
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     blobs_test(
         pre=pre,
         txs=txs,
@@ -214,9 +221,7 @@ def test_get_cells_only_nonexisting(
     Test that `getBlobsV4` returns an array of `null` entries (one per
     requested hash) when all requested blobs are non-existing.
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     blobs_test(
         pre=pre,
         txs=[],
@@ -245,10 +250,9 @@ def test_get_cells_min_request_size(
     The response must hold one entry per requested hash: a cell matrix for
     the existing blob and `null` for each non-existing hash.
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest())
-        for i in range(Spec.MIN_SUPPORTED_REQUEST_SIZE - 1)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(
+        Spec.MIN_SUPPORTED_REQUEST_SIZE - 1
+    )
     blobs_test(
         pre=pre,
         txs=txs,
@@ -278,9 +282,7 @@ def test_get_cells_interleaved_missing(
     non-existing hashes are interleaved with existing ones (leading,
     middle, and trailing positions of the request).
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     blobs_test(
         pre=pre,
         txs=txs,

--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -19,17 +19,26 @@ from execution_testing import (
     NetworkWrappedTransaction,
     Transaction,
     TransactionException,
+    add_kzg_version,
 )
 from execution_testing.logging import (  # noqa: E501
     get_logger,
 )
 
-from .spec import ref_spec_7594
+from .spec import Spec, ref_spec_7594
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7594.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7594.version
 
 logger = get_logger(__name__)
+
+
+def generate_nonexisting_blob_hashes(count: int) -> List[Hash]:
+    """Return well-formed versioned hashes that match no pooled blob."""
+    return add_kzg_version(
+        [sha256(str(i).encode()).digest() for i in range(count)],
+        Spec.BLOB_COMMITMENT_VERSION_KZG,
+    )
 
 
 @pytest.fixture
@@ -385,9 +394,7 @@ def test_get_blobs_nonexisting_getblobsv1(
     Test that ensures clients respond with 'null' when at least one requested
     blob is not available (getBlobsV1 behavior: all-or-nothing response).
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     blobs_test(
         pre=pre,
         txs=txs,
@@ -412,9 +419,7 @@ def test_get_blobs_nonexisting_getblobsv2(
     Test that ensures clients respond with 'null' when at least one requested
     blob is not available (getBlobsV2 behavior: all-or-nothing response).
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     print("Testing getBlobsV2 (all-or-nothing behavior)")
     for tx_idx, tx_hashes in enumerate(txs_versioned_hashes):
         for blob_idx, vh in enumerate(tx_hashes):
@@ -447,9 +452,7 @@ def test_get_blobs_nonexisting_getblobsv3(
     Test that ensures clients respond with partial results when some requested
     blobs are not available (getBlobsV3 behavior: null only for missing blobs).
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     print("Testing getBlobsV3 (partial response behavior)")
     for tx_idx, tx_hashes in enumerate(txs_versioned_hashes):
         for blob_idx, vh in enumerate(tx_hashes):
@@ -479,9 +482,7 @@ def test_get_blobs_only_nonexisting_getblobsv3(
     hash) when all requested blobs are non-existing, rather than returning a
     single null for the entire response.
     """
-    nonexisting_blob_hashes = [
-        Hash(sha256(str(i).encode()).digest()) for i in range(5)
-    ]
+    nonexisting_blob_hashes = generate_nonexisting_blob_hashes(5)
     print("Testing getBlobsV3 (only non-existing blobs)")
     for i, nh in enumerate(nonexisting_blob_hashes):
         print(f"  non-existing {i}: {nh.hex()}")


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The non-existing blob hashes requested in the `getBlobsV1`-`V4` negative tests were raw `sha256` digests, so their first byte was a random version instead of the KZG version byte `0x01`. Route them through `add_kzg_version` so the requests carry well-formed versioned hashes that are still absent from the pool. Spotted while running execute blobs for the sparse blob pool tests against devnet-8 clients. Also bumps the EIP-8070 reference spec pin (status change only).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to #3344 and #3346.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
