### PR TITLE
feat(zkevm): automate zkevm benchmark filling releases

### DIFF
--- a/.github/actions/build-evm-client/geth/action.yaml
+++ b/.github/actions/build-evm-client/geth/action.yaml
@@ -6,7 +6,7 @@ inputs:
     required: true
     default: 'ethereum/go-ethereum'
   ref:
-    description: 'Reference to branch, commit, or tag to use to build the EVM binary'
+    description: 'Branch or full commit SHA to use to build the EVM binary'
     required: true
     default: 'master'
   golang:
@@ -16,13 +16,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get latest geth commit
+    - name: Resolve geth commit
       id: geth-sha
       shell: bash
+      env:
+        GETH_REPOSITORY: ${{ inputs.repo }}
+        GETH_REF: ${{ inputs.ref }}
       run: |
-        SHA=$(git ls-remote https://github.com/${{ inputs.repo }}.git refs/heads/${{ inputs.ref }} | cut -f1)
-        echo "sha=$SHA" >> $GITHUB_OUTPUT
-        echo "Latest geth commit: $SHA"
+        SHA=$(python3 .github/scripts/resolve_git_ref.py "$GETH_REPOSITORY" "$GETH_REF")
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+        echo "Resolved geth commit: $SHA"
     - name: Prepare cache target dir
       shell: bash
       run: mkdir -p "$GITHUB_WORKSPACE/go-ethereum/cmd/evm"

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -76,6 +76,12 @@ runs:
         if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 5 ]; then
           exit "$EXIT_CODE"
         fi
+    - name: Validate zkEVM Benchmark Fixtures
+      if: inputs.split_label == '' && inputs.release_name == 'zkevm-benchmark'
+      shell: bash
+      run: |
+        uv run -q .github/scripts/validate_zkevm_benchmark_fixtures.py \
+          fixtures_${{ inputs.release_name }}.tar.gz
     - name: Generate Benchmark Genesis Files
       if: inputs.split_label == '' && contains(inputs.release_name, 'benchmark')
       uses: ./.github/actions/build-benchmark-genesis

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -4,6 +4,12 @@ benchmark:
   ref: glamsterdam-devnet-7
   evm-bin: evm
   xdist: auto
+zkevm-benchmark:
+  impl: geth
+  repo: jsign/go-ethereum
+  ref: df17b59f9dfd731f0b7da0a85c30548f3db45b0b
+  evm-bin: evm
+  xdist: auto
 eels:
   impl: eels
   repo: null

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -22,6 +22,11 @@ benchmark_fast:
   fill-params: --fork=Amsterdam --generate-all-formats --gas-benchmark-values 100 ./tests/benchmark/compute
   feature_only: true
 
+zkevm-benchmark:
+  evm-type: zkevm-benchmark
+  fill-params: --fork=Amsterdam --gas-benchmark-values=10,30,60 -m blockchain_test ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
+  feature_only: true
+
 # Shared entry for all `<feat>-devnet` releases; matched by `-devnet` suffix.
 devnet:
   evm-type: eels

