### PR TITLE
chore(tests): mark memory heavy tests as bigmem

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -182,6 +182,10 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
+        "bigmem: Tests that consume a large amount of memory.",
+    )
+    config.addinivalue_line(
+        "markers",
         "eip_checklist(item_id, eip=None): Mark a test as implementing a "
         "specific checklist item. The first positional parameter is the "
         "checklist item ID. The optional 'eip' keyword parameter specifies "

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -334,6 +334,7 @@ def total_cost_floor_per_token(fork: Fork) -> int:
     return gas_costs.TX_DATA_TOKEN_FLOOR
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "exceed_tx_gas_limit,correct_intrinsic_cost_in_transaction_gas_limit",

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -36,7 +36,7 @@ from .spec import Spec, ref_spec_7934
 REFERENCE_SPEC_GIT_PATH = ref_spec_7934.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7934.version
 
-pytestmark = pytest.mark.xdist_group(name="bigmem")
+pytestmark = [pytest.mark.bigmem, pytest.mark.xdist_group(name="bigmem")]
 
 
 HEADER_TIMESTAMP = 123456789

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2066,6 +2066,7 @@ def test_set_code_to_self_destructing_account_deployed_in_same_tx(
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 def test_set_code_multiple_first_valid_authorization_tuples_same_signer(
     state_test: StateTestFiller,
@@ -2116,6 +2117,7 @@ def test_set_code_multiple_first_valid_authorization_tuples_same_signer(
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 def test_set_code_multiple_valid_authorization_tuples_same_signer_increasing_nonce(  # noqa: E501
     state_test: StateTestFiller,
@@ -2167,6 +2169,7 @@ def test_set_code_multiple_valid_authorization_tuples_same_signer_increasing_non
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 def test_set_code_multiple_valid_authorization_tuples_same_signer_increasing_nonce_self_sponsored(  # noqa: E501
     state_test: StateTestFiller,
@@ -2268,6 +2271,7 @@ def test_set_code_multiple_valid_authorization_tuples_first_invalid_same_signer(
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 def test_set_code_all_invalid_authorization_tuples(
     state_test: StateTestFiller,
@@ -2310,6 +2314,7 @@ def test_set_code_all_invalid_authorization_tuples(
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 def test_set_code_using_chain_specific_id(
     state_test: StateTestFiller,
@@ -2361,6 +2366,7 @@ SECP256K1N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 SECP256K1N_OVER_2 = SECP256K1N // 2
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "v,r,s",
@@ -2428,6 +2434,7 @@ def test_set_code_using_valid_synthetic_signatures(
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "v,r,s",

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
@@ -1751,6 +1751,7 @@ class DelegationTo(Enum):
     RESET = 3
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize(
@@ -1848,6 +1849,7 @@ def test_double_auth(
     )
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.valid_from("Prague")
 @pytest.mark.eels_base_coverage
@@ -2069,6 +2071,7 @@ def test_set_code_type_tx_pre_fork(
 
 
 @pytest.mark.valid_from("Prague")
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 def test_delegation_replacement_call_previous_contract(
     state_test: StateTestFiller,

--- a/tests/shanghai/eip3855_push0/test_push0.py
+++ b/tests/shanghai/eip3855_push0/test_push0.py
@@ -27,6 +27,7 @@ REFERENCE_SPEC_VERSION = ref_spec_3855.version
 pytestmark = pytest.mark.valid_from("Shanghai")
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "contract_code,expected_storage",
@@ -134,6 +135,7 @@ class TestPush0CallContext:
         )
         return pre.deploy_contract(call_code)
 
+    @pytest.mark.bigmem
     @pytest.mark.xdist_group(name="bigmem")
     @pytest.mark.parametrize(
         "call_opcode",

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -111,6 +111,7 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
 """Test cases using a contract creating transaction"""
 
 
+@pytest.mark.bigmem
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "initcode_name",
@@ -505,6 +506,7 @@ class TestCreateInitcode:
             sender=sender,
         )
 
+    @pytest.mark.bigmem
     @pytest.mark.xdist_group(name="bigmem")
     @pytest.mark.slow()
     def test_create_opcode_initcode(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Marks the memory heavy tests with the existing `bigmem` marker: the max size EIP-7702 set code cases, PUSH0 and initcode stress cases, the transaction gas limit cap cases and the max block RLP size module (which already carried the `bigmem` xdist group but not the marker itself).

Marker only, no test logic changes. The marker infrastructure already exists and is in use on this branch. This lets constrained runners and CI lanes deselect the heavy cases explicitly.

Surfaced while reviewing `projects/zkevm`, where these tests exceed guest memory during stateless re-execution. The marks are accurate independently of that work.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

