### PR TITLE
feat(ci): auto-publish mainnet fixture patch releases from the nightly fill

### DIFF
--- a/.github/configs/mainnet_fixture_version.yaml
+++ b/.github/configs/mainnet_fixture_version.yaml
@@ -1,0 +1,20 @@
+# Mainnet fixture release series (`tests@vX.Y.Z`) selected by
+# maintainers.
+#
+# - `fork` (X): the released mainnet fork line. A new-mainnet-fork PR
+#   increments it and resets `consensus_revision` to zero.
+# - `consensus_revision` (Y): the acknowledged consensus revision of
+#   the released fork. A consensus-changing PR for the released fork
+#   increments it.
+#
+# This file records semantic release intent, the fixture index records
+# artifact content. While this series matches the newest published
+# release, the first eligible nightly at least 14 days after that
+# release publishes accumulated fixture-content changes as the next
+# patch (Z). Moving the series here never authorizes the nightly to
+# create a major or minor release: it pauses the automation until the
+# matching `vX.Y.0` release is dispatched manually. A cached dispatch
+# is valid only when that nightly was built after this series change;
+# otherwise dispatch a fresh fill.
+fork: 20
+consensus_revision: 0

--- a/.github/configs/mainnet_release_notes.md
+++ b/.github/configs/mainnet_release_notes.md
@@ -1,0 +1,11 @@
+### `tests@{version}`
+
+Scheduled mainnet fixture release: a single `fixtures.tar.gz` with all tests for all forks up to the latest mainnet fork. It supersedes [`{previous_tag}`]({previous_tag_url}).
+
+### New tests
+{test_prs}
+
+Fixture diff since [`{previous_tag}`]({previous_tag_url}): {diff_counts}.
+Fixture index root: `{root_hash}`
+
+**Full Changelog**: {compare_url}