--- a/.github/scripts/check_zkevm_benchmark_release.py
+++ b/.github/scripts/check_zkevm_benchmark_release.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env -S uv run --script
+"""Check a zkEVM benchmark release request against GitHub state."""
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, NoReturn
+
+
+def fail(message: str) -> NoReturn:
+    """Print an error and stop the request."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def github_api(path: str) -> Any:
+    """Return all pages from a GitHub API request."""
+    result = subprocess.run(
+        ["gh", "api", "--paginate", "--slurp", path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"gh api failed for {path}: {result.stderr.strip()}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        fail(f"gh api returned invalid JSON for {path}: {error}")
+
+
+def flatten_pages(response: Any) -> list[dict[str, Any]]:
+    """Flatten the page list returned by ``gh api --slurp``."""
+    if not isinstance(response, list):
+        fail("gh api returned an invalid paginated response")
+    items: list[dict[str, Any]] = []
+    for page in response:
+        if not isinstance(page, list):
+            fail("gh api returned an invalid page")
+        for item in page:
+            if not isinstance(item, dict):
+                fail("gh api returned an invalid item")
+            items.append(item)
+    return items
+
+
+def matching_refs(repository: str, tag: str) -> list[dict[str, Any]]:
+    """Return refs that match *tag*."""
+    path = f"repos/{repository}/git/matching-refs/tags/{tag}"
+    return flatten_pages(github_api(path))
+
+
+def check_release(version: str, source_ref: str) -> None:
+    """Check the source input and destination release state."""
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    if not repository:
+        fail("GITHUB_REPOSITORY is empty")
+
+    source_tag = f"tests-zkevm@{version}"
+    destination_tag = f"tests-zkevm-benchmark@{version}"
+    if source_ref != source_tag:
+        fail(
+            f"source ref must be '{source_tag}' for version '{version}', "
+            f"got '{source_ref}'"
+        )
+
+    destination_refs = matching_refs(repository, destination_tag)
+    if any(
+        ref.get("ref") == f"refs/tags/{destination_tag}"
+        for ref in destination_refs
+    ):
+        fail(f"destination tag '{destination_tag}' already exists")
+
+    releases = flatten_pages(
+        github_api(f"repos/{repository}/releases?per_page=100")
+    )
+    if any(release.get("tag_name") == destination_tag for release in releases):
+        fail(
+            f"destination release or draft '{destination_tag}' already exists"
+        )
+
+    print(f"Source tag: {source_tag}")
+    print(f"Destination release: {destination_tag}")
+
+
+def main() -> None:
+    """Check the command-line release request."""
+    if len(sys.argv) != 3:
+        print(
+            "Usage: check_zkevm_benchmark_release.py <version> <source-ref>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    check_release(sys.argv[1], sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/resolve_git_ref.py
+++ b/.github/scripts/resolve_git_ref.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env -S uv run --script
+"""Resolve a GitHub repository branch or full commit SHA."""
+
+import re
+import subprocess
+import sys
+
+FULL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def resolve_git_ref(repository: str, ref: str) -> str:
+    """Return the commit SHA for a branch name or full commit SHA."""
+    if not repository:
+        raise ValueError("repository is empty")
+    if not ref:
+        raise ValueError("ref is empty")
+    if FULL_COMMIT_RE.fullmatch(ref):
+        return ref.lower()
+
+    branch_ref = ref if ref.startswith("refs/heads/") else f"refs/heads/{ref}"
+    result = subprocess.run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            f"https://github.com/{repository}.git",
+            branch_ref,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"could not resolve branch '{ref}' in repository '{repository}'"
+        )
+
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise ValueError(
+            f"branch '{ref}' in repository '{repository}' resolved to "
+            f"{len(lines)} commits"
+        )
+    sha = lines[0].split(maxsplit=1)[0]
+    if not FULL_COMMIT_RE.fullmatch(sha):
+        raise ValueError(
+            f"branch '{ref}' in repository '{repository}' returned an "
+            "invalid commit SHA"
+        )
+    return sha.lower()
+
+
+def main() -> None:
+    """Resolve the command-line repository and ref."""
+    if len(sys.argv) != 3:
+        print(
+            "Usage: resolve_git_ref.py <owner/repository> <branch-or-sha>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    try:
+        print(resolve_git_ref(sys.argv[1], sys.argv[2]))
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_release_scripts.py
+++ b/.github/scripts/tests/test_release_scripts.py
@@ -5,6 +5,7 @@ Each test invokes the script via `uv run` to validate the actual CLI
 interface, matching how GitHub Actions calls them.
 """
 
+import io
 import json
 import os
 import subprocess
@@ -20,15 +21,23 @@ TARBALL_SCRIPT = SCRIPTS_DIR / "create_release_tarball.py"
 MERGE_INDEX_SCRIPT = SCRIPTS_DIR / "merge_index_files.py"
 CHECK_COMMITS_SCRIPT = SCRIPTS_DIR / "check_new_commits.py"
 RESOLVE_CACHED_SCRIPT = SCRIPTS_DIR / "resolve_cached_release.py"
