### PR TITLE
refactor(tests): EIP-8037 test gas calculation logic and post state verification

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -22,10 +22,8 @@ class ReferenceSpec:
     version: str
 
 
-# TODO: update version once
-# https://github.com/ethereum/EIPs/pull/11328 is merged
 ref_spec_8037 = ReferenceSpec(
-    "EIPS/eip-8037.md", "a12902ae1b811c45a81b51bfce671cf7a1fb27f3"
+    "EIPS/eip-8037.md", "5a8c80897aeb0952322cd0dfff767c541002b8c3"
 )
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -424,15 +424,14 @@ def test_block_gas_used_call_new_account(
         intrinsic_gas + parent_code.execution_cost(fork) + intrinsic_gas
     )
     block_state = parent_code.state_cost(fork)
+    assert block_state > block_execution, "requires state gas to dominate"
 
     blockchain_test(
         pre=pre,
         blocks=[
             Block(
                 txs=txs,
-                header_verify=Header(
-                    gas_used=max(block_execution, block_state)
-                ),
+                header_verify=Header(gas_used=block_state),
             )
         ],
         post={parent: Account(storage=parent_storage)},
@@ -461,7 +460,9 @@ def test_block_gas_used_create_tx(
     create_state = fork.transaction_top_frame_state_gas(contract_creation=True)
     stop_execution = intrinsic_calc()
 
-    expected = max(create_execution + stop_execution, create_state)
+    assert create_state > create_execution + stop_execution, (
+        "create state should dominate"
+    )
 
     sender = pre.fund_eoa()
     txs = [
@@ -478,7 +479,7 @@ def test_block_gas_used_create_tx(
         blocks=[
             Block(
                 txs=txs,
-                header_verify=Header(gas_used=expected),
+                header_verify=Header(gas_used=create_state),
             )
         ],
         post={

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -41,9 +41,10 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 def sstore_tx_gas(fork: Fork, num_sstores: int = 1) -> tuple[int, int]:
     """Return (execution, state) gas for a tx with N cold SSTOREs."""
+    code = Op.SSTORE(0, 1, original_value=0, new_value=1)
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
-    evm_total = num_sstores * Op.SSTORE(0, 1).execution_cost(fork)
-    state = num_sstores * Op.SSTORE(new_value=1).state_cost(fork)
+    evm_total = num_sstores * code.execution_cost(fork)
+    state = num_sstores * code.state_cost(fork)
     return intrinsic_gas + evm_total, state
 
 
@@ -64,9 +65,9 @@ def sstore_txs(
     txs, post = [], {}
     for _ in range(n):
         storage = Storage()
-        code = Bytecode(Op.STOP)
+        code = Bytecode()
         for _ in range(num_sstores):
-            code = Op.SSTORE(storage.store_next(1), 1) + code
+            code += Op.SSTORE(storage.store_next(1), 1)
         contract = pre.deploy_contract(code=code)
         txs.append(
             Transaction(
@@ -153,26 +154,60 @@ def test_block_gas_used_execution_dominates(
     fork: Fork,
 ) -> None:
     """
-    Verify block.gas_used = block_execution_gas when state gas is zero.
+    Verify block.gas_used = block_execution_gas when execution dominates.
 
-    A block containing only STOP transactions to existing contracts
-    produces no state gas. The block header gas_used must equal the
-    sum of execution gas across all transactions, since
-    max(execution, 0) = execution.
+    The contract sets a fresh slot, then exhausts an exactly sized gas
+    limit on memory expansion, so the state dimension is non-zero while
+    the larger execution dimension sets the header.
     """
-    num_txs = 3
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
-    txs = stop_txs(pre, fork, num_txs)
+    sink_memory_size = 256 * 1024
+
+    storage = Storage()
+    code = Op.SSTORE(
+        storage.store_next(1, "slot_set"),
+        1,
+        # gas accounting
+        original_value=0,
+        new_value=1,
+    ) + Op.MSTORE8(
+        sink_memory_size - 1,
+        0,
+        # gas accounting
+        new_memory_size=sink_memory_size,
+    )
+
+    contract = pre.deploy_contract(code=code)
+
+    block_execution = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + code.execution_cost(fork)
+    )
+    block_state = code.state_cost(fork)
+    assert block_execution > block_state, "requires execution to dominate"
+
+    gas_limit = block_execution + block_state
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is None or gas_limit <= gas_limit_cap
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_limit),
+    )
 
     blockchain_test(
         pre=pre,
         blocks=[
             Block(
-                txs=txs,
-                header_verify=Header(gas_used=num_txs * intrinsic_gas),
+                txs=[tx],
+                header_verify=Header(
+                    gas_used=max(block_execution, block_state)
+                ),
             )
         ],
-        post={},
+        post={contract: Account(storage=storage)},
+        expected_receipt_status=1,
     )
 
 
@@ -257,7 +292,7 @@ def test_block_gas_refund_eip7778_no_block_reduction(
         current_value=1,
         new_value=0,
     )(0, 0)
-    tx_execution = intrinsic_gas + code.gas_cost(fork) - sstore_state_gas
+    tx_execution = intrinsic_gas + code.execution_cost(fork)
     expected = num_txs * tx_execution
     txs = []
     for _ in range(num_txs):
@@ -285,7 +320,6 @@ def test_block_gas_refund_eip7778_no_block_reduction(
 @pytest.mark.parametrize(
     "num_txs,num_sstores",
     [
-        pytest.param(1, 1, id="single_sstore_single_tx"),
         pytest.param(5, 1, id="single_sstore"),
         pytest.param(20, 1, id="single_sstore_many_txs"),
         pytest.param(10, 5, id="multi_sstore_many_txs"),
@@ -304,37 +338,24 @@ def test_block_2d_gas_boundary_exact_fit(
 
     Clients that sum execution + state will reject this valid block.
     """
-    block_gas_limit = 30_000_000
-    while True:
-        # We have a circular dependency to calculate the block gas limit based
-        # on the transactions required gas (tx gas increments as we increase
-        # the block gas limit to fit). This loops tries incrementing the
-        # block gas limit by consistent steps in order to find the minimum gas
-        # allows the transactions required to fit.
-        env = Environment(
-            gas_limit=block_gas_limit,
-        )
-        tx_execution, tx_state = sstore_tx_gas(fork, num_sstores)
-        intrinsic_execution = fork.transaction_intrinsic_cost_calculator()()
+    tx_execution, tx_state = sstore_tx_gas(fork, num_sstores)
+    # No reservoir below the cap: a tx pays both dimensions out of its
+    # own limit, and this is exactly what it spends.
+    tx_limit = tx_execution + tx_state
 
-        tx_limit = tx_execution + tx_state + tx_execution // 10
+    block_execution, block_state = tx_execution * num_txs, tx_state * num_txs
+    total_cost = block_execution + block_state
+    header_gas_used = max(block_execution, block_state)
 
-        # Per-tx worst-case state contribution: tx.gas - intrinsic_execution.
-        # The block_gas_limit must leave enough state budget for every tx.
-        worst_state_per_tx = tx_limit - intrinsic_execution
-        minimum_block_gas_limit = max(
-            # Execution dimension: last tx must fit.
-            (num_txs - 1) * tx_execution + tx_limit,
-            # State dimension: cumulative worst-case must fit.
-            num_txs * worst_state_per_tx,
-        )
-        if block_gas_limit >= minimum_block_gas_limit:
-            break
-        block_gas_limit += 1_000_000
+    # The largest limit that still traps a client billing the header as
+    # sum(execution, state) instead of max(execution, state): such a
+    # client rejects the block for outgrowing its own gas limit, and
+    # misses the header either way.
+    block_gas_limit = total_cost - 1
 
-    block_execution = num_txs * tx_execution
-    block_state = num_txs * tx_state
-    expected_gas_used = max(block_execution, block_state)
+    assert header_gas_used <= block_gas_limit, "the block must be valid"
+
+    env = Environment(gas_limit=block_gas_limit)
 
     txs, post = sstore_txs(
         pre,
@@ -351,7 +372,7 @@ def test_block_2d_gas_boundary_exact_fit(
             Block(
                 txs=txs,
                 gas_limit=block_gas_limit,
-                header_verify=Header(gas_used=expected_gas_used),
+                header_verify=Header(gas_used=header_gas_used),
             )
         ],
         post=post,
@@ -371,34 +392,49 @@ def test_block_gas_used_call_new_account(
     GAS_NEW_ACCOUNT state gas) then SSTORE. Combined with a STOP tx,
     the 2D max must reflect state gas from account creation.
     """
-    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
-
     target = pre.fund_eoa(amount=0)
 
-    call = Op.CALL(
+    parent_storage = Storage()
+    parent_code = Op.CALL(
         gas=100_000,
         address=target,
         value=1,
+        # gas accounting
         value_transfer=True,
         account_new=True,
+    ) + Op.SSTORE(
+        parent_storage.store_next(1),
+        1,
+        # gas accounting
+        original_value=0,
+        new_value=1,
     )
-    parent_storage = Storage()
-    parent = pre.deploy_contract(
-        code=(call + Op.SSTORE(parent_storage.store_next(1), 1)),
-        balance=10**18,
-    )
+    parent = pre.deploy_contract(code=parent_code, balance=10**18)
 
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     txs = [
         Transaction(
             to=parent,
-            state_gas_reservoir=call.state_cost(fork) + sstore_state_gas,
+            state_gas_reservoir=parent_code.state_cost(fork),
             sender=pre.fund_eoa(),
         ),
     ] + stop_txs(pre, fork, 1)
 
+    block_execution = (
+        intrinsic_gas + parent_code.execution_cost(fork) + intrinsic_gas
+    )
+    block_state = parent_code.state_cost(fork)
+
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=txs)],
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(
+                    gas_used=max(block_execution, block_state)
+                ),
+            )
+        ],
         post={parent: Account(storage=parent_storage)},
     )
 
@@ -416,26 +452,24 @@ def test_block_gas_used_create_tx(
     Combined with a STOP tx, verify the 2D max is correct.
     """
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
-    create_state_gas = fork.create_state_gas(code_size=0)
-
     init_code = bytes(Op.STOP)
-    create_execution = (
-        intrinsic_calc(
-            calldata=init_code,
-            contract_creation=True,
-        )
-        - create_state_gas
-    )
+
+    create_execution = intrinsic_calc(
+        calldata=init_code,
+        contract_creation=True,
+    ) + fork.transaction_top_frame_gas_calculator()(contract_creation=True)
+    create_state = fork.transaction_top_frame_state_gas(contract_creation=True)
     stop_execution = intrinsic_calc()
 
-    expected = max(create_execution + stop_execution, create_state_gas)
+    expected = max(create_execution + stop_execution, create_state)
 
+    sender = pre.fund_eoa()
     txs = [
         Transaction(
             to=None,
             data=init_code,
-            state_gas_reservoir=create_state_gas,
-            sender=pre.fund_eoa(),
+            state_gas_reservoir=create_state,
+            sender=sender,
         ),
     ] + stop_txs(pre, fork, 1)
 
@@ -447,7 +481,11 @@ def test_block_gas_used_create_tx(
                 header_verify=Header(gas_used=expected),
             )
         ],
-        post={},
+        post={
+            compute_create_address(address=sender, nonce=0): Account(
+                nonce=1, code=b""
+            )
+        },
     )
 
 
@@ -468,6 +506,11 @@ def test_multi_block_dimension_flip(
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     tx_execution, tx_state = sstore_tx_gas(fork)
 
+    # Block 1 has no state gas at all, execution leads by default;
+    block_1_execution = n * intrinsic_gas
+    block_2_execution, block_2_state = n * tx_execution, n * tx_state
+    assert block_2_state > block_2_execution, "block 2 must lead on state"
+
     block_1 = stop_txs(pre, fork, n)
     block_2, post_2 = sstore_txs(pre, fork, n)
 
@@ -476,13 +519,11 @@ def test_multi_block_dimension_flip(
         blocks=[
             Block(
                 txs=block_1,
-                header_verify=Header(gas_used=n * intrinsic_gas),
+                header_verify=Header(gas_used=block_1_execution),
             ),
             Block(
                 txs=block_2,
-                header_verify=Header(
-                    gas_used=max(n * tx_execution, n * tx_state),
-                ),
+                header_verify=Header(gas_used=block_2_state),
             ),
         ],
         post=post_2,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
@@ -11,9 +11,10 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    compute_create_address,
 )
 
-from .spec import ref_spec_8037
+from .spec import init_code_at_high_bytes, ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -47,18 +48,15 @@ def test_create_charges_state_gas(
 ) -> None:
     """Test CREATE charges state gas for new account creation."""
     init_code = Op.STOP
+    mstore_value, size = init_code_at_high_bytes(init_code)
 
     storage = Storage()
     contract = pre.deploy_contract(
         code=(
-            Op.MSTORE(
-                0,
-                int.from_bytes(bytes(init_code), "big")
-                << (256 - 8 * len(init_code)),
-            )
+            Op.MSTORE(0, mstore_value)
             + Op.SSTORE(
                 storage.store_next(True),
-                Op.GT(Op.CREATE(0, 0, len(init_code)), 0),
+                Op.GT(Op.CREATE(0, 0, size), 0),
             )
         ),
     )
@@ -78,11 +76,14 @@ def test_create_tx_deploys_contract(
     pre: Alloc,
 ) -> None:
     """Test contract creation transaction succeeds with state gas."""
+    sender = pre.fund_eoa()
     tx = Transaction(
         to=None,
         data=Op.STOP,
         state_gas_reservoir=0,
-        sender=pre.fund_eoa(),
+        sender=sender,
     )
 
-    state_test(pre=pre, post={}, tx=tx)
+    created = compute_create_address(address=sender, nonce=0)
+    post = {created: Account(nonce=1, code=b"")}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -15,10 +15,13 @@ from execution_testing import (
     Alloc,
     AuthorizationTuple,
     Fork,
+    Header,
     Op,
+    RecipientType,
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionReceipt,
 )
 
 from .spec import ref_spec_8037
@@ -41,12 +44,9 @@ def test_sstore_via_delegation_pointer(
     contract code in the EOA's context. The SSTORE state gas should
     be charged from the reservoir just as it would for a direct call.
     """
-    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
-
     storage = Storage()
-    contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1),
-    )
+    contract_code = Op.SSTORE(storage.store_next(1), 1)
+    contract = pre.deploy_contract(code=contract_code)
 
     # EOA with pre-existing delegation to the contract
     delegator = pre.fund_eoa(delegation=contract)
@@ -62,20 +62,51 @@ def test_sstore_via_delegation_pointer(
         writes_delegation=False,
         first_write=False,
     )
-    auth_state_gas = fork.transaction_top_frame_state_gas(
-        authorizations=[authorization]
+    intrinsic_execution = fork.transaction_intrinsic_cost_calculator()(
+        authorization_list_or_count=[authorization],
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
     )
+    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+        recipient_type=RecipientType.DELEGATION_7702,
+        delegation_warm=False,
+        authorizations=[authorization],
+    )
+    auth_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.DELEGATION_7702,
+        authorizations=[authorization],
+    )
+    assert auth_state_gas == 0
+
+    block_execution = (
+        intrinsic_execution
+        + top_frame_execution
+        + contract_code.execution_cost(fork)
+    )
+    block_state = auth_state_gas + contract_code.state_cost(fork)
+    assert block_state > block_execution
+
     sender = pre.fund_eoa()
     tx = Transaction(
         to=delegator,
-        state_gas_reservoir=auth_state_gas + sstore_state_gas,
+        state_gas_reservoir=block_state,
         authorization_list=[authorization],
         sender=sender,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=block_execution + block_state,
+        ),
     )
 
     # SSTORE writes to the delegator's storage context
     post = {delegator: Account(storage=storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    state_test(
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=max(block_execution, block_state)
+        ),
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -90,22 +121,48 @@ def test_sstore_direct_call_same_contract(
     Baseline comparison: calling the contract directly (not via a
     delegation pointer) charges SSTORE state gas identically.
     """
-    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
-
     storage = Storage()
-    contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1),
+    contract_code = Op.SSTORE(storage.store_next(1), 1)
+    contract = pre.deploy_contract(code=contract_code)
+
+    intrinsic_execution = fork.transaction_intrinsic_cost_calculator()(
+        return_cost_deducted_prior_execution=True,
     )
+    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+        recipient_type=RecipientType.CONTRACT,
+    )
+    top_frame_state = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.CONTRACT,
+    )
+    assert top_frame_state == 0
+
+    block_execution = (
+        intrinsic_execution
+        + top_frame_execution
+        + contract_code.execution_cost(fork)
+    )
+    block_state = top_frame_state + contract_code.state_cost(fork)
+    assert block_state > block_execution
 
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        state_gas_reservoir=sstore_state_gas,
+        state_gas_reservoir=block_state,
         sender=sender,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=block_execution + block_state,
+        ),
     )
 
     post = {contract: Account(storage=storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    state_test(
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=max(block_execution, block_state)
+        ),
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -124,18 +181,16 @@ def test_delegation_pointer_new_account_state_gas(
     target = pre.nonexistent_account()
 
     parent_storage = Storage()
+
     call = Op.CALL(
-        gas=100_000,
+        gas=0,
         address=target,
         value=1,
         value_transfer=True,
         account_new=True,
     )
-    contract = pre.deploy_contract(
-        code=Op.SSTORE(parent_storage.store_next(1), call),
-        balance=1,
-    )
-    new_account_state_gas = call.state_cost(fork)
+    contract_code = Op.SSTORE(parent_storage.store_next(1), call)
+    contract = pre.deploy_contract(code=contract_code, balance=1)
 
     # EOA delegates to the contract
     delegator = pre.fund_eoa(delegation=contract, amount=1)
@@ -151,18 +206,55 @@ def test_delegation_pointer_new_account_state_gas(
         writes_delegation=False,
         first_write=False,
     )
-    auth_state_gas = fork.transaction_top_frame_state_gas(
-        authorizations=[authorization]
+    intrinsic_execution = fork.transaction_intrinsic_cost_calculator()(
+        authorization_list_or_count=[authorization],
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
     )
+    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+        recipient_type=RecipientType.DELEGATION_7702,
+        delegation_warm=False,
+        authorizations=[authorization],
+    )
+    auth_state_gas = fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.DELEGATION_7702,
+        authorizations=[authorization],
+    )
+    assert auth_state_gas == 0
+
+    # The callee leaves the value-transfer stipend unused, so it returns
+    # to this frame instead of being spent.
+    block_execution = (
+        intrinsic_execution
+        + top_frame_execution
+        + contract_code.execution_cost(fork)
+        - fork.gas_costs().CALL_STIPEND
+    )
+    block_state = auth_state_gas + contract_code.state_cost(fork)
+    assert block_state > block_execution
 
     sender = pre.fund_eoa()
     tx = Transaction(
         to=delegator,
-        state_gas_reservoir=auth_state_gas + new_account_state_gas,
+        state_gas_reservoir=block_state,
         authorization_list=[authorization],
         sender=sender,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=block_execution + block_state,
+        ),
     )
 
     # CALL success stored in delegator's storage context
-    post = {delegator: Account(storage=parent_storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    post = {
+        delegator: Account(storage=parent_storage, balance=0),
+        target: Account(balance=1),
+    }
+
+    state_test(
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=max(block_execution, block_state)
+        ),
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
@@ -42,40 +42,82 @@ pytestmark = pytest.mark.valid_at_transition_to("EIP8037")
 def test_sstore_state_gas_at_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas activates at the EIP-8037 fork boundary.
 
-    Before the fork, an SSTORE zero-to-nonzero succeeds with only
-    execution gas (no state gas dimension). After the fork, the same
-    operation requires state gas. Both blocks use TX_MAX_GAS_LIMIT
-    which provides enough gas in either regime.
+    A sub-call granted only the store's execution gas succeeds before
+    the fork, and after it only when a reservoir carries the new state
+    charge into the child frame.
     """
-    contract_before = pre.deploy_contract(
-        code=Op.SSTORE(0, 1),
+    before_fork = fork.fork_at(timestamp=14_999)
+    after_fork = fork.fork_at(timestamp=15_000)
+
+    sstore_code = Op.SSTORE(0, 1, original_value=0, new_value=1)
+    # Each side gets only what its own fork prices as execution gas.
+    before_grant = sstore_code.gas_cost(before_fork)
+    execution_gas = sstore_code.execution_cost(after_fork)
+    state_gas = sstore_code.state_cost(after_fork)
+    assert sstore_code.state_cost(before_fork) == 0, "no state dimension yet"
+    assert state_gas > 0
+
+    storage_before = Storage()
+    target_before = pre.deploy_contract(code=sstore_code)
+    caller_before = pre.deploy_contract(
+        code=Op.SSTORE(
+            storage_before.store_next(1, "subcall_succeeds"),
+            Op.CALL(gas=before_grant, address=target_before),
+        ),
     )
-    contract_after = pre.deploy_contract(
-        code=Op.SSTORE(0, 1),
+
+    storage_funded = Storage()
+    target_funded = pre.deploy_contract(code=sstore_code)
+    caller_funded = pre.deploy_contract(
+        code=Op.SSTORE(
+            storage_funded.store_next(1, "reservoir_pays_state_gas"),
+            Op.CALL(gas=execution_gas, address=target_funded),
+        ),
+    )
+
+    storage_starved = Storage()
+    target_starved = pre.deploy_contract(code=sstore_code)
+    caller_starved = pre.deploy_contract(
+        code=Op.SSTORE(
+            storage_starved.store_next(0, "subcall_runs_out_of_state_gas"),
+            Op.CALL(gas=execution_gas, address=target_starved),
+        ),
     )
 
     blocks = [
-        # Before fork: SSTORE succeeds with execution gas only
+        # Pre-fork: the grant is the whole price.
         Block(
             timestamp=14_999,
             txs=[
                 Transaction(
-                    to=contract_before,
+                    to=caller_before,
                     state_gas_reservoir=0,
                     sender=pre.fund_eoa(),
                 ),
             ],
         ),
-        # After fork: SSTORE succeeds — state gas drawn from gas_left
+        # Post-fork: the reservoir pays the state charge.
         Block(
             timestamp=15_000,
             txs=[
                 Transaction(
-                    to=contract_after,
+                    to=caller_funded,
+                    state_gas_reservoir=state_gas,
+                    sender=pre.fund_eoa(),
+                ),
+            ],
+        ),
+        # Post-fork, no reservoir: the state charge halts the child.
+        Block(
+            timestamp=15_001,
+            txs=[
+                Transaction(
+                    to=caller_starved,
                     state_gas_reservoir=0,
                     sender=pre.fund_eoa(),
                 ),
@@ -84,8 +126,12 @@ def test_sstore_state_gas_at_transition(
     ]
 
     post = {
-        contract_before: Account(storage={0: 1}),
-        contract_after: Account(storage={0: 1}),
+        caller_before: Account(storage=storage_before),
+        target_before: Account(storage={0: 1}),
+        caller_funded: Account(storage=storage_funded),
+        target_funded: Account(storage={0: 1}),
+        caller_starved: Account(storage=storage_starved),
+        target_starved: Account(storage={0: 0}),
     }
 
     blockchain_test(pre=pre, blocks=blocks, post=post)
@@ -192,20 +238,18 @@ def test_reservoir_available_after_transition(
     which child calls can draw from for state operations.
     """
     after_fork = fork.fork_at(timestamp=15_000)
-    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(after_fork)
+    child_code = Op.SSTORE(0, 1, original_value=0, new_value=1)
+    sstore_state_gas = child_code.state_cost(after_fork)
 
     child_storage = Storage()
-    child = pre.deploy_contract(
-        code=Op.SSTORE(child_storage.store_next(1), 1),
-    )
+    child_storage.store_next(1, "child_slot_set")
+    child = pre.deploy_contract(code=child_code)
 
     parent_storage = Storage()
     parent = pre.deploy_contract(
-        code=(
-            Op.SSTORE(
-                parent_storage.store_next(1),
-                Op.CALL(gas=100_000, address=child),
-            )
+        code=Op.SSTORE(
+            parent_storage.store_next(1, "subcall_succeeds"),
+            Op.CALL(gas=child_code.execution_cost(after_fork), address=child),
         ),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -50,18 +50,15 @@ def test_selfdestruct_new_beneficiary_state_gas(
     spilled into `gas_left` (in-cap tx): the block bills NEW_ACCOUNT in
     the state dimension and the beneficiary is created.
     """
-    new_account_state_gas = Op.SELFDESTRUCT(account_new=True).state_cost(fork)
-    beneficiary = 0xDEAD
+    beneficiary = pre.nonexistent_account()
+    code = Op.SELFDESTRUCT(beneficiary, account_new=True)
+    state_cost = code.state_cost(fork)
 
-    contract = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary), balance=1
-    )
+    contract = pre.deploy_contract(code=code, balance=1)
     tx = Transaction(
         to=contract,
         sender=pre.fund_eoa(),
-        state_gas_reservoir=(
-            new_account_state_gas if funding == "reservoir" else 0
-        ),
+        state_gas_reservoir=(state_cost if funding == "reservoir" else 0),
     )
 
     state_test(
@@ -71,13 +68,14 @@ def test_selfdestruct_new_beneficiary_state_gas(
             contract: Account(balance=0),
         },
         tx=tx,
-        blockchain_test_header_verify=Header(gas_used=new_account_state_gas),
+        blockchain_test_header_verify=Header(gas_used=state_cost),
     )
 
 
 @pytest.mark.valid_from("EIP8037")
 def test_selfdestruct_existing_beneficiary_no_state_gas(
     state_test: StateTestFiller,
+    fork: Fork,
     pre: Alloc,
 ) -> None:
     """
@@ -86,25 +84,37 @@ def test_selfdestruct_existing_beneficiary_no_state_gas(
     When the beneficiary already exists, no new account is created
     and no state gas is charged.
     """
-    beneficiary = pre.fund_eoa(amount=0)
+    beneficiary = pre.fund_eoa(amount=1)
+    code = Op.SELFDESTRUCT(beneficiary, account_new=False)
 
     contract = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary),
+        code=code,
         balance=1,
+    )
+
+    gas_limit = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + code.execution_cost(fork)
     )
 
     tx = Transaction(
         to=contract,
-        state_gas_reservoir=0,
+        gas_limit=gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    state_test(pre=pre, post={}, tx=tx)
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={beneficiary: Account(balance=2), contract: Account(balance=0)},
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
 def test_selfdestruct_zero_balance_no_state_gas(
     state_test: StateTestFiller,
+    fork: Fork,
     pre: Alloc,
 ) -> None:
     """
@@ -115,25 +125,36 @@ def test_selfdestruct_zero_balance_no_state_gas(
     does not exist.
     """
     # Non-existent beneficiary but contract has zero balance
-    beneficiary = 0xDEAD
+    beneficiary = pre.nonexistent_account()
+    code = Op.SELFDESTRUCT(beneficiary, account_new=False)
 
     contract = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary),
+        code=code,
         balance=0,
+    )
+
+    gas_limit = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + code.execution_cost(fork)
     )
 
     tx = Transaction(
         to=contract,
-        state_gas_reservoir=0,
+        gas_limit=gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    state_test(pre=pre, post={}, tx=tx)
+    state_test(
+        pre=pre,
+        post={beneficiary: Account.NONEXISTENT, contract: Account(balance=0)},
+        tx=tx,
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
 def test_selfdestruct_to_self_in_create_tx(
-    state_test: StateTestFiller,
+    blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
 ) -> None:
@@ -141,34 +162,45 @@ def test_selfdestruct_to_self_in_create_tx(
     Test SELFDESTRUCT to self in the transaction the contract was created.
 
     When a contract created in the current transaction SELFDESTRUCTs
-    to itself, the balance is burned and the account is deleted. No
-    new account state gas is charged since the beneficiary already
-    exists.
+    to itself, the balance stays at the cleared account. No new account
+    state gas is charged for the sweep since the beneficiary already
+    exists: the CREATE paid it, and the clearing does not refill it.
     """
-    gas_limit_cap = fork.transaction_gas_limit_cap()
-    assert gas_limit_cap is not None
-
-    inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
-
-    contract = pre.deploy_contract(
-        code=(
-            Op.MSTORE(
-                0,
-                int.from_bytes(bytes(inner_code), "big")
-                << (256 - 8 * len(inner_code)),
-            )
-            + Op.POP(Op.CREATE(1, 0, len(inner_code)))
-        ),
-        balance=1,
+    inner_code = Op.SELFDESTRUCT(
+        Op.ADDRESS,
+        # gas accounting
+        address_warm=True,
+        account_new=False,
     )
+    mstore_value, size = init_code_at_high_bytes(inner_code)
+
+    code = Op.MSTORE(0, mstore_value) + Op.POP(
+        Op.CREATE(1, 0, size, init_code_size=size, new_memory_size=32)
+    )
+    contract = pre.deploy_contract(code=code, balance=1)
+    created = compute_create_address(address=contract, nonce=1)
+
+    expected_state = code.state_cost(fork)
 
     tx = Transaction(
         to=contract,
-        gas_limit=gas_limit_cap * 2,
+        state_gas_reservoir=expected_state,
         sender=pre.fund_eoa(),
     )
 
-    state_test(pre=pre, post={}, tx=tx)
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_state),
+            ),
+        ],
+        post={
+            contract: Account(balance=0, nonce=2),
+            created: Account(balance=1, nonce=0, code=b""),
+        },
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -184,32 +216,33 @@ def test_selfdestruct_new_beneficiary_header_gas_used(
     beneficiary, charging GAS_NEW_ACCOUNT state gas. The block must
     be accepted with correct 2D gas accounting in the header.
     """
-    new_account_state_gas = Op.SELFDESTRUCT(account_new=True).state_cost(fork)
+    beneficiary = pre.nonexistent_account()
 
-    beneficiary = pre.fund_eoa(amount=0)
-
-    storage = Storage()
+    inner_code = Op.SELFDESTRUCT(beneficiary, account_new=True)
     inner = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(beneficiary),
+        code=inner_code,
         balance=1,
     )
+
+    storage = Storage()
+    call_code = Op.CALL(gas=100_000, address=inner) + Op.SSTORE(
+        storage.store_next(1, "completed"), 1
+    )
     caller = pre.deploy_contract(
-        code=(
-            Op.CALL(gas=100_000, address=inner)
-            + Op.SSTORE(storage.store_next(1, "completed"), 1)
-        ),
+        code=call_code,
     )
 
+    state_cost = inner_code.state_cost(fork) + call_code.state_cost(fork)
     tx = Transaction(
         to=caller,
-        state_gas_reservoir=new_account_state_gas,
+        state_gas_reservoir=state_cost,
         sender=pre.fund_eoa(),
     )
 
     blockchain_test(
         pre=pre,
         blocks=[
-            Block(txs=[tx]),
+            Block(txs=[tx], header_verify=Header(gas_used=state_cost)),
         ],
         post={caller: Account(storage=storage)},
     )
@@ -238,7 +271,7 @@ def test_selfdestruct_state_gas_refilled_on_ancestor_revert(
 
     expected_execution = (
         fork.transaction_intrinsic_cost_calculator()()
-        + caller_code.gas_cost(fork)
+        + caller_code.execution_cost(fork)
         + inner_code.execution_cost(fork)
     )
     tx = Transaction(to=caller, sender=pre.fund_eoa())
@@ -279,7 +312,9 @@ def test_create_selfdestruct_no_refund_account_and_storage(
             current_value=0,
             new_value=1,
         )(i, 1)
-    init_code += Op.SELFDESTRUCT.with_metadata(address_warm=True)(Op.ADDRESS)
+    init_code += Op.SELFDESTRUCT(
+        Op.ADDRESS, account_new=False, address_warm=True
+    )
     mstore_value, size = init_code_at_high_bytes(init_code)
 
     # Metadata so `.gas_cost(fork)` matches runtime charges.
@@ -300,11 +335,15 @@ def test_create_selfdestruct_no_refund_account_and_storage(
     )
     execution_used = (
         intrinsic_gas
-        + factory_code.gas_cost(fork)
-        + init_code.gas_cost(fork)
-        - total_state_gas
+        + factory_code.execution_cost(fork)
+        + init_code.execution_cost(fork)
     )
-    expected_gas_used = max(execution_used, total_state_gas)
+
+    assert total_state_gas > execution_used, (
+        f"test requires state gas > execution gas, got "
+        f"state={total_state_gas} execution={execution_used}"
+    )
+    expected_gas_used = total_state_gas
 
     tx = Transaction(
         to=factory,
@@ -312,12 +351,16 @@ def test_create_selfdestruct_no_refund_account_and_storage(
         sender=pre.fund_eoa(),
     )
 
+    created = compute_create_address(
+        address=factory, nonce=1, opcode=create_opcode
+    )
+
     blockchain_test(
         pre=pre,
         blocks=[
             Block(txs=[tx], header_verify=Header(gas_used=expected_gas_used)),
         ],
-        post={},
+        post={created: Account.NONEXISTENT},
     )
 
 
@@ -379,6 +422,17 @@ def test_create_selfdestruct_no_refund_code_deposit_state_gas(
     created_address = compute_create_address(address=factory, nonce=1)
 
     total_state_gas = factory_code.state_cost(fork) + initcode.state_cost(fork)
+    total_execution_gas = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + factory_code.execution_cost(fork)
+        + initcode.execution_cost(fork)
+    )
+
+    assert total_state_gas > total_execution_gas, (
+        "requires state gas > execution gas"
+    )
+
     tx = Transaction(
         to=factory,
         data=bytes(initcode),
@@ -388,7 +442,9 @@ def test_create_selfdestruct_no_refund_code_deposit_state_gas(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx])],
+        blocks=[
+            Block(txs=[tx], header_verify=Header(gas_used=total_state_gas))
+        ],
         post={created_address: Account.NONEXISTENT},
     )
 
@@ -439,7 +495,15 @@ def test_create_selfdestruct_code_deposit_no_refund_header_check(
         sender=pre.fund_eoa(),
     )
 
-    baseline_block_execution = 0x94C8
+    baseline_block_execution = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + factory_code.execution_cost(fork)
+        + initcode.execution_cost(fork)
+    )
+    assert total_state_gas > baseline_block_execution, (
+        "requires state gas > execution gas"
+    )
     expected_gas_used = max(baseline_block_execution, total_state_gas)
 
     blockchain_test(
@@ -495,12 +559,13 @@ def test_create_selfdestruct_sstore_restoration_refund(
     state_used = new_account_state_gas
     execution_used = (
         intrinsic_gas
-        + factory_code.gas_cost(fork)
-        + init_code.gas_cost(fork)
-        - new_account_state_gas
-        - sstore_state_gas
+        + factory_code.execution_cost(fork)
+        + init_code.execution_cost(fork)
     )
     expected_gas_used = max(execution_used, state_used)
+    assert expected_gas_used == state_used, (
+        "expected state gas to dominate execution gas"
+    )
 
     tx = Transaction(
         to=factory,
@@ -547,7 +612,9 @@ def test_selfdestruct_pre_existing_account_no_refund(
     # No refund offset: both caller_code and victim_code are pure
     # execution gas (SELFDESTRUCT to self, no value-to-new-account).
     tx_execution = (
-        intrinsic_gas + caller_code.gas_cost(fork) + victim_code.gas_cost(fork)
+        intrinsic_gas
+        + caller_code.execution_cost(fork)
+        + victim_code.execution_cost(fork)
     )
 
     tx = Transaction(
@@ -572,9 +639,7 @@ def test_selfdestruct_pre_existing_account_no_refund(
         pytest.param(2, id="two_hops"),
     ],
 )
-@pytest.mark.with_all_call_opcodes(
-    selector=lambda call_opcode: call_opcode in (Op.DELEGATECALL, Op.CALLCODE)
-)
+@pytest.mark.parametrize("call_opcode", [Op.DELEGATECALL, Op.CALLCODE])
 @pytest.mark.valid_from("EIP8037")
 def test_selfdestruct_via_delegatecall_chain_no_refund(
     blockchain_test: BlockchainTestFiller,
@@ -593,7 +658,7 @@ def test_selfdestruct_via_delegatecall_chain_no_refund(
     # just delegate further down. Track each frame's bytecode so we
     # can sum its execution gas into `expected_gas_used` below.
     sd_code = Op.SELFDESTRUCT.with_metadata(address_warm=True)(Op.ADDRESS)
-    chain_execution_gas = sd_code.gas_cost(fork)
+    chain_execution_gas = sd_code.execution_cost(fork)
     delegate_target = pre.deploy_contract(code=sd_code)
     for _ in range(num_hops - 1):
         hop_code = (
@@ -604,7 +669,7 @@ def test_selfdestruct_via_delegatecall_chain_no_refund(
             )
             + Op.STOP
         )
-        chain_execution_gas += hop_code.gas_cost(fork)
+        chain_execution_gas += hop_code.execution_cost(fork)
         delegate_target = pre.deploy_contract(code=hop_code)
 
     # A's deployed runtime: one delegation into the top of the chain.
@@ -668,11 +733,10 @@ def test_selfdestruct_via_delegatecall_chain_no_refund(
     total_state_gas = factory_code.state_cost(fork) + initcode.state_cost(fork)
     execution_used = (
         intrinsic_gas
-        + factory_code.gas_cost(fork)
-        + initcode.gas_cost(fork)
-        + deployed_code.gas_cost(fork)
+        + factory_code.execution_cost(fork)
+        + initcode.execution_cost(fork)
+        + deployed_code.execution_cost(fork)
         + chain_execution_gas
-        - total_state_gas
     )
     expected_gas_used = max(execution_used, total_state_gas)
 
@@ -709,6 +773,7 @@ def test_selfdestruct_new_beneficiary_account_write_cost(
     execution gas plus the account-creation state gas, and not the
     legacy combined execution account-creation cost.
     """
+    # TODO: Modify to subcall scenario
     beneficiary = pre.fund_eoa(amount=0)
 
     victim_code = Op.SELFDESTRUCT(beneficiary, account_new=True)
@@ -720,9 +785,10 @@ def test_selfdestruct_new_beneficiary_account_write_cost(
     # `ACCOUNT_WRITE` execution cost and the account-creation state gas
     # into `gas_cost`.
     intrinsic = fork.transaction_intrinsic_cost_calculator()()
+    gas_limit = intrinsic + victim_code.gas_cost(fork)
     tx = Transaction(
         to=victim,
-        gas_limit=(intrinsic + victim_code.gas_cost(fork) + 4_000),
+        gas_limit=gas_limit,
         sender=pre.fund_eoa(),
     )
 
@@ -786,6 +852,9 @@ def test_create_tx_selfdestruct_initcode_state_gas(
     ) + init_code.state_cost(fork)
     expected_execution = intrinsic_execution + init_code.execution_cost(fork)
     expected_gas_used = max(expected_execution, expected_state)
+    assert expected_gas_used == expected_state, (
+        "expected state gas to dominate execution gas"
+    )
 
     tx = Transaction(
         to=None,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -9,7 +9,6 @@ already exists or the originator has zero balance.
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
 """
-# NOTE: Finish test review
 
 import pytest
 from execution_testing import (

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -9,6 +9,7 @@ already exists or the originator has zero balance.
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
 """
+# NOTE: Finish test review
 
 import pytest
 from execution_testing import (
@@ -773,26 +774,43 @@ def test_selfdestruct_new_beneficiary_account_write_cost(
     execution gas plus the account-creation state gas, and not the
     legacy combined execution account-creation cost.
     """
-    # TODO: Modify to subcall scenario
     beneficiary = pre.fund_eoa(amount=0)
 
     victim_code = Op.SELFDESTRUCT(beneficiary, account_new=True)
     victim = pre.deploy_contract(code=victim_code, balance=1)
 
-    # Tight budget: slack is less than the legacy 25,000 execution
-    # account-creation cost minus `ACCOUNT_WRITE`, so any execution draw
-    # beyond `ACCOUNT_WRITE` would OOG. The opcode metadata folds the
-    # `ACCOUNT_WRITE` execution cost and the account-creation state gas
-    # into `gas_cost`.
-    intrinsic = fork.transaction_intrinsic_cost_calculator()()
-    gas_limit = intrinsic + victim_code.gas_cost(fork)
+    storage = Storage()
+    execution_cost = victim_code.execution_cost(fork)
+    state_cost = victim_code.state_cost(fork)
+
+    slot = storage.store_next(1, "subcall_succeeds")
+
+    caller_code = Op.SSTORE(
+        slot,
+        Op.CALL(gas=execution_cost, address=victim),
+        # gas accounting
+        key_warm=False,
+        original_value=2,
+        current_value=2,
+        new_value=1,
+    )
+    caller = pre.deploy_contract(code=caller_code, storage={slot: 2})
+
     tx = Transaction(
-        to=victim,
-        gas_limit=gas_limit,
+        to=caller,
+        state_gas_reservoir=state_cost,
         sender=pre.fund_eoa(),
     )
 
-    state_test(pre=pre, post={beneficiary: Account(balance=1)}, tx=tx)
+    state_test(
+        pre=pre,
+        post={
+            beneficiary: Account(balance=1),
+            victim: Account(balance=0),
+            caller: Account(storage=storage),
+        },
+        tx=tx,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

While extending EIP-8037 coverage I reviewed the existing suite and noticed that a number of tests do not restrict the behavior the test names and docstring intended to do. This PR marks those tests and starts tightening them.

### Case 1: set `state_gas_reservior` to 0 does not mean no state gas charge

Take `test_state_gas_selfdestruct.py::test_selfdestruct_existing_beneficiary_no_state_gas` as a representative example:

In my opinion, some of the verification is not strict enough, below is an example for unmodified `test_state_gas_selfdestruct`:

```python
@pytest.mark.valid_from("EIP8037")
def test_selfdestruct_existing_beneficiary_no_state_gas(
    state_test: StateTestFiller,
    pre: Alloc,
) -> None:
    """Test SELFDESTRUCT to existing beneficiary charges no state gas."""
    beneficiary = pre.fund_eoa(amount=0)

    contract = pre.deploy_contract(
        code=Op.SELFDESTRUCT(beneficiary),
        balance=1,
    )

    tx = Transaction(
        to=contract,
        state_gas_reservoir=0,
        sender=pre.fund_eoa(),
    )

    state_test(pre=pre, post={}, tx=tx)
```

The test intends to show that a `SELFDESTRUCT` sweep to an existing beneficiary charges no state gas. It has two independent problems.

1. It exercises the opposite scenario. `pre.fund_eoa(amount=0)` returns a fresh address but writes nothing to the pre-allocation, so the selfdestruting actually create a new account, charging the `NEW_ACCOUNT` cost. However, the test implementation does not catch the error at all.

2. In this test, the `tx.gas_limit` is not configured, while the `state_gas_reservior` configure to 0. In this case, the transaction gas limit case would be configured to transaction gas limit cap. So it is possible that a misimplemented client draw gas from `gas_left` and increase `state_gas_from_gas_left `, and the transaction is still possible to pass.

Transactions are constructed via `BlockchainTest::generate_block_data`, which calls `with_gas_limit()` to set gas limits:

```python
txs = [
    tx.with_gas_limit(
        max_gas_limit=max_tx_gas_limit,
        transaction_gas_limit_cap=fork.transaction_gas_limit_cap(),
        state_gas_reservoir_enabled=fork.state_gas_reservoir_enabled(),
    )
    for tx in txs
]
```
If `gas_limit` is not already set, `with_gas_limit()` calculates it implicitly:

```python
if "gas_limit" not in self.model_fields_set:
    updated_values["gas_limit"] = self._calculate_implicit_gas_limit(...)
```

In `_calculate_implicit_gas_limit()`, when `state_gas_reservoir_enabled` is True, the transaction gas limit becomes:

```python
tx_gas_limit = min(tx_gas_limit, transaction_gas_limit_cap) + state_gas_reservoir
```


To actually constrain the state dimension, a test needs one of: (1)  Header verification, and (2)  A transaction gas limit that excludes the state cost.


### Case 2: If the test is intended to validate state gas calculation, the header gas cost should not be derived from `max(execution_gas, state_gas)`

Take `test_create_selfdestruct_code_deposit_no_refund_header_check` as an example. This test verifies that code deposit costs are not refunded (state gas cost dimension). Currently, using `max(state_gas, execution_gas)` works fine because state gas always dominates in Amsterdam.

However, consider future upgrades where: (1) execution gas costs for certain operations increase significantly, or (2) state gas costs drop substantially. If `execution_gas` ever exceeds `state_gas`, the test would still pass -> but it would no longer validate the state gas for "no refund" scenario. The test would be measuring a different code path without catching the regression.

In other words: the test's intention (validating no-refund behavior) now depends on which gas component is larger. Using max() masks this dependency and creates a brittle test that silently fails to catch the intended behavior change.


There are several instances in the test suite, this PR adds stricter verification to tighten it.

### Scope
This PR refactors the following files, remaining refactor would be created in separate PRs.
- [x] tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
- [x] tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
- [x] tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
- [x] tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
- [x] tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