--- a/.github/scripts/publish_mainnet_release.py
+++ b/.github/scripts/publish_mainnet_release.py
@@ -1,0 +1,689 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyyaml",
+# ]
+# ///
+"""
+Gate and prepare the scheduled mainnet patch release.
+
+Usage: `publish_mainnet_release.py` (all inputs come from the
+environment).
+
+Maintainers explicitly select the mainnet `X.Y` release series in
+`.github/configs/mainnet_fixture_version.yaml`. Major and
+consensus-minor releases are manual. When the latest published release
+already matches that series, the first eligible nightly at least 14
+days after it automatically publishes accumulated, validated
+fixture-content changes as the next `Z` patch.
+
+This script is that gate, run by the `publish` job at the end of the
+scheduled nightly fill in `release_fixtures.yaml`. It compares the
+newest published `tests@vX.Y.Z` against the configured series:
+
+- Configured series equals the published `X.Y`: publish `vX.Y.Z+1`
+  when at least 14 days have elapsed, the merged index root changed and
+  the content validates.
+  Additions, modifications, removals, renames, filler changes,
+  refactors and serialization changes are all ordinary patch content.
+- Configured series is `X.Y+1` or `X+1.0`: publish nothing and report
+  that the manual `vX.Y.0` release of the configured series is
+  required. Its publication starts a new 14-day patch window.
+- Any other relation between the configured and the published series
+  is a configuration error and fails.
+
+The configuration records semantic release intent, the fixture index
+records artifact content. Consensus semantics are never inferred from
+fixture differences or changed paths.
+
+Nothing is published either when
+
+- no `tests@vX.Y.Z` tag exists to bump (first releases are manual),
+- a `tests@` draft above the newest published version is awaiting
+  publish (a manual release in preparation),
+- the index root equals the newest release's recorded root (identical
+  content, nothing to ship), or
+- the content difference cannot be validated: the previous index is
+  missing, corrupt or ambiguous, an index holds duplicate fixture
+  identities, tests disappeared en masse (a partial fill), the fork
+  set changed without a configured fork transition, or the commit
+  listing for the notes was capped by the API.
+
+Fixture identity is the (json_path, id) pair. The previous index is
+read from the newest release's `fixtures_index.json.gz` asset, falling
+back to streaming the early metadata members of its `fixtures.tar.gz`,
+so releases predating these assets validate fine.
+
+The `A-tests` label never gates, it only selects which PRs the notes
+list. PRs without the label are left out.
+
+Read `GITHUB_REPOSITORY`, `ROOT_HASH` (the merged index root of this
+run's fill), `TARGET_SHA` (the commit it built) and `INDEX_DIR` (the
+directory holding this run's `fixtures_index.json.gz`) from the
+environment and query the GitHub API via the `gh` CLI (authenticated
+by `GH_TOKEN`). `MAINNET_VERSION_CONFIG` overrides the series
+configuration path (used by the tests). Print `dispatch=true|false`
+and `version` as `key=value` lines for `$GITHUB_OUTPUT`, write
+`release_notes.md` to the working directory when dispatching and
+append the decision to the `$GITHUB_STEP_SUMMARY` file.
+"""
+
+import gzip
+import json
+import os
+import re
+import subprocess
+import sys
+import tarfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import yaml
+
+TAG_PREFIX = "tests@"
+TESTS_LABEL = "A-tests"
+
+# Every release the workflow creates carries the merged index root and
+# the gzipped index itself as assets, read back by the next gate run.
+ROOT_ASSET = "index_root.txt"
+INDEX_ASSET = "fixtures_index.json.gz"
+TARBALL_ASSET = "fixtures.tar.gz"
+# The index sits among the leading `.meta` members of the release
+# tarball (paths are sorted and `.meta` sorts before every fixture
+# directory), so streaming the front of the tarball recovers it. Other
+# metadata files (e.g. `fixtures.ini`) may precede it.
+INDEX_TAR_MEMBER = "fixtures/.meta/index.json"
+INDEX_TAR_PREFIX = "fixtures/.meta/"
+INDEX_SCAN_LIMIT = 16
+PATCH_INTERVAL = timedelta(days=14)
+
+SERIES_CONFIG = Path(
+    os.environ.get("MAINNET_VERSION_CONFIG")
+    or Path(__file__).parents[1] / "configs" / "mainnet_fixture_version.yaml"
+)
+NOTES_TEMPLATE = (
+    Path(__file__).parents[1] / "configs" / "mainnet_release_notes.md"
+)
+NOTES_FILE = "release_notes.md"
+
+VERSION_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
+# The squash-merge subject ends in the PR reference, e.g. "(#3123)".
+PR_RE = re.compile(r"\(#([0-9]+)\)")
+
+
+def gh_api(
+    path: str,
+    paginate: bool = False,
+    accept: str | None = None,
+    ok_404: bool = False,
+) -> str:
+    """
+    Return the stdout of `gh api <path>`, exiting non-zero on error.
+
+    With *paginate*, follow the Link header through every page and
+    return a JSON array of per-page responses (`--slurp`). With
+    *accept*, request that media type (e.g. an asset's raw content).
+    With *ok_404*, a missing resource returns "" instead of exiting.
+    """
+    flags = ["--paginate", "--slurp"] if paginate else []
+    if accept:
+        flags += ["-H", f"Accept: {accept}"]
+    result = subprocess.run(
+        ["gh", "api", *flags, path], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        if ok_404 and "HTTP 404" in result.stderr:
+            return ""
+        print(f"Error: gh api {path} failed:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return result.stdout
+
+
+def gh_api_bytes(path: str) -> bytes:
+    """Return the raw content behind *path* (a release asset)."""
+    result = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/octet-stream", path],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: gh api {path} failed:", file=sys.stderr)
+        print(result.stderr.decode(errors="replace"), file=sys.stderr)
+        sys.exit(1)
+    return result.stdout
+
+
+def append_summary(text: str) -> None:
+    """Append *text* to the GitHub step summary, or stderr if unset."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(text + "\n")
+    else:
+        print(text, file=sys.stderr)
+
+
+def parse_version(version: str) -> tuple[int, int, int] | None:
+    """Return the (major, minor, patch) of a `vX.Y.Z` string, or None."""
+    m = VERSION_RE.match(version)
+    if not m:
+        return None
+    major, minor, patch = (int(g) for g in m.groups())
+    return major, minor, patch
+
+
+def load_series_config() -> tuple[int, int]:
+    """
+    Return the maintainer-selected (fork, consensus_revision) series.
+
+    The configuration records semantic release intent. A missing or
+    malformed file fails: the automation must never guess the intended
+    series.
+    """
+    try:
+        config = yaml.safe_load(SERIES_CONFIG.read_text())
+        fork = config["fork"]
+        revision = config["consensus_revision"]
+        if (
+            not isinstance(fork, int)
+            or isinstance(fork, bool)
+            or not isinstance(revision, int)
+            or isinstance(revision, bool)
+        ):
+            raise TypeError("series values must be integers")
+        if fork < 0 or revision < 0:
+            raise ValueError("series values must not be negative")
+        return fork, revision
+    except (OSError, KeyError, TypeError, ValueError, yaml.YAMLError) as e:
+        print(f"Error: invalid {SERIES_CONFIG.name}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def next_patch_time(release: dict) -> datetime | None:
+    """Return the earliest automatic patch time, or None when unknown."""
+    published_at = release.get("published_at")
+    if not published_at:
+        return None
+    try:
+        published = datetime.fromisoformat(
+            str(published_at).replace("Z", "+00:00")
+        )
+        if published.tzinfo is None:
+            raise ValueError("timestamp has no timezone")
+    except ValueError as e:
+        print(
+            f"Error: newest release has invalid published_at: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return published + PATCH_INTERVAL
+
+
+def current_time() -> datetime:
+    """Return now in UTC; RELEASE_NOW makes interval tests deterministic."""
+    override = os.environ.get("RELEASE_NOW")
+    if not override:
+        return datetime.now(timezone.utc)
+    try:
+        value = datetime.fromisoformat(override.replace("Z", "+00:00"))
+        if value.tzinfo is None:
+            raise ValueError("timestamp has no timezone")
+        return value
+    except ValueError as e:
+        print(f"Error: invalid RELEASE_NOW: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def series_transition(
+    configured: tuple[int, int], published: tuple[int, int]
+) -> str:
+    """
+    Return the state of the configured series against the published one.
+
+    "current" allows patch automation, "consensus" and "fork" await the
+    manual `vX.Y.0` release of the configured series. Every other
+    relation is a configuration error and fails safely: the automation
+    must never guess an intended series.
+    """
+    x, y = published
+    if configured == (x, y):
+        return "current"
+    if configured == (x, y + 1):
+        return "consensus"
+    if configured == (x + 1, 0):
+        return "fork"
+    fork, revision = configured
+    if configured < (x, y):
+        reason = "is behind the published series"
+    elif fork == x:
+        reason = "skips consensus revisions"
+    elif fork == x + 1:
+        reason = "advances the fork without resetting consensus_revision"
+    else:
+        reason = "is an invalid fork transition"
+    print(
+        f"Error: the configured series {fork}.{revision} {reason} "
+        f"(published: {x}.{y})",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def newest_tests_tag(repository: str) -> str:
+    """
+    Return the newest published `tests@vX.Y.Z` tag, or "" when none.
+
+    Draft releases do not create git tags, so the tag listing holds
+    exactly the published releases. The listing is paginated in
+    ref-name order, not version order, so every page must be fetched
+    before taking the maximum. Duplicated in resolve_cached_release.py
+    (each script runs standalone), keep the two in sync.
+    """
+    pages = json.loads(
+        gh_api(
+            f"repos/{repository}/git/matching-refs/tags/{TAG_PREFIX}",
+            paginate=True,
+        )
+    )
+    refs = [ref for page in pages for ref in page]
+    tags = [ref["ref"].removeprefix("refs/tags/") for ref in refs]
+    versioned = [
+        (version, tag)
+        for tag in tags
+        if (version := parse_version(tag.removeprefix(TAG_PREFIX)))
+    ]
+    if not versioned:
+        return ""
+    return max(versioned)[1]
+
+
+def published_release(repository: str, tag: str) -> dict:
+    """
+    Return the published release tagged *tag*, or {} when deleted.
+
+    Drafts hold no tag, so the endpoint resolves published releases
+    only. A tag whose release object was deleted resolves to {}: its
+    fingerprints are unrecoverable, so nothing can be validated against
+    it and the automation skips.
+    """
+    raw = gh_api(f"repos/{repository}/releases/tags/{tag}", ok_404=True)
+    return json.loads(raw) if raw else {}
+
+
+def pending_draft(repository: str, newest: tuple[int, int, int]) -> str | None:
+    """
+    Return the tag of a `tests@` draft newer than *newest*, or None.
+
+    A pending draft above the newest published version is a manual
+    release in preparation, so the automation pauses. Older drafts
+    (such as throwaway versions from cached-release test dispatches)
+    do not count. The listing is paginated so a draft cannot hide
+    behind a long release history.
+    """
+    pages = json.loads(
+        gh_api(f"repos/{repository}/releases?per_page=100", paginate=True)
+    )
+    releases = [release for page in pages for release in page]
+    for release in releases:
+        tag = str(release["tag_name"])
+        if not release["draft"] or not tag.startswith(TAG_PREFIX):
+            continue
+        version = parse_version(tag.removeprefix(TAG_PREFIX))
+        if version and version > newest:
+            return tag
+    return None
+
+
+def release_asset_id(release: dict, name: str) -> int | None:
+    """Return the id of the asset called *name*, or None when absent."""
+    for asset in release.get("assets") or []:
+        if asset["name"] == name:
+            return int(asset["id"])
+    return None
+
+
+def release_root(repository: str, release: dict) -> str | None:
+    """
+    Return the index root recorded on *release*, or None when absent.
+
+    Releases predating the root recording carry no `index_root.txt`
+    asset and compare as unknown.
+    """
+    asset_id = release_asset_id(release, ROOT_ASSET)
+    if asset_id is None:
+        return None
+    content = gh_api(
+        f"repos/{repository}/releases/assets/{asset_id}",
+        accept="application/octet-stream",
+    )
+    return content.strip() or None
+
+
+def index_from_tarball(repository: str, asset_id: int) -> dict | None:
+    """
+    Return the fixture index inside a release tarball, or None.
+
+    Stream the tarball asset and scan its leading metadata members for
+    the index (other `.meta` files such as `fixtures.ini` may precede
+    it). Stop without downloading the archive as soon as a fixture
+    member appears or the scan limit is hit.
+    """
+    process = subprocess.Popen(
+        [
+            "gh",
+            "api",
+            "-H",
+            "Accept: application/octet-stream",
+            f"repos/{repository}/releases/assets/{asset_id}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        assert process.stdout is not None
+        with tarfile.open(fileobj=process.stdout, mode="r|gz") as tar:
+            for scanned, member in enumerate(tar):
+                if member.name == INDEX_TAR_MEMBER:
+                    extracted = tar.extractfile(member)
+                    if extracted is None:
+                        return None
+                    return json.load(extracted)
+                if (
+                    scanned + 1 >= INDEX_SCAN_LIMIT
+                    or not member.name.startswith(INDEX_TAR_PREFIX)
+                ):
+                    return None
+        return None
+    except (tarfile.TarError, json.JSONDecodeError, OSError):
+        return None
+    finally:
+        process.kill()
+        process.wait()
+
+
+def previous_index(repository: str, release: dict) -> dict | None:
+    """
+    Return the fixture index recorded on *release*, or None.
+
+    Prefer the dedicated index asset, falling back to the tarball on a
+    corrupt one. Releases predating the asset still carry the index
+    inside their tarball, so every release since the scheme began can
+    be validated against.
+    """
+    asset_id = release_asset_id(release, INDEX_ASSET)
+    if asset_id is not None:
+        raw = gh_api_bytes(f"repos/{repository}/releases/assets/{asset_id}")
+        try:
+            return json.loads(gzip.decompress(raw))
+        except (gzip.BadGzipFile, json.JSONDecodeError, EOFError):
+            pass
+    asset_id = release_asset_id(release, TARBALL_ASSET)
+    if asset_id is None:
+        return None
+    return index_from_tarball(repository, asset_id)
+
+
+def index_cases(index: dict) -> dict[tuple[str, str], str] | None:
+    """
+    Return the fixture identity to hash mapping of an index, or None.
+
+    Fixture identity is the (json_path, id) pair. A duplicate identity
+    makes the index ambiguous, so None is returned instead of silently
+    overwriting an entry.
+    """
+    cases: dict[tuple[str, str], str] = {}
+    for case in index["test_cases"]:
+        identity = (case["json_path"], case["id"])
+        if identity in cases:
+            return None
+        cases[identity] = case["fixture_hash"]
+    return cases
+
+
+def merged_test_prs(
+    repository: str, prev_tag: str, target_sha: str
+) -> tuple[list[str], bool]:
+    """
+    Return the merged `A-tests` PR subjects in the range and whether
+    the listing was complete.
+
+    Walk the commits between *prev_tag* and *target_sha* (the exact
+    content difference of the release), take each squash subject's PR
+    reference, and keep the PRs that carry the tests label. The compare
+    listing is paginated but the API caps very long ranges: a capped
+    listing is reported so nothing ships with silently incomplete
+    notes. A reference that is not a PR of this repo (a hand-written
+    subject) is skipped.
+    """
+    pages = json.loads(
+        gh_api(
+            f"repos/{repository}/compare/{prev_tag}...{target_sha}",
+            paginate=True,
+        )
+    )
+    commits = [commit for page in pages for commit in page["commits"]]
+    total = pages[0]["total_commits"] if pages else 0
+    complete = len(commits) == total
+
+    subjects: dict[int, str] = {}
+    for commit in commits:
+        subject = (commit["commit"]["message"].splitlines() or [""])[0]
+        numbers = PR_RE.findall(subject)
+        if numbers:
+            subjects.setdefault(int(numbers[-1]), subject)
+
+    matching = []
+    for number, subject in subjects.items():
+        raw = gh_api(f"repos/{repository}/pulls/{number}", ok_404=True)
+        if not raw:
+            continue
+        labels = [label["name"] for label in json.loads(raw)["labels"]]
+        if TESTS_LABEL in labels:
+            matching.append(subject)
+    return matching, complete
+
+
+def render_notes(
+    repository: str,
+    version: str,
+    prev_tag: str,
+    test_prs: str,
+    diff_counts: str,
+    root: str,
+) -> None:
+    """Render the repo notes template into `release_notes.md`."""
+    releases_url = f"https://github.com/{repository}/releases/tag"
+    compare_url = (
+        f"https://github.com/{repository}/compare/"
+        f"{prev_tag}...{TAG_PREFIX}{version}"
+    )
+    notes = NOTES_TEMPLATE.read_text().format(
+        version=version,
+        previous_tag=prev_tag,
+        previous_tag_url=f"{releases_url}/{prev_tag.replace('@', '%40')}",
+        test_prs=test_prs,
+        diff_counts=diff_counts,
+        root_hash=root,
+        compare_url=compare_url,
+    )
+    Path(NOTES_FILE).write_text(notes)
+
+
+def skip(reason: str) -> None:
+    """Print the no-release decision and its *reason*."""
+    print("dispatch=false")
+    append_summary(reason)
+
+
+def main() -> None:
+    """Print the release decision and write the notes and summary."""
+    repository = os.environ["GITHUB_REPOSITORY"]
+    root = os.environ["ROOT_HASH"]
+    target_sha = os.environ["TARGET_SHA"]
+    index_dir = Path(os.environ["INDEX_DIR"])
+    if not root:
+        print(
+            "Error: ROOT_HASH is empty, no index was merged",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    configured = load_series_config()
+    prev_tag = newest_tests_tag(repository)
+    if not prev_tag:
+        skip(
+            f"No published `{TAG_PREFIX}vX.Y.Z` release exists. Cut the "
+            "first mainnet release manually."
+        )
+        return
+    x, y, z = parse_version(  # type: ignore[misc]
+        prev_tag.removeprefix(TAG_PREFIX)
+    )
+
+    # The configured series is authoritative: maintainers select X.Y,
+    # the nightly only ever selects Z.
+    state = series_transition(configured, (x, y))
+    if state != "current":
+        kind = "consensus revision" if state == "consensus" else "fork"
+        manual = f"v{configured[0]}.{configured[1]}.0"
+        skip(
+            f"The configured series acknowledges a new {kind}: the "
+            f"manual `{TAG_PREFIX}{manual}` release is required (the "
+            "`cached` dispatch may reuse a nightly built after the series "
+            "change; otherwise dispatch a fresh fill). "
+            "Its publication starts a new 14-day automatic-patch "
+            "window."
+        )
+        return
+    version = f"v{x}.{y}.{z + 1}"
+
+    draft_tag = pending_draft(repository, (x, y, z))
+    if draft_tag:
+        skip(
+            f"Draft `{draft_tag}` is awaiting publish. Leaving the "
+            "release to its author."
+        )
+        return
+
+    release = published_release(repository, prev_tag)
+    prev_root = release_root(repository, release)
+    if prev_root == root:
+        skip(
+            f"The index root is unchanged since `{prev_tag}`. "
+            "Nothing to release."
+        )
+        return
+
+    due = next_patch_time(release)
+    if due is not None and current_time() < due:
+        skip(
+            "Automatic patches are published at most once every 14 days. "
+            f"The next patch window opens at `{due.isoformat()}`; changes "
+            "remain in the nightly artifact until then."
+        )
+        return
+
+    current_index = json.loads(
+        gzip.decompress((index_dir / INDEX_ASSET).read_bytes())
+    )
+    current_cases = index_cases(current_index)
+    if current_cases is None:
+        print(
+            "Error: this run's index holds duplicate fixture identities",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    prev_index = previous_index(repository, release)
+    if prev_index is not None and prev_index.get("root_hash") == root:
+        # A release without the root asset still records its root
+        # inside the index, so the equality gate works there too.
+        skip(
+            f"The index root is unchanged since `{prev_tag}`. "
+            "Nothing to release."
+        )
+        return
+    if prev_index is None:
+        skip(
+            f"The index of `{prev_tag}` could not be recovered, so the "
+            "content difference cannot be validated. Cut a manual "
+            "release to restore the baseline."
+        )
+        return
+    prev_cases = index_cases(prev_index)
+    if prev_cases is None:
+        skip(
+            f"The index of `{prev_tag}` holds duplicate fixture "
+            "identities, so the content difference cannot be validated. "
+            "Cut a manual release to restore the baseline."
+        )
+        return
+
+    # Validate the content difference. The counts never select the
+    # version, they only guard against shipping a broken artifact and
+    # inform the notes.
+    added = [t for t in current_cases if t not in prev_cases]
+    removed = [t for t in prev_cases if t not in current_cases]
+    changed = [
+        t
+        for t, fixture_hash in current_cases.items()
+        if t in prev_cases and prev_cases[t] != fixture_hash
+    ]
+    counts = (
+        f"{len(added)} added, {len(removed)} removed, {len(changed)} changed"
+    )
+    # Deliberate removals are far smaller than a fork range: a mass
+    # disappearance means a partial fill or a collection regression.
+    if len(removed) > max(1000, len(prev_cases) // 20):
+        skip(
+            f"{len(removed)} tests vanished since `{prev_tag}`, which "
+            "looks like a partial fill rather than a deliberate "
+            "removal. Not releasing."
+        )
+        return
+    prev_forks = set(prev_index.get("forks") or [])
+    current_forks = set(current_index.get("forks") or [])
+    if prev_forks and prev_forks != current_forks:
+        skip(
+            "The fork set of the fixture index changed "
+            f"({sorted(prev_forks ^ current_forks)}) within the "
+            "configured series. A new mainnet fork needs the configured "
+            "fork bumped, any other fill-range change needs a manual "
+            "release to accept the new fork set."
+        )
+        return
+
+    pr_subjects, complete = merged_test_prs(repository, prev_tag, target_sha)
+    if not complete:
+        skip(
+            f"The commit listing for `{prev_tag}...{target_sha}` was "
+            "capped by the API, so the notes cannot be completed. Cut "
+            "a manual release."
+        )
+        return
+    test_prs = (
+        "\n".join(f"- {subject}" for subject in pr_subjects)
+        if pr_subjects
+        else "None."
+    )
+
+    render_notes(repository, version, prev_tag, test_prs, counts, root)
+
+    print("dispatch=true")
+    print(f"version={version}")
+    detail = (
+        "Merged `A-tests` PRs:\n"
+        + "\n".join(f"- {subject}" for subject in pr_subjects)
+        if pr_subjects
+        else "No merged `A-tests` PRs in the range."
+    )
+    append_summary(
+        f"Publishing `{TAG_PREFIX}{version}` (supersedes `{prev_tag}`). "
+        f"{counts} tests.\n{detail}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_release_scripts.py
+++ b/.github/scripts/tests/test_release_scripts.py
@@ -5,6 +5,9 @@ Each test invokes the script via `uv run` to validate the actual CLI
 interface, matching how GitHub Actions calls them.
 """
 
+import base64
+import gzip
+import io
 import json
 import os
 import subprocess
@@ -20,6 +23,8 @@ TARBALL_SCRIPT = SCRIPTS_DIR / "create_release_tarball.py"
 MERGE_INDEX_SCRIPT = SCRIPTS_DIR / "merge_index_files.py"
 CHECK_COMMITS_SCRIPT = SCRIPTS_DIR / "check_new_commits.py"
 RESOLVE_CACHED_SCRIPT = SCRIPTS_DIR / "resolve_cached_release.py"
+PUBLISH_MAINNET_SCRIPT = SCRIPTS_DIR / "publish_mainnet_release.py"
+VALIDATE_MAINNET_SCRIPT = SCRIPTS_DIR / "validate_mainnet_release.py"
 
 
 def run_script(script: Path, *args: str) -> subprocess.CompletedProcess:
@@ -190,9 +195,9 @@ class TestValidateInputs:
         assert result.returncode == 0
 
 
-# Fake `gh` served from PATH: answers the API calls the commit-check
-# and cached-release scripts make with canned JSON from env vars, and
-# fails loudly on any other (or unconfigured) call. The API path is
+# Fake `gh` served from PATH: answers the API calls the commit-check,
+# cached-release and draft-gate scripts make with canned JSON from env
+# vars, and fails loudly on any other (or unconfigured) call. The API path is
 # the last argument (flags such as `--paginate --slurp` may precede
 # it). Per-run artifact responses come from
 # `FAKE_GH_ARTIFACTS_<run_id>`, falling back to `FAKE_GH_ARTIFACTS`.
@@ -207,10 +212,34 @@ case "$path" in
     response="${!var:-$FAKE_GH_ARTIFACTS}"
     ;;
   *matching-refs*) response="$FAKE_GH_TAGS" ;;