+CHECK_ZKEVM_RELEASE_SCRIPT = SCRIPTS_DIR / "check_zkevm_benchmark_release.py"
+RESOLVE_GIT_REF_SCRIPT = SCRIPTS_DIR / "resolve_git_ref.py"
+VALIDATE_ZKEVM_FIXTURES_SCRIPT = (
+    SCRIPTS_DIR / "validate_zkevm_benchmark_fixtures.py"
+)
 
 
-def run_script(script: Path, *args: str) -> subprocess.CompletedProcess:
+def run_script(
+    script: Path, *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess:
     """Run a uv inline-deps script and return the result."""
     return subprocess.run(
         ["uv", "run", "-q", str(script), *args],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,
+        env=env,
     )
 
 
@@ -71,6 +80,25 @@ class TestGenerateBuildMatrix:
         assert matrix[0]["label"] == ""
         assert matrix[0]["from_fork"] == ""
         assert matrix[0]["until_fork"] == ""
+
+    def test_zkevm_benchmark_produces_single_entry(self):
+        """Verify the zkEVM benchmark feature is an unsplit build."""
+        result = run_script(
+            BUILD_MATRIX_SCRIPT,
+            "zkevm-benchmark",
+            "v0.9.0",
+        )
+        assert result.returncode == 0
+        out = parse_matrix_output(result.stdout)
+        matrix = json.loads(out["build_matrix"])
+        assert matrix == [
+            {
+                "feature": "zkevm-benchmark",
+                "label": "",
+                "from_fork": "",
+                "until_fork": "",
+            }
+        ]
 
     def test_devnet_name_resolves_to_shared_feature(self):
         """Verify a <feat>-devnet name resolves to the devnet feature."""
@@ -200,6 +228,9 @@ FAKE_GH = """#!/usr/bin/env bash
 path="${@: -1}"
 case "$path" in
   *actions/workflows*) response="$FAKE_GH_RUNS" ;;
+  *matching-refs/tags/tests-zkevm-benchmark*)
+    response="${FAKE_GH_DESTINATION_TAGS:-$FAKE_GH_TAGS}"
+    ;;
   */artifacts)
     run_id="${path##*/runs/}"
     run_id="${run_id%%/*}"
@@ -207,6 +238,7 @@ case "$path" in
     response="${!var:-$FAKE_GH_ARTIFACTS}"
     ;;
   *matching-refs*) response="$FAKE_GH_TAGS" ;;
+  *releases*) response="$FAKE_GH_RELEASES" ;;
   *compare/tests@*) response="$FAKE_GH_COMPARE_TAG" ;;
   *compare*) response="$FAKE_GH_COMPARE" ;;
   *) response="" ;;
@@ -222,6 +254,270 @@ printf '%s' "$response"
 LIVE_ARTIFACTS = '{"artifacts": [{"expired": false}]}'
 EXPIRED_ARTIFACTS = '{"artifacts": [{"expired": true}]}'
 NO_ARTIFACTS = '{"artifacts": []}'
+
+
+class TestResolveGitRef:
+    """Test resolve_git_ref.py."""
+
+    def run_with_fake_git(
+        self, tmp_path: Path, ref: str, output: str, exit_code: int
+    ) -> subprocess.CompletedProcess:
+        """Run the resolver with a fake git command."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_git = bin_dir / "git"
+        fake_git.write_text(
+            f"#!/usr/bin/env bash\nprintf '%s' '{output}'\nexit {exit_code}\n"
+        )
+        fake_git.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        return run_script(
+            RESOLVE_GIT_REF_SCRIPT,
+            "example/geth",
+            ref,
+            env=env,
+        )
+
+    def test_full_commit_does_not_query_remote(self):
+        """Verify a full commit SHA resolves without a git command."""
+        commit = "a" * 40
+        result = run_script(RESOLVE_GIT_REF_SCRIPT, "example/geth", commit)
+        assert result.returncode == 0
+        assert result.stdout.strip() == commit
+
+    def test_branch_resolves_to_full_commit(self, tmp_path):
+        """Verify a branch uses the commit returned by git ls-remote."""
+        commit = "b" * 40
+        result = self.run_with_fake_git(
+            tmp_path,
+            "devnet",
+            f"{commit}\trefs/heads/devnet\n",
+            0,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == commit
+
+    def test_unresolved_branch_fails(self, tmp_path):
+        """Verify an unresolved branch stops the build."""
+        result = self.run_with_fake_git(tmp_path, "missing", "", 2)
+        assert result.returncode == 1
+        assert "could not resolve branch 'missing'" in result.stderr
+
+    def test_empty_ref_fails(self):
+        """Verify an empty ref stops the build."""
+        result = run_script(RESOLVE_GIT_REF_SCRIPT, "example/geth", "")
+        assert result.returncode == 1
+        assert "ref is empty" in result.stderr
+
+
+class TestCheckZkevmBenchmarkRelease:
+    """Test check_zkevm_benchmark_release.py."""
+
+    @staticmethod
+    def run_check(
+        tmp_path: Path,
+        destination_tags: str = "[[]]",
+        releases: str = "[[]]",
+        version: str = "v0.9.0",
+        source_ref: str = "tests-zkevm@v0.9.0",
+    ) -> subprocess.CompletedProcess:
+        """Run the release check with canned GitHub API responses."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(FAKE_GH)
+        fake_gh.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["GITHUB_REPOSITORY"] = "ethereum/execution-specs"
+        env["FAKE_GH_DESTINATION_TAGS"] = destination_tags
+        env["FAKE_GH_RELEASES"] = releases
+        return run_script(
+            CHECK_ZKEVM_RELEASE_SCRIPT,
+            version,
+            source_ref,
+            env=env,
+        )
+
+    def test_new_release_request_passes(self, tmp_path):
+        """Verify a matching source input and unused destination pass."""
+        result = self.run_check(tmp_path)
+        assert result.returncode == 0
+        assert "Destination release: tests-zkevm-benchmark@v0.9.0" in (
+            result.stdout
+        )
+
+    def test_existing_destination_tag_fails(self, tmp_path):
+        """Verify an existing destination tag stops the request."""
+        destination_tags = json.dumps(
+            [[{"ref": "refs/tags/tests-zkevm-benchmark@v0.9.0"}]]
+        )
+        result = self.run_check(tmp_path, destination_tags=destination_tags)
+        assert result.returncode == 1
+        assert "destination tag" in result.stderr
+
+    def test_existing_destination_draft_fails(self, tmp_path):
+        """Verify an existing destination draft stops the request."""
+        releases = json.dumps(
+            [[{"tag_name": "tests-zkevm-benchmark@v0.9.0", "draft": True}]]
+        )
+        result = self.run_check(tmp_path, releases=releases)
+        assert result.returncode == 1
+        assert "release or draft" in result.stderr
+
+    def test_mismatched_source_ref_fails_without_api_call(self, tmp_path):
+        """Verify the source ref and release version must match."""
+        result = self.run_check(
+            tmp_path,
+            source_ref="tests-zkevm@v0.8.0",
+        )
+        assert result.returncode == 1
+        assert "source ref must be 'tests-zkevm@v0.9.0'" in result.stderr
+
+
+class TestValidateZkevmBenchmarkFixtures:
+    """Test validate_zkevm_benchmark_fixtures.py."""
+
+    fixture_path = (
+        "fixtures/blockchain_tests/for_amsterdam_at_0060M/"
+        "benchmark/compute/test_example.json"
+    )
+
+    @staticmethod
+    def valid_fixture() -> dict:
+        """Return one valid zkEVM benchmark fixture file."""
+        return {
+            "test_example": {
+                "network": "Amsterdam",
+                "blocks": [
+                    {
+                        "statelessInputBytes": "0x1234",
+                        "statelessOutputBytes": "0xabcd",
+                    }
+                ],
+                "_info": {
+                    "metadata": {
+                        "opcode_count_per_block": [{"ADD": 1}],
+                    }
+                },
+            }
+        }
+
+    @staticmethod
+    def make_archive(tmp_path: Path, files: dict[str, dict]) -> Path:
+        """Create a fixture archive from JSON file mappings."""
+        archive_path = tmp_path / "fixtures_zkevm-benchmark.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as archive:
+            for name, contents in files.items():
+                data = json.dumps(contents).encode()
+                member = tarfile.TarInfo(name)
+                member.size = len(data)
+                archive.addfile(member, io.BytesIO(data))
+        return archive_path
+
+    def run_validator(
+        self, tmp_path: Path, files: dict[str, dict]
+    ) -> subprocess.CompletedProcess:
+        """Create and validate one fixture archive."""
+        archive_path = self.make_archive(tmp_path, files)
+        return run_script(VALIDATE_ZKEVM_FIXTURES_SCRIPT, str(archive_path))
+
+    def test_valid_archive_passes(self, tmp_path):
+        """Verify an archive with all configured gas limits passes."""
+        files = {
+            self.fixture_path.replace("0060M", gas_limit): self.valid_fixture()
+            for gas_limit in ("0010M", "0030M", "0060M")
+        }
+        result = self.run_validator(tmp_path, files)
+        assert result.returncode == 0
+        assert "Validated 3 fixture cases in 3 fixture files" in result.stdout
+
+    def test_empty_archive_fails(self, tmp_path):
+        """Verify an empty archive fails."""
+        result = self.run_validator(tmp_path, {})
+        assert result.returncode == 1
+        assert "contains no zkEVM benchmark fixtures" in result.stderr
+
+    def test_wrong_target_directory_fails(self, tmp_path):
+        """Verify fixtures must use a configured gas limit."""
+        path = self.fixture_path.replace("0060M", "0050M")
+        result = self.run_validator(tmp_path, {path: self.valid_fixture()})
+        assert result.returncode == 1
+        assert "target must be one of" in result.stderr
+
+    def test_wrong_fork_directory_fails(self, tmp_path):
+        """Verify fixtures cannot target another fork."""
+        path = self.fixture_path.replace("amsterdam", "prague")
+        result = self.run_validator(tmp_path, {path: self.valid_fixture()})
+        assert result.returncode == 1
+        assert "target must be one of" in result.stderr
+
+    def test_extra_fixture_format_fails(self, tmp_path):
+        """Verify the archive cannot contain another fixture format."""
+        engine_path = (
+            "fixtures/blockchain_tests_engine/for_amsterdam_at_0060M/"
+            "benchmark/compute/test_example.json"
+        )
+        result = self.run_validator(
+            tmp_path,
+            {
+                self.fixture_path: self.valid_fixture(),
+                engine_path: self.valid_fixture(),
+            },
+        )
+        assert result.returncode == 1
+        assert "unexpected fixture formats" in result.stderr
+
+    def test_missing_stateless_input_fails(self, tmp_path):
+        """Verify the final block must contain stateless input bytes."""
+        fixture = self.valid_fixture()
+        del fixture["test_example"]["blocks"][-1]["statelessInputBytes"]
+        result = self.run_validator(tmp_path, {self.fixture_path: fixture})
+        assert result.returncode == 1
+        assert "statelessInputBytes must be" in result.stderr
+
+    def test_malformed_stateless_output_fails(self, tmp_path):
+        """Verify the final block output must contain complete bytes."""
+        fixture = self.valid_fixture()
+        fixture["test_example"]["blocks"][-1]["statelessOutputBytes"] = "0x1"
+        result = self.run_validator(tmp_path, {self.fixture_path: fixture})
+        assert result.returncode == 1
+        assert "statelessOutputBytes must be" in result.stderr
+
+    def test_empty_blocks_fails(self, tmp_path):
+        """Verify each fixture case must contain a block."""
+        fixture = self.valid_fixture()
+        fixture["test_example"]["blocks"] = []
+        result = self.run_validator(tmp_path, {self.fixture_path: fixture})
+        assert result.returncode == 1
+        assert "blocks must be a non-empty list" in result.stderr
+
+    def test_opcode_count_length_must_match_blocks(self, tmp_path):
+        """Verify opcode count metadata has one entry for each block."""
+        fixture = self.valid_fixture()
+        metadata = fixture["test_example"]["_info"]["metadata"]
+        metadata["opcode_count_per_block"] = []
+        result = self.run_validator(tmp_path, {self.fixture_path: fixture})
+        assert result.returncode == 1
+        assert "has 0 entries for 1 blocks" in result.stderr
+
+    def test_opcode_count_metadata_is_required(self, tmp_path):
+        """Verify each fixture case contains opcode count metadata."""
+        fixture = self.valid_fixture()
+        del fixture["test_example"]["_info"]["metadata"]
+        result = self.run_validator(tmp_path, {self.fixture_path: fixture})
+        assert result.returncode == 1
+        assert "opcode_count_per_block must be a list" in result.stderr
+
+    def test_final_opcode_count_must_not_be_empty(self, tmp_path):
+        """Verify the final opcode count contains at least one opcode."""
+        fixture = self.valid_fixture()
+        metadata = fixture["test_example"]["_info"]["metadata"]
+        metadata["opcode_count_per_block"] = [{}]
+        result = self.run_validator(tmp_path, {self.fixture_path: fixture})
+        assert result.returncode == 1
+        assert "final opcode count must be a non-empty object" in result.stderr
 
 
 class TestCheckNewCommits:

--- a/.github/scripts/validate_zkevm_benchmark_fixtures.py
+++ b/.github/scripts/validate_zkevm_benchmark_fixtures.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S uv run --script
+"""Validate a zkEVM benchmark fixture archive before release."""
+
+import json
+import re
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any, NoReturn
+
+EXPECTED_FORMAT = "blockchain_tests"
+EXPECTED_TARGETS = {
+    "for_amsterdam_at_0010M",
+    "for_amsterdam_at_0030M",
+    "for_amsterdam_at_0060M",
+}
+FIXTURE_FORMATS = {
+    "state_tests",
+    "blockchain_tests",
+    "blockchain_tests_engine",
+    "blockchain_tests_engine_x",
+    "blockchain_tests_sync",
+}
+HEX_BYTES_RE = re.compile(r"^0x(?:[0-9a-fA-F]{2})+$")
+
+
+def fail(message: str) -> NoReturn:
+    """Raise a release validation error."""
+    raise ValueError(message)
+
+
+def validate_hex_bytes(value: Any, field: str) -> None:
+    """Validate one non-empty hexadecimal byte string."""
+    if not isinstance(value, str) or not HEX_BYTES_RE.fullmatch(value):
+        fail(f"{field} must be a non-empty, even-length 0x byte string")
+
+
+def validate_case(case_name: str, fixture: Any) -> None:
+    """Validate one fixture case."""
+    if not isinstance(fixture, dict):
+        fail(f"{case_name}: fixture must be an object")
+    if fixture.get("network") != "Amsterdam":
+        fail(f"{case_name}: network must be Amsterdam")
+
+    blocks = fixture.get("blocks")
+    if not isinstance(blocks, list) or not blocks:
+        fail(f"{case_name}: blocks must be a non-empty list")
+    final_block = blocks[-1]
+    if not isinstance(final_block, dict):
+        fail(f"{case_name}: final block must be an object")
+    validate_hex_bytes(
+        final_block.get("statelessInputBytes"),
+        f"{case_name}: final block statelessInputBytes",
+    )
+    validate_hex_bytes(
+        final_block.get("statelessOutputBytes"),
+        f"{case_name}: final block statelessOutputBytes",
+    )
+
+    info = fixture.get("_info")
+    metadata = info.get("metadata") if isinstance(info, dict) else None
+    opcode_counts = (
+        metadata.get("opcode_count_per_block")
+        if isinstance(metadata, dict)
+        else None
+    )
+    if not isinstance(opcode_counts, list):
+        fail(f"{case_name}: opcode_count_per_block must be a list")
+    if len(opcode_counts) != len(blocks):
+        fail(
+            f"{case_name}: opcode_count_per_block has {len(opcode_counts)} "
+            f"entries for {len(blocks)} blocks"
+        )
+    if not isinstance(opcode_counts[-1], dict) or not opcode_counts[-1]:
+        fail(f"{case_name}: final opcode count must be a non-empty object")
+
+
+def validate_archive(archive_path: Path) -> tuple[int, int]:
+    """Validate *archive_path* and return its file and fixture counts."""
+    fixture_files = 0
+    fixture_cases = 0
+    seen_formats: set[str] = set()
+
+    with tarfile.open(archive_path, mode="r:gz") as archive:
+        for member in archive:
+            path = PurePosixPath(member.name)
+            member_formats = FIXTURE_FORMATS.intersection(path.parts)
+            seen_formats.update(member_formats)
+            if not member.isfile() or path.suffix != ".json":
+                continue
+            if EXPECTED_FORMAT not in path.parts or ".meta" in path.parts:
+                continue
+
+            format_index = path.parts.index(EXPECTED_FORMAT)
+            if len(path.parts) <= format_index + 1:
+                fail(f"{member.name}: missing benchmark target directory")
+            target = path.parts[format_index + 1]
+            if target not in EXPECTED_TARGETS:
+                fail(
+                    f"{member.name}: target must be one of "
+                    f"{', '.join(sorted(EXPECTED_TARGETS))}. Got {target}"
+                )
+
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                fail(f"{member.name}: could not read fixture file")
+            try:
+                contents = json.load(extracted)
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                fail(f"{member.name}: invalid JSON: {error}")
+            if not isinstance(contents, dict) or not contents:
+                fail(f"{member.name}: fixture file must be a non-empty object")
+
+            fixture_files += 1
+            for case_name, fixture in contents.items():
+                validate_case(f"{member.name}:{case_name}", fixture)
+                fixture_cases += 1
+
+    unexpected_formats = seen_formats - {EXPECTED_FORMAT}
+    if unexpected_formats:
+        fail(
+            "archive contains unexpected fixture formats: "
+            + ", ".join(sorted(unexpected_formats))
+        )
+    if fixture_files == 0 or fixture_cases == 0:
+        fail("archive contains no zkEVM benchmark fixtures")
+    return fixture_files, fixture_cases
+
+
+def main() -> None:
+    """Validate the command-line fixture archive."""
+    if len(sys.argv) != 2:
+        print(
+            "Usage: validate_zkevm_benchmark_fixtures.py <archive.tar.gz>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    archive_path = Path(sys.argv[1])
+    try:
+        fixture_files, fixture_cases = validate_archive(archive_path)
+    except (OSError, tarfile.TarError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+    print(
+        f"Validated {fixture_cases} fixture cases in "
+        f"{fixture_files} fixture files."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release_fixtures.yaml
+++ b/.github/workflows/release_fixtures.yaml
@@ -27,7 +27,7 @@ on:
         required: true
         type: string
       branch:
-        description: "Branch to release from, e.g. devnets/bal/7 (required for *-devnet features)"
+        description: "Branch or source tag to release from, e.g. devnets/bal/7"
         required: false
         type: string
       evm:
@@ -94,6 +94,16 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "short_sha=${sha:0:7}" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-uv
+
+      - name: Check zkEVM benchmark release request
+        if: inputs.feature == 'zkevm-benchmark'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SOURCE_REF: ${{ inputs.branch }}
+        run: |
+          uv run -q .github/scripts/check_zkevm_benchmark_release.py \
+            "$INPUT_VERSION" "$INPUT_SOURCE_REF"
 
       - name: Check for new commits (scheduled runs)
         id: check

--- a/docs/dev/releasing_tests.md
+++ b/docs/dev/releasing_tests.md
@@ -12,9 +12,9 @@ gh workflow run release_fixtures.yaml -f feature=<feature> -f version=vX.Y.Z [-f
 
 | Input      | Required          | Description                                                                                          |
 | ---------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
-| `feature`  | yes               | Feature name, e.g. `tests`, `benchmark`, or a `<feat>-devnet` name.                                   |
+| `feature`  | yes               | Feature name, for example `tests`, `benchmark`, `zkevm-benchmark`, or a `<feat>-devnet` name.          |
 | `version`  | yes               | Release version `vX.Y.Z` (validated against `^v[0-9]+\.[0-9]+\.[0-9]+$`). Tagged as `tests-<feature>@<version>` (the `tests` feature tags as `tests@<version>`). |
-| `branch`   | devnet only       | Branch to build and release from. Optional for non-devnet features; **required** for devnet releases. |
+| `branch`   | feature-dependent | Branch or source tag to release from. Devnet and zkEVM benchmark releases require this input.         |
 | `evm`      | no                | Override the evm impl (e.g. `geth`, `evmone`). Defaults to the feature's `evm-type` in `feature.yaml`. |
 | `evm_repo` | no                | Override the t8n tool repo (e.g. `ethereum/go-ethereum`).                                              |
 | `evm_ref`  | no                | Override the t8n tool branch / tag / commit.                                                          |
@@ -39,6 +39,24 @@ Devnet releases must use a `<feat>-devnet` feature name (e.g. `feature=bal-devne
 gh workflow run release_fixtures.yaml -f feature=bal-devnet -f version=v7.0.0 -f branch=devnets/bal/7
 ```
 
+## zkEVM benchmark releases
+
+Publish the source `tests-zkevm@vX.Y.Z` release before you make its benchmark release. The benchmark version must match the source version.
+
+```bash
+gh workflow run release_fixtures.yaml \
+  --ref 'tests-zkevm@vX.Y.Z' \
+  -f feature=zkevm-benchmark \
+  -f version=vX.Y.Z \
+  -f branch='tests-zkevm@vX.Y.Z'
+```
+
+The workflow uses the Geth repository and commit in `evm.yaml` by default. A releaser can use the existing `evm`, `evm_repo`, and `evm_ref` inputs to override that configuration.
+
+The workflow fills Amsterdam compute benchmarks at 10M, 30M, and 60M gas. It produces only `blockchain_test` fixtures.
+
+Before upload, the workflow checks the stateless data in each fixture. It also checks the source version and the destination release.
+
 ## What the workflow produces
 
 On success the workflow:
@@ -51,6 +69,7 @@ On success the workflow:
 | ---------------- | ------- | ------------- | -------- |
 | `feature=tests version=v24.0.0` | `tests@v24.0.0` | `tests@v24.0.0` | `fixtures.tar.gz` |
 | `feature=bal-devnet version=v7.0.0 branch=devnets/bal/7` | `tests-bal-devnet@v7.0.0` | `tests-bal-devnet@v7.0.0` | `fixtures_bal-devnet.tar.gz` |
+| `feature=zkevm-benchmark version=v0.9.0 branch=tests-zkevm@v0.9.0` | `tests-zkevm-benchmark@v0.9.0` | `tests-zkevm-benchmark@v0.9.0` | `fixtures_zkevm-benchmark.tar.gz`, `benchmark_genesis.tar.gz` |
 
 The release is created as a draft; review and publish it from the GitHub releases page.
 

--- a/docs/running_tests/releases.md
+++ b/docs/running_tests/releases.md
@@ -2,7 +2,8 @@
 
 Test fixtures are published as feature-scoped releases on the
 [`ethereum/execution-specs`](https://github.com/ethereum/execution-specs/releases)
-repository: `tests@vX.Y.Z`, `<feat>-devnet@vX.Y.Z`, and `benchmark@vX.Y.Z`. Each release is
+repository: `tests@vX.Y.Z`, `<feat>-devnet@vX.Y.Z`, `benchmark@vX.Y.Z`, and
+`zkevm-benchmark@vX.Y.Z`. Each release is
 a self-contained `.tar.gz` of JSON fixtures that execution clients consume in CI.
 
 This page describes the release types, their versioning, the fixture formats they contain,
@@ -28,6 +29,7 @@ and cadence.
 | Tests     | `tests@vX.Y.Z`         | `fixtures.tar.gz`               | All forks, all tests (eventually including `ethereum/tests` state tests)        | latest `forks/*` branch |
 | Devnet    | `<feat>-devnet@vX.Y.Z` | `fixtures_<feat>-devnet.tar.gz` | All forks, all tests, for an upcoming-fork feature under active devnet testing   | the devnet branch       |
 | Benchmark | `benchmark@vX.Y.Z`     | `fixtures_benchmark.tar.gz`     | EVM benchmarking tests                                                          | latest `forks/*` branch |
+| zkEVM benchmark | `zkevm-benchmark@vX.Y.Z` | `fixtures_zkevm-benchmark.tar.gz` | Amsterdam compute benchmarks with stateless input and output bytes | matching `tests-zkevm@vX.Y.Z` tag |
 
 - "Tests" releases track clients' production branches and are tagged frequently (roughly
   once or twice a week). They are the "must pass" release for mainnet CI, and supersede the
@@ -35,8 +37,8 @@ and cadence.
 - "Devnet" releases target a specific feature under active development (e.g. `bal-devnet`).
   They are advisory/non-blocking and may not yet cover every EIP; see the corresponding
   release notes for the coverage provided.
-- "Benchmark" (and, in future, zkEVM) releases are produced separately for their
-  specialized consumers.
+- "Benchmark" releases are produced separately for their specialized consumers.
+- "zkEVM benchmark" releases contain 10M, 30M, and 60M `blockchain_test` fixtures. Their versions match their source `tests-zkevm` releases.
 
 ## Versioning Scheme
 
@@ -63,6 +65,8 @@ spec change in your target, so read the release notes before adopting it.
 
 This also lets two devnets of the same feature be maintained in parallel (e.g. `v3.0.1`
 alongside `v7.0.0`) without ambiguity, the same way `2.x` and `3.x` coexist under semver.
+
+A `zkevm-benchmark` version must match its source `tests-zkevm` version. A benchmark-only correction requires a new `tests-zkevm` source release.
 
 ## Fixture Formats
 
@@ -171,6 +175,7 @@ to release URLs and downloads them. For example:
 uv run consume cache --input=latest  # shorthand for tests@latest
 uv run consume cache --input=tests@latest
 uv run consume cache --input=bal-devnet@v7.0.0
+uv run consume cache --input=zkevm-benchmark@v0.9.0
 ```
 
 Raw tarballs can also be fetched directly with the GitHub CLI:


### PR DESCRIPTION
### Description
Automates zkEVM benchmark fixture releases from matching tests-zkevm@vX.Y.Z tags. It fills Amsterdam benchmarks at 10M, 30M, and 60M gas, validates the generated stateless data, prevents mismatched or duplicate releases, and documents the release workflow.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
