### PR TITLE
chore(rpc): create `LiveBlock` model for blocks from RPC

### DIFF
--- a/packages/testing/src/execution_testing/cli/gentest/request_manager.py
+++ b/packages/testing/src/execution_testing/cli/gentest/request_manager.py
@@ -58,11 +58,11 @@ class RPCRequest:
         assert res is not None, "Block not found"
 
         return Environment(
-            fee_recipient=res["miner"],
-            number=res["number"],
-            difficulty=res["difficulty"],
-            gas_limit=res["gasLimit"],
-            timestamp=res["timestamp"],
+            fee_recipient=res.fee_recipient,
+            number=res.number,
+            difficulty=res.difficulty,
+            gas_limit=res.gas_limit,
+            timestamp=res.timestamp,
         )
 
     def debug_trace_call(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/exceptions.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/exceptions.py
@@ -24,6 +24,7 @@ from execution_testing.client_clis.clis.reth import RethExceptionMapper
 from execution_testing.exceptions import ExceptionMapper
 from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.logging import get_logger
+from execution_testing.rpc import LiveBlock
 
 logger = get_logger(__name__)
 
@@ -47,7 +48,7 @@ class GenesisBlockMismatchExceptionError(Exception):
         self,
         *,
         expected_header: FixtureHeader,
-        got_genesis_block: Dict[str, str],
+        got_genesis_block: LiveBlock,
     ):
         """
         Initialize the exception with the expected and received genesis block
@@ -56,10 +57,13 @@ class GenesisBlockMismatchExceptionError(Exception):
         message = (
             "Genesis block hash mismatch.\n\n"
             f"Expected: {expected_header.block_hash}\n"
-            f"     Got: {got_genesis_block['hash']}."
+            f"     Got: {got_genesis_block.hash}."
+        )
+        got_genesis_block_dict = got_genesis_block.model_dump(
+            by_alias=True, mode="json", exclude_none=True
         )
         differences, unexpected_fields = self.compare_models(
-            expected_header, FixtureHeader(**got_genesis_block)
+            expected_header, FixtureHeader(**got_genesis_block_dict)
         )
         if differences:
             message += (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_build.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_build.py
@@ -185,7 +185,7 @@ def _bootstrap_engine_at_genesis(
         logger.info("Calling getBlockByNumber to get genesis block...")
         genesis_block = eth_rpc.get_block_by_number(0)
         assert genesis_block is not None, "genesis_block is None"
-        if genesis_block["hash"] != str(genesis_header.block_hash):
+        if genesis_block.hash != genesis_header.block_hash:
             raise GenesisBlockMismatchExceptionError(
                 expected_header=genesis_header,
                 got_genesis_block=genesis_block,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -110,9 +110,9 @@ def test_blockchain_via_engine(
             logger.info("Calling getBlockByNumber to get genesis block...")
             genesis_block = eth_rpc.get_block_by_number(0)
             assert genesis_block is not None, "genesis_block is None"
-            if genesis_block["hash"] != str(genesis_header.block_hash):
+            if genesis_block.hash != genesis_header.block_hash:
                 expected = genesis_header.block_hash
-                got = genesis_block["hash"]
+                got = genesis_block.hash
                 logger.fail(
                     f"Genesis block hash mismatch. "
                     f"Expected: {expected}, Got: {got}"

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_rlp.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_rlp.py
@@ -7,18 +7,16 @@ start-up.
 """
 
 import logging
-from typing import Any, Dict
 
 from pydantic import ValidationError
 
-from execution_testing.base_types import HexNumber
 from execution_testing.fixtures import BlockchainFixture
 from execution_testing.fixtures.blockchain import (
     FixtureBlock,
     FixtureHeader,
 )
 from execution_testing.forks import Fork, TransitionFork
-from execution_testing.rpc import EthRPC
+from execution_testing.rpc import EthRPC, LiveBlock
 
 from ..helpers.exceptions import GenesisBlockMismatchExceptionError
 from ..helpers.timing import TimingData