+  *contents/.github/configs/mainnet_fixture_version.yaml*)
+    response="$FAKE_GH_SERIES_CONFIG"
+    ;;
+  *releases/assets/*)
+    asset="${path##*/assets/}"
+    file_var="FAKE_GH_ASSET_FILE_${asset}"
+    if [ -n "${!file_var:-}" ]; then
+      cat "${!file_var}"
+      exit 0
+    fi
+    var="FAKE_GH_ASSET_${asset}"
+    response="${!var}"
+    ;;
+  *releases/tags/*) response="$FAKE_GH_RELEASE_TAG" ;;
+  *"releases?"*) response="$FAKE_GH_RELEASES" ;;
+  *pulls/*)
+    pr="${path##*/pulls/}"
+    var="FAKE_GH_PR_${pr}"
+    response="${!var:-$FAKE_GH_PR}"
+    ;;
   *compare/tests@*) response="$FAKE_GH_COMPARE_TAG" ;;
   *compare*) response="$FAKE_GH_COMPARE" ;;
   *) response="" ;;
 esac
+if [ "$response" = "__404__" ]; then
+  echo "gh: Not Found (HTTP 404)" >&2
+  exit 1
+fi
 if [ -z "$response" ]; then
   echo "unexpected gh call: $*" >&2
   exit 1
@@ -872,3 +901,834 @@ class TestMergeIndexFiles:
         result = _run_merge_script()
         assert result.returncode == 1
         assert "Usage" in result.stderr
