### PR TITLE
fix(consume): add missing reth exception mapper entries

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -115,8 +115,15 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.GAS_USED_OVERFLOW: (
             r"transaction gas limit \w+ is more than blocks available gas \w+"
         ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (
+            r"failed to apply .* requests contract call: "
+            r"contract has no code"
+        ),
         # BAL Exceptions
         BlockException.INVALID_BAL_HASH: (r"block access list hash mismatch"),
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            r"block access list item cost exceeds gas limit"
+        ),
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"block access list hash mismatch|"
             r"BAL rejection: FinalHashMismatch"


### PR DESCRIPTION
Adds two missing `RethExceptionMapper` patterns surfaced by the glamsterdam-devnet-8 hive runs:

- `BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED`: reth rejects oversized BALs with "block access list item cost exceeds gas limit: items=..., max_items=..., gas_limit=...", which currently maps to no exception and fails the `test_bal_gas_limit_boundary` / `test_fork_transition_bal_size_constraint` tests as undefined exception messages.
- `SYSTEM_CONTRACT_EMPTY`: reth (via alloy-evm) now rejects blocks whose request predeploys have no code with "failed to apply <type> requests contract call: contract has no code". The message intentionally also matches the existing `SYSTEM_CONTRACT_CALL_FAILED` pattern; the mapper collects all matches so both deployment and modified-contract tests verify.