### PR TITLE
perf(fill): stream fixture writes, cache pubkeys, and skip redundant BAL hash check, warn on opcode trace failure

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -41,7 +41,6 @@ from execution_testing.test_types import (
     Transaction,
     Withdrawal,
 )
-from execution_testing.test_types.block_access_list import BlockAccessList
 from execution_testing.test_types.receipt_types import TransactionReceipt
 
 from .cli_types import (
@@ -167,6 +166,11 @@ class ClientBackend:
     """Raw datadir head, set by the fill-stateful plugin pre-session."""
     start_block: Dict[str, Any] | None
     """Client head after global pre-run setup; per-test chains off this."""
+
+    # An engine ``ExecutionPayload`` carries the BAL body but not its hash, so
+    # the hash in our ``Result`` is EEST's own derivation from that body --
+    # not an independent attestation to verify against.
+    attests_block_access_list_hash: ClassVar[bool] = False
 
     # t8n-compatibility stubs — fill's filler reads these on the backend.
     opcode_count: OpcodeCount | None = None
@@ -513,9 +517,13 @@ class ClientBackend:
         block_access_list_hash: Hash | None = None
         bal_rlp = getattr(built_payload, "block_access_list", None)
         if bal_rlp is not None:
-            block_access_list_hash = Hash(
-                BlockAccessList.from_rlp(bal_rlp).rlp.keccak256()
-            )
+            # Hash the client's own bytes. Decoding them into a
+            # ``BlockAccessList`` only to re-encode and hash that would yield a
+            # different value whenever the client's RLP is non-canonical --
+            # silently replacing what the client committed to -- and on a
+            # BAL-heavy block the round trip costs more than the whole block's
+            # execution.
+            block_access_list_hash = Hash(bal_rlp.keccak256())
 
         return Result(
             state_root=built_payload.state_root,

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -167,9 +167,6 @@ class ClientBackend:
     start_block: Dict[str, Any] | None
     """Client head after global pre-run setup; per-test chains off this."""
 
-    # An engine ``ExecutionPayload`` carries the BAL body but not its hash, so
-    # the hash in our ``Result`` is EEST's own derivation from that body --
-    # not an independent attestation to verify against.
     attests_block_access_list_hash: ClassVar[bool] = False
 
     # t8n-compatibility stubs — fill's filler reads these on the backend.
@@ -517,12 +514,8 @@ class ClientBackend:
         block_access_list_hash: Hash | None = None
         bal_rlp = getattr(built_payload, "block_access_list", None)
         if bal_rlp is not None:
-            # Hash the client's own bytes. Decoding them into a
-            # ``BlockAccessList`` only to re-encode and hash that would yield a
-            # different value whenever the client's RLP is non-canonical --
-            # silently replacing what the client committed to -- and on a
-            # BAL-heavy block the round trip costs more than the whole block's
-            # execution.
+            # Hash the client's own bytes: a re-encode of the decoded BAL
+            # would diverge whenever the client's RLP is non-canonical.
             block_access_list_hash = Hash(bal_rlp.keccak256())
 
         return Result(

--- a/packages/testing/src/execution_testing/client_clis/filler_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/filler_backend.py
@@ -18,7 +18,7 @@ fill's perspective.
 callers continue to work unchanged.
 """
 
-from typing import List, Protocol, runtime_checkable
+from typing import ClassVar, List, Protocol, runtime_checkable
 
 from execution_testing.exceptions import ExceptionMapper
 
@@ -42,6 +42,22 @@ class FillerBackend(Protocol):
     Maps backend-specific errors to EEST transaction/block exceptions.
     ``exception_mapper.reliable`` indicates whether the mapping is trusted
     for test assertions (t8n: True; live-client: typically False).
+    """
+
+    attests_block_access_list_hash: ClassVar[bool]
+    """
+    Whether ``Result.block_access_list_hash`` is an *independent* attestation
+    of the EIP-7928 BAL hash, i.e. computed by the backend rather than derived
+    by EEST from the BAL body the backend returned.
+
+    True for ``TransitionTool``: t8n reports the hash from the spec's own
+    ``hash_block_access_list``, so comparing it against EEST's re-encoding of
+    the decoded BAL cross-checks two implementations.
+
+    False for ``ClientBackend``: an engine ``ExecutionPayload`` carries the BAL
+    *body* but no hash, so EEST derives the hash itself. Verifying that against
+    a second derivation from the same bytes is vacuous, and the round trip it
+    requires dominates stateful fill time on BAL-heavy blocks.
     """
 
     def evaluate(

--- a/packages/testing/src/execution_testing/client_clis/filler_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/filler_backend.py
@@ -46,18 +46,10 @@ class FillerBackend(Protocol):
 
     attests_block_access_list_hash: ClassVar[bool]
     """
-    Whether ``Result.block_access_list_hash`` is an *independent* attestation
-    of the EIP-7928 BAL hash, i.e. computed by the backend rather than derived
-    by EEST from the BAL body the backend returned.
-
-    True for ``TransitionTool``: t8n reports the hash from the spec's own
-    ``hash_block_access_list``, so comparing it against EEST's re-encoding of
-    the decoded BAL cross-checks two implementations.
-
-    False for ``ClientBackend``: an engine ``ExecutionPayload`` carries the BAL
-    *body* but no hash, so EEST derives the hash itself. Verifying that against
-    a second derivation from the same bytes is vacuous, and the round trip it
-    requires dominates stateful fill time on BAL-heavy blocks.
+    Whether ``Result.block_access_list_hash`` is computed by the backend
+    rather than derived by EEST from the BAL body the backend returned
+    (t8n: True; live-client: False, since an engine ``ExecutionPayload``
+    carries the body but no hash).
     """
 
     def evaluate(

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -207,6 +207,9 @@ class TransitionTool(EthereumCLI):
     supports_opcode_count: ClassVar[bool] = False
     supports_xdist: ClassVar[bool] = True
     supports_blob_params: ClassVar[bool] = False
+    # t8n computes the BAL hash itself (spec ``hash_block_access_list``), so it
+    # is worth cross-checking against EEST's own re-encoding of the BAL.
+    attests_block_access_list_hash: ClassVar[bool] = True
     fork_name_map: ClassVar[Dict[str, str]] = {}
 
     @abstractmethod

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -207,8 +207,6 @@ class TransitionTool(EthereumCLI):
     supports_opcode_count: ClassVar[bool] = False
     supports_xdist: ClassVar[bool] = True
     supports_blob_params: ClassVar[bool] = False
-    # t8n computes the BAL hash itself (spec ``hash_block_access_list``), so it
-    # is worth cross-checking against EEST's own re-encoding of the BAL.
     attests_block_access_list_hash: ClassVar[bool] = True
     fork_name_map: ClassVar[Dict[str, str]] = {}
 

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -13,6 +13,7 @@ from typing import (
     IO,
     ClassVar,
     Dict,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -28,16 +29,92 @@ from .base import BaseFixture
 from .consume import FixtureConsumer
 from .file import Fixtures
 
+#: Suffix of a per-fixture part file. Each fixture is written to its own file
+#: containing nothing but that fixture's indented JSON, so neither the write
+#: nor the merge ever holds a whole fixture in memory.
+PART_SUFFIX = ".fixture.json"
+
+#: Characters copied per read when streaming a part file into the merged
+#: output. Deliberately small: a single fixture line can itself be megabytes
+#: (one payload's transactions, or a block access list, is one hex string on
+#: one line), so copying line-by-line would still scale with the longest line.
+COPY_CHUNK_SIZE = 1 << 16
+
+#: A top-level key line in a document this module wrote. `json.dumps(...,
+#: indent=4)` puts top-level keys at exactly four spaces, and JSON escapes
+#: newlines inside strings, so a line can only start this way at depth one.
+_TOP_LEVEL_KEY = re.compile(r'^ {4}("(?:[^"\\]|\\.)*"): ')
+
+
+def _copy_indented(src: Path, out: IO[str]) -> None:
+    r"""
+    Append `src` to `out`, indenting every line but the first by four spaces.
+
+    Reproduces `value.replace("\\n", "\\n    ")` byte for byte without
+    materialising either the value or the indented copy. Copying proceeds in
+    fixed-size chunks rather than by line: chunk-wise replacement is exact
+    because the pattern is the single character "\\n", which can never be
+    split across a boundary, and a chunk never spans more than
+    `COPY_CHUNK_SIZE` characters however long the line is.
+    """
+    with open(src) as f:
+        while True:
+            chunk = f.read(COPY_CHUNK_SIZE)
+            if not chunk:
+                break
+            out.write(chunk.replace("\n", "\n    "))
+
+
+def _copy_range(src: IO[str], out: IO[str], start: int, end: int) -> None:
+    """Copy `src[start:end]` to `out` in bounded chunks."""
+    src.seek(start)
+    remaining = end - start
+    while remaining > 0:
+        chunk = src.read(min(COPY_CHUNK_SIZE, remaining))
+        if not chunk:
+            break
+        out.write(chunk)
+        remaining -= len(chunk)
+
+
+def _iter_document_entries(path: Path) -> Iterator[Tuple[str, int, int]]:
+    """
+    Yield `(key, value_start, value_end)` for each top-level entry of a
+    fixture document previously written by this module.
+
+    Used to fold an existing target file into a new merge without parsing it,
+    so re-running a session against an existing output stays O(1) in memory.
+    The byte range is the value exactly as written, already indented for
+    re-emission at depth one.
+    """
+    with open(path) as f:
+        pending = None
+        offset = 0
+        for line in f:
+            match = _TOP_LEVEL_KEY.match(line)
+            if match:
+                if pending is not None:
+                    # The previous value ended before this line, minus ",\n".
+                    yield pending[0], pending[1], offset - 2
+                pending = (json.loads(match.group(1)), offset + match.end())
+            offset += len(line)
+        if pending is not None:
+            # The last value ends before the document's closing "\n}".
+            yield pending[0], pending[1], offset - 2
+
 
 def merge_partial_fixture_files(output_dir: Path) -> None:
     """
-    Merge all partial fixture JSONL files into final JSON fixture files.
+    Merge per-fixture part files into final JSON fixture files.
 
-    Called at session end after all workers have written their partials.
-    Each partial file contains JSONL lines: {"k": fixture_id, "v": json_str}
+    Called at session end after all workers have written their parts. Each
+    worker appends one tiny JSONL line per fixture -- {"k": fixture_id,
+    "p": part_filename} -- to a per-target index, and writes the fixture
+    itself to `part_filename`.
 
-    Processes one target file at a time, reading its partials sequentially
-    into a dict. Memory = O(entries per target), freed before next target.
+    Memory is O(number of fixtures) for the index plus one copy chunk: a
+    single fixture is never held in memory, however large it is. Output is
+    byte-identical to `json.dumps(dict(sorted(...)), indent=4)`.
     """
     # Find all partial files
     partial_files = list(output_dir.rglob("*.partial.*.jsonl"))
@@ -62,48 +139,72 @@ def merge_partial_fixture_files(output_dir: Path) -> None:
 
     # Merge each group into its target file
     for target_path, partials in partials_by_target.items():
-        # Seed from existing target file (if any) so that
-        # repeated single-test sessions accumulate into one file.
-        entries: Dict[str, str] = {}
+        # `sources` maps a fixture id to where its already-formatted value
+        # lives, never to the value itself. Two shapes:
+        #   ("part", path)        -- a per-fixture part file
+        #   ("seed", start, end)  -- a byte range of the existing target
+        sources: Dict[str, Tuple] = {}
+        part_files: List[Path] = []
+
+        # Fold in the existing target (if any) so repeated single-test
+        # sessions accumulate into one file, as before. Recorded as byte
+        # ranges rather than parsed, so a huge target costs nothing.
+        seed_path: Optional[Path] = None
         if target_path.exists():
-            with open(target_path) as existing:
-                try:
-                    existing_data = json.load(existing)
-                    for k, v in existing_data.items():
-                        entries[k] = json.dumps(v, indent=4)
-                except json.JSONDecodeError:
-                    pass
+            seed_path = target_path.with_suffix(".seed.json")
+            target_path.replace(seed_path)
+            try:
+                for key, start, end in _iter_document_entries(seed_path):
+                    sources[key] = ("seed", start, end)
+            except (OSError, ValueError):
+                sources.clear()
 
         for partial in partials:
             with open(partial) as f:
                 for line in f:
                     line = line.strip()
-                    if line:
-                        entry = json.loads(line)
-                        entries[entry["k"]] = entry["v"]
+                    if not line:
+                        continue
+                    entry = json.loads(line)
+                    part_path = partial.parent / entry["p"]
+                    sources[entry["k"]] = ("part", part_path)
+                    part_files.append(part_path)
 
-        # Write sorted entries to output file
-        with open(target_path, "w") as out_f:
-            out_f.write("{\n")
-            sorted_keys = sorted(entries.keys())
-            last_idx = len(sorted_keys) - 1
-            for i, key in enumerate(sorted_keys):
-                key_json = json.dumps(key)
-                value_indented = entries[key].replace("\n", "\n    ")
-                out_f.write(f"    {key_json}: {value_indented}")
-                out_f.write(",\n" if i < last_idx else "\n")
-            out_f.write("}")
+        # Write sorted entries, streaming each value from its source.
+        seed_handle = open(seed_path) if seed_path is not None else None
+        try:
+            with open(target_path, "w") as out_f:
+                out_f.write("{\n")
+                sorted_keys = sorted(sources.keys())
+                last_idx = len(sorted_keys) - 1
+                for i, key in enumerate(sorted_keys):
+                    out_f.write(f"    {json.dumps(key)}: ")
+                    source = sources[key]
+                    if source[0] == "part":
+                        _copy_indented(source[1], out_f)
+                    else:
+                        assert seed_handle is not None
+                        _copy_range(seed_handle, out_f, source[1], source[2])
+                    out_f.write(",\n" if i < last_idx else "\n")
+                out_f.write("}")
+        finally:
+            if seed_handle is not None:
+                seed_handle.close()
 
-        # Free memory before processing next target
-        entries.clear()
+        sources.clear()
 
-        # Clean up partial files
+        # Clean up index files, their part files, and the seed copy.
         for partial in partials:
             partial.unlink()
             # Also remove lock files
             lock_file = partial.with_suffix(".lock")
             if lock_file.exists():
                 lock_file.unlink()
+        for part in part_files:
+            if part.exists():
+                part.unlink()
+        if seed_path is not None and seed_path.exists():
+            seed_path.unlink()
 
 
 @dataclass(kw_only=True, slots=True)
@@ -223,6 +324,8 @@ class FixtureCollector:
     # Streaming file handles - kept open for module duration
     _partial_fixture_files: Dict[Path, IO[str]] = field(default_factory=dict)
     _partial_index_file: Optional[IO[str]] = field(default=None)
+    # Monotonic per-collector counter making part-file names unique.
+    _part_counter: int = field(default=0)
     _worker_id_cached: bool = field(default=False, init=False)
 
     # Lightweight tracking for verification (path, format class, debug_path)
@@ -334,13 +437,35 @@ class FixtureCollector:
         fixture_id: str,
         fixture: BaseFixture,
     ) -> None:
-        """Stream a single fixture to its partial JSONL file."""
-        value = json.dumps(fixture.json_dict_with_info(), indent=4)
-        line = json.dumps({"k": fixture_id, "v": value}) + "\n"
+        """
+        Write a fixture to its own part file and index it.
+
+        `json.dump` serialises straight into the file, so the fixture's JSON
+        is never materialised as a string. The previous approach built the
+        whole document with `json.dumps` and then embedded it, escaped, in a
+        JSONL envelope -- two full-size copies on write and three more on
+        merge, i.e. ~7x the fixture size. Benchmark prestate fixtures reach
+        7 GB, where that reliably exhausted a 60 GB host.
+        """
+        part_path = self._next_part_path(fixture_path)
+        part_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(part_path, "w") as part_f:
+            json.dump(fixture.json_dict_with_info(), part_f, indent=4)
 
         f = self._get_partial_fixture_file(fixture_path)
-        f.write(line)
+        f.write(json.dumps({"k": fixture_id, "p": part_path.name}) + "\n")
         f.flush()  # Ensure data is written immediately
+
+    def _next_part_path(self, fixture_path: Path) -> Path:
+        """Return a unique part-file path for the next fixture of a target."""
+        worker_id = self._get_worker_id()
+        suffix = f".{worker_id}" if worker_id else ".main"
+        stem = fixture_path.name[: -len(fixture_path.suffix)]
+        seq = self._part_counter
+        self._part_counter += 1
+        return (
+            fixture_path.parent / f"{stem}.partial{suffix}.{seq}{PART_SUFFIX}"
+        )
 
     def _get_partial_index_file(self) -> "IO[str]":
         """Get or create the file handle for streaming index entries."""

--- a/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
@@ -425,3 +425,167 @@ class TestLegacyCompatibility:
         new_output = new_files[0].read_text()
 
         assert new_output == legacy_output
+
+
+class TestStreamingWrites:
+    """
+    Tests for the streaming write/merge path.
+
+    Fixtures for the stateful benchmarks reach several gigabytes each. The
+    write and merge must therefore never hold a whole fixture in memory, and
+    must still produce output byte-identical to `json.dumps`.
+    """
+
+    def _make_big_fixture(self, nonce: int, payload_kb: int) -> BaseFixture:
+        """A fixture whose JSON is large enough to dwarf any copy budget."""
+        fixture = TransactionFixture(
+            transaction="0x" + "ab" * (payload_kb * 512),
+            result={"Paris": FixtureResult(intrinsic_gas=nonce)},
+        )
+        fixture.fill_info(
+            "t8n-test",
+            f"big fixture {nonce}",
+            fixture_source_url="http://example.com",
+            ref_spec=None,
+            _info_metadata={},
+        )
+        return fixture
+
+    def test_merge_does_not_materialise_the_fixture(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """
+        Merging must allocate far less than the fixture it merges.
+
+        The previous implementation embedded each fixture as an escaped string
+        inside a JSONL envelope, then on merge read that line back, parsed it
+        and re-indented it with `.replace()` -- several full-size copies, so
+        peak allocation exceeded the document size. This pins the streaming
+        behaviour deterministically rather than by timing.
+        """
+        import tracemalloc
+
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        fixture = self._make_big_fixture(0, payload_kb=4096)
+        collector.add_fixture(_make_info("big", module_path), fixture)
+        collector.close_streaming_files()
+
+        document_size = sum(
+            p.stat().st_size for p in output_dir.rglob("*.fixture.json")
+        )
+        assert document_size > 4_000_000, (
+            "fixture not large enough to be a test"
+        )
+
+        tracemalloc.start()
+        merge_partial_fixture_files(output_dir)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        # Generous: a streaming merge needs a copy chunk plus the index, so
+        # well under the document. The old code peaked above document_size.
+        assert peak < document_size // 2, (
+            f"merge peaked at {peak} bytes for a {document_size}-byte "
+            "fixture -- it is not streaming"
+        )
+
+    def test_large_fixture_output_matches_json_dumps(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """A multi-megabyte fixture must still round-trip byte-identically."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        fixture = self._make_big_fixture(1, payload_kb=512)
+        info = _make_info("big", module_path)
+        collector.add_fixture(info, fixture)
+        collector.close_streaming_files()
+        merge_partial_fixture_files(output_dir)
+
+        written = next(
+            p for p in output_dir.rglob("*.json") if ".partial." not in p.name
+        ).read_text()
+        expected = json.dumps(
+            {info.get_id(): fixture.json_dict_with_info()}, indent=4
+        )
+        assert written == expected
+
+    def test_existing_target_is_folded_in(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """
+        A second session must accumulate into the existing target file.
+
+        The existing document is folded in by byte range rather than parsed,
+        so this also covers `_iter_document_entries` against real output.
+        """
+        first = _make_fixture(0)
+        first_info = _make_info("first", module_path)
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        collector.add_fixture(first_info, first)
+        collector.close_streaming_files()
+        merge_partial_fixture_files(output_dir)
+
+        second = _make_fixture(1)
+        second_info = _make_info("second", module_path)
+        collector2 = FixtureCollector(
+            output_dir=output_dir,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        collector2.add_fixture(second_info, second)
+        collector2.close_streaming_files()
+        merge_partial_fixture_files(output_dir)
+
+        target = next(
+            p for p in output_dir.rglob("*.json") if ".partial." not in p.name
+        )
+        written = target.read_text()
+        expected = json.dumps(
+            dict(
+                sorted(
+                    {
+                        first_info.get_id(): first.json_dict_with_info(),
+                        second_info.get_id(): second.json_dict_with_info(),
+                    }.items()
+                )
+            ),
+            indent=4,
+        )
+        assert written == expected
+        assert json.loads(written), "must remain valid JSON"
+
+    def test_part_and_seed_files_are_cleaned_up(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """No part, index or seed file may survive a merge."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        for i in range(3):
+            collector.add_fixture(
+                _make_info(f"t{i}", module_path), _make_fixture(i)
+            )
+        collector.close_streaming_files()
+        merge_partial_fixture_files(output_dir)
+
+        assert not list(output_dir.rglob("*.fixture.json"))
+        assert not list(output_dir.rglob("*.partial.*.jsonl"))
+        assert not list(output_dir.rglob("*.seed.json"))

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1016,15 +1016,23 @@ class BlockchainTest(BaseTest):
                 "provided by the transition tool"
             )
 
-            computed_block_access_list_hash = Hash(t8n_bal.rlp.keccak256())
-            assert (
-                computed_block_access_list_hash
-                == header.block_access_list_hash
-            ), (
-                "Block access list hash in header does not match the "
-                f"computed hash from BAL: {header.block_access_list_hash} "
-                f"!= {computed_block_access_list_hash}"
-            )
+            # Only meaningful when the backend attested the hash itself: then
+            # this cross-checks the backend's hash against EEST's re-encoding
+            # of the decoded BAL. When the backend does not (a client returns
+            # the BAL body only, so the header hash below is already EEST's
+            # derivation from these same bytes), the comparison is `a == a` and
+            # the re-encode it needs is the single most expensive step of a
+            # stateful fill.
+            if t8n.attests_block_access_list_hash:
+                computed_block_access_list_hash = Hash(t8n_bal.rlp.keccak256())
+                assert (
+                    computed_block_access_list_hash
+                    == header.block_access_list_hash
+                ), (
+                    "Block access list hash in header does not match the "
+                    f"computed hash from BAL: {header.block_access_list_hash} "
+                    f"!= {computed_block_access_list_hash}"
+                )
 
         if block.rlp_modifier is not None:
             # Modify any parameter specified in the `rlp_modifier` after

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1016,13 +1016,6 @@ class BlockchainTest(BaseTest):
                 "provided by the transition tool"
             )
 
-            # Only meaningful when the backend attested the hash itself: then
-            # this cross-checks the backend's hash against EEST's re-encoding
-            # of the decoded BAL. When the backend does not (a client returns
-            # the BAL body only, so the header hash below is already EEST's
-            # derivation from these same bytes), the comparison is `a == a` and
-            # the re-encode it needs is the single most expensive step of a
-            # stateful fill.
             if t8n.attests_block_access_list_hash:
                 computed_block_access_list_hash = Hash(t8n_bal.rlp.keccak256())
                 assert (

--- a/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
@@ -1,6 +1,6 @@
 """Test suite for transaction signing and serialization."""
 
-from typing import Tuple
+from typing import Any, Tuple
 
 import pytest
 from spec256k1 import PublicKey
@@ -11,6 +11,25 @@ from .. import transaction_types
 from ..account_types import EOA
 from ..transaction_types import Transaction
 from ..utils import keccak256
+
+SIGNING_KEY = Hash(bytes(range(1, 33)))
+OTHER_KEY = Hash(bytes(range(33, 65)))
+
+
+def signable_transaction(**kwargs: Any) -> Transaction:
+    """Return a minimal legacy transaction ready to be signed."""
+    return Transaction(ty=0, gas_limit=21_000, nonce=0, **kwargs)
+
+
+def recover_sender(tx: Transaction) -> Address:
+    """Recover the sender of a signed transaction from its signature."""
+    public_key = PublicKey.from_signature_and_message(
+        tx.signature_bytes,
+        tx.rlp_signing_bytes().keccak256(),
+    )
+    return Address(
+        keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
+    )
 
 
 @pytest.mark.parametrize(
@@ -305,87 +324,55 @@ def test_gas_limit_none_alias_is_unset(alias: str) -> None:
     assert tx.gas_limit == 21_000
 
 
-class TestSenderDerivation:
+def test_derived_sender_matches_recovery() -> None:
+    """The derived sender equals the one recovered from the signature."""
+    signed = signable_transaction(
+        secret_key=SIGNING_KEY
+    ).with_signature_and_sender()
+    assert signed.sender == recover_sender(signed)
+
+
+def test_known_sender_skips_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender holding the signing key is reused as-is."""
+
+    def unexpected_recovery(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError(
+            "recovered the public key even though the sender was known"
+        )
+
+    monkeypatch.setattr(
+        transaction_types.PublicKey,
+        "from_signature_and_message",
+        unexpected_recovery,
+    )
+    sender = EOA(key=SIGNING_KEY)
+    signed = signable_transaction(sender=sender).with_signature_and_sender()
+    assert signed.sender == sender
+
+
+@pytest.mark.parametrize(
+    "sender",
+    [
+        pytest.param(EOA(key=OTHER_KEY), id="holds_another_key"),
+        pytest.param(EOA(address=0x1234), id="keyless"),
+    ],
+)
+def test_sender_without_the_signing_key_is_derived(sender: EOA) -> None:
+    """A sender that does not hold the signing key is not trusted."""
+    tx = signable_transaction(sender=sender, secret_key=SIGNING_KEY)
+    assert tx.with_signature_and_sender().sender == EOA(key=SIGNING_KEY)
+
+
+def test_reassigned_sender_does_not_override_the_signer() -> None:
     """
-    Tests for deriving the sender without recovering it from the signature.
+    A sender reassigned after construction is not trusted.
 
-    Recovering the public key from the signature costs more than the signing
-    itself, and the signer's address is usually already known. These tests pin
-    the equivalence and, importantly, the case where the declared sender is
-    *not* the signer.
+    `validate_assignment=True` lets `sender` be replaced while
+    `secret_key` keeps the original key.
     """
-
-    KEY_A = Hash(bytes(range(1, 33)))
-    KEY_B = Hash(bytes(range(33, 65)))
-
-    def _tx(self, **kwargs: object) -> Transaction:
-        return Transaction(ty=0, gas_limit=21_000, nonce=0, **kwargs)
-
-    def test_derived_sender_matches_recovery(self) -> None:
-        """
-        Deriving from the private key must equal recovering from the signature.
-
-        This is the property the whole change rests on: the signature was
-        produced by `secret_key`, so recovery can only return that key.
-        """
-        signed = self._tx(secret_key=self.KEY_A).with_signature_and_sender()
-
-        recovered = PublicKey.from_signature_and_message(
-            signed.signature_bytes,
-            signed.rlp_signing_bytes().keccak256(),
-        )
-        expected = Address(
-            keccak256(recovered.format(compressed=False)[1:])[32 - 20 :]
-        )
-        assert signed.sender == expected
-
-    def test_known_sender_is_reused_without_a_public_key_operation(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """
-        When the declared sender holds the signing key, no public-key
-        operation may happen at all -- that is the point of the fast path.
-        """
-        sender = EOA(key=self.KEY_A)
-
-        def _boom(*_args: object, **_kwargs: object) -> object:
-            raise AssertionError(
-                "recovered the public key even though the sender was known"
-            )
-
-        monkeypatch.setattr(
-            transaction_types.PublicKey, "from_signature_and_message", _boom
-        )
-        signed = self._tx(sender=sender).with_signature_and_sender()
-        assert signed.sender == sender
-
-    def test_reassigned_sender_does_not_override_the_signer(self) -> None:
-        """
-        A sender that does not hold the signing key must not be trusted.
-
-        `Transaction` sets `validate_assignment=True`, so `sender` can be
-        reassigned after construction while `secret_key` keeps the original
-        key. Trusting `sender` here would emit a transaction whose `sender`
-        field contradicts its own signature.
-        """
-        signer = EOA(key=self.KEY_A)
-        other = EOA(key=self.KEY_B)
-        assert signer != other
-
-        tx = self._tx(sender=signer)
-        assert tx.secret_key == self.KEY_A, "secret_key comes from sender.key"
-        tx.sender = other  # allowed: validate_assignment
-
-        signed = tx.with_signature_and_sender()
-        assert signed.sender == signer, (
-            "the signer must win, not the sender field"
-        )
-
-    def test_keyless_sender_falls_back_to_derivation(self) -> None:
-        """`EOA.key` is optional, so a keyless sender must not be trusted."""
-        keyless = EOA(address=0x1234)
-        assert keyless.key is None
-
-        tx = self._tx(sender=keyless, secret_key=self.KEY_A)
-        signed = tx.with_signature_and_sender()
-        assert signed.sender == EOA(key=self.KEY_A)
+    tx = signable_transaction(sender=EOA(key=SIGNING_KEY))
+    assert tx.secret_key == SIGNING_KEY
+    tx.sender = EOA(key=OTHER_KEY)
+    assert tx.with_signature_and_sender().sender == EOA(key=SIGNING_KEY)

--- a/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
@@ -3,10 +3,14 @@
 from typing import Tuple
 
 import pytest
+from spec256k1 import PublicKey
 
-from execution_testing.base_types import AccessList, Hash
+from execution_testing.base_types import AccessList, Address, Hash
 
+from .. import transaction_types
+from ..account_types import EOA
 from ..transaction_types import Transaction
+from ..utils import keccak256
 
 
 @pytest.mark.parametrize(
@@ -299,3 +303,89 @@ def test_gas_limit_none_alias_is_unset(alias: str) -> None:
     tx = Transaction.model_validate({alias: None})
     assert "gas_limit" not in tx.model_fields_set
     assert tx.gas_limit == 21_000
+
+
+class TestSenderDerivation:
+    """
+    Tests for deriving the sender without recovering it from the signature.
+
+    Recovering the public key from the signature costs more than the signing
+    itself, and the signer's address is usually already known. These tests pin
+    the equivalence and, importantly, the case where the declared sender is
+    *not* the signer.
+    """
+
+    KEY_A = Hash(bytes(range(1, 33)))
+    KEY_B = Hash(bytes(range(33, 65)))
+
+    def _tx(self, **kwargs: object) -> Transaction:
+        return Transaction(ty=0, gas_limit=21_000, nonce=0, **kwargs)
+
+    def test_derived_sender_matches_recovery(self) -> None:
+        """
+        Deriving from the private key must equal recovering from the signature.
+
+        This is the property the whole change rests on: the signature was
+        produced by `secret_key`, so recovery can only return that key.
+        """
+        signed = self._tx(secret_key=self.KEY_A).with_signature_and_sender()
+
+        recovered = PublicKey.from_signature_and_message(
+            signed.signature_bytes,
+            signed.rlp_signing_bytes().keccak256(),
+        )
+        expected = Address(
+            keccak256(recovered.format(compressed=False)[1:])[32 - 20 :]
+        )
+        assert signed.sender == expected
+
+    def test_known_sender_is_reused_without_a_public_key_operation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        When the declared sender holds the signing key, no public-key
+        operation may happen at all -- that is the point of the fast path.
+        """
+        sender = EOA(key=self.KEY_A)
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError(
+                "recovered the public key even though the sender was known"
+            )
+
+        monkeypatch.setattr(
+            transaction_types.PublicKey, "from_signature_and_message", _boom
+        )
+        signed = self._tx(sender=sender).with_signature_and_sender()
+        assert signed.sender == sender
+
+    def test_reassigned_sender_does_not_override_the_signer(self) -> None:
+        """
+        A sender that does not hold the signing key must not be trusted.
+
+        `Transaction` sets `validate_assignment=True`, so `sender` can be
+        reassigned after construction while `secret_key` keeps the original
+        key. Trusting `sender` here would emit a transaction whose `sender`
+        field contradicts its own signature.
+        """
+        signer = EOA(key=self.KEY_A)
+        other = EOA(key=self.KEY_B)
+        assert signer != other
+
+        tx = self._tx(sender=signer)
+        assert tx.secret_key == self.KEY_A, "secret_key comes from sender.key"
+        tx.sender = other  # allowed: validate_assignment
+
+        signed = tx.with_signature_and_sender()
+        assert signed.sender == signer, (
+            "the signer must win, not the sender field"
+        )
+
+    def test_keyless_sender_falls_back_to_derivation(self) -> None:
+        """`EOA.key` is optional, so a keyless sender must not be trusted."""
+        keyless = EOA(address=0x1234)
+        assert keyless.key is None
+
+        tx = self._tx(sender=keyless, secret_key=self.KEY_A)
+        signed = tx.with_signature_and_sender()
+        assert signed.sender == EOA(key=self.KEY_A)

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -728,15 +728,34 @@ class Transaction(
         signing_hash = self.rlp_signing_bytes().keccak256()
 
         # Sign the bytes
-        signature_bytes = PrivateKey(self.secret_key).sign_recoverable(
-            signing_hash
-        )
-        public_key = PublicKey.from_signature_and_message(
-            signature_bytes, signing_hash
-        )
+        signing_key = PrivateKey(self.secret_key)
+        signature_bytes = signing_key.sign_recoverable(signing_hash)
 
-        sender = keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
-        updated_values["sender"] = Address(sender)
+        # The sender is the account belonging to `secret_key`, whichever route
+        # is taken below. Recovering it from the signature -- the previous
+        # approach -- costs more than the signing itself (47 us against 40 us),
+        # and a benchmark fill signs tens of thousands of transfers per block.
+        if self.sender is not None and self.sender.key == self.secret_key:
+            # The declared sender holds the signing key, so its address is
+            # already known and no public-key operation is needed at all.
+            # `model_post_init` sets `secret_key` from `sender.key` when a
+            # transaction is to be signed, which makes this the common case.
+            #
+            # The key comparison is what makes this safe: `sender` is
+            # reassignable (`validate_assignment=True`) and `EOA.key` may be
+            # `None`, so a sender that does not hold the signing key must not
+            # be trusted -- it would yield a transaction whose `sender` field
+            # contradicts its own signature.
+            updated_values["sender"] = self.sender
+        else:
+            # Either no sender, or one that does not hold the signing key.
+            # Derive the address from the private key: the same public key
+            # recovery would return, since the signature was produced by this
+            # key, but one point multiplication (28 us) instead of a recovery.
+            public_key = signing_key.public_key
+            updated_values["sender"] = Address(
+                keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
+            )
 
         v, r, s = (
             signature_bytes[64],

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -731,27 +731,15 @@ class Transaction(
         signing_key = PrivateKey(self.secret_key)
         signature_bytes = signing_key.sign_recoverable(signing_hash)
 
-        # The sender is the account belonging to `secret_key`, whichever route
-        # is taken below. Recovering it from the signature -- the previous
-        # approach -- costs more than the signing itself (47 us against 40 us),
-        # and a benchmark fill signs tens of thousands of transfers per block.
+        # The key comparison is what makes reusing `sender` safe: it is
+        # reassignable and `EOA.key` may be `None`, so a sender that does not
+        # hold the signing key would contradict its own signature.
         if self.sender is not None and self.sender.key == self.secret_key:
-            # The declared sender holds the signing key, so its address is
-            # already known and no public-key operation is needed at all.
-            # `model_post_init` sets `secret_key` from `sender.key` when a
-            # transaction is to be signed, which makes this the common case.
-            #
-            # The key comparison is what makes this safe: `sender` is
-            # reassignable (`validate_assignment=True`) and `EOA.key` may be
-            # `None`, so a sender that does not hold the signing key must not
-            # be trusted -- it would yield a transaction whose `sender` field
-            # contradicts its own signature.
             updated_values["sender"] = self.sender
         else:
-            # Either no sender, or one that does not hold the signing key.
-            # Derive the address from the private key: the same public key
-            # recovery would return, since the signature was produced by this
-            # key, but one point multiplication (28 us) instead of a recovery.
+            # The address the public key recovery would return, since the
+            # signature was produced by this key, but derived with one point
+            # multiplication instead.
             public_key = signing_key.public_key
             updated_values["sender"] = Address(
                 keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]


### PR DESCRIPTION
### Description
This PR contains 4 commits to optimize/warnings some parts of the filler process:

- don't verify the BAL hash against itself
- stream fixture writes
- ensure pubkey isn't calculated twice
- warn and discard a partial opcode trace


### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
