### PR TITLE
feat(zkevm): update geth branch for bench filling comparison

### DIFF
--- a/.github/workflows/benchmark-fill-parity.yaml
+++ b/.github/workflows/benchmark-fill-parity.yaml
@@ -13,7 +13,7 @@ on:
         description: "Geth branch to build"
         required: false
         type: string
-        default: "jsign-glamsterdam-devnet-7-t8n-zkevm"
+        default: "glamsterdam-devnet-8-t8n-zkevm"
       benchmark_file:
         description: "Benchmark test file to fill"
         required: false
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   GETH_REPO: ${{ inputs.geth_repo || 'jsign/go-ethereum' }}
-  GETH_BRANCH: ${{ inputs.geth_branch || 'jsign-glamsterdam-devnet-7-t8n-zkevm' }}
+  GETH_BRANCH: ${{ inputs.geth_branch || 'glamsterdam-devnet-8-t8n-zkevm' }}
   BENCHMARK_FILE: ${{ inputs.benchmark_file || 'tests/benchmark/compute/instruction/test_memory.py' }}
   FILL_FORK: ${{ inputs.fill_fork || 'Amsterdam' }}
   XDIST_WORKERS: ${{ inputs.xdist_workers || 'auto' }}


### PR DESCRIPTION
### Description
Update `go-ethereum` in CI for benchmark fill comparison to `glamsterdam-devnet-8`+https://github.com/ethereum/go-ethereum/pull/35257

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
