### PR TITLE
fix(consume): map reth BAL account-miss and item-cost rejection messages

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -119,7 +119,11 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BAL_HASH: (r"block access list hash mismatch"),
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"block access list hash mismatch|"
-            r"BAL rejection: FinalHashMismatch"
+            r"BAL rejection: FinalHashMismatch|"
+            r"Bal error: Account .* not found in BAL"
+        ),
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            r"block access list item cost exceeds gas limit"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"block access list hash mismatch|"

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -125,6 +125,9 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
             r"block access list item cost exceeds gas limit"
         ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (
+            r"system contract .* has no code"
+        ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"block access list hash mismatch|"
             r"BAL rejection: FinalHashMismatch"


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Fully vibed.

Map two reth rejection messages that currently fail consume-engine with "Undefined exception message" (glamsterdam-quick, fixtures `tests-glamsterdam-devnet@v8.1.0`):

- `Bal error: Account .* not found in BAL` → `INVALID_BLOCK_ACCESS_LIST`: reth executes payloads against the BAL as a state overlay, so a corrupted BAL that omits a touched account surfaces this message; for the `test_bal_invalid_*` engine cases (~9 fails) the rejection is semantically correct and only unmapped. (Reth also returns this message for blocks that are invalid for gas/system-contract reasons — those tests keep failing on the exception mismatch, now with a clearer diagnostic; that ordering issue is reth-side.)
- `block access list item cost exceeds gas limit` → `BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED`: correct rejections of `test_bal_gas_limit_boundary` / `test_fork_transition_bal_size_constraint` engine cases (~5 fails), only unmapped.

Both verified with `message_to_exception` against the exact messages from run 1786545713-b58ee7108bac1061a0e86683cb053c10.

Same shape as the geth mapper additions in #3347.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Cute_dog.jpg/640px-Cute_dog.jpg)

**Update:** also maps `system contract .* has no code` → `SYSTEM_CONTRACT_EMPTY`, the message introduced by https://github.com/alloy-rs/evm/pull/400 / https://github.com/paradigmxyz/reth/pull/26695 for the EIP-8282 empty-predeploy rejection (covers the 4 `test_builder_*_contract_deployment` engine fails). Verified both new messages disambiguate from `SYSTEM_CONTRACT_CALL_FAILED`.