### PR TITLE
fix(consume): emit genesis slotNumber as hex string like all other fields

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/single_test_client.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/single_test_client.py
@@ -34,9 +34,6 @@ def client_genesis(fixture: BlockchainFixtureCommon) -> dict:
     alloc = to_json(fixture.pre)
     # NOTE: nethermind requires account keys without '0x' prefix
     genesis["alloc"] = {k.replace("0x", ""): v for k, v in alloc.items()}
-    # NOTE: geth expects slotNumber as plain integer, not hex string
-    if "slotNumber" in genesis:
-        genesis["slotNumber"] = int(genesis["slotNumber"], 16)
     return genesis
 
 


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Drop the consume-simulator special case that converted the genesis `slotNumber` to a plain decimal integer, making it the only non-hex numeric field in the emitted genesis JSON.

The workaround is stale: geth parses `slotNumber` via a `math.HexOrDecimal64` override (`core/gen_genesis.go`) and accepts hex strings, raw numbers, and decimal strings (verified against the devnet-8 pin `366048e`). The decimal emission actively breaks besu, which canonically parses genesis values as hex: `"999"` parses as `0x999` = 2457, so `test_slotnum_genesis` fails with `slot_number: expected 0x03e7, got 0x0999` (consume-rlp) or a genesis forkchoice update stuck `SYNCING` (consume-engine).

All currently-passing clients accept the hex form: geth/erigon (`HexOrDecimal64`), ethrex (`hex_str_opt` takes string or number), nethermind (`ULongConverter` hex path), nimbus (uint64 reader takes both).

Example run: https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786549384-264b0fb999b2d081299a3f589120dd18

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Sciurus_vulgaris_-_Squirrel_-_Eichh%C3%B6rnchen.jpg/640px-Sciurus_vulgaris_-_Squirrel_-_Eichh%C3%B6rnchen.jpg)
