### PR TITLE
refactor(client-clis): bound the opcode-count trace time explicitly

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -30,6 +30,9 @@ from execution_testing.base_types import (
 )
 from execution_testing.client_clis import ClientBackend
 from execution_testing.client_clis.cli_types import EnginePayloadMetadata
+from execution_testing.client_clis.client_backend import (
+    DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT,
+)
 from execution_testing.fixtures import FixtureFillingPhase
 from execution_testing.fixtures.blockchain import (
     StatefulPreRunFixture,
@@ -145,6 +148,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "struct-log tracer otherwise (besu). Requires the `debug` "
             "namespace. Adds a full re-execution trace per block — slow; "
             "opt-in."
+        ),
+    )
+    group.addoption(
+        "--opcode-count-trace-timeout",
+        action="store",
+        dest="opcode_count_trace_timeout",
+        default=DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT,
+        type=str,
+        help=(
+            "Per-transaction bound for the --extract-opcode-count trace, as "
+            "a Go duration (e.g. 30s, 5m, 1h). Without it the client applies "
+            "its own (5s on geth), which a benchmark block's trace outruns; "
+            "the abandoned transaction is then tallied as zero."
         ),
     )
     group.addoption(
@@ -508,10 +524,17 @@ def extract_opcode_count(request: pytest.FixtureRequest) -> bool:
 
 
 @pytest.fixture(scope="session")
+def opcode_count_trace_timeout(request: pytest.FixtureRequest) -> str:
+    """The --opcode-count-trace-timeout bound sent with each trace."""
+    return request.config.getoption("opcode_count_trace_timeout")
+
+
+@pytest.fixture(scope="session")
 def client_backend(
     eth_rpc: ChainBuilderEthRPC,
     debug_rpc: DebugRPC,
     extract_opcode_count: bool,
+    opcode_count_trace_timeout: str,
     session_fork: Fork | TransitionFork,
     default_gas_price: int | None,
     default_max_fee_per_gas: int | None,
@@ -537,6 +560,7 @@ def client_backend(
         fork=session_fork,
         debug_rpc=debug_rpc,
         extract_opcode_count=extract_opcode_count,
+        opcode_count_trace_timeout=opcode_count_trace_timeout,
     )
 
     priority_fee = default_max_priority_fee_per_gas

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -75,6 +75,15 @@ STRUCT_LOG_TRACER_CONFIG = {
     "disableStorage": True,
 }
 
+# ``debug_trace*`` bounds each transaction's trace and abandons it when the
+# bound expires. The default is 5s on geth, which a benchmark block routinely
+# exceeds: a 300M-gas block of cheap opcodes executes >100M steps, and driving
+# a JS tracer through them costs tens of seconds. The abandoned transaction
+# then contributes nothing, so the block's tally is silently short -- or, with
+# a single transaction, missing outright. Ask for a bound no legitimate trace
+# can reach, while still capping one that has genuinely hung.
+OPCODE_COUNT_TRACE_TIMEOUT = "1h"
+
 
 def _normalize_opcode_name(name: str) -> str | None:
     """
@@ -332,6 +341,9 @@ class ClientBackend:
         fails (logged, never fatal). Prefers the JS tracer; a client
         that rejects it falls back to struct logs for the session,
         while transient errors only skip the block.
+
+        Both paths carry ``OPCODE_COUNT_TRACE_TIMEOUT``; without it the
+        client's own default cuts long traces short.
         """
         if not self.extract_opcode_count or self.debug_rpc is None:
             return None
@@ -358,7 +370,8 @@ class ClientBackend:
         """Raw ``debug_traceBlockByHash`` call; exceptions propagate."""
         assert self.debug_rpc is not None
         return self.debug_rpc.trace_block_by_hash(
-            str(block_hash), tracer_config
+            str(block_hash),
+            {"timeout": OPCODE_COUNT_TRACE_TIMEOUT, **tracer_config},
         )
 
     def _payload_attributes(

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -75,14 +75,7 @@ STRUCT_LOG_TRACER_CONFIG = {
     "disableStorage": True,
 }
 
-# ``debug_trace*`` bounds each transaction's trace and abandons it when the
-# bound expires. The default is 5s on geth, which a benchmark block routinely
-# exceeds: a 300M-gas block of cheap opcodes executes >100M steps, and driving
-# a JS tracer through them costs tens of seconds. The abandoned transaction
-# then contributes nothing, so the block's tally is silently short -- or, with
-# a single transaction, missing outright. Ask for a bound no legitimate trace
-# can reach, while still capping one that has genuinely hung.
-OPCODE_COUNT_TRACE_TIMEOUT = "1h"
+DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT = "1h"
 
 
 def _normalize_opcode_name(name: str) -> str | None:
@@ -199,6 +192,7 @@ class ClientBackend:
         fork: Fork | TransitionFork,
         debug_rpc: DebugRPC | None = None,
         extract_opcode_count: bool = False,
+        opcode_count_trace_timeout: str = DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT,
     ) -> None:
         """Initialize with the RPC clients and the session fork."""
         self.testing_rpc = testing_rpc
@@ -207,6 +201,7 @@ class ClientBackend:
         self.fork = fork
         self.debug_rpc = debug_rpc
         self.extract_opcode_count = extract_opcode_count
+        self.opcode_count_trace_timeout = opcode_count_trace_timeout
         # Sticky fallback to struct logs (besu has no JS tracer).
         self._js_tracer_unsupported = False
         self.exception_mapper = ClientBackendExceptionMapper()
@@ -341,9 +336,6 @@ class ClientBackend:
         fails (logged, never fatal). Prefers the JS tracer; a client
         that rejects it falls back to struct logs for the session,
         while transient errors only skip the block.
-
-        Both paths carry ``OPCODE_COUNT_TRACE_TIMEOUT``; without it the
-        client's own default cuts long traces short.
         """
         if not self.extract_opcode_count or self.debug_rpc is None:
             return None
@@ -371,7 +363,7 @@ class ClientBackend:
         assert self.debug_rpc is not None
         return self.debug_rpc.trace_block_by_hash(
             str(block_hash),
-            {"timeout": OPCODE_COUNT_TRACE_TIMEOUT, **tracer_config},
+            {"timeout": self.opcode_count_trace_timeout, **tracer_config},
         )
 
     def _payload_attributes(

--- a/packages/testing/src/execution_testing/client_clis/tests/test_opcode_count_trace.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_opcode_count_trace.py
@@ -1,0 +1,93 @@
+"""Test suite for the opcode-count trace request in ``ClientBackend``."""
+
+from typing import Any, Dict, List, Tuple
+
+from execution_testing.base_types import Hash
+from execution_testing.client_clis import ClientBackend
+from execution_testing.client_clis.client_backend import (
+    OPCODE_COUNT_TRACE_TIMEOUT,
+    OPCODE_COUNT_TRACER_JS,
+    STRUCT_LOG_TRACER_CONFIG,
+)
+from execution_testing.rpc.rpc_types import JSONRPCError
+
+BLOCK_HASH = Hash(0)
+
+
+class StubDebugRPC:
+    """
+    Records the ``debug_traceBlockByHash`` config it is called with and
+    replays a canned response per call.
+    """
+
+    def __init__(self, responses: List[Any]) -> None:
+        self.responses = responses
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    def trace_block_by_hash(
+        self, block_hash: str, tracer_config: Dict[str, Any]
+    ) -> Any:
+        """Record the request, then return or raise the canned response."""
+        self.calls.append((block_hash, tracer_config))
+        response = self.responses[len(self.calls) - 1]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _backend(responses: List[Any]) -> ClientBackend:
+    """
+    Stub ``ClientBackend`` wired to ``StubDebugRPC``.
+
+    ``__new__`` skips ``__init__``: the trace path needs no live client.
+    """
+    backend = ClientBackend.__new__(ClientBackend)
+    backend.extract_opcode_count = True
+    backend._js_tracer_unsupported = False
+    backend.debug_rpc = StubDebugRPC(responses)  # type: ignore[assignment]
+    return backend
+
+
+def test_js_tracer_request_carries_a_timeout() -> None:
+    """
+    The JS-tracer request must set ``timeout``.
+
+    A client's own default bounds each transaction's trace (5s on geth) and
+    abandons it when that expires. A benchmark block outruns it, and the
+    abandoned transaction contributes no counts, so the tally is silently
+    short rather than absent.
+    """
+    backend = _backend([[{"result": {"PUSH0": 3}}]])
+
+    backend.extract_block_opcode_count(BLOCK_HASH)
+
+    _, config = backend.debug_rpc.calls[0]  # type: ignore[union-attr]
+    assert config["timeout"] == OPCODE_COUNT_TRACE_TIMEOUT
+    assert config["tracer"] == OPCODE_COUNT_TRACER_JS
+
+
+def test_struct_log_fallback_request_carries_a_timeout() -> None:
+    """The struct-log fallback is bounded the same way, and stays intact."""
+    backend = _backend(
+        [
+            JSONRPCError(code=-32601, message="method not found"),
+            [{"result": {"structLogs": [{"op": "PUSH0"}]}}],
+        ]
+    )
+
+    backend.extract_block_opcode_count(BLOCK_HASH)
+
+    _, config = backend.debug_rpc.calls[1]  # type: ignore[union-attr]
+    assert config["timeout"] == OPCODE_COUNT_TRACE_TIMEOUT
+    for key, value in STRUCT_LOG_TRACER_CONFIG.items():
+        assert config[key] == value
+
+
+def test_timeout_is_a_duration_the_client_can_parse() -> None:
+    """
+    The value reaches the client verbatim, so it has to be a Go duration
+    string -- a bare number is rejected.
+    """
+    assert isinstance(OPCODE_COUNT_TRACE_TIMEOUT, str)
+    assert OPCODE_COUNT_TRACE_TIMEOUT[-1] in "smh"
+    assert float(OPCODE_COUNT_TRACE_TIMEOUT[:-1]) > 0

--- a/packages/testing/src/execution_testing/client_clis/tests/test_opcode_count_trace.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_opcode_count_trace.py
@@ -1,93 +1,86 @@
 """Test suite for the opcode-count trace request in ``ClientBackend``."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
+
+import pytest
 
 from execution_testing.base_types import Hash
 from execution_testing.client_clis import ClientBackend
 from execution_testing.client_clis.client_backend import (
-    OPCODE_COUNT_TRACE_TIMEOUT,
+    DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT,
     OPCODE_COUNT_TRACER_JS,
     STRUCT_LOG_TRACER_CONFIG,
 )
 from execution_testing.rpc.rpc_types import JSONRPCError
 
 BLOCK_HASH = Hash(0)
+JS_TRACER_REJECTED = JSONRPCError(code=-32601, message="method not found")
+JS_TRACE = [{"result": {"PUSH0": 3}}]
+STRUCT_LOG_TRACE = [{"result": {"structLogs": [{"op": "PUSH0"}]}}]
 
 
 class StubDebugRPC:
-    """
-    Records the ``debug_traceBlockByHash`` config it is called with and
-    replays a canned response per call.
-    """
+    """Record each trace request's config and replay a canned response."""
 
     def __init__(self, responses: List[Any]) -> None:
         self.responses = responses
-        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+        self.configs: List[Dict[str, Any]] = []
 
     def trace_block_by_hash(
-        self, block_hash: str, tracer_config: Dict[str, Any]
+        self, _block_hash: str, tracer_config: Dict[str, Any]
     ) -> Any:
-        """Record the request, then return or raise the canned response."""
-        self.calls.append((block_hash, tracer_config))
-        response = self.responses[len(self.calls) - 1]
+        """Record the request config, then return or raise the response."""
+        self.configs.append(tracer_config)
+        response = self.responses[len(self.configs) - 1]
         if isinstance(response, Exception):
             raise response
         return response
 
 
-def _backend(responses: List[Any]) -> ClientBackend:
-    """
-    Stub ``ClientBackend`` wired to ``StubDebugRPC``.
-
-    ``__new__`` skips ``__init__``: the trace path needs no live client.
-    """
+def _trace_configs(
+    responses: List[Any],
+    timeout: str = DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT,
+) -> List[Dict[str, Any]]:
+    """Return the configs ``extract_block_opcode_count`` sends per call."""
+    # ``__new__`` skips ``__init__``: the trace path needs no live client.
     backend = ClientBackend.__new__(ClientBackend)
     backend.extract_opcode_count = True
+    backend.opcode_count_trace_timeout = timeout
     backend._js_tracer_unsupported = False
-    backend.debug_rpc = StubDebugRPC(responses)  # type: ignore[assignment]
-    return backend
-
-
-def test_js_tracer_request_carries_a_timeout() -> None:
-    """
-    The JS-tracer request must set ``timeout``.
-
-    A client's own default bounds each transaction's trace (5s on geth) and
-    abandons it when that expires. A benchmark block outruns it, and the
-    abandoned transaction contributes no counts, so the tally is silently
-    short rather than absent.
-    """
-    backend = _backend([[{"result": {"PUSH0": 3}}]])
-
+    debug_rpc = StubDebugRPC(responses)
+    backend.debug_rpc = debug_rpc  # type: ignore[assignment]
     backend.extract_block_opcode_count(BLOCK_HASH)
-
-    _, config = backend.debug_rpc.calls[0]  # type: ignore[union-attr]
-    assert config["timeout"] == OPCODE_COUNT_TRACE_TIMEOUT
-    assert config["tracer"] == OPCODE_COUNT_TRACER_JS
+    return debug_rpc.configs
 
 
-def test_struct_log_fallback_request_carries_a_timeout() -> None:
-    """The struct-log fallback is bounded the same way, and stays intact."""
-    backend = _backend(
-        [
-            JSONRPCError(code=-32601, message="method not found"),
-            [{"result": {"structLogs": [{"op": "PUSH0"}]}}],
-        ]
-    )
+@pytest.mark.parametrize(
+    "responses,traced_call,tracer_config",
+    [
+        pytest.param(
+            [JS_TRACE],
+            0,
+            {"tracer": OPCODE_COUNT_TRACER_JS},
+            id="js_tracer",
+        ),
+        pytest.param(
+            [JS_TRACER_REJECTED, STRUCT_LOG_TRACE],
+            1,
+            STRUCT_LOG_TRACER_CONFIG,
+            id="struct_log_fallback",
+        ),
+    ],
+)
+def test_trace_request_carries_the_timeout(
+    responses: List[Any],
+    traced_call: int,
+    tracer_config: Dict[str, Any],
+) -> None:
+    """
+    Both tracer paths bound the trace and keep their own config intact.
+    """
+    configs = _trace_configs(responses)
 
-    backend.extract_block_opcode_count(BLOCK_HASH)
-
-    _, config = backend.debug_rpc.calls[1]  # type: ignore[union-attr]
-    assert config["timeout"] == OPCODE_COUNT_TRACE_TIMEOUT
-    for key, value in STRUCT_LOG_TRACER_CONFIG.items():
+    config = configs[traced_call]
+    assert config["timeout"] == DEFAULT_OPCODE_COUNT_TRACE_TIMEOUT
+    for key, value in tracer_config.items():
         assert config[key] == value
-
-
-def test_timeout_is_a_duration_the_client_can_parse() -> None:
-    """
-    The value reaches the client verbatim, so it has to be a Go duration
-    string -- a bare number is rejected.
-    """
-    assert isinstance(OPCODE_COUNT_TRACE_TIMEOUT, str)
-    assert OPCODE_COUNT_TRACE_TIMEOUT[-1] in "smh"
-    assert float(OPCODE_COUNT_TRACE_TIMEOUT[:-1]) > 0


### PR DESCRIPTION
### Description

`extract_block_opcode_count` calls `debug_traceBlockByHash` without a `timeout`, so the client falls back to its own default — **5s per transaction on geth**. That is far below what a benchmark block needs.

Stepping the JS tracer runs at roughly 460k opcodes/s per transaction, so any transaction executing more than ~2.3M opcodes blows the deadline. geth abandons that trace and returns an error where the entry's `result` would be. `_opcode_count_from_js_tracer` skips an entry with no usable result, so the block still produces a **well-formed tally that is short by whole transactions** — and where every transaction times out, the fixture records no count at all. Nothing is raised and nothing is logged.

This is not a corner case for the compute benchmarks. In a 4884-fixture jochemnet build:

- **2182 (44.7%)** carry no opcode count for their benchmark block.
- The split falls exactly along step count, not along anything test-specific. `EXP` is counted, `ADD`/`MUL`/`SUB` are not. `codecopy` is counted at `code_size_1024` but not at `code_size_0` or `code_size_32`; `mcopy` at `copy_size_256` but not `copy_size_0`/`32`. The affected share climbs with the gas value, 42.3% at 100M to 48.4% at 300M.
- Cross-referencing `.benchmarkoor-pytest-report.json`, all 2182 have a `call` duration of **at least 5.42s**, with a hard floor right there, while fixtures that *did* get a count run as long as 250s. That floor is the 5s default plus overhead.

### Fix

Inject `timeout` in `_trace_block`, which covers the JS tracer and the struct-log fallback in one place. `timeout` is the standard geth-compatible `TraceConfig` field. The `tracer_config` spread comes second, so an explicit per-call value still wins.

The value needs to be one no legitimate trace can reach while still capping one that has genuinely hung; `1h` is ~100x the slowest transaction I measured.

### Verification

Re-ran all 2182 affected blocks against the same geth build (`ethpandaops/geth:glamsterdam-devnet-7`, `v1.17.6-unstable-bdf6e17f`) on the same stateful datadir, with `timeout` set:

- Every one produces a count, with all transactions covered.
- The heaviest, `test_push[...opcode_PUSH0...value_300M]`, tallies **143,118,396 opcodes in 25.6s** — 5x over the old 5s ceiling on its own, and that is with geth tracing the block's transactions in parallel.
- **Control:** 12 fixtures that already had counts reproduce **byte-for-byte**.
- `test_identity_uncachable[size_32, 300M]` now yields exactly **1,693,322** `STATICCALL`s with all 18 transactions covered. That case had previously been read as a benchmark bug when a single lost transaction left the tally 94,698 short.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

Also ran `just test-tests` (1997 passed). The two new tests fail without the change and pass with it.

### Cute Animal Picture

![red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Red_Panda_%2824986761703%29.jpg/960px-Red_Panda_%2824986761703%29.jpg)