@@ -27,19 +25,22 @@ logger = logging.getLogger(__name__)
 
 
 def _validate_rpc_header_fields(
-    block: Dict[str, Any],
+    block: LiveBlock,
     fixture_fork: Fork | TransitionFork,
 ) -> None:
     applicable_fork = fixture_fork.fork_at(
-        block_number=HexNumber(block["number"]),
-        timestamp=HexNumber(block["timestamp"]),
+        block_number=block.number,
+        timestamp=block.timestamp,
+    )
+    block_dict = block.model_dump(
+        by_alias=True, mode="json", exclude_none=True
     )
     try:
-        FixtureHeader.model_validate({**block, "fork": applicable_fork})
+        FixtureHeader.model_validate({**block_dict, "fork": applicable_fork})
     except ValidationError as e:
         raise AssertionError(
             f"Invalid or missing required header field for "
-            f"block {block['number']}: {e}"
+            f"block {block.number}: {e}"
         ) from e
 
 
@@ -57,7 +58,7 @@ def test_via_rlp(
         logger.info("Calling getBlockByNumber to get genesis block...")
         genesis_block = eth_rpc.get_block_by_number(0)
         assert genesis_block, "`getBlockByNumber` didn't return a block."
-        if genesis_block["hash"] != str(fixture.genesis.block_hash):
+        if genesis_block.hash != fixture.genesis.block_hash:
             raise GenesisBlockMismatchExceptionError(
                 expected_header=fixture.genesis,
                 got_genesis_block=genesis_block,
@@ -67,18 +68,22 @@ def test_via_rlp(
         block = eth_rpc.get_block_by_number("latest")
         assert block, "`getBlockByNumber` didn't return a block."
         _validate_rpc_header_fields(block, fixture.fork)
-        if block["hash"] != str(fixture.last_block_hash):
+        if block.hash != fixture.last_block_hash:
             try:
-                block_header = FixtureHeader.model_validate(block).model_dump()
+                block_header = FixtureHeader.model_validate(
+                    block.model_dump(
+                        by_alias=True, mode="json", exclude_none=True
+                    )
+                ).model_dump()
                 last_block = FixtureBlock.model_validate(fixture.blocks[-1])
                 last_block_header = last_block.header.model_dump()
 
-                if block_header["number"] != last_block_header["number"]:
+                if block.number != last_block.header.number:
                     # raise with clearer message if block number mismatches
                     raise AssertionError(
                         f"block number mismatch in last block: got "
-                        f"`{block_header['number']}`, "
-                        f"expected `{last_block_header['number']}``"
+                        f"`{block.number}`, "
+                        f"expected `{last_block.header.number}``"
                     )
 
                 # find all mismatched fields
@@ -99,6 +104,6 @@ def test_via_rlp(
             except Exception:
                 raise AssertionError(
                     f"blockHash mismatch in last block: "
-                    f"got `{block['hash']}`, "
+                    f"got `{block.hash}`, "
                     f"expected `{fixture.last_block_hash}`"
                 ) from None

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -93,9 +93,9 @@ def test_blockchain_via_sync(
         logger.info("Verifying genesis block on client under test...")
         genesis_block = eth_rpc.get_block_by_number(0)
         assert genesis_block is not None, "genesis_block is None"
-        if genesis_block["hash"] != str(fixture.genesis.block_hash):
+        if genesis_block.hash != fixture.genesis.block_hash:
             expected = fixture.genesis.block_hash
-            got = genesis_block["hash"]
+            got = genesis_block.hash
             logger.fail(
                 f"Genesis block hash mismatch. "
                 f"Expected: {expected}, Got: {got}"
@@ -447,7 +447,7 @@ def test_blockchain_via_sync(
         # Get the target block number for logging
         target_block = eth_rpc.get_block_by_hash(last_valid_block_hash)
         target_block_number = (
-            int(target_block["number"], 16) if target_block else "unknown"
+            int(target_block.number) if target_block else "unknown"
         )
         logger.info(
             f"Waiting for sync client to reach block #{target_block_number} "
@@ -505,25 +505,25 @@ def test_blockchain_via_sync(
             )
 
         if sync_block is not None and client_block is not None:
-            if sync_block["stateRoot"] != client_block["stateRoot"]:
+            if sync_block.state_root != client_block.state_root:
                 raise LoggedError(
                     f"State root mismatch after sync. "
-                    f"Sync client: {sync_block['stateRoot']}, "
-                    f"Client under test: {client_block['stateRoot']}"
+                    f"Sync client: {sync_block.state_root}, "
+                    f"Client under test: {client_block.state_root}"
                 )
 
             # Verify against expected post-state hash if provided
             if fixture.post_state_hash:
-                if sync_block["stateRoot"] != str(fixture.post_state_hash):
+                if sync_block.state_root != fixture.post_state_hash:
                     raise LoggedError(
                         f"Final state root mismatch. "
                         f"Expected: {fixture.post_state_hash}, "
-                        f"Got: {sync_block['stateRoot']}"
+                        f"Got: {sync_block.state_root}"
                     )
 
             logger.info(
                 f"Block state verified via eth_getBlockByHash: "
-                f"{sync_block['stateRoot']}"
+                f"{sync_block.state_root}"
             )
 
     logger.info("Sync test completed successfully!")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -280,7 +280,7 @@ def env_gas_limit(eth_rpc: EthRPC) -> HexNumber:
     """
     head_block = eth_rpc.get_block_by_number()
     assert head_block is not None, "Unable to obtain head block from RPC"
-    return HexNumber(head_block["gasLimit"])
+    return head_block.gas_limit
 
 
 def base_test_parametrizer(cls: Type[BaseTest]) -> Any:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -6,7 +6,7 @@ submitted.
 import time
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, List, Mapping, Sequence, Tuple
+from typing import Any, List, Sequence, Tuple
 from urllib.parse import urlparse
 
 from filelock import FileLock
@@ -25,6 +25,7 @@ from execution_testing.forks import Fork, TransitionFork
 from execution_testing.rpc import (
     DEFAULT_REQUEST_TIMEOUT,
     EngineRPC,
+    LiveBlock,
     TestingRPC,
     TimeoutType,
 )
@@ -41,7 +42,7 @@ from execution_testing.test_types import Withdrawal
 
 def _genesis_header_differences(
     expected: FixtureHeader,
-    actual_block: Mapping[str, Any],
+    actual_block: LiveBlock,
 ) -> List[str]:
     """
     Return the per-field differences between the expected genesis header and
@@ -51,8 +52,11 @@ def _genesis_header_differences(
     Return an empty list when the client's block cannot be parsed as a
     header, in which case the caller only reports the block hashes.
     """
+    actual_block_dict = actual_block.model_dump(
+        by_alias=True, mode="json", exclude_none=True
+    )
     try:
-        actual_header = FixtureHeader.model_validate(actual_block)
+        actual_header = FixtureHeader.model_validate(actual_block_dict)
     except ValidationError:
         return []
     expected_json = to_json(expected)
@@ -70,7 +74,7 @@ def _genesis_header_differences(
         if field != "hash"
         and expected_json.get(field) != actual_json.get(field)
     ]
-    if actual_header.block_hash != Hash(actual_block["hash"]):
+    if actual_header.block_hash != actual_block.hash:
         differences.append(
             "note: the client's header does not hash to the block hash it "
             "reports when re-encoded locally, so the fields listed above may "
@@ -87,7 +91,7 @@ class GenesisMismatchError(Exception):
     def __init__(
         self,
         expected: FixtureHeader,
-        actual_block: Mapping[str, Any],
+        actual_block: LiveBlock,
     ) -> None:
         """Initialize the exception with both genesis headers."""
         self.expected = expected
@@ -96,7 +100,7 @@ class GenesisMismatchError(Exception):
             "the client's genesis block does not match the one built "
             "locally:"
             f"\n  expected block hash: {expected.block_hash}"
-            f"\n  client block hash:   {Hash(actual_block['hash'])}"
+            f"\n  client block hash:   {actual_block.hash}"
         )
         differences = _genesis_header_differences(expected, actual_block)
         if differences:
@@ -167,14 +171,13 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                 # Get the head block hash
                 head_block = self.get_block_by_number("latest")
                 assert head_block is not None
-                block_number = HexNumber(head_block["number"])
-                timestamp = HexNumber(head_block["timestamp"])
                 head_fork = self.fork.fork_at(
-                    block_number=block_number, timestamp=timestamp
+                    block_number=head_block.number,
+                    timestamp=head_block.timestamp,
                 )
                 # Send initial forkchoice updated
                 forkchoice_state = ForkchoiceState(
-                    head_block_hash=head_block["hash"],
+                    head_block_hash=head_block.hash,
                 )
                 forkchoice_version = (
                     head_fork.engine_forkchoice_updated_version()
@@ -207,7 +210,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         assert genesis_block is not None, (
             "client did not return its genesis block"
         )
-        if Hash(genesis_block["hash"]) != expected.block_hash:
+        if genesis_block.hash != expected.block_hash:
             raise GenesisMismatchError(expected, genesis_block)
 
     @property
@@ -221,26 +224,26 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         """
         return self.block_building_lock
 
-    def _next_timestamp(self, head_block: Mapping[str, Any]) -> int:
+    def _next_timestamp(self, head_block: LiveBlock) -> int:
         """Return the timestamp of the block following ``head_block``."""
-        return int(HexNumber(head_block["timestamp"]) + 1)
+        return int(head_block.timestamp) + 1
 
-    def _next_fork(self, head_block: Mapping[str, Any]) -> Fork:
+    def _next_fork(self, head_block: LiveBlock) -> Fork:
         """Return the fork of the block following ``head_block``."""
         return self.fork.fork_at(
             block_number=0, timestamp=self._next_timestamp(head_block)
         )
 
-    def _head_fork(self, head_block: Mapping[str, Any]) -> Fork:
+    def _head_fork(self, head_block: LiveBlock) -> Fork:
         """Return the fork of ``head_block`` itself."""
         return self.fork.fork_at(
-            block_number=int(HexNumber(head_block["number"])),
-            timestamp=int(HexNumber(head_block["timestamp"])),
+            block_number=int(head_block.number),
+            timestamp=int(head_block.timestamp),
         )
 
     def _payload_attributes(
         self,
-        head_block: Mapping[str, Any],
+        head_block: LiveBlock,
         *,
         withdrawals: List[Withdrawal] | None = None,
     ) -> PayloadAttributes:
@@ -254,15 +257,15 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             if not self._head_fork(head_block).header_slot_number_required():
                 next_slot_number = 1
             else:
-                assert "slotNumber" in head_block, (
+                assert head_block.slot_number is not None, (
                     "fork requires a slot number in the block header but the "
                     "client does not report one for its head block"
                 )
-                next_slot_number = int(HexNumber(head_block["slotNumber"]) + 1)
+                next_slot_number = int(head_block.slot_number) + 1
         return PayloadAttributes.for_fork(
             next_fork,
             timestamp=next_timestamp,
-            target_gas_limit=int(HexNumber(head_block["gasLimit"])),
+            target_gas_limit=int(head_block.gas_limit),
             slot_number=next_slot_number,
             withdrawals=withdrawals,
         )
@@ -330,7 +333,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         assert head_block is not None
 
         forkchoice_state = ForkchoiceState(
-            head_block_hash=head_block["hash"],
+            head_block_hash=head_block.hash,
         )
         next_fork = self._next_fork(head_block)
         payload_attributes = self._payload_attributes(head_block)
@@ -407,7 +410,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             assert head_block is not None
             payload_attributes = self._payload_attributes(head_block)
             new_payload = self.testing_rpc.build_block(
-                parent_block_hash=Hash(head_block["hash"]),
+                parent_block_hash=head_block.hash,
                 payload_attributes=payload_attributes,
                 transactions=transactions,
                 extra_data=Bytes(b""),  # TODO: This is marked as optional
@@ -453,7 +456,7 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
             # the client pull from its mempool, but we want a
             # deterministic tx-free block.
             new_payload = self.testing_rpc.build_block(
-                parent_block_hash=Hash(head_block["hash"]),
+                parent_block_hash=head_block.hash,
                 payload_attributes=payload_attributes,
                 transactions=[],
                 extra_data=Bytes(b""),

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -16,7 +16,7 @@ setup-phase block prepended to ``self.blocks``.
 import os
 import secrets
 from pathlib import Path
-from typing import Any, Generator, List
+from typing import Generator, List
 from urllib.parse import urlparse, urlunparse
 
 import pytest
@@ -25,7 +25,6 @@ from filelock import FileLock
 from execution_testing.base_types import (
     Address,
     Hash,
-    HexNumber,
     Number,
 )
 from execution_testing.client_clis import ClientBackend
@@ -45,7 +44,7 @@ from execution_testing.forks import (
 )
 from execution_testing.logging import get_logger
 from execution_testing.recipient_type import RecipientType
-from execution_testing.rpc import DebugRPC, EngineRPC, EthRPC
+from execution_testing.rpc import DebugRPC, EngineRPC, EthRPC, LiveBlock
 from execution_testing.specs.blockchain import (
     payload_metadata_to_fixture,
 )
@@ -454,7 +453,7 @@ def worker_key(
     else:
         account = eth_rpc.get_account(
             session_worker_key,
-            block_number=int(start["number"], 16),
+            block_number=int(start.number),
             skip_code=True,
         )
     session_worker_key.nonce = Number(account.nonce)
@@ -599,9 +598,9 @@ def client_backend(
 @pytest.fixture(scope="session")
 def snapshot_block(
     request: pytest.FixtureRequest, eth_rpc: "ChainBuilderEthRPC"
-) -> Any:
+) -> LiveBlock:
     """
-    Resolve the snapshot anchor to a client block dict.
+    Resolve the snapshot anchor to a client block.
 
     Accepts a 32-byte hash (preferred — survives reorgs), an integer
     block number (hex/dec), or ``None`` for ``latest``. The returned
@@ -647,7 +646,7 @@ def _session_pre_run(
     eth_rpc: ChainBuilderEthRPC,
     session_worker_key: EOA,
     session_fork: Fork | TransitionFork,
-    snapshot_block: Any,
+    snapshot_block: LiveBlock,
     sender_funding_transactions_gas_price: int,
     session_temp_folder: Path,
     request: pytest.FixtureRequest,
@@ -673,8 +672,8 @@ def _session_pre_run(
     #    record — a later reorg can't silently re-anchor by block number.
     client_backend.snapshot_block = snapshot_block
     logger.info(
-        f"Snapshot block {snapshot_block['number']} "
-        f"hash={snapshot_block['hash'][:20]}..."
+        f"Snapshot block {snapshot_block.number} "
+        f"hash={str(snapshot_block.hash)[:20]}..."
     )
 
     # 2. Fund seed key via CL withdrawal, unless it is already funded (e.g.
@@ -723,8 +722,8 @@ def _session_pre_run(
     assert start_block is not None, "Failed to fetch start block"
     client_backend.start_block = start_block
     logger.info(
-        f"Start block {start_block['number']} "
-        f"hash={start_block['hash'][:20]}..."
+        f"Start block {start_block.number} "
+        f"hash={str(start_block.hash)[:20]}..."
     )
 
     # 5. Persist captured payloads to pre_run/<start_block_hash>.json.
@@ -738,12 +737,12 @@ def _session_pre_run(
         pre_run_dir.mkdir(parents=True, exist_ok=True)
         fork_at_genesis = session_fork.fork_at(block_number=0, timestamp=0)
         payloads = [payload_metadata_to_fixture(p) for p in captured]
-        start_block_hash = Hash(start_block["hash"])
+        start_block_hash = start_block.hash
         fixture = StatefulPreRunFixture(
             network=str(fork_at_genesis),
-            snapshot_block_number=HexNumber(snapshot_block["number"]),
-            snapshot_block_hash=Hash(snapshot_block["hash"]),
-            start_block_number=HexNumber(start_block["number"]),
+            snapshot_block_number=snapshot_block.number,
+            snapshot_block_hash=snapshot_block.hash,
+            start_block_number=start_block.number,
             start_block_hash=start_block_hash,
             payloads=payloads,
         )
@@ -807,11 +806,12 @@ def _reset_chain_between_tests(
     yield
     if client_backend.start_block is None:
         return
-    start_hex = client_backend.start_block["number"]
-    expected_hash = client_backend.start_block["hash"]
+    start_number = int(client_backend.start_block.number)
+    start_hex = str(client_backend.start_block.number)
+    expected_hash = str(client_backend.start_block.hash)
     # Skip when head already at start (geth rejects same-block setHead).
     current_head = eth_rpc.get_block_by_number("latest")
-    if current_head is not None and current_head["hash"] == expected_hash:
+    if current_head is not None and str(current_head.hash) == expected_hash:
         return
     try:
         debug_rpc.rewind_head(block_number=start_hex, block_hash=expected_hash)
@@ -823,9 +823,9 @@ def _reset_chain_between_tests(
     # tip, so "latest" is unreliable there. The block at start_block's number
     # is the start block on both geth (debug_setHead moves latest) and
     # nethermind (resetHead leaves it stale).
-    head = eth_rpc.get_block_by_number(start_hex)
-    if head is None or head["hash"] != expected_hash:
-        observed = head["hash"] if head is not None else "<none>"
+    head = eth_rpc.get_block_by_number(start_number)
+    if head is None or str(head.hash) != expected_hash:
+        observed = str(head.hash) if head is not None else "<none>"
         pytest.exit(
             f"head rewind landed on hash {observed} but expected "
             f"{expected_hash} (start_block at number {start_hex}). The "

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -31,6 +31,7 @@ from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
     GetPayloadResponse,
     JSONRPCError,
+    LiveBlock,
     PayloadAttributes,
     PayloadStatusEnum,
 )
@@ -163,9 +164,9 @@ class ClientBackend:
     """
 
     exception_mapper: ExceptionMapper
-    snapshot_block: Dict[str, Any] | None
+    snapshot_block: LiveBlock | None
     """Raw datadir head, set by the fill-stateful plugin pre-session."""
-    start_block: Dict[str, Any] | None
+    start_block: LiveBlock | None
     """Client head after global pre-run setup; per-test chains off this."""
 
     # t8n-compatibility stubs — fill's filler reads these on the backend.

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -321,7 +321,7 @@ class BlobTransaction(BaseExecute):
         latest_block = eth_rpc.get_block_by_number("latest")
         assert latest_block is not None, "Failed to fetch the latest block."
         forkchoice_state = ForkchoiceState(
-            head_block_hash=Hash(latest_block["hash"]),
+            head_block_hash=latest_block.hash,
         )
         valid_length = len(self.custody_columns) == CUSTODY_COLUMNS_BYTE_LENGTH
         try:

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -28,6 +28,7 @@ from .rpc_types import (
     ForkConfigBlobSchedule,
     JSONRPCRequest,
     JSONRPCResponse,
+    LiveBlock,
     RPCCall,
     TransactionProtocol,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "ForkchoiceUpdateTimeoutError",
     "JSONRPCRequest",
     "JSONRPCResponse",
+    "LiveBlock",
     "NetRPC",
     "NewPayloadTimeoutError",
     "RPCCall",

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -56,6 +56,7 @@ from .rpc_types import (
     JSONRPCError,
     JSONRPCRequest,
     JSONRPCResponse,
+    LiveBlock,
     PayloadAttributes,
     PayloadStatus,
     PayloadStatusEnum,
@@ -581,7 +582,7 @@ class EthRPC(BaseRPC):
 
     def get_block_by_number(
         self, block_number: BlockNumberType = "latest", full_txs: bool = True
-    ) -> Any | None:
+    ) -> LiveBlock | None:
         """
         `eth_getBlockByNumber`: Returns information about a block by block
         number.
@@ -593,9 +594,12 @@ class EthRPC(BaseRPC):
         )
         logger.info(f"Requesting info about block {block}..")
         params = [block, full_txs]
-        return self.post_request(
+        response = self.post_request(
             request=RPCCall(method="getBlockByNumber", params=params)
         ).result_or_raise()
+        if response is None:
+            return None
+        return LiveBlock.model_validate(response)
 
     def get_block_receipts(
         self, block_hash: Hash
@@ -610,13 +614,16 @@ class EthRPC(BaseRPC):
 
     def get_block_by_hash(
         self, block_hash: Hash, full_txs: bool = True
-    ) -> Any | None:
+    ) -> LiveBlock | None:
         """`eth_getBlockByHash`: Returns information about a block by hash."""
         logger.info(f"Requesting block info of {block_hash}..")
         params = [f"{block_hash}", full_txs]
-        return self.post_request(
+        response = self.post_request(
             request=RPCCall(method="getBlockByHash", params=params)
         ).result_or_raise()
+        if response is None:
+            return None
+        return LiveBlock.model_validate(response)
 
     def get_block_by_hash_with_retry(
         self,
@@ -625,7 +632,7 @@ class EthRPC(BaseRPC):
         max_attempts: int = 5,
         wait_fixed: float = 1.0,
         on_retry: Callable[[RetryCallState], None] | None = None,
-    ) -> dict[str, Any]:
+    ) -> LiveBlock:
         """
         Get block by hash, retrying if not yet available.
 
@@ -637,7 +644,7 @@ class EthRPC(BaseRPC):
                 Receives tenacity RetryCallState. If None, logs at debug level.
 
         Returns:
-            Block data as a dictionary.
+            The block.
 
         Raises:
             BlockNotAvailableError: If block not available after max_attempts.
@@ -661,7 +668,7 @@ class EthRPC(BaseRPC):
             before_sleep=retry_callback,
             reraise=True,
         )
-        def _get_block() -> dict[str, Any]:
+        def _get_block() -> LiveBlock:
             nonlocal attempts
             attempts += 1
             block = self.get_block_by_hash(block_hash)

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -156,6 +156,32 @@ class TransactionByHashResponse(Transaction):
         assert self.transaction_hash == self.hash
 
 
+class LiveBlock(CamelModel):
+    """
+    Block returned by ``eth_getBlockByNumber``/``eth_getBlockByHash`` on a
+    live EL client, as captured by the fill-stateful / execute live-client
+    backends to anchor the session/test chain.
+    """
+
+    # Unlike other response models in this file, extra fields are kept
+    # rather than ignored: callers re-validate this model's dump as a
+    # ``FixtureHeader`` (which needs extraData, logsBloom, ... fields this
+    # model doesn't declare), so nothing may be dropped.
+    model_config = CamelModel.model_config | {"extra": "allow"}
+
+    number: HexNumber
+    hash: Hash
+    timestamp: HexNumber
+    state_root: Hash = Field(alias="stateRoot")
+    gas_limit: HexNumber = Field(alias="gasLimit")
+    fee_recipient: Address = Field(
+        alias="miner",
+        validation_alias=AliasChoices("miner", "coinbase"),
+    )
+    difficulty: HexNumber | None = None
+    slot_number: HexNumber | None = None
+
+
 class ForkchoiceState(CamelModel):
     """Represents the forkchoice state of the beacon chain."""
 

--- a/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
+++ b/packages/testing/src/execution_testing/rpc/tests/test_request_timeout.py
@@ -15,6 +15,7 @@ from execution_testing.forks import Cancun
 from execution_testing.rpc import (
     DEFAULT_REQUEST_TIMEOUT,
     EthRPC,
+    LiveBlock,
     RPCCall,
     SendTransactionExceptionError,
 )
@@ -129,11 +130,16 @@ def test_chain_builder_accepts_request_timeout(tmp_path: Path) -> None:
     engine_rpc.forkchoice_updated.return_value.payload_status.status = (
         PayloadStatusEnum.VALID
     )
-    head_block = {
-        "number": "0x0",
-        "timestamp": "0x0",
-        "hash": f"0x{'00' * 32}",
-    }
+    head_block = LiveBlock.model_validate(
+        {
+            "number": "0x0",
+            "timestamp": "0x0",
+            "hash": f"0x{'00' * 32}",
+            "stateRoot": f"0x{'00' * 32}",
+            "gasLimit": "0x1c9c380",
+            "miner": f"0x{'00' * 20}",
+        }
+    )
     with patch.object(
         ChainBuilderEthRPC, "get_block_by_number", return_value=head_block
     ):

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1476,7 +1476,7 @@ class BlockchainTest(BaseTest):
                     f"max_fee_per_blob_gas={max_fee_per_blob_gas}."
                 )
             execute_plan.prepare_transactions(
-                env=Environment(gas_limit=HexNumber(start_block["gasLimit"])),
+                env=Environment(gas_limit=start_block.gas_limit),
                 gas_price=gas_price,
                 max_fee_per_gas=max_fee_per_gas,
                 max_priority_fee_per_gas=max_priority_fee_per_gas,
@@ -1495,9 +1495,7 @@ class BlockchainTest(BaseTest):
                 max_fee_per_blob_gas=max_fee_per_blob_gas,
             )
 
-        self.pre.verify_deployed_accounts(
-            int(HexNumber(start_block["number"]))
-        )
+        self.pre.verify_deployed_accounts(int(start_block.number))
 
         # Materialise queued pre-alloc txs into a synthetic setup block.
         blocks_to_process: List[Block] = []
@@ -1517,9 +1515,13 @@ class BlockchainTest(BaseTest):
         # recomputes block_hash from RLP and that diverges from the
         # client's authoritative hash unless every header byte is
         # reproduced exactly.
-        start_block_number = int(HexNumber(start_block["number"]))
-        start_block_hash = Hash(start_block["hash"])
-        parent_header = FixtureHeader.model_validate(start_block)
+        start_block_number = int(start_block.number)
+        start_block_hash = start_block.hash
+        parent_header = FixtureHeader.model_validate(
+            start_block.model_dump(
+                by_alias=True, mode="json", exclude_none=True
+            )
+        )
         env = Environment(
             parent_difficulty=parent_header.difficulty,
             parent_timestamp=parent_header.timestamp,
@@ -1608,8 +1610,8 @@ class BlockchainTest(BaseTest):
             fork=self.fork,
             last_block_hash=head_hash,
             config=FixtureConfig(fork=self.fork),
-            snapshot_block_number=HexNumber(snapshot_block["number"]),
-            snapshot_block_hash=Hash(snapshot_block["hash"]),
+            snapshot_block_number=snapshot_block.number,
+            snapshot_block_hash=snapshot_block.hash,
             start_block_number=HexNumber(start_block_number),
             start_block_hash=start_block_hash,
             setup_payloads=setup_payloads,

--- a/packages/testing/src/execution_testing/specs/tests/test_stateful_receipt_status.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_stateful_receipt_status.py
@@ -17,7 +17,7 @@ from execution_testing.fixtures.blockchain import (
     FixtureHeader,
 )
 from execution_testing.forks import Osaka
-from execution_testing.rpc.rpc_types import GetPayloadResponse
+from execution_testing.rpc.rpc_types import GetPayloadResponse, LiveBlock
 from execution_testing.test_types import (
     Alloc,
     Environment,
@@ -118,9 +118,10 @@ def client_backend() -> ClientBackend:
         by_alias=True, mode="json", exclude_none=True
     )
     block_dict["hash"] = str(start_header.block_hash)
+    start_block = LiveBlock.model_validate(block_dict)
     backend.fork = FORK
-    backend.snapshot_block = block_dict
-    backend.start_block = block_dict
+    backend.snapshot_block = start_block
+    backend.start_block = start_block
     backend.extract_opcode_count = False
     backend.debug_rpc = None
     return backend


### PR DESCRIPTION
### Description

Create a `LiveBlock` model to parse all responses from RPC, which partially matches the `FixtureHeader` field definitions.

Simplifies a lot of code where we access the returned dictionary by key name and then parse into the appropriate type manually to then use the value.

### Related Issues or PRs
N/A.

### Checklist
- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
