### PR TITLE
fix(tests,tools): make the EIP-7805 FOCIL tests fill on the current Amsterdam

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -409,9 +409,16 @@ class T8N(Load):
                     self.fork.check_inclusion_list_transactions(
                         block_env,
                         block_output,
-                        tuple(self.convert_transaction(tx) for tx in self.txs),
                         tuple(
-                            self.convert_transaction(tx)
+                            self.fork.encode_transaction(
+                                self.convert_transaction(tx)
+                            )
+                            for tx in self.txs
+                        ),
+                        tuple(
+                            self.fork.encode_transaction(
+                                self.convert_transaction(tx)
+                            )
                             for tx in self.inclusion_list_txs
                         ),
                     )

--- a/tests/bogota/eip7805_focil/helpers.py
+++ b/tests/bogota/eip7805_focil/helpers.py
@@ -52,9 +52,11 @@ class PendingInclusionListTx(NamedTuple):
 # limit and spends exactly the same amount on a ballast transaction, leaving
 # `remaining_gas` — and therefore every "fits" / "does not fit" boundary —
 # byte-for-byte what it was.
-# Gas to add. Realised as a whole number of empty transfers so the amount is
-# always representable on the fork's calldata-cost lattice (a flat target like
-# 64_000 is not, once EIP-7623's floor makes marginal calldata cost non-linear).
+#
+# The headroom is realised as a whole number of empty transfers so the amount
+# is always representable on the fork's calldata-cost lattice (a flat target
+# like 64_000 is not, once EIP-7623's floor makes marginal calldata cost
+# non-linear).
 
 
 def bal_gas_headroom(fork: Fork) -> int:

--- a/tests/bogota/eip7805_focil/helpers.py
+++ b/tests/bogota/eip7805_focil/helpers.py
@@ -55,13 +55,16 @@ class PendingInclusionListTx(NamedTuple):
 # Gas to add. Realised as a whole number of empty transfers so the amount is
 # always representable on the fork's calldata-cost lattice (a flat target like
 # 64_000 is not, once EIP-7623's floor makes marginal calldata cost non-linear).
-BAL_GAS_HEADROOM_TARGET = 64_000
 
 
 def bal_gas_headroom(fork: Fork) -> int:
     """Gas added to a block's limit to leave room for its own access list."""
     empty_transfer_gas = fork.transaction_intrinsic_cost_calculator()()