+
+
+FRESH_ROOT = "0x" + "11" * 32
+OLD_ROOT = "0x" + "22" * 32
+
+TEST_A = "tests/berlin/test_foo.py::test_a[fork_Berlin-blockchain_test]"
+TEST_B = "tests/osaka/test_bar.py::test_b[fork_Osaka-state_test]"
+HASH_A = "0x" + "aa" * 32
+HASH_B = "0x" + "bb" * 32
+HASH_C = "0x" + "cc" * 32
+
+
+def release_json(
+    release_id: int,
+    tag: str,
+    draft: bool = True,
+    asset_ids: dict[str, int] | None = None,
+    published_at: str = "2026-07-01T00:00:00Z",
+) -> dict:
+    """Return a canned release object with named assets."""
+    return {
+        "id": release_id,
+        "tag_name": tag,
+        "draft": draft,
+        "published_at": published_at,
+        "assets": [
+            {"id": asset_id, "name": name}
+            for name, asset_id in (asset_ids or {}).items()
+        ],
+    }
+
+
+def index_json(
+    cases: dict[str, str] | None = None,
+    forks: list[str] | None = None,
+    root: str = FRESH_ROOT,
+    raw_cases: list[dict] | None = None,
+) -> dict:
+    """
+    Return a canned fixture index.
+
+    *cases* maps test ids to fixture hashes with a json_path derived
+    from the id; *raw_cases* supplies full test-case entries when the
+    (json_path, id) identity itself is under test.
+    """
+    test_cases = raw_cases or [
+        {
+            "id": case_id,
+            "fixture_hash": fixture_hash,
+            "fork": "",
+            "format": "",
+            "json_path": case_id.split("::")[0] + ".json",
+        }
+        for case_id, fixture_hash in (cases or {}).items()
+    ]
+    return {
+        "root_hash": root,
+        "created_at": "2026-01-01T00:00:00Z",
+        "test_count": len(test_cases),
+        "forks": forks or [],
+        "fixture_formats": [],
+        "test_cases": test_cases,
+    }
+
+
+def gz_index(path: Path, index: dict) -> Path:
+    """Write a gzipped index asset file."""
+    path.write_bytes(gzip.compress(json.dumps(index).encode()))
+    return path
+
+
+def tarball_with_index(
+    path: Path,
+    index: dict,
+    leading_member: str | None = None,
+    trailing_member: bool = False,
+) -> Path:
+    """
+    Write a small release-shaped tarball carrying the index.
+
+    *leading_member* names a file placed before the index (a non-meta
+    path there stops the recovery scan before the index is reached);
+    *trailing_member* appends a fixture file after it.
+    """
+    with tarfile.open(path, "w:gz") as tar:
+
+        def add(name: str, payload: bytes) -> None:
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+
+        if leading_member:
+            add(leading_member, b"{}")
+        add("fixtures/.meta/index.json", json.dumps(index).encode())
+        if trailing_member:
+            add("fixtures/state_tests/a.json", b"{}")
+    return path
+
+
+def series_config(path: Path, fork: int, revision: int) -> Path:
+    """Write a canned mainnet series configuration file."""
+    path.write_text(f"fork: {fork}\nconsensus_revision: {revision}\n")
+    return path
+
+
+class TestPublishMainnetRelease:
+    """Test publish_mainnet_release.py."""
+
+    # Serves the notes walk: one squash commit with a tests-labeled
+    # PR, one without, and a direct push carrying no PR reference,
+    # spread over two pages to pin the pagination flattening.
+    COMMITS = [
+        {
+            "sha": "1" * 40,
+            "commit": {"message": "feat(tests): add foo tests (#101)\n\nbody"},
+        },
+        {
+            "sha": "2" * 40,
+            "commit": {"message": "chore(docs): tweak page (#102)"},
+        },
+        {
+            "sha": "3" * 40,
+            "commit": {"message": "Direct push without a PR"},
+        },
+    ]
+    TAG_COMPARE_WITH_PRS = json.dumps(
+        [
+            {"total_commits": 3, "commits": COMMITS[:2]},
+            {"total_commits": 3, "commits": COMMITS[2:]},
+        ]
+    )
+    LABELS = {101: ["C-feat", "A-tests"], 102: ["A-doc"]}
+    ROOT_AND_INDEX = {"index_root.txt": 501, "fixtures_index.json.gz": 502}
+
+    def published(
+        self,
+        assets: dict[str, int] | None = None,
+        published_at: str = "2026-07-01T00:00:00Z",
+    ) -> str:
+        """Return the canned newest published release (tests@v4.0.0)."""
+        return json.dumps(
+            release_json(
+                12,
+                "tests@v4.0.0",
+                draft=False,
+                asset_ids=(self.ROOT_AND_INDEX if assets is None else assets),
+                published_at=published_at,
+            )
+        )
+
+    def run_gate(
+        self,
+        tmp_path: Path,
+        tags: str = "",
+        releases: str = "",
+        release_tag: str = "",
+        text_assets: dict[int, str] | None = None,
+        prev_index: dict | None = None,
+        asset_files: dict[int, Path] | None = None,
+        current_index: dict | None = None,
+        root_hash: str = FRESH_ROOT,
+        tag_compare: str = "",
+        pr_labels: dict[int, list[str] | None] | None = None,
+        config_fork: int = 4,
+        config_revision: int = 0,
+        config_text: str | None = None,
+    ) -> tuple[subprocess.CompletedProcess, Path]:
+        """
+        Run the script with a fake `gh` on PATH; return it + summary.
+
+        The published release canned via *release_tag* serves text
+        assets from *text_assets* (the root as id 501 by convention),
+        *prev_index* as the gzipped index asset id 502, and arbitrary
+        binary asset files from *asset_files*. A `pr_labels` value of
+        None serves a 404 for that PR number. The series configuration
+        is injected via `MAINNET_VERSION_CONFIG` from *config_fork*
+        and *config_revision*, or verbatim from *config_text*.
+        """
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(FAKE_GH)
+        fake_gh.chmod(0o755)
+
+        index_dir = tmp_path / "index"
+        index_dir.mkdir(exist_ok=True)
+        current = (
+            current_index
+            if current_index is not None
+            else index_json({}, root=root_hash)
+        )
+        gz_index(index_dir / "fixtures_index.json.gz", current)
+
+        config = tmp_path / "mainnet_fixture_version.yaml"
+        if config_text is None:
+            series_config(config, config_fork, config_revision)
+        else:
+            config.write_text(config_text)
+
+        summary = tmp_path / "summary.md"
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["GITHUB_REPOSITORY"] = "ethereum/execution-specs"
+        env["ROOT_HASH"] = root_hash
+        env["RELEASE_NOW"] = "2026-08-22T00:00:00Z"
+        env["TARGET_SHA"] = "b" * 40
+        env["INDEX_DIR"] = str(index_dir)
+        env["MAINNET_VERSION_CONFIG"] = str(config)
+        env["GITHUB_STEP_SUMMARY"] = str(summary)
+        env["FAKE_GH_TAGS"] = tags
+        env["FAKE_GH_RELEASES"] = releases
+        env["FAKE_GH_RELEASE_TAG"] = release_tag
+        env["FAKE_GH_COMPARE_TAG"] = tag_compare
+        for asset_id, content in (text_assets or {}).items():
+            env[f"FAKE_GH_ASSET_{asset_id}"] = content
+        if prev_index is not None:
+            env["FAKE_GH_ASSET_FILE_502"] = str(
+                gz_index(tmp_path / "prev_index.json.gz", prev_index)
+            )
+        for asset_id, path in (asset_files or {}).items():
+            env[f"FAKE_GH_ASSET_FILE_{asset_id}"] = str(path)
+        for number, labels in (pr_labels or {}).items():
+            if labels is None:
+                env[f"FAKE_GH_PR_{number}"] = "__404__"
+            else:
+                env[f"FAKE_GH_PR_{number}"] = json.dumps(
+                    {"labels": [{"name": name} for name in labels]}
+                )
+
+        result = subprocess.run(
+            ["uv", "run", "-q", str(PUBLISH_MAINNET_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+        )
+        return result, summary
+
+    def publish_setup(self, current_cases: dict[str, str]) -> dict:
+        """Return run_gate kwargs for a valid same-series content diff."""
+        return {
+            "tags": TESTS_TAGS,
+            "releases": "[[]]",
+            "release_tag": self.published(),
+            "text_assets": {501: OLD_ROOT + "\n"},
+            "prev_index": index_json({TEST_A: HASH_A}, root=OLD_ROOT),
+            "current_index": index_json(current_cases, root=FRESH_ROOT),
+            "tag_compare": self.TAG_COMPARE_WITH_PRS,
+            "pr_labels": self.LABELS,
+        }
+
+    def test_matching_series_unchanged_root_skips(self, tmp_path):
+        """Verify an unchanged root releases nothing."""
+        # No index, compare or PR responses are canned, so a zero exit
+        # proves neither was consulted.
+        result, summary = self.run_gate(
+            tmp_path,
+            tags=TESTS_TAGS,
+            releases="[[]]",
+            release_tag=self.published({"index_root.txt": 501}),
+            text_assets={501: FRESH_ROOT},
+        )
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        assert out["dispatch"] == "false"
+        assert "version" not in out
+        assert not (tmp_path / "release_notes.md").exists()
+        assert "unchanged" in summary.read_text()
+
+    def test_patch_waits_for_fortnightly_window(self, tmp_path):
+        """Verify changed content does not publish within 14 days."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["release_tag"] = self.published(
+            published_at="2026-08-10T00:00:01Z"
+        )
+        # The interval gate stops before the notes walk.
+        setup["tag_compare"] = ""
+        setup["pr_labels"] = {}
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "once every 14 days" in summary.read_text()
+
+    def test_patch_publishes_at_fortnightly_boundary(self, tmp_path):
+        """Verify the 14-day boundary itself is eligible."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["release_tag"] = self.published(
+            published_at="2026-08-08T00:00:00Z"
+        )
+        result, _ = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "true"
+
+    def test_added_fixtures_publish(self, tmp_path):
+        """Verify a pure test addition publishes the next patch."""
+        result, summary = self.run_gate(
+            tmp_path,
+            **self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B}),
+        )
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        # The scheduled gate has exactly two outputs and no draft
+        # concept: publishing a validated patch is its only action.
+        assert set(out) == {"dispatch", "version"}
+        assert out["dispatch"] == "true"
+        assert out["version"] == "v4.0.1"
+        notes = (tmp_path / "release_notes.md").read_text()
+        assert "tests@v4.0.1" in notes
+        assert "feat(tests): add foo tests (#101)" in notes
+        assert "#102" not in notes
+        assert "1 added, 0 removed, 0 changed" in notes
+        assert FRESH_ROOT in notes
+        assert "compare/tests@v4.0.0...tests@v4.0.1" in notes
+        assert "1 added, 0 removed, 0 changed" in summary.read_text()
+
+    def test_modified_fixtures_publish(self, tmp_path):
+        """Verify modified fixtures are ordinary patch content."""
+        # Filler, refactor and serialization changes look exactly like
+        # this: same identities, new hashes. The configured series is
+        # authoritative, so no consensus semantics are inferred.
+        result, summary = self.run_gate(
+            tmp_path, **self.publish_setup({TEST_A: HASH_C})
+        )
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        assert out["dispatch"] == "true"
+        assert out["version"] == "v4.0.1"
+        assert "0 added, 0 removed, 1 changed" in summary.read_text()
+
+    def test_removed_fixtures_publish(self, tmp_path):
+        """Verify a modest test removal publishes the next patch."""
+        setup = self.publish_setup({TEST_A: HASH_A})
+        setup["prev_index"] = index_json(
+            {TEST_A: HASH_A, TEST_B: HASH_B}, root=OLD_ROOT
+        )
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "true"
+        assert "1 removed" in summary.read_text()
+
+    def test_renamed_fixtures_publish_as_composite_identity(self, tmp_path):
+        """Verify identity is (json_path, id): a rename adds and removes."""
+        prev_case = {
+            "id": TEST_A,
+            "fixture_hash": HASH_A,
+            "fork": "",
+            "format": "",
+            "json_path": "old/a.json",
+        }
+        setup = self.publish_setup({})
+        setup["prev_index"] = index_json(raw_cases=[prev_case], root=OLD_ROOT)
+        setup["current_index"] = index_json(
+            raw_cases=[{**prev_case, "json_path": "new/a.json"}],
+            root=FRESH_ROOT,
+        )
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "true"
+        assert "1 added, 1 removed, 0 changed" in summary.read_text()
+
+    def test_consensus_revision_bump_blocks_patches(self, tmp_path):
+        """
+        Verify an acknowledged consensus revision awaits the manual
+        release.
+        """
+        # Only the tag listing is canned: the gate must decide from the
+        # configuration alone, before any root or index fetch, so this
+        # also proves a changed root cannot slip a patch through.
+        result, summary = self.run_gate(
+            tmp_path, tags=TESTS_TAGS, config_revision=1
+        )
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        assert out["dispatch"] == "false"
+        assert "version" not in out
+        text = summary.read_text()
+        assert "tests@v4.1.0" in text
+        assert "14-day automatic-patch window" in text
+
+    def test_fork_bump_blocks_patches(self, tmp_path):
+        """Verify an acknowledged new fork awaits the manual release."""
+        result, summary = self.run_gate(
+            tmp_path, tags=TESTS_TAGS, config_fork=5
+        )
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "tests@v5.0.0" in summary.read_text()
+
+    def test_published_manual_release_resumes_patch_series(self, tmp_path):
+        """Verify patches resume after the new series and time window."""
+        tags = json.dumps(
+            [
+                [{"ref": "refs/tags/tests@v4.0.0"}],
+                [{"ref": "refs/tags/tests@v4.1.0"}],
+            ]
+        )
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["tags"] = tags
+        result, _ = self.run_gate(tmp_path, config_revision=1, **setup)
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        assert out["dispatch"] == "true"
+        assert out["version"] == "v4.1.1"
+
+    def test_configured_series_behind_fails(self, tmp_path):
+        """Verify a configuration behind the published series fails."""
+        result, _ = self.run_gate(tmp_path, tags=TESTS_TAGS, config_fork=3)
+        assert result.returncode == 1
+        assert "behind" in result.stderr
+
+    def test_skipped_consensus_revision_fails(self, tmp_path):
+        """Verify a consensus revision skipping a value fails."""
+        result, _ = self.run_gate(tmp_path, tags=TESTS_TAGS, config_revision=2)
+        assert result.returncode == 1
+        assert "skips" in result.stderr
+
+    def test_invalid_fork_transition_fails(self, tmp_path):
+        """Verify a fork skipping a value fails."""
+        result, _ = self.run_gate(tmp_path, tags=TESTS_TAGS, config_fork=6)
+        assert result.returncode == 1
+        assert "invalid fork transition" in result.stderr
+
+    def test_fork_bump_without_reset_fails(self, tmp_path):
+        """Verify a fork bump keeping a consensus revision fails."""
+        result, _ = self.run_gate(
+            tmp_path, tags=TESTS_TAGS, config_fork=5, config_revision=1
+        )
+        assert result.returncode == 1
+        assert "resetting" in result.stderr
+
+    def test_malformed_configuration_fails(self, tmp_path):
+        """Verify a malformed series configuration fails."""
+        result, _ = self.run_gate(
+            tmp_path, tags=TESTS_TAGS, config_text="fork: 4\n"
+        )
+        assert result.returncode == 1
+        assert "invalid mainnet_fixture_version.yaml" in result.stderr
+
+    def test_changed_fork_set_skips(self, tmp_path):
+        """Verify a changed fork set without a fork transition skips."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["prev_index"] = index_json(
+            {TEST_A: HASH_A}, forks=["Berlin"], root=OLD_ROOT
+        )
+        setup["current_index"] = index_json(
+            {TEST_A: HASH_A, TEST_B: HASH_B},
+            forks=["Berlin", "Osaka"],
+            root=FRESH_ROOT,
+        )
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "fork set" in summary.read_text()
+
+    def test_mass_removal_skips(self, tmp_path):
+        """Verify a mass test disappearance releases nothing."""
+        prev = {f"tests/t.py::t[{i}]": HASH_A for i in range(1200)}
+        setup = self.publish_setup(dict(list(prev.items())[:100]))
+        setup["prev_index"] = index_json(prev, root=OLD_ROOT)
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "vanished" in summary.read_text()
+
+    def test_duplicate_identities_in_current_index_fail(self, tmp_path):
+        """Verify a duplicate identity in this run's index fails."""
+        case = {
+            "id": TEST_A,
+            "fixture_hash": HASH_A,
+            "fork": "",
+            "format": "",
+            "json_path": "a.json",
+        }
+        setup = self.publish_setup({})
+        setup["current_index"] = index_json(
+            raw_cases=[case, dict(case)], root=FRESH_ROOT
+        )
+        result, _ = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 1
+        assert "duplicate fixture identities" in result.stderr
+
+    def test_duplicate_identities_in_prev_index_skip(self, tmp_path):
+        """Verify a duplicate identity in the previous index skips."""
+        case = {
+            "id": TEST_A,
+            "fixture_hash": HASH_A,
+            "fork": "",
+            "format": "",
+            "json_path": "a.json",
+        }
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["prev_index"] = index_json(
+            raw_cases=[case, dict(case)], root=OLD_ROOT
+        )
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "duplicate" in summary.read_text()
+
+    def test_root_equality_via_the_index_asset(self, tmp_path):
+        """Verify a release without a root asset still compares roots."""
+        result, summary = self.run_gate(
+            tmp_path,
+            tags=TESTS_TAGS,
+            releases="[[]]",
+            release_tag=self.published({"fixtures_index.json.gz": 502}),
+            prev_index=index_json({TEST_A: HASH_A}, root=FRESH_ROOT),
+            current_index=index_json({TEST_A: HASH_A}, root=FRESH_ROOT),
+        )
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "unchanged" in summary.read_text()
+
+    def test_legacy_tarball_with_leading_ini_recovers(self, tmp_path):
+        """Verify metadata files before the index do not stop recovery."""
+        tar = tarball_with_index(
+            tmp_path / "prev.tar.gz",
+            index_json({TEST_A: HASH_A}, root=OLD_ROOT),
+            leading_member="fixtures/.meta/fixtures.ini",
+            trailing_member=True,
+        )
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["release_tag"] = self.published(
+            {"index_root.txt": 501, "fixtures.tar.gz": 500}
+        )
+        setup.pop("prev_index")
+        setup["asset_files"] = {500: tar}
+        result, _ = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        assert out["dispatch"] == "true"
+        assert out["version"] == "v4.0.1"
+
+    def test_tarball_without_metadata_index_skips(self, tmp_path):
+        """Verify a tarball whose index is not in early metadata skips."""
+        tar = tarball_with_index(
+            tmp_path / "prev.tar.gz",
+            index_json({TEST_A: HASH_A}, root=OLD_ROOT),
+            leading_member="fixtures/state_tests/a.json",
+        )
+        setup = self.publish_setup({TEST_A: HASH_A})
+        setup["release_tag"] = self.published(
+            {"index_root.txt": 501, "fixtures.tar.gz": 500}
+        )
+        setup.pop("prev_index")
+        setup["asset_files"] = {500: tar}
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "could not be recovered" in summary.read_text()
+
+    def test_corrupt_index_asset_falls_back_to_the_tarball(self, tmp_path):
+        """Verify a corrupt index asset falls back to the tarball."""
+        garbage = tmp_path / "garbage.gz"
+        garbage.write_bytes(b"not gzip at all")
+        tar = tarball_with_index(
+            tmp_path / "prev.tar.gz",
+            index_json({TEST_A: HASH_A}, root=OLD_ROOT),
+        )
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["release_tag"] = self.published(
+            {
+                "index_root.txt": 501,
+                "fixtures_index.json.gz": 502,
+                "fixtures.tar.gz": 500,
+            }
+        )
+        setup.pop("prev_index")
+        setup["asset_files"] = {502: garbage, 500: tar}
+        result, _ = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "true"
+
+    def test_unrecoverable_prev_index_skips(self, tmp_path):
+        """Verify an unvalidatable content difference releases nothing."""
+        setup = self.publish_setup({TEST_A: HASH_A})
+        setup["release_tag"] = self.published({"index_root.txt": 501})
+        setup.pop("prev_index")
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "could not be recovered" in summary.read_text()
+
+    def test_deleted_release_behind_the_tag_skips(self, tmp_path):
+        """Verify a tag whose release was deleted skips, not crashes."""
+        setup = self.publish_setup({TEST_A: HASH_A})
+        setup["release_tag"] = "__404__"
+        setup.pop("prev_index")
+        setup.pop("text_assets")
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "could not be recovered" in summary.read_text()
+
+    def test_capped_compare_listing_skips(self, tmp_path):
+        """Verify an API-capped commit listing releases nothing."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["tag_compare"] = json.dumps(
+            [{"total_commits": 5, "commits": self.COMMITS}]
+        )
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "capped" in summary.read_text()
+
+    def test_pending_next_patch_draft_blocks(self, tmp_path):
+        """Verify a pending draft of the next patch version blocks."""
+        # The draft sits on the second page to pin the pagination
+        # flattening.
+        releases = json.dumps([[], [release_json(77, "tests@v4.0.1")]])
+        result, summary = self.run_gate(
+            tmp_path, tags=TESTS_TAGS, releases=releases
+        )
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "awaiting publish" in summary.read_text()
+
+    def test_higher_version_draft_blocks(self, tmp_path):
+        """Verify a pending manual release draft blocks."""
+        releases = json.dumps([[release_json(88, "tests@v4.1.0")]])
+        result, summary = self.run_gate(
+            tmp_path, tags=TESTS_TAGS, releases=releases
+        )
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "awaiting publish" in summary.read_text()
+
+    def test_older_and_published_entries_do_not_block(self, tmp_path):
+        """Verify drafts at or below the published version are ignored."""
+        releases = json.dumps(
+            [
+                [
+                    # A cached-release test dispatch's leftover draft.
+                    release_json(11, "tests@v0.0.913"),
+                    # A published release, a re-draft at the published
+                    # version and another feature's draft.
+                    release_json(12, "tests@v4.0.0", draft=False),
+                    release_json(14, "tests@v4.0.0"),
+                    release_json(13, "tests-bal@v99.0.0"),
+                ]
+            ]
+        )
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["releases"] = releases
+        result, _ = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        out = parse_matrix_output(result.stdout)
+        assert out["dispatch"] == "true"
+        assert out["version"] == "v4.0.1"
+
+    def test_numeric_version_ordering(self, tmp_path):
+        """Verify the newest tag is picked numerically, not textually."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["tags"] = json.dumps(
+            [
+                [{"ref": "refs/tags/tests@v9.0.0"}],
+                [{"ref": "refs/tags/tests@v10.0.0"}],
+            ]
+        )
+        result, _ = self.run_gate(tmp_path, config_fork=10, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["version"] == "v10.0.1"
+
+    def test_dangling_pr_reference_is_skipped(self, tmp_path):
+        """Verify a subject referencing a non-PR does not fail the gate."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["pr_labels"] = {101: None, 102: ["A-doc"]}
+        result, summary = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "true"
+        assert "No merged" in summary.read_text()
+
+    def test_no_labeled_prs_still_publishes(self, tmp_path):
+        """Verify a content change without tests labels still releases."""
+        setup = self.publish_setup({TEST_A: HASH_A, TEST_B: HASH_B})
+        setup["pr_labels"] = {101: ["C-feat"], 102: ["A-doc"]}
+        result, _ = self.run_gate(tmp_path, **setup)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "true"
+        notes = (tmp_path / "release_notes.md").read_text()
+        assert "None." in notes
+        assert "#101" not in notes
+
+    def test_no_published_tag_skips(self, tmp_path):
+        """Verify a repo without a `tests@` tag skips the release."""
+        result, summary = self.run_gate(tmp_path, tags=NO_TAGS)
+        assert result.returncode == 0, result.stderr
+        assert parse_matrix_output(result.stdout)["dispatch"] == "false"
+        assert "manually" in summary.read_text()
+
+    def test_empty_root_hash_fails(self, tmp_path):
+        """Verify a missing merged index root fails loudly."""
+        result, _ = self.run_gate(tmp_path, root_hash="")
+        assert result.returncode == 1
+        assert "ROOT_HASH" in result.stderr
+
+
+class TestValidateMainnetRelease:
+    """Test validate_mainnet_release.py."""
+
+    def run_validate(
+        self,
+        tmp_path: Path,
+        version: str,
+        tags: str = TESTS_TAGS,
+        config_fork: int = 4,
+        config_revision: int = 0,
+        cached_target_series: tuple[int, int] | None = None,
+        cached_target_missing: bool = False,
+    ) -> subprocess.CompletedProcess:
+        """Run the validator with a fake `gh` on PATH."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(FAKE_GH)
+        fake_gh.chmod(0o755)
+
+        config = series_config(
+            tmp_path / "mainnet_fixture_version.yaml",
+            config_fork,
+            config_revision,
+        )
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["GITHUB_REPOSITORY"] = "ethereum/execution-specs"
+        env["INPUT_VERSION"] = version
+        env["MAINNET_VERSION_CONFIG"] = str(config)
+        env["FAKE_GH_TAGS"] = tags
+        if cached_target_series is not None or cached_target_missing:
+            env["CACHED_TARGET_SHA"] = "c" * 40
+            if cached_target_missing:
+                env["FAKE_GH_SERIES_CONFIG"] = "__404__"
+            else:
+                assert cached_target_series is not None
+                target_text = (
+                    f"fork: {cached_target_series[0]}\n"
+                    f"consensus_revision: {cached_target_series[1]}\n"
+                )
+                env["FAKE_GH_SERIES_CONFIG"] = json.dumps(
+                    {
+                        "content": base64.b64encode(
+                            target_text.encode()
+                        ).decode()
+                    }
+                )
+        return subprocess.run(
+            ["uv", "run", "-q", str(VALIDATE_MAINNET_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+        )
+
+    def test_same_series_patch_allowed(self, tmp_path):
+        """Verify a forward patch of the published series passes."""
+        result = self.run_validate(tmp_path, "v4.0.1")
+        assert result.returncode == 0, result.stderr
+
+    def test_same_series_backward_rejected(self, tmp_path):
+        """Verify a version at or below the newest release is rejected."""
+        result = self.run_validate(tmp_path, "v4.0.0")
+        assert result.returncode == 1
+        assert "greater" in result.stderr
+
+    def test_configured_consensus_release_allowed(self, tmp_path):
+        """Verify the configured consensus release version passes."""
+        result = self.run_validate(tmp_path, "v4.1.0", config_revision=1)
+        assert result.returncode == 0, result.stderr
+
+    def test_configured_fork_release_allowed(self, tmp_path):
+        """Verify the configured new-fork release version passes."""
+        result = self.run_validate(tmp_path, "v5.0.0", config_fork=5)
+        assert result.returncode == 0, result.stderr
+
+    def test_cached_new_series_requires_matching_nightly(self, tmp_path):
+        """Verify a new-series release accepts a matching cached fill."""
+        result = self.run_validate(
+            tmp_path,
+            "v4.1.0",
+            config_revision=1,
+            cached_target_series=(4, 1),
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_cached_new_series_rejects_stale_nightly(self, tmp_path):
+        """Verify pre-consensus cached fixtures cannot start a series."""
+        result = self.run_validate(
+            tmp_path,
+            "v4.1.0",
+            config_revision=1,
+            cached_target_series=(4, 0),
+        )
+        assert result.returncode == 1
+        assert "not the required 4.1" in result.stderr
+
+    def test_cached_new_series_rejects_pre_config_nightly(self, tmp_path):
+        """Verify a nightly predating the series file cannot be reused."""
+        result = self.run_validate(
+            tmp_path,
+            "v4.1.0",
+            config_revision=1,
+            cached_target_missing=True,
+        )
+        assert result.returncode == 1
+        assert "predates mainnet_fixture_version.yaml" in result.stderr
+
+    def test_new_series_without_configuration_rejected(self, tmp_path):
+        """Verify a new series needs the configuration updated first."""
+        result = self.run_validate(tmp_path, "v4.1.0")
+        assert result.returncode == 1
+        assert "mainnet_fixture_version.yaml" in result.stderr
+
+    def test_wrong_new_series_version_rejected(self, tmp_path):
+        """Verify a new-series version must exactly match `vX.Y.0`."""
+        result = self.run_validate(tmp_path, "v4.1.1", config_revision=1)
+        assert result.returncode == 1
+        assert "exactly" in result.stderr
+        result = self.run_validate(tmp_path, "v5.0.0", config_revision=1)
+        assert result.returncode == 1
+        assert "exactly" in result.stderr
+
+    def test_invalid_configuration_rejected(self, tmp_path):
+        """Verify an invalid configured transition is rejected."""
+        result = self.run_validate(tmp_path, "v4.2.0", config_revision=2)
+        assert result.returncode == 1
+        assert "skips" in result.stderr
+
+    def test_first_release_allowed(self, tmp_path):
+        """Verify any first release passes with no published tag."""
+        result = self.run_validate(tmp_path, "v1.0.0", tags=NO_TAGS)
+        assert result.returncode == 0, result.stderr

--- a/.github/scripts/validate_mainnet_release.py
+++ b/.github/scripts/validate_mainnet_release.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyyaml",
+# ]
+# ///
+"""
+Validate a manual mainnet `tests@` release against the configured
+series.
+
+Usage: `validate_mainnet_release.py` (all inputs come from the
+environment).
+
+Maintainers explicitly select the mainnet `X.Y` release series in
+`.github/configs/mainnet_fixture_version.yaml`. Major and
+consensus-minor releases are manual, and this check keeps them in
+lockstep with that configuration when `release_fixtures.yaml` is
+dispatched for the `tests` feature:
+
+- A version inside the published series (a manual patch or re-fill)
+  must simply be greater than the newest published release.
+- A version starting a new series must be exactly the configured
+  `vX.Y.0`, and the configuration must be a valid successor of the
+  published series (checked by `series_transition`, which also rejects
+  a malformed configuration).
+- A cached new-series release must use a nightly whose target commit
+  already contains that exact configured series. This prevents a
+  consensus or fork release from attaching stale pre-change fixtures.
+- A version starting a series the configuration does not acknowledge
+  is rejected: update the configuration first.
+
+Read `GITHUB_REPOSITORY`, `INPUT_VERSION` and optional
+`CACHED_TARGET_SHA` from the environment and query the GitHub API via
+the `gh` CLI (authenticated by `GH_TOKEN`). Exit zero when the release
+may proceed.
+"""
+
+import base64
+import binascii
+import json
+import os
+import sys
+
+import yaml
+from publish_mainnet_release import (
+    TAG_PREFIX,
+    gh_api,
+    load_series_config,
+    newest_tests_tag,
+    parse_version,
+    series_transition,
+)
+
+SERIES_CONFIG_REPO_PATH = ".github/configs/mainnet_fixture_version.yaml"
+
+
+def fail(message: str) -> None:
+    """Print an error to stderr and exit non-zero."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def cached_target_series(repository: str, target_sha: str) -> tuple[int, int]:
+    """Return the release series committed in a cached nightly target."""
+    raw = gh_api(
+        f"repos/{repository}/contents/{SERIES_CONFIG_REPO_PATH}?ref={target_sha}",
+        ok_404=True,
+    )
+    if not raw:
+        fail(
+            "the cached nightly predates mainnet_fixture_version.yaml; "
+            "dispatch a fresh fill or select a newer nightly"
+        )
+    try:
+        payload = json.loads(raw)
+        text = base64.b64decode(payload["content"]).decode()
+        config = yaml.safe_load(text)
+        fork = config["fork"]
+        revision = config["consensus_revision"]
+        if (
+            not isinstance(fork, int)
+            or isinstance(fork, bool)
+            or not isinstance(revision, int)
+            or isinstance(revision, bool)
+            or fork < 0
+            or revision < 0
+        ):
+            raise ValueError("series values must be non-negative integers")
+        return fork, revision
+    except (
+        binascii.Error,
+        KeyError,
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as e:
+        fail(f"the cached nightly has invalid release-series config: {e}")
+
+
+def main() -> None:
+    """Validate the requested version and exit accordingly."""
+    repository = os.environ["GITHUB_REPOSITORY"]
+    requested_input = os.environ["INPUT_VERSION"]
+    requested = parse_version(requested_input)
+    if requested is None:
+        fail(f"version '{requested_input}' must match vX.Y.Z")
+        return
+
+    configured = load_series_config()
+    prev_tag = newest_tests_tag(repository)
+    if not prev_tag:
+        print("No published release yet, any first release is allowed.")
+        return
+    published = parse_version(prev_tag.removeprefix(TAG_PREFIX))
+    assert published is not None
+
+    if requested[:2] == published[:2]:
+        if requested <= published:
+            fail(
+                f"version '{requested_input}' must be greater than the "
+                f"newest release ({prev_tag})"
+            )
+        print(f"{requested_input} continues the published series.")
+        return
+
+    state = series_transition(configured, published[:2])
+    if state == "current":
+        fail(
+            f"version '{requested_input}' starts a new series but the "
+            f"configuration still selects {configured[0]}."
+            f"{configured[1]}: update mainnet_fixture_version.yaml first"
+        )
+    expected = f"v{configured[0]}.{configured[1]}.0"
+    if requested != (configured[0], configured[1], 0):
+        fail(
+            f"the configured series requires exactly '{expected}', not "
+            f"'{requested_input}'"
+        )
+    cached_target_sha = os.environ.get("CACHED_TARGET_SHA")
+    if cached_target_sha:
+        target_series = cached_target_series(repository, cached_target_sha)
+        if target_series != configured:
+            fail(
+                f"the cached nightly selects series {target_series[0]}."
+                f"{target_series[1]}, not the required {configured[0]}."
+                f"{configured[1]}; dispatch a fresh fill or select a "
+                "nightly built after the series change"
+            )
+    print(f"{requested_input} starts the configured series.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release_fixtures.yaml
+++ b/.github/workflows/release_fixtures.yaml
@@ -4,10 +4,16 @@ run-name: ${{ github.event_name == 'schedule' && 'Nightly Fill' || format('Creat
 
 # Scheduled runs fill the mainnet `tests` feature (all tests, all fixture
 # formats, up to the latest mainnet fork -- no dev forks) through the exact
-# release pipeline, but skip the `release` job, so no tag or draft release
-# is created: a rotating, always-available artifact of the mainnet
-# fixtures. The cron fires at 02:00 UTC: the self-hosted runners are past
-# the EU/US daytime peaks and results are ready before the EU morning.
+# release pipeline, but skip the `release` job: a rotating,
+# always-available artifact of the mainnet fixtures. The cron fires at
+# 02:00 UTC: the self-hosted runners are past the EU/US daytime peaks and
+# results are ready before the EU morning. Scheduled runs end in the
+# `publish` job instead: maintainers explicitly select the mainnet
+# `X.Y` release series (mainnet_fixture_version.yaml), major and
+# consensus-minor releases are manual, and when the latest published
+# release already matches that series, the first eligible nightly at
+# least 14 days later publishes accumulated, validated fixture-content
+# changes as the next `Z` patch (see the job comment below).
 #
 # A manual `tests` release can reuse the newest of those artifacts
 # instead of refilling via the `cached` checkbox: `build` and `combine`
@@ -118,6 +124,21 @@ jobs:
           # resolve_cached_release.py.
           uv run -q .github/scripts/resolve_cached_release.py >> "$GITHUB_OUTPUT"
 
+      - name: Validate the version against the configured series
+        if: github.event_name == 'workflow_dispatch' && inputs.feature == 'tests'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+          CACHED_TARGET_SHA: ${{ steps.cached.outputs.target_sha }}
+        run: |
+          # Manual mainnet releases must stay in lockstep with the
+          # maintainer-selected series in mainnet_fixture_version.yaml.
+          # A cached new-series release must also use a nightly built
+          # after that series change, never stale pre-consensus fixtures.
+          # The rules live in (and are unit-tested via)
+          # validate_mainnet_release.py.
+          uv run -q .github/scripts/validate_mainnet_release.py
+
       - name: Validate input and generate build matrix
         id: matrix
         shell: bash
@@ -173,6 +194,11 @@ jobs:
     needs: [setup, build]
     if: needs.setup.outputs.combine_labels != ''
     runs-on: ubuntu-latest
+    outputs:
+      # Content-only root hash of the merged fixture index (per-fixture
+      # hashes exclude `_info`, so refilling identical content yields
+      # the identical root). The scheduled `publish` job gates on it.
+      root_hash: ${{ steps.index_root.outputs.root_hash }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -185,13 +211,19 @@ jobs:
         shell: bash
         run: |
           mkdir -p combined
+          # Tolerate only truly absent artifacts (a range that collected
+          # no tests). Any other download failure must fail the job: the
+          # scheduled `publish` gate consumes the merged result, and a
+          # silently dropped range would release incomplete fixtures.
+          UPLOADED=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" --paginate --jq '.artifacts[].name')
           for label in ${{ needs.setup.outputs.combine_labels }}; do
-            echo "Downloading: fixtures__${label}"
-            if gh run download ${{ github.run_id }} -n "fixtures__${label}" --dir "split_artifacts/fixtures__${label}"; then
-              cp -r "split_artifacts/fixtures__${label}"/* combined/
-            else
+            if ! grep -qx "fixtures__${label}" <<< "$UPLOADED"; then
               echo "No artifact for ${label} (no tests collected, skipping)"
+              continue
             fi
+            echo "Downloading: fixtures__${label}"
+            gh run download ${{ github.run_id }} -n "fixtures__${label}" --dir "split_artifacts/fixtures__${label}"
+            cp -r "split_artifacts/fixtures__${label}"/* combined/
           done
           echo "Combined directory contents:"
           find combined -maxdepth 3 -type d | head -30 || true
@@ -209,6 +241,26 @@ jobs:
           done
           if [ ${#SPLIT_DIRS[@]} -gt 0 ]; then
             uv run python .github/scripts/merge_index_files.py combined/.meta/index.json "${SPLIT_DIRS[@]}"
+          fi
+      - name: Record the merged index root
+        id: index_root
+        shell: bash
+        run: |
+          # The root file and the gzipped index ride in the artifacts
+          # next to the tarball so every release path (scheduled, fresh
+          # or cached manual) attaches the content fingerprint it
+          # ships, read back by the next scheduled gate.
+          if [ -f combined/.meta/index.json ]; then
+            # `// empty` and the guard keep a literal `null` (a merge
+            # regression) from poisoning every later root comparison.
+            root=$(jq -r '.root_hash // empty' combined/.meta/index.json)
+            if [ -z "$root" ]; then
+              echo "Error: the merged index has no root_hash" >&2
+              exit 1
+            fi
+            printf '%s\n' "$root" > index_root.txt
+            gzip -c combined/.meta/index.json > fixtures_index.json.gz
+            echo "root_hash=$root" >> "$GITHUB_OUTPUT"
           fi
       - name: Free disk space
         run: rm -rf split_artifacts/
@@ -233,17 +285,40 @@ jobs:
           # cached-release resolver derives this exact name from each
           # run's head SHA. The tarball inside carries the feature name.
           name: fixtures_${{ needs.setup.outputs.short_sha }}
-          path: ${{ steps.tarball.outputs.path }}
+          path: |
+            ${{ steps.tarball.outputs.path }}
+            index_root.txt
+            fixtures_index.json.gz
           # Keep nightly tarballs for five days; a quiet nightly re-runs
           # after four (see check_new_commits.py), so a live artifact
           # always exists. Release tarballs keep the repo default since
           # the release job attaches them to a draft release anyway.
           retention-days: ${{ github.event_name == 'schedule' && '5' || '' }}
+      - name: Upload index artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          # A small index-only artifact so the scheduled `publish` job
+          # can classify the content difference without downloading
+          # the tarball. Named without the `fixtures_` prefix to stay
+          # out of the release job's `-p "fixtures_*"` download and
+          # the cached-release resolver's artifact naming.
+          name: index_${{ needs.setup.outputs.short_sha }}
+          path: |
+            index_root.txt
+            fixtures_index.json.gz
+          retention-days: ${{ github.event_name == 'schedule' && '5' || '' }}
 
   release:
     runs-on: ubuntu-latest
     needs: [setup, build, combine]
-    # Scheduled runs stop after `combine`: no tag, no draft release.
+    # Serialize the release-creation step with scheduled mainnet patch
+    # publication. Their earlier fill/setup work may run concurrently,
+    # but two jobs must never select and create the same next `tests@`
+    # version at once. Other feature/version pairs remain independent.
+    concurrency:
+      group: ${{ inputs.feature == 'tests' && 'mainnet-tests-release' || format('fixture-release-{0}-{1}', inputs.feature, inputs.version) }}
+      cancel-in-progress: false
+    # Scheduled runs skip this job in favor of `publish` below.
     # Cached releases skip the fill, so a skipped `build` is expected;
     # `setup` must have succeeded explicitly, because a failed `setup`
     # also leaves `build` skipped and would otherwise start this job
@@ -324,5 +399,102 @@ jobs:
             RELEASE_ARGS+=(--notes-start-tag "$PREV_TAG")
           fi
 
+          # Attach the tarballs plus the recorded index root and the
+          # gzipped index when the fill produced them (split features
+          # only; also absent when a cached release reuses a nightly
+          # from before content-fingerprint recording).
+          ASSETS=(./artifacts/**/*.tar.gz)
+          for extra in index_root.txt fixtures_index.json.gz; do
+            if compgen -G "./artifacts/**/${extra}" > /dev/null; then
+              ASSETS+=(./artifacts/**/"${extra}")
+            fi
+          done
+
           # Creates the tag on the target commit and the release on success.
-          gh release create "$TAG_NAME" "${RELEASE_ARGS[@]}" ./artifacts/**/*.tar.gz
+          gh release create "$TAG_NAME" "${RELEASE_ARGS[@]}" "${ASSETS[@]}"
+
+  # Scheduled runs end here. Maintainers explicitly select the mainnet
+  # `X.Y` release series in mainnet_fixture_version.yaml: major (new
+  # fork) and consensus-minor releases are manual, and while the
+  # configured series is ahead this job pauses and points at the
+  # required manual `vX.Y.0`. When the latest published release
+  # already matches the configured series, the first eligible nightly
+  # at least 14 days later publishes accumulated, validated fixture-
+  # content changes as the next `Z` patch. Anything it cannot
+  # validate (a partial fill, an unreadable or ambiguous index, a
+  # changed fork set, a capped commit listing, a pending `tests@`
+  # draft) produces no release at all: publishing a validated patch is
+  # this job's only release-producing action.
+  publish:
+    runs-on: ubuntu-latest
+    needs: [setup, combine]
+    # Share the release-creation lock with manual mainnet releases so a
+    # fortnightly patch cannot race a manually dispatched tests release.
+    concurrency:
+      group: mainnet-tests-release
+      cancel-in-progress: false
+    # `success()` is implied: a quiet nightly (no new commits) skips
+    # `build`, `combine` and with them this job. An empty root means no
+    # index was merged, so there is nothing to compare.
+    if: github.event_name == 'schedule' && needs.combine.outputs.root_hash != ''
+    permissions:
+      contents: write
+      # The tarball is downloaded from this run's own artifact.
+      actions: read
+      # Squash-subject PR references are resolved for the notes.
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: false
+          ref: ${{ needs.setup.outputs.target_sha }}
+      - uses: ./.github/actions/setup-uv
+
+      - name: Download this run's index
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download ${{ github.run_id }} \
+            -n "index_${{ needs.setup.outputs.short_sha }}" \
+            --dir ./index
+
+      - name: Gate the release
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROOT_HASH: ${{ needs.combine.outputs.root_hash }}
+          TARGET_SHA: ${{ needs.setup.outputs.target_sha }}
+          INDEX_DIR: ./index
+        run: |
+          # The series state machine, the root gate, the index
+          # integrity checks, the pending-draft check and the notes
+          # rendering live in (and are unit-tested via)
+          # publish_mainnet_release.py.
+          uv run -q .github/scripts/publish_mainnet_release.py >> "$GITHUB_OUTPUT"
+
+      - name: Download this run's tarball
+        if: steps.gate.outputs.dispatch == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download ${{ github.run_id }} \
+            -n "fixtures_${{ needs.setup.outputs.short_sha }}" \
+            --dir ./artifacts
+
+      - name: Publish the release
+        if: steps.gate.outputs.dispatch == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.gate.outputs.version }}
+          TARGET_SHA: ${{ needs.setup.outputs.target_sha }}
+        run: |
+          # Publishes the validated patch, creating the tag on the
+          # commit this nightly built. The content-fingerprint files
+          # ride along so the next gate can read them back.
+          gh release create "tests@${VERSION}" \
+            --target "$TARGET_SHA" \
+            --title "tests@${VERSION}" \
+            --notes-file release_notes.md \
+            ./artifacts/fixtures.tar.gz \
+            ./artifacts/index_root.txt \
+            ./artifacts/fixtures_index.json.gz


### PR DESCRIPTION
### Description

Automates fortnightly mainnet fixture patch releases from the existing nightly fill while keeping every mainnet-fork (`X`) and consensus-revision (`Y`) release manual.

The release policy is explicit:

| Version component | Meaning | Release path |
| --- | --- | --- |
| `X` | Mainnet fork line | Manual `vX.0.0` release |
| `Y` | Consensus revision for that fork | Manual `vX.Y.0` release |
| `Z` | Non-consensus fixture changes | Automatic patch, at most once every 14 days |

Maintainers select the active `X.Y` series in `.github/configs/mainnet_fixture_version.yaml`. A consensus-changing PR increments `consensus_revision`; a new-mainnet-fork PR increments `fork` and resets the revision to zero. The scheduled workflow never chooses an `X` or `Y` bump: while the configured series is ahead of the latest published release it publishes nothing and points to the exact manual `vX.Y.0` release required.

When the configured and published series match, nightly fixture changes accumulate. The first eligible nightly at least 14 days after the latest published `tests@` release publishes the next `Z` patch from that run's own artifact. An unchanged fixture root produces no release. A manual major or minor release starts a fresh 14-day patch window.

### Content and integrity gates

Every combined fill records two small assets alongside `fixtures.tar.gz`:

- `index_root.txt` provides the cheap content-equality check;
- `fixtures_index.json.gz` supports per-fixture validation and added/removed/changed counts.

The scheduled job publishes only a validated patch. It produces no release when the previous or current index is missing, corrupt or ambiguous; `(json_path, id)` identities are duplicated; a mass disappearance suggests a partial fill; the fork set changes unexpectedly; release-note commit enumeration is incomplete; or a newer manual draft is pending.

Manual mainnet release creation and scheduled patch publication share a concurrency lock, preventing both paths from selecting or creating the same next `tests@` version simultaneously.

Releases predating the standalone index asset bootstrap from the leading metadata members of `fixtures.tar.gz`; the streaming reader allows files such as `fixtures.ini` before `index.json` and stops before downloading the fixture body.

### Manual releases and cached artifacts

Manual `tests` releases are validated against the configured series. A new-series release must be exactly the configured `vX.Y.0`.

Cached releases remain fast, but a cached new-series release may reuse only a nightly whose target commit already contains that exact series marker. This prevents a just-merged consensus or fork release from accidentally attaching fixtures built before the change. If no matching nightly exists, the workflow requires a fresh fill or an explicitly selected newer nightly.

The `A-tests` label never gates publication; it only selects PRs for the generated release notes.

### Verification

- `91 passed` in `.github/scripts/tests/test_release_scripts.py`
- `just static`

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI failures.
- [x] PR title follows the repository's conventional title format.

### Cute Animal Picture

![Sleeping cat](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Sleeping_cat_on_her_back.jpg/960px-Sleeping_cat_on_her_back.jpg)