-    count = -(-BAL_GAS_HEADROOM_TARGET // empty_transfer_gas)
+    bal_gas_headroom_target = (
+        fork.empty_block_bal_item_count()
+        * fork.gas_costs().BLOCK_ACCESS_LIST_ITEM
+    )
+    count = -(-bal_gas_headroom_target // empty_transfer_gas)
     return count * empty_transfer_gas
 
 

--- a/tests/bogota/eip7805_focil/helpers.py
+++ b/tests/bogota/eip7805_focil/helpers.py
@@ -36,6 +36,35 @@ class PendingInclusionListTx(NamedTuple):
     sender_balance: int = 10**18
 
 
+# EIP-7928 caps a block's access list at `block_gas_limit //
+# GAS_BLOCK_ACCESS_LIST_ITEM` items (2000 gas per item on Amsterdam). These
+# scenarios size the block gas limit to the transactions alone, which on the
+# current Amsterdam leaves no budget for the block's own access list: the
+# system-contract predeploys touched every block (beacon roots, history, the
+# EIP-7002/7251 request contracts and the EIP-8282 builder deposit/exit pair)
+# plus the senders, recipients and coinbase come to ~30 items against a limit
+# of ~22, and every fixture fails to fill with
+# `BlockAccessListGasLimitExceededError`.
+#
+# Raising the limit alone would change what the scenarios assert, because the
+# gas a pending IL transaction is allowed is derived from
+# `block_gas_limit - gas_used_by_included_txs`. So `build_block` raises the
+# limit and spends exactly the same amount on a ballast transaction, leaving
+# `remaining_gas` — and therefore every "fits" / "does not fit" boundary —
+# byte-for-byte what it was.
+# Gas to add. Realised as a whole number of empty transfers so the amount is
+# always representable on the fork's calldata-cost lattice (a flat target like
+# 64_000 is not, once EIP-7623's floor makes marginal calldata cost non-linear).
+BAL_GAS_HEADROOM_TARGET = 64_000
+
+
+def bal_gas_headroom(fork: Fork) -> int:
+    """Gas added to a block's limit to leave room for its own access list."""
+    empty_transfer_gas = fork.transaction_intrinsic_cost_calculator()()
+    count = -(-BAL_GAS_HEADROOM_TARGET // empty_transfer_gas)
+    return count * empty_transfer_gas
+
+
 class BuiltBlock(NamedTuple):
     """
     Concrete block data plus the derived gas headroom.
@@ -56,6 +85,10 @@ class BuiltBlock(NamedTuple):
     1. Sender `nonce` is correct
     2. Sender `balance` could have afforded the tx
 
+    `effective_gas_limit` is the gas limit the block must actually declare:
+    the caller's `block_gas_limit` plus `BAL_GAS_HEADROOM`. Pass it to
+    `Environment(gas_limit=...)` instead of the raw value.
+
     These helpers only describe the block body, the flattened IL view, and
     the gas headroom for a scenario. The actual satisfaction check is done by
     the Amsterdam fork logic after block execution, when it re-validates any
@@ -66,6 +99,7 @@ class BuiltBlock(NamedTuple):
     block_txs: list[Transaction]
     inclusion_list_txs: list[Transaction]
     remaining_gas: int
+    effective_gas_limit: int
 
 
 def _resolve_sender(
@@ -220,10 +254,30 @@ def build_block(
     gas_used_by_included_txs = sum(
         tx_spec.actual_gas_used for tx_spec in included_block_tx_specs
     )
+
+    # Ballast: burns exactly the extra gas the raised limit adds, so
+    # `remaining_gas` below is identical to what it was before the limit was
+    # raised for the EIP-7928 access-list budget. It is a plain transfer from a
+    # fresh sender and appears in no inclusion list, so it cannot affect which
+    # IL transactions are appendable.
+    empty_transfer_gas = fork.transaction_intrinsic_cost_calculator()()
+    headroom = bal_gas_headroom(fork)
+    ballast_txs = [
+        generate_custom_tx(
+            pre,
+            fork=fork,
+            actual_gas_used=empty_transfer_gas,
+            is_inclusion_list_tx=False,
+        ).tx
+        for _ in range(headroom // empty_transfer_gas)
+    ]
+
     return BuiltBlock(
-        block_txs=[tx_with_origin.tx for tx_with_origin in included_block_txs],
+        block_txs=ballast_txs
+        + [tx_with_origin.tx for tx_with_origin in included_block_txs],
         inclusion_list_txs=flatten_inclusion_list_txs(
             included_block_txs + pending_inclusion_list_txs
         ),
         remaining_gas=block_gas_limit - gas_used_by_included_txs,
+        effective_gas_limit=block_gas_limit + headroom,
     )

--- a/tests/bogota/eip7805_focil/test_focil.py
+++ b/tests/bogota/eip7805_focil/test_focil.py
@@ -23,6 +23,7 @@ from execution_testing.test_types.transaction_types import (
 from ethereum.forks.amsterdam.fork import VERSIONED_HASH_VERSION_KZG
 
 from .helpers import (
+    bal_gas_headroom,
     IncludedBlockTx,
     PendingInclusionListTx,
     build_block,
@@ -103,7 +104,9 @@ def test_block_with_same_sender_included_il_txs_is_valid(
     )
     assert built_block.remaining_gas == SAME_SENDER_BLOCK_HEADROOM
     blockchain_test(
-        genesis_environment=Environment(gas_limit=block_gas_limit),
+        genesis_environment=Environment(
+            gas_limit=built_block.effective_gas_limit
+        ),
         pre=pre,
         post={},
         blocks=[
@@ -136,7 +139,7 @@ def test_block_with_reverting_included_il_tx_is_valid(
         gas_limit=100_000,
     )
     blockchain_test(
-        genesis_environment=Environment(gas_limit=200_000),
+        genesis_environment=Environment(gas_limit=200_000 + bal_gas_headroom(fork)),
         pre=pre,
         post={},
         blocks=[
@@ -338,7 +341,7 @@ def test_block_status_depends_on_pending_inclusion_list(
     )
     blockchain_test(
         genesis_environment=Environment(
-            gas_limit=block_gas_limit,
+            gas_limit=built_block.effective_gas_limit,
         ),
         pre=pre,
         post={},
@@ -382,7 +385,7 @@ def test_block_with_pending_blob_il_tx_is_valid(
     )
 
     blockchain_test(
-        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4),
+        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4 + bal_gas_headroom(fork)),
         pre=pre,
         post={},
         blocks=[
@@ -406,8 +409,6 @@ def test_block_with_invalid_signature_pending_il_tx_is_valid(
     If the signature is invalid, the tx is not appendable and omission is
     allowed.
     """
-    del fork
-
     sender = pre.fund_eoa(amount=10**18)
     recipient = pre.fund_eoa()
     invalid_signature_tx = Transaction(
@@ -420,7 +421,7 @@ def test_block_with_invalid_signature_pending_il_tx_is_valid(
     )
 
     blockchain_test(
-        genesis_environment=Environment(gas_limit=21_000 * 4),
+        genesis_environment=Environment(gas_limit=21_000 * 4 + bal_gas_headroom(fork)),
         pre=pre,
         post={},
         blocks=[
@@ -454,7 +455,7 @@ def test_block_with_intrinsic_gas_too_low_pending_il_tx_is_valid(
     )
 
     blockchain_test(
-        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4),
+        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4 + bal_gas_headroom(fork)),
         pre=pre,
         post={},
         blocks=[
@@ -481,11 +482,15 @@ def test_unsatisfied_when_block_tx_funds_pending_il_sender(
     """
     calc = fork.transaction_intrinsic_cost_calculator()
     simple_transfer_gas = calc()
+    # A transfer that carries value costs more intrinsic gas than an empty one
+    # on this fork, so alice's funding tx must be sized (and paid for) with
+    # `sends_value=True`. Bob's IL tx carries no value and keeps the plain cost.
+    value_transfer_gas = calc(sends_value=True)
     gas_price = TransactionDefaults.gas_price
 
     value_to_fund_bob = simple_transfer_gas * gas_price
     alice = pre.fund_eoa(
-        amount=simple_transfer_gas * gas_price + value_to_fund_bob,
+        amount=value_transfer_gas * gas_price + value_to_fund_bob,
     )
     bob = pre.fund_eoa(amount=0)
     recipient = pre.fund_eoa()
@@ -493,7 +498,7 @@ def test_unsatisfied_when_block_tx_funds_pending_il_sender(
     alice_tx = Transaction(
         sender=alice,
         to=bob,
-        gas_limit=simple_transfer_gas,
+        gas_limit=value_transfer_gas,
         value=value_to_fund_bob,
     )
     bob_il_tx = Transaction(
@@ -502,7 +507,7 @@ def test_unsatisfied_when_block_tx_funds_pending_il_sender(
         gas_limit=simple_transfer_gas,
     )
 
-    block_gas_limit = simple_transfer_gas * 5
+    block_gas_limit = simple_transfer_gas * 5 + bal_gas_headroom(fork)
     blockchain_test(
         genesis_environment=Environment(
             gas_limit=block_gas_limit,
@@ -586,7 +591,9 @@ def test_pending_il_depends_on_7702_authorization_nonce_effect(
     # Leave headroom after the set-code tx so the pending IL tx always
     # fits the block. The satisfied/unsatisfied outcome then depends only
     # on Bob's post-execution nonce, not on remaining gas.
-    block_gas_limit = set_code_gas + simple_transfer_gas * 2
+    block_gas_limit = (
+        set_code_gas + simple_transfer_gas * 2 + bal_gas_headroom(fork)
+    )
     blockchain_test(
         genesis_environment=Environment(gas_limit=block_gas_limit),
         pre=pre,
@@ -622,7 +629,7 @@ def test_unsatisfied_with_contract_creating_pending_il_tx(
         gas_limit=create_gas,
     )
 
-    block_gas_limit = create_gas * 2
+    block_gas_limit = create_gas * 2 + bal_gas_headroom(fork)
     blockchain_test(
         genesis_environment=Environment(gas_limit=block_gas_limit),
         pre=pre,
@@ -696,7 +703,7 @@ def test_unsatisfied_with_typed_pending_il_tx(
             gas_price=TransactionDefaults.gas_price,
         )
 
-    block_gas_limit = gas_limit * 2
+    block_gas_limit = gas_limit * 2 + bal_gas_headroom(fork)
     blockchain_test(
         genesis_environment=Environment(gas_limit=block_gas_limit),
         pre=pre,

--- a/tests/bogota/eip7805_focil/test_focil.py
+++ b/tests/bogota/eip7805_focil/test_focil.py
@@ -23,9 +23,9 @@ from execution_testing.test_types.transaction_types import (
 from ethereum.forks.amsterdam.fork import VERSIONED_HASH_VERSION_KZG
 
 from .helpers import (
-    bal_gas_headroom,
     IncludedBlockTx,
     PendingInclusionListTx,
+    bal_gas_headroom,
     build_block,
 )
 from .spec import Spec, ref_spec_7805
@@ -139,7 +139,9 @@ def test_block_with_reverting_included_il_tx_is_valid(
         gas_limit=100_000,
     )
     blockchain_test(
-        genesis_environment=Environment(gas_limit=200_000 + bal_gas_headroom(fork)),
+        genesis_environment=Environment(
+            gas_limit=200_000 + bal_gas_headroom(fork)
+        ),
         pre=pre,
         post={},
         blocks=[
@@ -385,7 +387,9 @@ def test_block_with_pending_blob_il_tx_is_valid(
     )
 
     blockchain_test(
-        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4 + bal_gas_headroom(fork)),
+        genesis_environment=Environment(
+            gas_limit=simple_transfer_gas * 4 + bal_gas_headroom(fork)
+        ),
         pre=pre,
         post={},
         blocks=[
@@ -421,7 +425,9 @@ def test_block_with_invalid_signature_pending_il_tx_is_valid(
     )
 
     blockchain_test(
-        genesis_environment=Environment(gas_limit=21_000 * 4 + bal_gas_headroom(fork)),
+        genesis_environment=Environment(
+            gas_limit=21_000 * 4 + bal_gas_headroom(fork)
+        ),
         pre=pre,
         post={},
         blocks=[
@@ -455,7 +461,9 @@ def test_block_with_intrinsic_gas_too_low_pending_il_tx_is_valid(
     )
 
     blockchain_test(
-        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4 + bal_gas_headroom(fork)),
+        genesis_environment=Environment(
+            gas_limit=simple_transfer_gas * 4 + bal_gas_headroom(fork)
+        ),
         pre=pre,
         post={},
         blocks=[
@@ -484,7 +492,8 @@ def test_unsatisfied_when_block_tx_funds_pending_il_sender(
     simple_transfer_gas = calc()
     # A transfer that carries value costs more intrinsic gas than an empty one
     # on this fork, so alice's funding tx must be sized (and paid for) with
-    # `sends_value=True`. Bob's IL tx carries no value and keeps the plain cost.
+    # `sends_value=True`. Bob's IL tx carries no value and keeps the plain
+    # cost.
     value_transfer_gas = calc(sends_value=True)
     gas_price = TransactionDefaults.gas_price
 


### PR DESCRIPTION
### Description

The FOCIL tests on this branch don't fill: 21 of 24 fail. Three independent causes, none of them in the tests' assertions. With these fixed all 24 fill, and the expected outcomes are unchanged.

**1. `t8n` passes decoded transactions where raw ones are expected**

`check_inclusion_list_transactions` takes `Tuple[LegacyTransaction | Bytes, ...]` and calls `get_transaction_hash`, which asserts `isinstance(tx, (LegacyTransaction, Bytes))`. The t8n caller passes `convert_transaction(...)`, which returns a decoded fork transaction, so every typed-transaction case dies on `AssertionError`. Both tuples now go through `encode_transaction`.

**2. The scenarios leave no gas budget for the block's own access list**

They size `block_gas_limit` to their transactions alone. The EIP-7928 budget is `block_gas_limit // GAS_BLOCK_ACCESS_LIST_ITEM`, and the system-contract predeploys touched every block plus senders, recipients and coinbase come to ~30 items against a limit of ~22, so filling stops at `BlockAccessListGasLimitExceededError`.

Raising the limit alone would change what the scenarios assert, because the gas a pending inclusion-list transaction is allowed derives from `block_gas_limit - gas_used_by_included_txs`. So `build_block` raises the limit and spends exactly the same amount on ballast transactions, leaving `remaining_gas` — and therefore every "fits" / "does not fit" boundary — unchanged. The ballast is a whole number of empty transfers so the amount is always representable on the fork's calldata-cost lattice.

**3. One funding transfer predates value-carrying transactions costing extra intrinsic gas**

`test_unsatisfied_when_block_tx_funds_pending_il_sender` sizes and funds alice's transfer with `calc()`, but it carries value, so it needs `calc(sends_value=True)` and was failing `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`.

### Assertions are untouched

Of the changed lines in `test_focil.py`, none touch `expected_status`, `pytest.param`, assertions, sender balances, nonces or inclusion-list composition — they are gas-limit plumbing, imports, and the `sends_value` fix. Scenario ids are unchanged, and the reference implementation validates all 24 expected outcomes during fill.

### Deliberately not included

This branch's Amsterdam differs from glamsterdam-devnet-8 (`ACCOUNT_WRITE` 8000 vs 9000, `CREATE_ACCESS` derived from `COLD_STORAGE_ACCESS` rather than `COLD_ACCOUNT_ACCESS`), so a contract creation's intrinsic gas is 23000 here against devnet-8's 24000. That is a rebase question rather than a bug, so the gas schedule is left alone — flagging it because `unsatisfied_with_contract_creating_pending_il_tx` is the one scenario whose outcome moves with it.

Also worth noting: #3307 relocates `evm_tools`, so change 1 will need rebasing onto the new path if that lands first.

### Testing

`uv run fill tests/bogota/eip7805_focil --fork Bogota` → 24 passed.

The filled fixtures were additionally run against a client implementation (ethrex) as a cross-check.