### PR TITLE
feat(test-fill): Optimistic grouping flag

### DIFF
--- a/docs/running_tests/test_formats/blockchain_test_engine_x.md
+++ b/docs/running_tests/test_formats/blockchain_test_engine_x.md
@@ -28,10 +28,12 @@ Each file in the `pre_alloc` folder corresponds to a pre-allocation group identi
 
 ```json
 {
-   "test_count": 88,
-   "pre_account_count": 174,
+   "testCount": 88,
+   "preAccountCount": 174,
    "testIds": ["test1", "test2", ...],
    "network": "Prague",
+   "chainId": "0x01",
+   "groupHash": "0xb664b0d847df2cf7",
    "environment": { ... },
    "pre": { ... }
 }
@@ -39,10 +41,13 @@ Each file in the `pre_alloc` folder corresponds to a pre-allocation group identi
 
 #### Pre-Allocation Group Fields
 
-- **`test_count`**: Number of tests in this pre-allocation group
-- **`pre_account_count`**: Number of accounts in the pre-allocation group
+- **`testCount`**: Number of tests in this pre-allocation group
+- **`preAccountCount`**: Number of accounts in the pre-allocation group
 - **`testIds`**: Array of test identifiers that belong to this group
 - **`network`**: Fork name (e.g., "Prague", "Cancun")
+- **`chainId`**: Chain id the group's genesis is configured for
+- **`groupHash`**: The group's own hash; matches the file name and the [`preHash`](#-prehash-string) of every test in the group
+- **`groupSalt`**: Optional isolation salt; only present for groups that were explicitly isolated
 - **`environment`**: Complete [`Environment`](./common_types.md#environment) object with execution context
 - **`pre`**: Pre-allocation group [`Alloc`](./common_types.md#alloc-mappingaddressaccount) object containing initial account states
 
@@ -69,10 +74,8 @@ For each [`BlockchainTestEngineXFixture`](#blockchaintestenginexfixture) test ob
 
 4. **Verify Final State**:
    - Compare the final chain head against [`lastblockhash`](#-lastblockhash-hash)
-   - If [`postStateDiff`](#-poststatediff-optionalalloc) is present:
-     - Apply the state differences to the pre-allocation group
-     - Verify the resulting state matches the client's final state
-   - If `post` field were present (not typical), verify it directly
+   - Apply [`postStateDiff`](#-poststatediff-alloc) to the pre-allocation group
+   - Verify the resulting state matches the client's final state
 
 ## Structures
 
@@ -88,7 +91,7 @@ This field is going to be replaced by the value contained in `config.network`.
 
 #### - `preHash`: `string`
 
-Hash identifier referencing a pre-allocation group in the `pre_alloc` folder. This hash uniquely identifies the combination of fork, environment, and pre-allocation state that defines the group.
+Hash identifier referencing a pre-allocation group in the `pre_alloc` folder. This hash uniquely identifies the combination of fork, environment, and pre-allocation state that defines the group. It is `0x`-prefixed, 8 bytes wide, and matches both the group file's name and its `groupHash` field.
 
 #### - `genesisBlockHeader`: [`FixtureHeader`](./blockchain_test.md#fixtureheader)
 
@@ -106,7 +109,7 @@ Optional synchronization payload. When present, this payload is typically used t
 
 Hash of the last valid block after all payloads have been processed, or the genesis block hash if all payloads are invalid.
 
-#### - `postStateDiff`: [`Optional`](./common_types.md#optional)`[`[`Alloc`](./common_types.md#alloc-mappingaddressaccount)`]`
+#### - `postStateDiff`: [`Alloc`](./common_types.md#alloc-mappingaddressaccount)
 
 State differences from the pre-allocation group after test execution. This optimization stores only the accounts that changed, were created, or were deleted during test execution, rather than the complete final state.
 

--- a/docs/running_tests/test_formats/blockchain_test_engine_x.md
+++ b/docs/running_tests/test_formats/blockchain_test_engine_x.md
@@ -34,7 +34,6 @@ Each file in the `pre_alloc` folder corresponds to a pre-allocation group identi
    "network": "Prague",
    "chainId": "0x01",
    "groupHash": "0xb664b0d847df2cf7",
-   "environment": { ... },
    "pre": { ... }
 }
 ```
@@ -48,7 +47,6 @@ Each file in the `pre_alloc` folder corresponds to a pre-allocation group identi
 - **`chainId`**: Chain id the group's genesis is configured for
 - **`groupHash`**: The group's own hash; matches the file name and the [`preHash`](#-prehash-string) of every test in the group
 - **`groupSalt`**: Optional isolation salt; only present for groups that were explicitly isolated
-- **`environment`**: Complete [`Environment`](./common_types.md#environment) object with execution context
 - **`pre`**: Pre-allocation group [`Alloc`](./common_types.md#alloc-mappingaddressaccount) object containing initial account states
 
 ## Consumption
@@ -58,12 +56,11 @@ For each [`BlockchainTestEngineXFixture`](#blockchaintestenginexfixture) test ob
 1. **Load Pre-Allocation Group**:
    - Read the appropriate file from the `pre_alloc` folder in the same directory
    - Locate the pre-allocation group using [`preHash`](#-prehash-string)
-   - Extract the `pre` allocation and `environment` from the group
+   - Extract the `pre` allocation from the group
 
 2. **Initialize Client**:
    - Use [`network`](#-network-fork) to configure the execution fork schedule
    - Use the pre-allocation group's `pre` allocation as the starting state
-   - Use the pre-allocation group's `environment` as the execution context
    - Use [`genesisBlockHeader`](#-genesisblockheader-fixtureheader) as the genesis block header
 
 3. **Execute Engine API Sequence**:

--- a/docs/running_tests/test_formats/blockchain_test_engine_x.md
+++ b/docs/running_tests/test_formats/blockchain_test_engine_x.md
@@ -34,6 +34,7 @@ Each file in the `pre_alloc` folder corresponds to a pre-allocation group identi
    "network": "Prague",
    "chainId": "0x01",
    "groupHash": "0xb664b0d847df2cf7",
+   "genesis": { ... },
    "pre": { ... }
 }
 ```
@@ -47,6 +48,7 @@ Each file in the `pre_alloc` folder corresponds to a pre-allocation group identi
 - **`chainId`**: Chain id the group's genesis is configured for
 - **`groupHash`**: The group's own hash; matches the file name and the [`preHash`](#-prehash-string) of every test in the group
 - **`groupSalt`**: Optional isolation salt; only present for groups that were explicitly isolated
+- **`genesis`**: Genesis block header ([`FixtureHeader`](./blockchain_test.md#fixtureheader)) shared by every test in the group, derived from the environment the group was keyed on; its state root matches the state root of `pre`
 - **`pre`**: Pre-allocation group [`Alloc`](./common_types.md#alloc-mappingaddressaccount) object containing initial account states
 
 ## Consumption
@@ -56,12 +58,12 @@ For each [`BlockchainTestEngineXFixture`](#blockchaintestenginexfixture) test ob
 1. **Load Pre-Allocation Group**:
    - Read the appropriate file from the `pre_alloc` folder in the same directory
    - Locate the pre-allocation group using [`preHash`](#-prehash-string)
-   - Extract the `pre` allocation from the group
+   - Extract the `pre` allocation and `genesis` header from the group
 
 2. **Initialize Client**:
    - Use [`network`](#-network-fork) to configure the execution fork schedule
    - Use the pre-allocation group's `pre` allocation as the starting state
-   - Use [`genesisBlockHeader`](#-genesisblockheader-fixtureheader) as the genesis block header
+   - Use the pre-allocation group's `genesis` as the genesis block header
 
 3. **Execute Engine API Sequence**:
    - For each [`FixtureEngineNewPayload`](#fixtureenginenewpayload) in [`engineNewPayloads`](#-enginenewpayloads-listfixtureenginenewpayload):
@@ -89,10 +91,6 @@ This field is going to be replaced by the value contained in `config.network`.
 #### - `preHash`: `string`
 
 Hash identifier referencing a pre-allocation group in the `pre_alloc` folder. This hash uniquely identifies the combination of fork, environment, and pre-allocation state that defines the group. It is `0x`-prefixed, 8 bytes wide, and matches both the group file's name and its `groupHash` field.
-
-#### - `genesisBlockHeader`: [`FixtureHeader`](./blockchain_test.md#fixtureheader)
-
-Genesis block header. The state root in this header must match the state root calculated from the pre-allocation group referenced by [`preHash`](#-prehash-string).
 
 #### - `engineNewPayloads`: [`List`](./common_types.md#list)`[`[`FixtureEngineNewPayload`](#fixtureenginenewpayload)`]`
 

--- a/packages/testing/src/execution_testing/cli/compare_fixtures.py
+++ b/packages/testing/src/execution_testing/cli/compare_fixtures.py
@@ -15,7 +15,7 @@ from typing import List, Set
 
 import click
 
-from execution_testing.base_types import HexNumber
+from execution_testing.base_types import Hash
 from execution_testing.fixtures.consume import (
     IndexFile,
     TestCaseIndexFile,
@@ -36,7 +36,7 @@ def load_index(folder: Path) -> IndexFile:
     return IndexFile.model_validate_json(index_path.read_text())
 
 
-def get_fixture_hashes(index: IndexFile) -> Set[HexNumber]:
+def get_fixture_hashes(index: IndexFile) -> Set[Hash]:
     """Extract fixture hashes and their corresponding file paths from index."""
     hash_set = set()
 
@@ -49,14 +49,14 @@ def get_fixture_hashes(index: IndexFile) -> Set[HexNumber]:
 
 
 def find_duplicates(
-    base_hashes: Set[HexNumber], patch_hashes: Set[HexNumber]
-) -> Set[HexNumber]:
+    base_hashes: Set[Hash], patch_hashes: Set[Hash]
+) -> Set[Hash]:
     """Find fixture hashes that exist in both base and patch."""
     return base_hashes & patch_hashes
 
 
 def pop_all_by_hash(
-    index: IndexFile, fixture_hash: HexNumber
+    index: IndexFile, fixture_hash: Hash
 ) -> List[TestCaseIndexFile]:
     """Pops all test cases from an index file by their hash."""
     test_cases = []

--- a/packages/testing/src/execution_testing/cli/extract_config.py
+++ b/packages/testing/src/execution_testing/cli/extract_config.py
@@ -36,7 +36,7 @@ from execution_testing.fixtures import (
 )
 from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.fixtures.file import Fixtures
-from execution_testing.fixtures.pre_alloc_groups import PreAllocGroupBuilder
+from execution_testing.fixtures.pre_alloc_groups import PreAllocGroup
 from execution_testing.forks import Fork
 
 
@@ -177,8 +177,7 @@ class GenesisState(BaseModel):
 
         try:
             # Load as builder format and compute genesis on-demand
-            builder = PreAllocGroupBuilder.model_validate_json(fixture_bytes)
-            pre_alloc_group = builder.build()
+            pre_alloc_group = PreAllocGroup.model_validate_json(fixture_bytes)
             return cls(
                 header=pre_alloc_group.genesis,
                 alloc=pre_alloc_group.pre,

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -19,7 +19,6 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
-from execution_testing.base_types import HexNumber
 from execution_testing.fixtures.consume import (
     IndexFile,
     TestCaseIndexFile,
@@ -113,16 +112,14 @@ def generate_fixtures_index(
     try:
         root_hash = HashableItem.from_folder(folder_path=input_path).hash()
     except (KeyError, TypeError):
-        root_hash = b""  # just regenerate a new index file
+        root_hash = None
 
     if not force_flag and output_file.exists():
         index_data: IndexFile
         try:
             with open(output_file, "r") as f:
                 index_data = IndexFile(**json.load(f))
-            if index_data.root_hash and index_data.root_hash == HexNumber(
-                root_hash
-            ):
+            if index_data.root_hash and index_data.root_hash == root_hash:
                 if not quiet_mode:
                     rich.print(
                         f"Index file [bold cyan]{output_file}[/] "

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -272,8 +272,6 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
 
                 # Insert directly into trie for hash computation
                 fixture_hash = entry.get("fixture_hash")
-                if not fixture_hash:
-                    continue
 
                 path_parts = Path(entry["json_path"]).parts
                 current = root_trie

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar
 
 import click
-from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape as rich_escape
 
@@ -96,17 +95,14 @@ class HashableItem:
     ) -> "HashableItem":
         """Create a hashable item from a JSON file."""
         items = {}
-        file_text = file_path.read_text()
-        # Special-case the pre-alloc groups
-        try:
-            v = PreAllocGroup.from_file(file_path)
+        # Pre-alloc group files live under a "pre_alloc" folder
+        if file_path.parent.name == "pre_alloc":
             return cls(
                 type=HashableItemType.FILE,
-                root=v.hash(),
+                root=PreAllocGroup.from_file(file_path).hash(),
                 parents=parents + [file_path.name],
             )
-        except ValidationError:
-            pass
+        file_text = file_path.read_text()
         data = json.loads(file_text)
         for key, item in sorted(data.items()):
             if not isinstance(item, dict):

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -105,14 +105,14 @@ class HashableItem:
                 )
 
             # EEST uses 'hash'; ethereum/tests use 'generatedTestHash'
-            hash_value = Hash(
-                item["_info"].get("hash")
-                or item["_info"].get("generatedTestHash")
+            hash_str = item["_info"].get("hash") or item["_info"].get(
+                "generatedTestHash"
             )
-            if hash_value is None:
+            if hash_str is None:
                 raise KeyError(
                     f"Expected 'hash' or 'generatedTestHash' in {key}"
                 )
+            hash_value = Hash(hash_str)
 
             items[key] = cls(
                 type=HashableItemType.TEST,
@@ -161,9 +161,7 @@ class HashableItem:
             {
                 "id": e.id,
                 "json_path": str(e.json_path),
-                "fixture_hash": str(e.fixture_hash)
-                if e.fixture_hash
-                else None,
+                "fixture_hash": str(e.fixture_hash),
             }
             for e in entries
         ]
@@ -189,9 +187,7 @@ class HashableItem:
 
         # Single pass: insert all entries into trie
         for entry in entries:
-            fixture_hash = entry.get("fixture_hash")
-            if not fixture_hash:
-                continue
+            fixture_hash = entry["fixture_hash"]
 
             # Navigate/create path to file node
             path_parts = Path(entry["json_path"]).parts

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -11,10 +11,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar
 
 import click
+from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape as rich_escape
 
 from execution_testing.base_types import Hash
+from execution_testing.fixtures.pre_alloc_groups import PreAllocGroup
 
 if TYPE_CHECKING:
     from execution_testing.fixtures.consume import TestCaseIndexFile
@@ -69,7 +71,7 @@ class HashableItem:
 
         if print_type is None or self.type >= print_type:
             next_level += 1
-            lines.append(f"{' ' * level}{print_name}: 0x{self.hash().hex()}")
+            lines.append(f"{' ' * level}{print_name}: {self.hash().hex()}")
 
         # Stop recursion if we've reached max_depth
         if max_depth is not None and next_level > max_depth:
@@ -94,11 +96,24 @@ class HashableItem:
     ) -> "HashableItem":
         """Create a hashable item from a JSON file."""
         items = {}
-        with file_path.open("r") as f:
-            data = json.load(f)
+        file_text = file_path.read_text()
+        # Special-case the pre-alloc groups
+        try:
+            v = PreAllocGroup.from_file(file_path)
+            return cls(
+                type=HashableItemType.FILE,
+                root=v.hash(),
+                parents=parents + [file_path.name],
+            )
+        except ValidationError:
+            pass
+        data = json.loads(file_text)
         for key, item in sorted(data.items()):
             if not isinstance(item, dict):
-                raise TypeError(f"Expected dict, got {type(item)} for {key}")
+                raise TypeError(
+                    f"Expected dict, got {type(item)} for {key}, "
+                    f"json file: {file_path.name}"
+                )
             if "_info" not in item:
                 raise KeyError(
                     f"Expected '_info' in {key}, json file: {file_path.name}"
@@ -251,7 +266,7 @@ def render_hash_report(
     """Return canonical output lines for a folder."""
     item = HashableItem.from_folder(folder_path=folder)
     if root:
-        return [f"0x{item.hash().hex()}"]
+        return [item.hash().hex()]
     print_type: Optional[HashableItemType] = None
     if files:
         print_type = HashableItemType.FILE
@@ -276,7 +291,7 @@ def collect_hashes(
 
     if print_type is None or item.type >= print_type:
         if path:
-            result[path] = f"0x{item.hash().hex()}"
+            result[path] = item.hash().hex()
         depth += 1
         if max_depth is not None and depth > max_depth:
             return result
@@ -454,8 +469,8 @@ def compare_cmd(
         if root:
             if left_item.hash() == right_item.hash():
                 sys.exit(0)
-            left_hashes = {"root": f"0x{left_item.hash().hex()}"}
-            right_hashes = {"root": f"0x{right_item.hash().hex()}"}
+            left_hashes = {"root": left_item.hash().hex()}
+            right_hashes = {"root": right_item.hash().hex()}
         else:
             print_type: Optional[HashableItemType] = None
             if files:

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -14,6 +14,8 @@ import click
 from rich.console import Console
 from rich.markup import escape as rich_escape
 
+from execution_testing.base_types import Hash
+
 if TYPE_CHECKING:
     from execution_testing.fixtures.consume import TestCaseIndexFile
 
@@ -35,10 +37,10 @@ class HashableItem:
 
     type: HashableItemType
     parents: List[str] = field(default_factory=list)
-    root: Optional[bytes] = None
+    root: Optional[Hash] = None
     items: Optional[Dict[str, "HashableItem"]] = None
 
-    def hash(self) -> bytes:
+    def hash(self) -> Hash:
         """Return the hash of the item."""
         if self.root is not None:
             return self.root
@@ -46,7 +48,7 @@ class HashableItem:
             raise ValueError("No items to hash")
         # Use list + join instead of += to avoid O(n²) byte concatenation
         hash_parts = [item.hash() for _, item in sorted(self.items.items())]
-        return hashlib.sha256(b"".join(hash_parts)).digest()
+        return Hash(hashlib.sha256(b"".join(hash_parts)).digest())
 
     def format_lines(
         self,
@@ -103,24 +105,18 @@ class HashableItem:
                 )
 
             # EEST uses 'hash'; ethereum/tests use 'generatedTestHash'
-            hash_value = item["_info"].get("hash") or item["_info"].get(
-                "generatedTestHash"
+            hash_value = Hash(
+                item["_info"].get("hash")
+                or item["_info"].get("generatedTestHash")
             )
             if hash_value is None:
                 raise KeyError(
                     f"Expected 'hash' or 'generatedTestHash' in {key}"
                 )
 
-            if not isinstance(hash_value, str):
-                raise TypeError(
-                    f"Expected hash to be a string in {key}, "
-                    f"got {type(hash_value)}"
-                )
-
-            item_hash_bytes = bytes.fromhex(hash_value[2:])
             items[key] = cls(
                 type=HashableItemType.TEST,
-                root=item_hash_bytes,
+                root=hash_value,
                 parents=parents + [file_path.name],
             )
         return cls(type=HashableItemType.FILE, items=items, parents=parents)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/test_tracker.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/test_tracker.py
@@ -5,13 +5,15 @@ import logging
 import pytest
 from pytest import StashKey
 
+from execution_testing.test_types import AllocGroupHash
+
 logger = logging.getLogger(__name__)
 
 # Typed stash keys for session-scoped data (replaces dynamic attributes)
 enginex_group_counts_key: StashKey[dict[str, int]] = StashKey()
 
 
-def make_group_identifier(pre_hash: str, client_name: str) -> str:
+def make_group_identifier(pre_hash: AllocGroupHash, client_name: str) -> str:
     """Build xdist group key from pre-alloc hash and client name."""
     return f"{pre_hash}-{client_name}"
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/multi_test_client.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/multi_test_client.py
@@ -8,8 +8,11 @@ import pytest
 from hive.client import Client
 
 from execution_testing.base_types import to_json
-from execution_testing.fixtures import BlockchainEngineXFixture
-from execution_testing.fixtures.pre_alloc_groups import PreAllocGroup
+from execution_testing.fixtures import (
+    BlockchainEngineXFixture,
+    PreAllocGroup,
+)
+from execution_testing.test_types import AllocGroupHash
 
 from ..consume import FixturesSource
 from .helpers.ruleset import ruleset
@@ -142,19 +145,19 @@ def multi_test_client_manager() -> Generator[
 
 
 @pytest.fixture(scope="session")
-def pre_alloc_group_cache() -> dict[str, PreAllocGroup]:
+def pre_alloc_group_cache() -> dict[AllocGroupHash, PreAllocGroup]:
     """Cache for pre-allocation groups to avoid reloading from disk."""
     return {}
 
 
 @pytest.fixture(scope="session")
-def client_genesis_cache() -> dict[str, dict]:
+def client_genesis_cache() -> dict[AllocGroupHash, dict]:
     """Cache for client genesis configs to avoid redundant to_json calls."""
     return {}
 
 
 @pytest.fixture(scope="session")
-def environment_cache() -> dict[str, dict]:
+def environment_cache() -> dict[AllocGroupHash, dict]:
     """Cache for environment configs to avoid redundant computation."""
     return {}
 
@@ -163,7 +166,7 @@ def environment_cache() -> dict[str, dict]:
 def pre_alloc_group(
     fixture: BlockchainEngineXFixture,
     fixtures_source: FixturesSource,
-    pre_alloc_group_cache: dict[str, PreAllocGroup],
+    pre_alloc_group_cache: dict[AllocGroupHash, PreAllocGroup],
 ) -> PreAllocGroup:
     """Load the pre-allocation group for the current test case."""
     pre_hash = fixture.pre_hash
@@ -210,7 +213,7 @@ def pre_alloc_group(
 def client_genesis(
     pre_alloc_group: PreAllocGroup,
     fixture: BlockchainEngineXFixture,
-    client_genesis_cache: dict[str, dict],
+    client_genesis_cache: dict[AllocGroupHash, dict],
 ) -> dict:
     """
     Convert pre-alloc group genesis header and pre-state to client genesis.
@@ -243,7 +246,7 @@ def environment(
     pre_alloc_group: PreAllocGroup,
     fixture: BlockchainEngineXFixture,
     check_live_port: int,
-    environment_cache: dict[str, dict],
+    environment_cache: dict[AllocGroupHash, dict],
 ) -> dict:
     """
     Define environment variables for multi-test client startup.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -30,12 +30,7 @@ from _pytest.terminal import TerminalReporter
 from filelock import FileLock
 from pytest_metadata.plugin import metadata_key
 
-from execution_testing.base_types import (
-    Account,
-    Address,
-    ReferenceSpec,
-)
-from execution_testing.base_types import Alloc as BaseAlloc
+from execution_testing.base_types import ReferenceSpec
 from execution_testing.cli.gen_index import (
     merge_partial_indexes,
 )
@@ -44,7 +39,6 @@ from execution_testing.client_clis.clis.geth import FixtureConsumerTool
 from execution_testing.fixtures import (
     BaseFixture,
     BlockchainEngineFixture,
-    BlockchainEngineXFixture,
     BlockchainFixture,
     FixtureCollector,
     FixtureConsumer,
@@ -64,7 +58,7 @@ from execution_testing.fixtures.engine_x_checks import (
     verify_engine_x_execution,
 )
 from execution_testing.fixtures.pre_alloc_groups import (
-    GroupIndexEntry,
+    GroupIndexEntries,
     _get_worker_id,
     merge_partial_group_files,
     pack_pre_alloc_groups,
@@ -78,7 +72,7 @@ from execution_testing.forks import (
 )
 from execution_testing.specs import BaseTest
 from execution_testing.specs.base import FillResult, OpMode
-from execution_testing.test_types import EnvironmentDefaults
+from execution_testing.test_types import AllocGroupHash, EnvironmentDefaults
 from execution_testing.test_types.chain_config_types import (
     DEFAULT_CHAIN_ID,
     ChainConfigDefaults,
@@ -170,7 +164,7 @@ class FillingSession:
     # of tests it holds, so it can no longer be recomputed per-test; a test
     # finds its group through the packed index file instead (see
     # read_test_group_index).
-    _test_group_index: Dict[str, GroupIndexEntry] | None = field(
+    _test_group_index: GroupIndexEntries | None = field(
         default=None, repr=False
     )
 
@@ -237,7 +231,7 @@ class FillingSession:
         match self.filling_phase:
             case FixtureFillingPhase.PRE_ALLOC_GENERATION:
                 # Phase 1: Create empty container for collecting groups
-                self.pre_alloc_group_builders = PreAllocGroupBuilders(root={})
+                self.pre_alloc_group_builders = PreAllocGroupBuilders()
             case FixtureFillingPhase.FILL_AFTER_PRE_ALLOC_GENERATION:
                 # Phase 2: Load pre-alloc groups from disk
                 pre_alloc_folder = (
@@ -272,12 +266,14 @@ class FillingSession:
         """
         return self.filling_phase in fixture_format.format_phases
 
-    def get_pre_alloc_group(self, hash_key: str) -> PreAllocGroup:
+    def get_pre_alloc_group(
+        self, pre_alloc_hash: AllocGroupHash
+    ) -> PreAllocGroup:
         """
         Get a pre-allocation group by hash.
 
         Args:
-            hash_key: The hash of the pre-alloc group.
+            pre_alloc_hash: The hash of the pre-alloc group.
 
         Returns:
             The pre-allocation group.
@@ -289,20 +285,23 @@ class FillingSession:
         if self.pre_alloc_groups is None:
             raise ValueError("Pre-allocation groups not initialized")
 
-        if hash_key not in self.pre_alloc_groups:
+        if pre_alloc_hash not in self.pre_alloc_groups:
             pre_alloc_path = (
-                self.fixture_output.pre_alloc_groups_folder_path / hash_key
+                self.fixture_output.pre_alloc_groups_folder_path
+                / f"{pre_alloc_hash}.json"
             )
             raise ValueError(
-                f"Pre-allocation hash {hash_key} not found in "
+                f"Pre-allocation hash {pre_alloc_hash} not found in "
                 f"pre-allocation groups. Please check the file at: "
                 f"{pre_alloc_path}. Make sure phase 1 "
                 "(--generate-pre-alloc-groups) was run before phase 2."
             )
 
-        return self.pre_alloc_groups[hash_key]
+        return self.pre_alloc_groups[pre_alloc_hash]
 
-    def group_hash_for_test(self, test_id: str, phase1_hash: str) -> str:
+    def group_hash_for_test(
+        self, test_id: str, phase1_hash: AllocGroupHash
+    ) -> AllocGroupHash:
         """
         Return the packed pre-alloc group hash that owns ``test_id``.
 
@@ -384,57 +383,6 @@ class TransitionToolCacheStats:
             subkey_test_miss=data.get("subkey_test_miss", 0),
             unique_keys=data.get("unique_keys", 0),
         )
-
-
-def calculate_post_state_diff(
-    post_state: BaseAlloc, genesis_state: BaseAlloc
-) -> BaseAlloc:
-    """
-    Calculate the state difference between post_state and genesis_state.
-
-    This function enables significant space savings in Engine X fixtures by
-    storing only the accounts that changed during test execution, rather than
-    the full post-state which may contain thousands of unchanged accounts.
-
-    Returns an Alloc containing only the accounts that:
-    - Changed between genesis and post state (balance, nonce, storage, code)
-    - Were created during test execution (new accounts)
-    - Were deleted during test execution (represented as None)
-
-    Args:
-        post_state: Final state after test execution
-        genesis_state: Genesis pre-allocation state
-
-    Returns:
-        Alloc containing only the state differences for efficient storage
-
-    """
-    diff: Dict[Address, Account | None] = {}
-
-    # Find all addresses that exist in either state
-    all_addresses = set(post_state.root.keys()) | set(
-        genesis_state.root.keys()
-    )
-
-    for address in all_addresses:
-        genesis_account = genesis_state.root.get(address)
-        post_account = post_state.root.get(address)
-
-        # Account was deleted (exists in genesis but not in post)
-        if genesis_account is not None and post_account is None:
-            diff[address] = None
-
-        # Account was created (doesn't exist in genesis but exists in post)
-        elif genesis_account is None and post_account is not None:
-            diff[address] = post_account
-
-        # Account was modified (exists in both but different)
-        elif genesis_account != post_account:
-            diff[address] = post_account
-
-        # Account unchanged - don't include in diff
-
-    return BaseAlloc(diff)
 
 
 def default_output_directory() -> str:
@@ -630,6 +578,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Generate all fixture formats including BlockchainEngineX. "
             "Enables two-phase execution: Phase 1 generates pre-allocation "
             "groups, phase 2 generates all supported fixture formats."
+        ),
+    )
+    test_group.addoption(
+        "--disable-optimistic-pre-alloc-grouping",
+        action="store_true",
+        dest="optimistic_pre_alloc_grouping_disabled",
+        default=False,
+        help=(
+            "Disable optimistic grouping that uses heuristics to attempt to "
+            "predict tests that reuse the same addresses, but still try to "
+            "group them in order to reduce the group count."
         ),
     )
 
@@ -1519,6 +1478,14 @@ def commit_hash_or_tag() -> str:
     return get_current_commit_hash_or_tag()
 
 
+@pytest.fixture(scope="session")
+def optimistic_pre_alloc_grouping_disabled(
+    request: pytest.FixtureRequest,
+) -> bool:
+    """Whether optimistic pre-allocation grouping is disabled or not."""
+    return request.config.getoption("optimistic_pre_alloc_grouping_disabled")
+
+
 @pytest.fixture(scope="function")
 def fixture_source_url(
     request: pytest.FixtureRequest,
@@ -1580,6 +1547,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
         fixture_source_url: str,
         gas_benchmark_value: int,
         fixed_opcode_count: int | None,
+        optimistic_pre_alloc_grouping_disabled: bool,
         is_tx_gas_heavy_test: bool,
         is_exception_test: bool,
         is_inclusion_test: bool,
@@ -1657,8 +1625,9 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                             request.node.nodeid
                         )
 
-                pre_alloc_hash: str | None = None
+                pre_alloc_hash: AllocGroupHash | None = None
                 # Phase 1: Generate pre-allocation groups
+                test_id = _strip_xdist_group_suffix(request.node.nodeid)
                 if (
                     session.filling_phase
                     == FixtureFillingPhase.PRE_ALLOC_GENERATION
@@ -1666,7 +1635,6 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     # Use the original update_pre_alloc_groups method which
                     # returns the groups
                     assert session.pre_alloc_group_builders is not None
-                    test_id = _strip_xdist_group_suffix(request.node.nodeid)
                     genesis_environment = self.get_genesis_environment()
                     pre_alloc_hash = pre.compute_pre_alloc_group_hash(
                         fork=fork,
@@ -1690,21 +1658,21 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     FixtureFillingPhase.PRE_ALLOC_GENERATION
                     in fixture_format.format_phases
                 ):
-                    # Groups are packed after phase 1, so a test's group hash
-                    # can no longer be recomputed from its own pre; look it up
-                    # by test id instead, fingerprinted by the recomputed
-                    # phase 1 hash so a stale group folder fails loudly.
-                    test_id = _strip_xdist_group_suffix(request.node.nodeid)
-                    pre_alloc_hash = session.group_hash_for_test(
-                        test_id,
-                        phase1_hash=pre.compute_pre_alloc_group_hash(
-                            fork=fork,
-                            genesis_environment=(
-                                self.get_genesis_environment()
-                            ),
-                            group_salt=group_salt,
-                        ),
+                    pre_alloc_hash = pre.compute_pre_alloc_group_hash(
+                        fork=fork,
+                        genesis_environment=self.get_genesis_environment(),
+                        group_salt=group_salt,
                     )
+                    if not optimistic_pre_alloc_grouping_disabled:
+                        # Groups are packed after phase 1, so a test's group
+                        # hash can no longer be recomputed from its own pre;
+                        # look it up by test id instead, fingerprinted by the
+                        # recomputed phase 1 hash so a stale group folder fails
+                        # loudly.
+                        pre_alloc_hash = session.group_hash_for_test(
+                            test_id,
+                            phase1_hash=pre_alloc_hash,
+                        )
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
                 fill_result: FillResult | None = None
@@ -1746,28 +1714,6 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     ),
                     gas_benchmark_value=gas_benchmark_value,
                 )
-
-                # Post-process for Engine X format (add pre_hash and state
-                # diff)
-                if (
-                    FixtureFillingPhase.PRE_ALLOC_GENERATION
-                    in fixture_format.format_phases
-                    and pre_alloc_hash is not None
-                ):
-                    # TODO: This should be handled by the `generate` method
-                    # of the spec.
-                    assert isinstance(fixture, BlockchainEngineXFixture)
-                    fixture.pre_hash = pre_alloc_hash
-
-                    # Calculate state diff for efficiency
-                    if (
-                        hasattr(fixture, "post_state")
-                        and fixture.post_state is not None
-                    ):
-                        group = session.get_pre_alloc_group(pre_alloc_hash)
-                        fixture.post_state_diff = calculate_post_state_diff(
-                            fixture.post_state, group.pre
-                        )
 
                 fill_metadata: Dict[str, Any] = {}
                 if t8n.opcode_count is not None:
@@ -2132,13 +2078,17 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             _log_timing(
                 f"Phase 1 (master): merge done in {time.time() - t0:.1f}s"
             )
-            # Pack the fine-grained groups into fewer, larger ones so Engine X
-            # boots one client for many tests instead of one per test.
-            t0 = time.time()
-            pack_pre_alloc_groups(pre_alloc_folder)
-            _log_timing(
-                f"Phase 1 (master): pack done in {time.time() - t0:.1f}s"
-            )
+            if not session.config.getoption(
+                "optimistic_pre_alloc_grouping_disabled"
+            ):
+                # Pack the fine-grained groups into fewer, larger ones so
+                # Engine X boots one client for many tests instead of one per
+                # test.
+                t0 = time.time()
+                pack_pre_alloc_groups(pre_alloc_folder)
+                _log_timing(
+                    f"Phase 1 (master): pack done in {time.time() - t0:.1f}s"
+                )
         else:
             # Workers: clear in-memory state to reduce memory pressure while
             # waiting for other workers to finish
@@ -2200,37 +2150,40 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             file.unlink()
         _log_timing(f"Lock files removed in {time.time() - t0:.1f}s")
 
-    # Loudly fail the fill if pre-alloc group packing changed any Engine X
-    # test's execution (raises on drift, like a pre-alloc collision).
-    _log_timing("verify_engine_x_execution: starting...")
-    t0 = time.time()
-    engine_x_check = verify_engine_x_execution(fixture_output.directory)
-    engine_x_warning: str | None = None
-    if engine_x_check is not None:
-        if engine_x_check.compared > 0:
-            logger.info(engine_x_check.summary)
-        elif engine_x_check.skipped > 0:
+    if not session.config.getoption("optimistic_pre_alloc_grouping_disabled"):
+        # Loudly fail the fill if pre-alloc group packing changed any Engine X
+        # test's execution (raises on drift, like a pre-alloc collision).
+        _log_timing("verify_engine_x_execution: starting...")
+        t0 = time.time()
+        engine_x_check = verify_engine_x_execution(fixture_output.directory)
+        engine_x_warning: str | None = None
+        if engine_x_check is not None:
+            if engine_x_check.compared > 0:
+                logger.info(engine_x_check.summary)
+            elif engine_x_check.skipped > 0:
+                engine_x_warning = (
+                    "Engine X execution consistency check skipped: none of "
+                    f"the {engine_x_check.skipped} Engine X fixtures have a "
+                    "blockchain_tests_engine sibling fixture to compare "
+                    "against. Leaks from pre-alloc group packing are not "
+                    "verified for this output."
+                )
+        elif (fixture_output.directory / ENGINE_X_FIXTURES_DIR).is_dir():
             engine_x_warning = (
-                "Engine X execution consistency check skipped: none of "
-                f"the {engine_x_check.skipped} Engine X fixtures have a "
-                "blockchain_tests_engine sibling fixture to compare "
-                "against. Leaks from pre-alloc group packing are not "
-                "verified for this output."
+                "Engine X execution consistency check skipped: this fill "
+                "generated no blockchain_tests_engine fixtures to compare "
+                "against (e.g. filling with `-m blockchain_test_engine_x`). "
+                "Leaks from pre-alloc group packing are not verified for this "
+                "output."
             )
-    elif (fixture_output.directory / ENGINE_X_FIXTURES_DIR).is_dir():
-        engine_x_warning = (
-            "Engine X execution consistency check skipped: this fill "
-            "generated no blockchain_tests_engine fixtures to compare "
-            "against (e.g. filling with `-m blockchain_test_engine_x`). "
-            "Leaks from pre-alloc group packing are not verified for this "
-            "output."
+        if engine_x_warning is not None:
+            logger.warning(engine_x_warning)
+            # Repeated in the terminal summary; a log line alone is easy to
+            # miss.
+            session.config.engine_x_check_warning = engine_x_warning  # type: ignore[attr-defined] # noqa: E501
+        _log_timing(
+            f"verify_engine_x_execution: done in {time.time() - t0:.1f}s"
         )
-    if engine_x_warning is not None:
-        logger.warning(engine_x_warning)
-        # Repeated in the terminal summary; a log line alone is easy to
-        # miss.
-        session.config.engine_x_check_warning = engine_x_warning  # type: ignore[attr-defined] # noqa: E501
-    _log_timing(f"verify_engine_x_execution: done in {time.time() - t0:.1f}s")
 
     # Verify fixtures after merge if verification is enabled
     if session.config.getoption("verify_fixtures"):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -45,7 +45,6 @@ from execution_testing.fixtures import (
     FixtureFillingPhase,
     LabeledFixtureFormat,
     PreAllocGroup,
-    PreAllocGroupBuilder,
     PreAllocGroupBuilders,
     PreAllocGroups,
     StateFixture,
@@ -921,10 +920,8 @@ def pytest_terminal_summary(
                 # Count accounts by loading as builder (no genesis computation)
                 total_accounts = 0
                 for group_file in group_files:
-                    builder = PreAllocGroupBuilder.model_validate_json(
-                        group_file.read_text()
-                    )
-                    total_accounts += builder.get_pre_account_count()
+                    pre_alloc_group = PreAllocGroup.from_file(group_file)
+                    total_accounts += pre_alloc_group.pre_account_count
             else:
                 assert session_instance.pre_alloc_group_builders is not None
                 total_groups = len(
@@ -2073,14 +2070,18 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         if not is_worker:
             _log_timing("Phase 1 (master): merging partial group files...")
             t0 = time.time()
+            optimistic_pre_alloc_grouping_disabled = session.config.getoption(
+                "optimistic_pre_alloc_grouping_disabled"
+            )
+            assert isinstance(optimistic_pre_alloc_grouping_disabled, bool)
             pre_alloc_folder = fixture_output.pre_alloc_groups_folder_path
-            merge_partial_group_files(pre_alloc_folder)
+            merge_partial_group_files(
+                pre_alloc_folder, final=optimistic_pre_alloc_grouping_disabled
+            )
             _log_timing(
                 f"Phase 1 (master): merge done in {time.time() - t0:.1f}s"
             )
-            if not session.config.getoption(
-                "optimistic_pre_alloc_grouping_disabled"
-            ):
+            if not optimistic_pre_alloc_grouping_disabled:
                 # Pack the fine-grained groups into fewer, larger ones so
                 # Engine X boots one client for many tests instead of one per
                 # test.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -917,7 +917,7 @@ def pytest_terminal_summary(
                 )
                 group_files = list(pre_alloc_folder.glob("*.json"))
                 total_groups = len(group_files)
-                # Count accounts by loading as builder (no genesis computation)
+                # Count accounts from the final pre-alloc group files
                 total_accounts = 0
                 for group_file in group_files:
                     pre_alloc_group = PreAllocGroup.from_file(group_file)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -134,7 +134,7 @@ class Alloc(SharedAlloc):
             for deleted_address in sorted(self._deleted_addresses):
                 buffer += deleted_address
 
-        return AllocGroupHash.from_hash(buffer)
+        return AllocGroupHash.from_preimage(buffer)
 
     def compute_pre_alloc_group_hash(
         self,
@@ -145,15 +145,17 @@ class Alloc(SharedAlloc):
     ) -> AllocGroupHash:
         """Hash (fork, env) in order to group tests by genesis config."""
         combined_hash = (
-            AllocGroupHash.from_hash(fork.name())
-            ^ AllocGroupHash.from_hash(genesis_environment.canonical_json())
+            AllocGroupHash.from_preimage(fork.name())
+            ^ AllocGroupHash.from_preimage(
+                genesis_environment.canonical_json()
+            )
             ^ self.modified_accounts_salt()
         )
 
         # Check if this pre-allocation has a group salt
         if group_salt:
             # Add custom salt to hash
-            combined_hash = combined_hash ^ AllocGroupHash.from_hash(
+            combined_hash = combined_hash ^ AllocGroupHash.from_preimage(
                 group_salt
             )
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -1,6 +1,5 @@
 """Pre-alloc specifically conditioned for test filling."""
 
-import hashlib
 import inspect
 from functools import cache
 from hashlib import sha256
@@ -30,6 +29,7 @@ from execution_testing.test_types import (
     DETERMINISTIC_FACTORY_ADDRESS,
     DETERMINISTIC_FACTORY_BYTECODE,
     EOA,
+    AllocGroupHash,
     Environment,
     compute_deterministic_create2_address,
     contract_address_from_hash,
@@ -99,7 +99,7 @@ class Alloc(SharedAlloc):
         """Pre-processes the code before setting it."""
         return code
 
-    def modified_accounts_salt(self) -> int:
+    def modified_accounts_salt(self) -> AllocGroupHash:
         """
         Return a salt if this pre-allocation was affected by setting addresses
         to hard-coded accounts or has pre-funded addresses.
@@ -113,7 +113,7 @@ class Alloc(SharedAlloc):
             and not self._hardcoded_addresses_deployed_to
             and not self._deleted_addresses
         ):
-            return 0
+            return AllocGroupHash(0)
 
         # Build a hashable buffer from the modified accounts.
         buffer = b""
@@ -134,9 +134,7 @@ class Alloc(SharedAlloc):
             for deleted_address in sorted(self._deleted_addresses):
                 buffer += deleted_address
 
-        return int.from_bytes(
-            hashlib.sha256(buffer).digest()[:8], byteorder="big"
-        )
+        return AllocGroupHash.from_hash(buffer)
 
     def compute_pre_alloc_group_hash(
         self,
@@ -144,24 +142,22 @@ class Alloc(SharedAlloc):
         fork: Fork | TransitionFork,
         genesis_environment: Environment,
         group_salt: str | None,
-    ) -> str:
+    ) -> AllocGroupHash:
         """Hash (fork, env) in order to group tests by genesis config."""
-        fork_digest = hashlib.sha256(fork.name().encode("utf-8")).digest()
-        fork_hash = int.from_bytes(fork_digest[:8], byteorder="big")
         combined_hash = (
-            fork_hash
-            ^ hash(genesis_environment)
+            AllocGroupHash.from_hash(fork.name())
+            ^ AllocGroupHash.from_hash(genesis_environment.canonical_json())
             ^ self.modified_accounts_salt()
         )
 
         # Check if this pre-allocation has a group salt
         if group_salt:
             # Add custom salt to hash
-            salt_hash = hashlib.sha256(group_salt.encode("utf-8")).digest()
-            salt_int = int.from_bytes(salt_hash[:8], byteorder="big")
-            combined_hash = combined_hash ^ salt_int
+            combined_hash = combined_hash ^ AllocGroupHash.from_hash(
+                group_salt
+            )
 
-        return f"0x{combined_hash:016x}"
+        return AllocGroupHash(combined_hash)
 
     def _deterministic_deploy_contract(
         self,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filling_session.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filling_session.py
@@ -84,7 +84,7 @@ class TestFillingSession:
         config = MockConfig(use_pre_alloc_groups=True)
 
         # Mock the file system operations
-        group_hash = AllocGroupHash.from_hash("test_hash")
+        group_hash = AllocGroupHash.from_preimage("test_hash")
         test_group_builder = PreAllocGroupBuilder(
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
@@ -180,7 +180,7 @@ class TestFillingSession:
         """Test getting a pre-alloc group by hash."""
         config = MockConfig(use_pre_alloc_groups=True)
 
-        group_hash = AllocGroupHash.from_hash("test_hash")
+        group_hash = AllocGroupHash.from_preimage("test_hash")
         test_group_builder = PreAllocGroupBuilder(
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
@@ -203,7 +203,9 @@ class TestFillingSession:
                     session = FillingSession.from_config(config)  # type: ignore[arg-type]
 
         assert (
-            session.get_pre_alloc_group(AllocGroupHash.from_hash("test_hash"))
+            session.get_pre_alloc_group(
+                AllocGroupHash.from_preimage("test_hash")
+            )
             is test_group
         )
 
@@ -227,7 +229,7 @@ class TestFillingSession:
             ValueError, match="Pre-allocation hash .* not found"
         ):
             session.get_pre_alloc_group(
-                AllocGroupHash.from_hash("missing_hash")
+                AllocGroupHash.from_preimage("missing_hash")
             )
 
     def test_get_pre_alloc_group_not_initialized(self) -> None:
@@ -243,7 +245,9 @@ class TestFillingSession:
         with pytest.raises(
             ValueError, match="Pre-allocation groups not initialized"
         ):
-            session.get_pre_alloc_group(AllocGroupHash.from_hash("any_hash"))
+            session.get_pre_alloc_group(
+                AllocGroupHash.from_preimage("any_hash")
+            )
 
     def test_save_pre_alloc_groups(self) -> None:
         """Test saving pre-alloc groups to disk."""
@@ -260,7 +264,7 @@ class TestFillingSession:
         # here we only need a non-empty mapping for save_pre_alloc_groups
         # to exercise its mkdir/to_folder path.
         assert session.pre_alloc_group_builders is not None
-        group_hash = AllocGroupHash.from_hash("test_hash")
+        group_hash = AllocGroupHash.from_preimage("test_hash")
         session.pre_alloc_group_builders.root[group_hash] = (
             PreAllocGroupBuilder(
                 pre=Alloc().model_dump(mode="json"),

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filling_session.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filling_session.py
@@ -14,7 +14,7 @@ from execution_testing.fixtures import (
     PreAllocGroups,
 )
 from execution_testing.forks import Prague
-from execution_testing.test_types import Environment
+from execution_testing.test_types import AllocGroupHash, Environment
 
 from ..filler import FillingSession
 
@@ -84,15 +84,17 @@ class TestFillingSession:
         config = MockConfig(use_pre_alloc_groups=True)
 
         # Mock the file system operations
+        group_hash = AllocGroupHash.from_hash("test_hash")
         test_group_builder = PreAllocGroupBuilder(
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
             .model_dump(mode="json", exclude={"parent_hash"}),
             fork=Prague.name(),
+            group_hash=group_hash,
         )
         test_group = test_group_builder.build()
-        mock_groups = PreAllocGroups(root={"test_hash": test_group})
+        mock_groups = PreAllocGroups(root={group_hash: test_group})
 
         with patch(
             "execution_testing.cli.pytest_commands.plugins.filler.filler.FixtureOutput",
@@ -152,7 +154,7 @@ class TestFillingSession:
             generate_all_formats=True, use_pre_alloc_groups=True
         )
 
-        mock_groups = PreAllocGroups(root={})
+        mock_groups = PreAllocGroups()
 
         with patch(
             "execution_testing.cli.pytest_commands.plugins.filler.filler.FixtureOutput",
@@ -178,15 +180,17 @@ class TestFillingSession:
         """Test getting a pre-alloc group by hash."""
         config = MockConfig(use_pre_alloc_groups=True)
 
+        group_hash = AllocGroupHash.from_hash("test_hash")
         test_group_builder = PreAllocGroupBuilder(
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
             .model_dump(mode="json", exclude={"parent_hash"}),
             fork=Prague.name(),
+            group_hash=group_hash,
         )
         test_group = test_group_builder.build()
-        mock_groups = PreAllocGroups(root={"test_hash": test_group})
+        mock_groups = PreAllocGroups(root={group_hash: test_group})
 
         with patch(
             "execution_testing.cli.pytest_commands.plugins.filler.filler.FixtureOutput",
@@ -198,13 +202,16 @@ class TestFillingSession:
                 ):
                     session = FillingSession.from_config(config)  # type: ignore[arg-type]
 
-        assert session.get_pre_alloc_group("test_hash") is test_group
+        assert (
+            session.get_pre_alloc_group(AllocGroupHash.from_hash("test_hash"))
+            is test_group
+        )
 
     def test_get_pre_alloc_group_not_found(self) -> None:
         """Test getting a non-existent pre-alloc group."""
         config = MockConfig(use_pre_alloc_groups=True)
 
-        mock_groups = PreAllocGroups(root={})
+        mock_groups = PreAllocGroups()
 
         with patch(
             "execution_testing.cli.pytest_commands.plugins.filler.filler.FixtureOutput",
@@ -219,7 +226,9 @@ class TestFillingSession:
         with pytest.raises(
             ValueError, match="Pre-allocation hash .* not found"
         ):
-            session.get_pre_alloc_group("missing_hash")
+            session.get_pre_alloc_group(
+                AllocGroupHash.from_hash("missing_hash")
+            )
 
     def test_get_pre_alloc_group_not_initialized(self) -> None:
         """Test getting pre-alloc group when not initialized."""
@@ -234,7 +243,7 @@ class TestFillingSession:
         with pytest.raises(
             ValueError, match="Pre-allocation groups not initialized"
         ):
-            session.get_pre_alloc_group("any_hash")
+            session.get_pre_alloc_group(AllocGroupHash.from_hash("any_hash"))
 
     def test_save_pre_alloc_groups(self) -> None:
         """Test saving pre-alloc groups to disk."""
@@ -251,13 +260,15 @@ class TestFillingSession:
         # here we only need a non-empty mapping for save_pre_alloc_groups
         # to exercise its mkdir/to_folder path.
         assert session.pre_alloc_group_builders is not None
-        session.pre_alloc_group_builders.root["test_hash"] = (
+        group_hash = AllocGroupHash.from_hash("test_hash")
+        session.pre_alloc_group_builders.root[group_hash] = (
             PreAllocGroupBuilder(
                 pre=Alloc().model_dump(mode="json"),
                 environment=Environment()
                 .set_fork_requirements(Prague)
                 .model_dump(mode="json", exclude={"parent_hash"}),
                 fork=Prague.name(),
+                group_hash=group_hash,
             )
         )
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
@@ -687,71 +687,8 @@ def test_pre_alloc_grouping_by_test_type(
         for group_hash, group in groups.items():
             error_message += f"\n{group_hash}: \n"
             error_message += f"tests: {group.test_ids}\n"
-            env_json = group.environment.model_dump_json(
+            genesis_json = group.genesis.model_dump_json(
                 indent=2, exclude_none=True
             )
-            error_message += f"env: {env_json}\n"
+            error_message += f"genesis: {genesis_json}\n"
         raise AssertionError(error_message)
-
-    for group_hash, group in groups.items():
-        assert (
-            group.environment.fee_recipient == group.genesis.fee_recipient
-        ), (
-            f"Fee recipient mismatch for group {group_hash}: "
-            f"{group.environment.fee_recipient} != "
-            f"{group.genesis.fee_recipient}"
-        )
-        assert group.environment.prev_randao == group.genesis.prev_randao, (
-            f"Prev randao mismatch for group {group_hash}: "
-            f"{group.environment.prev_randao} != {group.genesis.prev_randao}"
-        )
-        assert group.environment.extra_data == group.genesis.extra_data, (
-            f"Extra data mismatch for group {group_hash}: "
-            f"{group.environment.extra_data} != {group.genesis.extra_data}"
-        )
-        assert group.environment.number == group.genesis.number, (
-            f"Number mismatch for group {group_hash}: "
-            f"{group.environment.number} != {group.genesis.number}"
-        )
-        assert group.environment.timestamp == group.genesis.timestamp, (
-            f"Timestamp mismatch for group {group_hash}: "
-            f"{group.environment.timestamp} != {group.genesis.timestamp}"
-        )
-        assert group.environment.difficulty == group.genesis.difficulty, (
-            f"Difficulty mismatch for group {group_hash}: "
-            f"{group.environment.difficulty} != {group.genesis.difficulty}"
-        )
-        assert group.environment.gas_limit == group.genesis.gas_limit, (
-            f"Gas limit mismatch for group {group_hash}: "
-            f"{group.environment.gas_limit} != {group.genesis.gas_limit}"
-        )
-        assert (
-            group.environment.base_fee_per_gas
-            == group.genesis.base_fee_per_gas
-        ), (
-            f"Base fee per gas mismatch for group {group_hash}: "
-            f"{group.environment.base_fee_per_gas} != "
-            f"{group.genesis.base_fee_per_gas}"
-        )
-        assert (
-            group.environment.excess_blob_gas == group.genesis.excess_blob_gas
-        ), (
-            f"Excess blob gas mismatch for group {group_hash}: "
-            f"{group.environment.excess_blob_gas} != "
-            f"{group.genesis.excess_blob_gas}"
-        )
-        assert (
-            group.environment.blob_gas_used == group.genesis.blob_gas_used
-        ), (
-            f"Blob gas used mismatch for group {group_hash}: "
-            f"{group.environment.blob_gas_used} != "
-            f"{group.genesis.blob_gas_used}"
-        )
-        assert (
-            group.environment.parent_beacon_block_root
-            == group.genesis.parent_beacon_block_root
-        ), (
-            f"Parent beacon block root mismatch for group {group_hash}: "
-            f"{group.environment.parent_beacon_block_root} != "
-            f"{group.genesis.parent_beacon_block_root}"
-        )

--- a/packages/testing/src/execution_testing/cli/show_pre_alloc_group_stats.py
+++ b/packages/testing/src/execution_testing/cli/show_pre_alloc_group_stats.py
@@ -159,7 +159,7 @@ def analyze_pre_alloc_folder(folder: Path) -> Dict:
     for hash_key, group in pre_alloc_groups.items():
         group_details.append(
             {
-                "hash": hash_key[:8] + "...",  # Shortened hash for display
+                "hash": str(hash_key),
                 "tests": group.test_count,
                 "accounts": group.pre_account_count,
                 "fork": group.fork.name(),

--- a/packages/testing/src/execution_testing/cli/tests/test_extract_config.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_extract_config.py
@@ -14,7 +14,6 @@ from execution_testing.forks import (
     forks_from_until,
     get_deployed_forks,
 )
-from execution_testing.test_types import Environment
 
 
 def forks_from_prague_onward() -> list[Fork]:
@@ -29,11 +28,8 @@ def test_genesis_state_from_pre_alloc_group_uses_stored_chain_id(
     fork: Fork,
 ) -> None:
     """Pre-alloc group files should preserve the configured chain ID."""
-    builder = PreAllocGroup(
+    group = PreAllocGroup(
         test_ids=["test_id"],
-        environment=Environment()
-        .set_fork_requirements(fork)
-        .model_dump(mode="json", exclude={"parent_hash"}),
         fork=fork.name(),
         chain_id=12345,
         genesis=FixtureHeader(
@@ -60,7 +56,7 @@ def test_genesis_state_from_pre_alloc_group_uses_stored_chain_id(
     )
     fixture_path = tmp_path / "pre_alloc.json"
     fixture_path.write_text(
-        builder.model_dump_json(by_alias=True, exclude_none=True, indent=2)
+        group.model_dump_json(by_alias=True, exclude_none=True, indent=2)
     )
 
     genesis_state = GenesisState.from_fixture(fixture_path)
@@ -75,11 +71,8 @@ def test_genesis_state_from_legacy_pre_alloc_group_defaults_chain_id(
     fork: Fork,
 ) -> None:
     """Legacy pre-alloc groups without chain ID should still default to 1."""
-    builder = PreAllocGroup(
+    group = PreAllocGroup(
         test_ids=["test_id"],
-        environment=Environment()
-        .set_fork_requirements(fork)
-        .model_dump(mode="json", exclude={"parent_hash"}),
         fork=fork.name(),
         genesis=FixtureHeader(
             parent_hash=0,
@@ -104,7 +97,7 @@ def test_genesis_state_from_legacy_pre_alloc_group_defaults_chain_id(
         test_count=1,
     )
     fixture_path = tmp_path / "legacy_pre_alloc.json"
-    fixture_path.write_text(builder.model_dump_json(exclude={"chain_id"}))
+    fixture_path.write_text(group.model_dump_json(exclude={"chain_id"}))
 
     genesis_state = GenesisState.from_fixture(fixture_path)
 

--- a/packages/testing/src/execution_testing/cli/tests/test_extract_config.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_extract_config.py
@@ -6,7 +6,8 @@ import pytest
 
 from execution_testing.base_types import Alloc
 from execution_testing.cli.extract_config import GenesisState
-from execution_testing.fixtures.pre_alloc_groups import PreAllocGroupBuilder
+from execution_testing.fixtures.blockchain import FixtureHeader
+from execution_testing.fixtures.pre_alloc_groups import PreAllocGroup
 from execution_testing.forks import (
     Fork,
     Prague,
@@ -28,15 +29,34 @@ def test_genesis_state_from_pre_alloc_group_uses_stored_chain_id(
     fork: Fork,
 ) -> None:
     """Pre-alloc group files should preserve the configured chain ID."""
-    builder = PreAllocGroupBuilder(
+    builder = PreAllocGroup(
         test_ids=["test_id"],
         environment=Environment()
         .set_fork_requirements(fork)
         .model_dump(mode="json", exclude={"parent_hash"}),
         fork=fork.name(),
         chain_id=12345,
+        genesis=FixtureHeader(
+            parent_hash=0,
+            ommers_hash=1,
+            fee_recipient=2,
+            state_root=3,
+            transactions_trie=4,
+            receipts_root=5,
+            logs_bloom=6,
+            difficulty=7,
+            number=8,
+            gas_limit=9,
+            gas_used=10,
+            timestamp=11,
+            extra_data=b"",
+            prev_randao=13,
+            nonce=14,
+        ),
         pre=Alloc().model_dump(mode="json"),
         group_hash=1,
+        pre_account_count=1,
+        test_count=1,
     )
     fixture_path = tmp_path / "pre_alloc.json"
     fixture_path.write_text(
@@ -55,14 +75,33 @@ def test_genesis_state_from_legacy_pre_alloc_group_defaults_chain_id(
     fork: Fork,
 ) -> None:
     """Legacy pre-alloc groups without chain ID should still default to 1."""
-    builder = PreAllocGroupBuilder(
+    builder = PreAllocGroup(
         test_ids=["test_id"],
         environment=Environment()
         .set_fork_requirements(fork)
         .model_dump(mode="json", exclude={"parent_hash"}),
         fork=fork.name(),
+        genesis=FixtureHeader(
+            parent_hash=0,
+            ommers_hash=1,
+            fee_recipient=2,
+            state_root=3,
+            transactions_trie=4,
+            receipts_root=5,
+            logs_bloom=6,
+            difficulty=7,
+            number=8,
+            gas_limit=9,
+            gas_used=10,
+            timestamp=11,
+            extra_data=b"",
+            prev_randao=13,
+            nonce=14,
+        ),
         pre=Alloc().model_dump(mode="json"),
         group_hash=1,
+        pre_account_count=1,
+        test_count=1,
     )
     fixture_path = tmp_path / "legacy_pre_alloc.json"
     fixture_path.write_text(builder.model_dump_json(exclude={"chain_id"}))

--- a/packages/testing/src/execution_testing/cli/tests/test_extract_config.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_extract_config.py
@@ -36,6 +36,7 @@ def test_genesis_state_from_pre_alloc_group_uses_stored_chain_id(
         fork=fork.name(),
         chain_id=12345,
         pre=Alloc().model_dump(mode="json"),
+        group_hash=1,
     )
     fixture_path = tmp_path / "pre_alloc.json"
     fixture_path.write_text(
@@ -61,6 +62,7 @@ def test_genesis_state_from_legacy_pre_alloc_group_defaults_chain_id(
         .model_dump(mode="json", exclude={"parent_hash"}),
         fork=fork.name(),
         pre=Alloc().model_dump(mode="json"),
+        group_hash=1,
     )
     fixture_path = tmp_path / "legacy_pre_alloc.json"
     fixture_path.write_text(builder.model_dump_json(exclude={"chain_id"}))

--- a/packages/testing/src/execution_testing/cli/tests/test_hasher.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_hasher.py
@@ -8,7 +8,7 @@ from typing import Generator, List
 import pytest
 from click.testing import CliRunner
 
-from execution_testing.base_types import HexNumber
+from execution_testing.base_types import Hash
 from execution_testing.cli.gen_index import merge_partial_indexes
 from execution_testing.cli.hasher import HashableItem, hasher
 from execution_testing.fixtures.consume import IndexFile, TestCaseIndexFile
@@ -18,11 +18,6 @@ HASH_2 = 0x2222222222222222222222222222222222222222222222222222222222222222
 HASH_3 = 0x3333333333333333333333333333333333333333333333333333333333333333
 HASH_4 = 0x4444444444444444444444444444444444444444444444444444444444444444
 HASH_9 = 0x9999999999999999999999999999999999999999999999999999999999999999
-
-
-def _hex_str(h: int) -> str:
-    """Convert an integer hash to its 0x-prefixed hex string."""
-    return f"0x{h:064x}"
 
 
 def _make_entry(
@@ -36,7 +31,7 @@ def _make_entry(
     return TestCaseIndexFile(
         id=test_id,
         json_path=Path(json_path),
-        fixture_hash=HexNumber(fixture_hash),
+        fixture_hash=fixture_hash,
         fork=fork,
         format=fmt,
     )
@@ -47,17 +42,19 @@ def _make_json_fixture(test_names_and_hashes: dict[str, int]) -> str:
     data = {}
     for name, h in test_names_and_hashes.items():
         data[name] = {
-            "_info": {"hash": _hex_str(h)},
+            "_info": {"hash": str(Hash(h))},
             "pre": {},
             "post": {},
         }
     return json.dumps(data)
 
 
-def create_fixture(path: Path, test_name: str, hash_value: str) -> None:
+def create_fixture(path: Path, test_name: str, hash_value: int) -> None:
     """Create a test fixture JSON file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({test_name: {"_info": {"hash": hash_value}}}))
+    path.write_text(
+        json.dumps({test_name: {"_info": {"hash": str(Hash(hash_value))}}})
+    )
 
 
 class TestCompareIdenticalDirectories:
@@ -67,8 +64,8 @@ class TestCompareIdenticalDirectories:
         """Same content in both dirs should exit 0 with no output."""
         dir_a = tmp_path / "dir_a" / "state_tests"
         dir_b = tmp_path / "dir_b" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
-        create_fixture(dir_b / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
+        create_fixture(dir_b / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -85,8 +82,8 @@ class TestCompareDifferentDirectories:
         """Different hashes should exit 1 with diff in stdout."""
         dir_a = tmp_path / "dir_a" / "state_tests"
         dir_b = tmp_path / "dir_b" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
-        create_fixture(dir_b / "test.json", "test1", "0xdef456")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
+        create_fixture(dir_b / "test.json", "test1", 0xDEF456)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -96,8 +93,8 @@ class TestCompareDifferentDirectories:
         assert "Fixture Hash Differences" in result.output
         # Verify the new format shows the path and both hashes
         assert "test1" in result.output
-        assert "0xabc123" in result.output
-        assert "0xdef456" in result.output
+        assert "abc123" in result.output
+        assert "def456" in result.output
 
 
 class TestCompareMissingDirectory:
@@ -106,7 +103,7 @@ class TestCompareMissingDirectory:
     def test_compare_missing_directory(self, tmp_path: Path) -> None:
         """One path doesn't exist should exit 2 with error in stderr."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -122,7 +119,7 @@ class TestCompareFlagParity:
     def test_compare_flag_parity_files(self, tmp_path: Path) -> None:
         """Hasher -f X vs hasher compare -f X X should exit 0."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         # Compare same directory with -f flag
@@ -134,7 +131,7 @@ class TestCompareFlagParity:
     def test_compare_flag_parity_tests(self, tmp_path: Path) -> None:
         """Hasher -t X vs hasher compare -t X X should exit 0."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         # Compare same directory with -t flag
@@ -146,7 +143,7 @@ class TestCompareFlagParity:
     def test_compare_flag_parity_root(self, tmp_path: Path) -> None:
         """Hasher -r X vs hasher compare -r X X should exit 0."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         # Compare same directory with -r flag
@@ -162,7 +159,7 @@ class TestBackwardsCompatibility:
     def test_backwards_compat(self, tmp_path: Path) -> None:
         """Hasher FOLDER without subcommand should work as before."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         # Old syntax without subcommand
@@ -173,7 +170,7 @@ class TestBackwardsCompatibility:
     def test_explicit_hash_subcommand(self, tmp_path: Path) -> None:
         """Hasher hash FOLDER should work."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         # Explicit hash subcommand
@@ -186,7 +183,7 @@ class TestBackwardsCompatibility:
     ) -> None:
         """Both syntaxes should produce identical output."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         # Old syntax
@@ -234,7 +231,7 @@ class TestHashCommandFlags:
     def test_hash_with_files_flag(self, tmp_path: Path) -> None:
         """Hasher hash -f FOLDER should work."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         result = runner.invoke(hasher, ["hash", "-f", str(dir_a.parent)])
@@ -244,7 +241,7 @@ class TestHashCommandFlags:
     def test_hash_with_tests_flag(self, tmp_path: Path) -> None:
         """Hasher hash -t FOLDER should work."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         result = runner.invoke(hasher, ["hash", "-t", str(dir_a.parent)])
@@ -254,7 +251,7 @@ class TestHashCommandFlags:
     def test_hash_with_root_flag(self, tmp_path: Path) -> None:
         """Hasher hash -r FOLDER should only print root hash."""
         dir_a = tmp_path / "dir_a" / "state_tests"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
 
         runner = CliRunner()
         result = runner.invoke(hasher, ["hash", "-r", str(dir_a.parent)])
@@ -272,8 +269,8 @@ class TestCompareDepthFlag:
         """--depth should limit how deep the comparison goes."""
         dir_a = tmp_path / "dir_a" / "folder" / "subfolder"
         dir_b = tmp_path / "dir_b" / "folder" / "subfolder"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
-        create_fixture(dir_b / "test.json", "test1", "0xdef456")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
+        create_fixture(dir_b / "test.json", "test1", 0xDEF456)
 
         runner = CliRunner()
 
@@ -296,8 +293,8 @@ class TestCompareDepthFlag:
         """--depth 2 should show subfolders."""
         dir_a = tmp_path / "dir_a" / "folder" / "subfolder"
         dir_b = tmp_path / "dir_b" / "folder" / "subfolder"
-        create_fixture(dir_a / "test.json", "test1", "0xabc123")
-        create_fixture(dir_b / "test.json", "test1", "0xdef456")
+        create_fixture(dir_a / "test.json", "test1", 0xABC123)
+        create_fixture(dir_b / "test.json", "test1", 0xDEF456)
 
         runner = CliRunner()
 
@@ -327,22 +324,22 @@ class TestCompareHierarchy:
         create_fixture(
             dir_a / "blockchain_tests" / "shanghai" / "test.json",
             "test1",
-            "0xaaa111",
+            0xAAA111,
         )
         create_fixture(
             dir_a / "state_tests" / "shanghai" / "test.json",
             "test1",
-            "0xbbb222",
+            0xBBB222,
         )
         create_fixture(
             dir_b / "blockchain_tests" / "shanghai" / "test.json",
             "test1",
-            "0xccc333",
+            0xCCC333,
         )
         create_fixture(
             dir_b / "state_tests" / "shanghai" / "test.json",
             "test1",
-            "0xddd444",
+            0xDDD444,
         )
 
         runner = CliRunner()
@@ -524,28 +521,6 @@ class TestHashableItemFromIndexEntries:
             hash_from_entries = HashableItem.from_index_entries(entries).hash()
             assert hash_from_folder == hash_from_entries
 
-    def test_entries_with_none_fixture_hash_skipped(self) -> None:
-        """Verify entries with fixture_hash=None are skipped."""
-        entries_with_none = [
-            _make_entry("t1", "tests/a.json", HASH_1),
-            TestCaseIndexFile(
-                id="t_null",
-                json_path=Path("tests/a.json"),
-                fixture_hash=None,
-                fork=None,
-                format=None,
-            ),
-        ]
-        entries_without_none = [
-            _make_entry("t1", "tests/a.json", HASH_1),
-        ]
-
-        hash_with = HashableItem.from_index_entries(entries_with_none).hash()
-        hash_without = HashableItem.from_index_entries(
-            entries_without_none
-        ).hash()
-        assert hash_with == hash_without
-
 
 class TestMergePartialIndexes:
     """Test the JSONL partial index merge pipeline end-to-end."""
@@ -569,7 +544,7 @@ class TestMergePartialIndexes:
         return {
             "id": test_id,
             "json_path": json_path,
-            "fixture_hash": _hex_str(fixture_hash),
+            "fixture_hash": str(Hash(fixture_hash)),
             "fork": fork,
             "format": fmt,
             "pre_hash": None,
@@ -862,4 +837,4 @@ class TestIndexFileMerge:
 
         merged = IndexFile.merge([idx_a, idx_b])
         expected_hash = HashableItem.from_index_entries(cases).hash()
-        assert merged.root_hash == HexNumber(expected_hash)
+        assert merged.root_hash == expected_hash

--- a/packages/testing/src/execution_testing/cli/tests/test_hasher.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_hasher.py
@@ -8,10 +8,13 @@ from typing import Generator, List
 import pytest
 from click.testing import CliRunner
 
-from execution_testing.base_types import Hash
+from execution_testing.base_types import Account, Address, Hash
 from execution_testing.cli.gen_index import merge_partial_indexes
 from execution_testing.cli.hasher import HashableItem, hasher
 from execution_testing.fixtures.consume import IndexFile, TestCaseIndexFile
+from execution_testing.fixtures.pre_alloc_groups import PreAllocGroupBuilder
+from execution_testing.forks import Fork, Prague
+from execution_testing.test_types import Alloc, Environment
 
 HASH_1 = 0x1111111111111111111111111111111111111111111111111111111111111111
 HASH_2 = 0x2222222222222222222222222222222222222222222222222222222222222222
@@ -57,6 +60,27 @@ def create_fixture(path: Path, test_name: str, hash_value: int) -> None:
     )
 
 
+def create_pre_alloc_group(
+    folder: Path, balance: int, fork: Fork = Prague
+) -> Path:
+    """Write a pre-allocation group file, as filling phase 1 produces it."""
+    folder.mkdir(parents=True, exist_ok=True)
+    builder = PreAllocGroupBuilder(
+        test_ids=["tests/test_group.py::test_group"],
+        environment=Environment().set_fork_requirements(fork),
+        fork=fork,
+        group_hash=0x0011223344556677,
+        pre=Alloc({Address(0x1000): Account(balance=balance)}),
+    )
+    group_file = folder / f"{builder.group_hash}.json"
+    group_file.write_text(
+        builder.build().model_dump_json(
+            by_alias=True, exclude_none=True, indent=2
+        )
+    )
+    return group_file
+
+
 class TestCompareIdenticalDirectories:
     """Test comparing identical directories."""
 
@@ -95,6 +119,66 @@ class TestCompareDifferentDirectories:
         assert "test1" in result.output
         assert "abc123" in result.output
         assert "def456" in result.output
+
+
+class TestComparePreAllocGroups:
+    """
+    Compare directories holding a `pre_alloc` group folder.
+
+    Group files are hashed by their `PreAllocGroup` content, which the hasher
+    keys off the folder name rather than off a trial parse, so a broken group
+    file fails as a group instead of falling through to the fixture path.
+    """
+
+    def test_compare_identical_groups(self, tmp_path: Path) -> None:
+        """Identical group files hash equal."""
+        for name in ("dir_a", "dir_b"):
+            root = tmp_path / name / "blockchain_tests_engine_x"
+            create_fixture(root / "test.json", "test1", 0xABC123)
+            create_pre_alloc_group(root / "pre_alloc", balance=1)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            hasher,
+            ["compare", str(tmp_path / "dir_a"), str(tmp_path / "dir_b")],
+        )
+        assert result.exit_code == 0
+        assert result.output == ""
+
+    def test_compare_different_groups(self, tmp_path: Path) -> None:
+        """A changed pre-allocation shows as a group file difference."""
+        for name, balance in (("dir_a", 1), ("dir_b", 2)):
+            root = tmp_path / name / "blockchain_tests_engine_x"
+            create_fixture(root / "test.json", "test1", 0xABC123)
+            create_pre_alloc_group(root / "pre_alloc", balance=balance)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            hasher,
+            ["compare", str(tmp_path / "dir_a"), str(tmp_path / "dir_b")],
+        )
+        assert result.exit_code == 1
+        assert "pre_alloc" in result.output
+        # The regular fixture sitting next to the group folder is untouched.
+        assert "test.json" not in result.output
+
+    def test_broken_group_file_reports_a_group_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A malformed group file fails as a group, not as a fixture."""
+        root = tmp_path / "dir_a" / "blockchain_tests_engine_x"
+        pre_alloc = root / "pre_alloc"
+        pre_alloc.mkdir(parents=True)
+        (pre_alloc / "broken.json").write_text(json.dumps({"test1": {}}))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            hasher,
+            ["compare", str(tmp_path / "dir_a"), str(tmp_path / "dir_a")],
+        )
+        assert result.exit_code == 2
+        assert "PreAllocGroup" in result.output
+        assert "_info" not in result.output
 
 
 class TestCompareMissingDirectory:

--- a/packages/testing/src/execution_testing/cli/tests/test_pytest_fill_command.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_pytest_fill_command.py
@@ -1,6 +1,5 @@
 """Tests for pytest commands (e.g., fill) click CLI."""
 
-import json
 import shutil
 from pathlib import Path
 from typing import Callable
@@ -10,6 +9,7 @@ from click.testing import CliRunner, Result
 from pytest import MonkeyPatch, Pytester, RunResult, TempPathFactory
 
 import execution_testing.cli.pytest_commands.plugins.filler.filler
+from execution_testing.fixtures import PreAllocGroup
 
 from ..pytest_commands.fill import fill
 
@@ -246,12 +246,13 @@ class TestFillPytester:
         pytester.copy_example(
             name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
         )
+        chain_id = 12345
         result = pytester.runpytest(
             "-c",
             "pytest-fill.ini",
             "--generate-pre-alloc-groups",
             "--chain-id",
-            "12345",
+            str(chain_id),
             f"--output={default_fixtures_output}",
             str(test_file),
             "-q",
@@ -265,8 +266,10 @@ class TestFillPytester:
         assert pre_alloc_files, f"No pre-alloc files found in {pre_alloc_dir}"
 
         for pre_alloc_file in pre_alloc_files:
-            payload = json.loads(pre_alloc_file.read_text())
-            assert payload["chainId"] == 12345, pre_alloc_file
+            payload = PreAllocGroup.model_validate_json(
+                pre_alloc_file.read_text()
+            )
+            assert payload.chain_id == 12345, pre_alloc_file
 
     def test_fill_html_option(
         self,

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -927,10 +927,12 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
     pre_hash: AllocGroupHash
     """Hash of the pre-allocation group this test belongs to."""
 
-    post_state_diff: Alloc
+    post_state_diff: Alloc | None = None
     """
     State difference from genesis after test execution (efficiency
     optimization).
+
+    TODO: Remove `| None = None` defaults once we are past `v20.0.1` release.
     """
 
     payloads: List[FixtureEngineNewPayload] = Field(

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -927,12 +927,10 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
     pre_hash: AllocGroupHash
     """Hash of the pre-allocation group this test belongs to."""
 
-    post_state_diff: Alloc | None = None
+    post_state_diff: Alloc
     """
     State difference from genesis after test execution (efficiency
     optimization).
-
-    TODO: Remove `| None = None` defaults once we are past `v20.0.1` release.
     """
 
     payloads: List[FixtureEngineNewPayload] = Field(

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -55,6 +55,7 @@ from execution_testing.exceptions import (
 )
 from execution_testing.forks import Fork, Paris, TransitionFork
 from execution_testing.test_types import (
+    AllocGroupHash,
     BlockAccessList,
     Environment,
     Removable,
@@ -923,10 +924,10 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
     }
     transition_tool_cache_key: ClassVar[str] = ""
 
-    pre_hash: str
+    pre_hash: AllocGroupHash
     """Hash of the pre-allocation group this test belongs to."""
 
-    post_state_diff: Alloc | None = None
+    post_state_diff: Alloc
     """
     State difference from genesis after test execution (efficiency
     optimization).

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -25,7 +25,7 @@ from execution_testing.cli.pytest_commands.plugins.shared.fixture_output import 
 )
 
 from .base import BaseFixture
-from .consume import FixtureConsumer
+from .consume import FixtureConsumer, TestCaseIndexFile
 from .file import Fixtures
 
 
@@ -303,15 +303,14 @@ class FixtureCollector:
         if self.generate_index and self.output_dir.name != "stdout":
             relative_path = fixture_path.relative_to(self.output_dir)
             fixture_fork = fixture.get_fork()
-            index_entry = {
-                "id": info.get_id(),
-                "json_path": str(relative_path),
-                "fixture_hash": str(fixture.hash) if fixture.hash else None,
-                "fork": fixture_fork.name() if fixture_fork else None,
-                "format": fixture.format_name,
-            }
-            if (pre_hash := getattr(fixture, "pre_hash", None)) is not None:
-                index_entry["pre_hash"] = pre_hash
+            index_entry = TestCaseIndexFile(
+                id=info.get_id(),
+                json_path=relative_path,
+                fixture_hash=fixture.hash,
+                fork=fixture_fork,
+                format=fixture.format_class(),
+                pre_hash=getattr(fixture, "pre_hash", None),
+            )
             self._stream_index_entry_to_partial(index_entry)
 
         return fixture_path
@@ -355,10 +354,10 @@ class FixtureCollector:
 
         return self._partial_index_file
 
-    def _stream_index_entry_to_partial(self, entry: Dict) -> None:
+    def _stream_index_entry_to_partial(self, entry: TestCaseIndexFile) -> None:
         """Stream a single index entry to partial JSONL file."""
         f = self._get_partial_index_file()
-        f.write(json.dumps(entry) + "\n")
+        f.write(entry.model_dump_json(exclude_none=True) + "\n")
         f.flush()  # Ensure data is written immediately
 
     def close_streaming_files(self) -> None:

--- a/packages/testing/src/execution_testing/fixtures/consume.py
+++ b/packages/testing/src/execution_testing/fixtures/consume.py
@@ -3,9 +3,9 @@
 import datetime
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterator, List, Optional, TextIO
+from typing import Annotated, Any, Iterator, List, Optional, TextIO
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, BeforeValidator, RootModel
 
 from execution_testing.base_types import Hash
 from execution_testing.forks import Fork, TransitionFork
@@ -13,6 +13,23 @@ from execution_testing.test_types import AllocGroupHash
 
 from .base import BaseFixture, FixtureFormat
 from .file import Fixtures
+
+
+def _left_pad_hash(value: Any) -> Any:
+    """Left-pad a hash that was serialized without its leading zeros."""
+    if isinstance(value, str):
+        return Hash(value, left_padding=True)
+    return value
+
+
+IndexHash = Annotated[Hash, BeforeValidator(_left_pad_hash)]
+"""
+A hash read from an index file.
+
+Index files written before hashes were typed stored them as numbers, which
+drops any leading zero bytes (and writes a missing root hash as ``0x0``), so
+a hash read back from one is padded to its full width instead of rejected.
+"""
 
 
 class FixtureConsumer(ABC):
@@ -48,7 +65,7 @@ class TestCaseBase(BaseModel):
     """Base model for a test case used in EEST consume commands."""
 
     id: str
-    fixture_hash: Hash
+    fixture_hash: IndexHash
     fork: Fork | TransitionFork | None = None
     format: FixtureFormat
     pre_hash: AllocGroupHash | None = None
@@ -85,7 +102,7 @@ class TestCaseIndexFile(TestCaseBase):
 class IndexFile(BaseModel):
     """The model definition used for fixture index files."""
 
-    root_hash: Hash | None
+    root_hash: IndexHash | None
     created_at: datetime.datetime
     test_count: int
     forks: Optional[List[Fork]] = []

--- a/packages/testing/src/execution_testing/fixtures/consume.py
+++ b/packages/testing/src/execution_testing/fixtures/consume.py
@@ -49,7 +49,7 @@ class TestCaseBase(BaseModel):
 
     id: str
     fixture_hash: Hash
-    fork: Fork | TransitionFork | None
+    fork: Fork | TransitionFork | None = None
     format: FixtureFormat
     pre_hash: AllocGroupHash | None = None
     __test__ = False  # stop pytest from collecting this class as a test

--- a/packages/testing/src/execution_testing/fixtures/consume.py
+++ b/packages/testing/src/execution_testing/fixtures/consume.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, RootModel
 
 from execution_testing.base_types import HexNumber
 from execution_testing.forks import Fork, TransitionFork
+from execution_testing.test_types import AllocGroupHash
 
 from .base import BaseFixture, FixtureFormat
 from .file import Fixtures
@@ -50,7 +51,7 @@ class TestCaseBase(BaseModel):
     fixture_hash: HexNumber | None = None
     fork: Fork | TransitionFork | None = None
     format: FixtureFormat
-    pre_hash: str | None = None
+    pre_hash: AllocGroupHash | None = None
     __test__ = False  # stop pytest from collecting this class as a test
 
 

--- a/packages/testing/src/execution_testing/fixtures/consume.py
+++ b/packages/testing/src/execution_testing/fixtures/consume.py
@@ -7,7 +7,7 @@ from typing import Iterator, List, Optional, TextIO
 
 from pydantic import BaseModel, RootModel
 
-from execution_testing.base_types import HexNumber
+from execution_testing.base_types import Hash
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.test_types import AllocGroupHash
 
@@ -48,8 +48,8 @@ class TestCaseBase(BaseModel):
     """Base model for a test case used in EEST consume commands."""
 
     id: str
-    fixture_hash: HexNumber | None = None
-    fork: Fork | TransitionFork | None = None
+    fixture_hash: Hash
+    fork: Fork | TransitionFork | None
     format: FixtureFormat
     pre_hash: AllocGroupHash | None = None
     __test__ = False  # stop pytest from collecting this class as a test
@@ -85,7 +85,7 @@ class TestCaseIndexFile(TestCaseBase):
 class IndexFile(BaseModel):
     """The model definition used for fixture index files."""
 
-    root_hash: HexNumber | None
+    root_hash: Hash | None
     created_at: datetime.datetime
     test_count: int
     forks: Optional[List[Fork]] = []
@@ -114,7 +114,7 @@ class IndexFile(BaseModel):
         root_hash = HashableItem.from_index_entries(all_cases).hash()
 
         return cls(
-            root_hash=HexNumber(root_hash),
+            root_hash=root_hash,
             created_at=datetime.datetime.now(datetime.timezone.utc),
             test_count=len(all_cases),
             forks=sorted(all_forks, key=lambda f: f.name()),

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -4,6 +4,7 @@ import json
 import os
 from collections import defaultdict
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 from typing import (
     Any,
@@ -33,8 +34,11 @@ from execution_testing.test_types.chain_config_types import DEFAULT_CHAIN_ID
 from .blockchain import FixtureHeader
 
 
-class PreAllocGroupBuilder(CamelModel):
-    """Pre-allocation group builder."""
+class PreAllocGroupCommon(CamelModel):
+    """
+    Common fields between the pre-alloc group builder and the final
+    pre-alloc group.
+    """
 
     test_ids: List[str] = Field(default_factory=list)
     environment: Environment = Field(
@@ -49,8 +53,26 @@ class PreAllocGroupBuilder(CamelModel):
             "groups only pack with groups carrying the same salt."
         ),
     )
-    group_hash: AllocGroupHash
+    group_hash: AllocGroupHash | None = None
+
+    @classmethod
+    def from_file(cls, file: Path) -> Self:
+        """Load a pre-allocation group or builder from a JSON file."""
+        return cls.model_validate_json(file.read_bytes())
+
+
+class PreAllocGroupBuilder(PreAllocGroupCommon):
+    """
+    Pre-allocation group temporary builder.
+
+    This file must _NOT_ be saved as the final output of the filling process.
+    """
+
     pre: Alloc
+
+    # Ensures the final pre-alloc group model is incompatible with the
+    # incomplete builder.
+    builder: str = "builder"
 
     def model_post_init(self, __context: Any) -> None:
         """
@@ -128,13 +150,18 @@ def _get_worker_id() -> Optional[str]:
     return os.environ.get("PYTEST_XDIST_WORKER")
 
 
-def merge_partial_group_files(folder: Path) -> None:
+def merge_partial_group_files(folder: Path, final: bool) -> None:
     """
     Merge all partial group files into final group files.
 
     Called by master process after all workers have finished Phase 1.
     Each worker writes {group_hash}.partial.{worker_id}.json files,
     which are merged here into {group_hash}.json files.
+
+    The `final` parameter establishes whether to save the files in builder
+    format, in order for them to be able to be re-processed by
+    `pack_pre_alloc_groups`, or the pre-alloc format to be included
+    in the output.
     """
     partial_files = list(folder.glob("*.partial.*.json"))
     if not partial_files:
@@ -195,11 +222,15 @@ def merge_partial_group_files(folder: Path) -> None:
 
         # Write final merged file
         if merged_builder is not None:
-            target_path.write_text(
-                merged_builder.model_dump_json(
+            if final:
+                output = merged_builder.build().model_dump_json(
                     by_alias=True, exclude_none=True, indent=2
                 )
-            )
+            else:
+                output = merged_builder.model_dump_json(
+                    by_alias=True, exclude_none=True, indent=2
+                )
+            target_path.write_text(output)
 
 
 def _packed_group_hash(test_ids: List[str]) -> AllocGroupHash:
@@ -424,7 +455,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
     builders = []
     phase1_hash_by_test: Dict[str, AllocGroupHash] = {}
     for file in files:
-        builder = PreAllocGroupBuilder.model_validate_json(file.read_text())
+        builder = PreAllocGroupBuilder.from_file(file)
         for test_id in builder.test_ids:
             phase1_hash_by_test[test_id] = AllocGroupHash(file.stem)
         builders.append(builder)
@@ -466,7 +497,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
             packed_hash = _packed_group_hash(merged.test_ids)
             merged.group_hash = packed_hash
             (folder / f"{packed_hash}.json").write_text(
-                merged.model_dump_json(
+                merged.build().model_dump_json(
                     by_alias=True, exclude_none=True, indent=2
                 )
             )
@@ -479,14 +510,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
 
 
 class PreAllocGroupBuilders(EthereumTestRootModel):
-    """
-    Root model mapping pre-allocation group hashes to test groups.
-
-    If lazy_load is True, the groups are not loaded from the folder until they
-    are accessed.
-
-    Iterating will fail if lazy_load is True.
-    """
+    """Root model mapping pre-allocation group builers to group hashes."""
 
     root: Dict[AllocGroupHash, PreAllocGroupBuilder] = Field(
         default_factory=dict
@@ -642,7 +666,7 @@ class GroupPreAlloc(Alloc):
         return self._pre_alloc_group_hash
 
 
-class PreAllocGroup(PreAllocGroupBuilder):
+class PreAllocGroup(PreAllocGroupCommon):
     """
     Pre-allocation group for tests with identical Environment and fork values.
 
@@ -663,28 +687,15 @@ class PreAllocGroup(PreAllocGroupBuilder):
         self.pre._cached_state_root = self.genesis.state_root
         self.pre._pre_alloc_group_hash = self.group_hash
 
-    @classmethod
-    def from_file(cls, file: Path) -> Self:
+    def hash(self) -> Hash:
         """
-        Load a pre-allocation group from a JSON file.
-
-        Files are stored in builder format (without genesis). Genesis is
-        computed on-demand when loading, ensuring state root computation
-        happens exactly once in Phase 2, not during Phase 1 merging.
+        Return a Hash based on the canonical JSON of the model.
         """
-        with open(file) as f:
-            data = f.read()
-
-        builder = PreAllocGroupBuilder.model_validate_json(data)
-        built = builder.build()
-        # Use cls.model_validate to ensure proper Self return type
-        v = cls.model_validate(built.model_dump())
-        if file.stem != str(v.group_hash):
-            raise Exception(
-                "invalid group hash found inside file: "
-                f"file={file}, group_hash={v.group_hash}"
-            )
-        return v
+        canonical_json = json.dumps(
+            self.model_dump(mode="json", by_alias=True, exclude_none=True),
+            sort_keys=True,
+        )
+        return Hash(sha256(canonical_json.encode("utf-8")).digest())
 
 
 class PreAllocGroups(EthereumTestRootModel):

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -37,14 +37,14 @@ from .blockchain import FixtureHeader
 
 class PreAllocGroupCommon(CamelModel):
     """
-    Common fields between the pre-alloc group builder and the final
-    pre-alloc group.
+    Fields that identify a pre-allocation group, in either of its two forms.
+
+    `PreAllocGroupBuilder` is the scratch accumulator phase 1 fills in and
+    must never publish; `PreAllocGroup` is the artifact consumers read. The
+    two are not interchangeable and share only the fields below.
     """
 
     test_ids: List[str] = Field(default_factory=list)
-    environment: Environment = Field(
-        ..., description="Grouping environment for this test group"
-    )
     fork: Fork | TransitionFork = Field(..., alias="network")
     chain_id: ZeroPaddedHexNumber = ZeroPaddedHexNumber(DEFAULT_CHAIN_ID)
     group_salt: str | None = Field(
@@ -69,11 +69,10 @@ class PreAllocGroupBuilder(PreAllocGroupCommon):
     This file must _NOT_ be saved as the final output of the filling process.
     """
 
+    environment: Environment = Field(
+        ..., description="Grouping environment for this test group"
+    )
     pre: Alloc
-
-    # Ensures the final pre-alloc group model is incompatible with the
-    # incomplete builder.
-    builder: str = "builder"
 
     def model_post_init(self, __context: Any) -> None:
         """
@@ -114,7 +113,6 @@ class PreAllocGroupBuilder(PreAllocGroupCommon):
         """Build the pre-alloc group."""
         return PreAllocGroup(
             test_ids=self.test_ids,
-            environment=self.environment,
             fork=self.fork,
             chain_id=self.chain_id,
             group_salt=self.group_salt,
@@ -671,8 +669,9 @@ class PreAllocGroup(PreAllocGroupCommon):
     """
     Pre-allocation group for tests with identical Environment and fork values.
 
-    Groups tests by a hash of their fixture Environment and fork to enable
-    pre-allocation group optimization.
+    Grouping is still keyed on the tests' fixture Environment and fork, but
+    that Environment lives in phase 1 (`PreAllocGroupBuilder`) only: what
+    reaches the final group is the `genesis` header derived from it.
     """
 
     pre: GroupPreAlloc

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -510,7 +510,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
 
 
 class PreAllocGroupBuilders(EthereumTestRootModel):
-    """Root model mapping pre-allocation group builers to group hashes."""
+    """Root model mapping pre-allocation group builders to group hashes."""
 
     root: Dict[AllocGroupHash, PreAllocGroupBuilder] = Field(
         default_factory=dict

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -284,7 +284,7 @@ def read_test_group_index(folder: Path) -> GroupIndexEntries:
         data = json.loads(file.read_text())
         for test_id in data.get("testIds", []):
             assert isinstance(test_id, str)
-            index.root[test_id] = GroupIndexEntry(
+            index[test_id] = GroupIndexEntry(
                 group_hash=AllocGroupHash(file.stem), phase1_hash=None
             )
     return index
@@ -305,7 +305,7 @@ def packed_group_hash_for_test(
     built from a different version of the test, so phase 2 would fill it
     against the wrong genesis.
     """
-    entry = index.root.get(test_id)
+    entry = index.get(test_id)
     if entry is None:
         raise ValueError(
             f"Test {test_id!r} was not assigned to any pre-allocation "

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -58,8 +58,19 @@ class PreAllocGroupCommon(CamelModel):
 
     @classmethod
     def from_file(cls, file: Path) -> Self:
-        """Load a pre-allocation group or builder from a JSON file."""
-        return cls.model_validate_json(file.read_bytes())
+        """
+        Load a pre-allocation group or builder from a JSON file.
+
+        Additionally, verify that the file name contains the group hash.
+        """
+        instance = cls.model_validate_json(file.read_bytes())
+        if str(instance.group_hash).lower() not in file.stem.lower():
+            raise Exception(
+                f"Pre-alloc group file name `{file}` does not contain the "
+                "group hash contained in the file "
+                f"`{str(instance.group_hash)}`"
+            )
+        return instance
 
 
 class PreAllocGroupBuilder(PreAllocGroupCommon):
@@ -135,7 +146,8 @@ class PreAllocGroupBuilder(PreAllocGroupCommon):
 
         Saves the builder format (without genesis/state_root) to avoid
         expensive state root computation during Phase 1. State root is
-        computed once when loading in Phase 2 via PreAllocGroup.from_file().
+        computed once when the `build` method is used to construct the final
+        `PreAllocGroup`.
         """
         suffix = f".{worker_id}" if worker_id else ".main"
         partial_path = file.with_suffix(f".partial{suffix}.json")
@@ -157,10 +169,9 @@ def merge_partial_group_files(folder: Path, final: bool) -> None:
     Each worker writes {group_hash}.partial.{worker_id}.json files,
     which are merged here into {group_hash}.json files.
 
-    The `final` parameter establishes whether to save the files in builder
-    format, in order for them to be able to be re-processed by
-    `pack_pre_alloc_groups`, or the pre-alloc format to be included
-    in the output.
+    The `final` parameter establishes whether to save the files in the final
+    pre-alloc format to be included in the output, or in the builder format,
+    in order for them to be able to be re-processed later.
     """
     partial_files = list(folder.glob("*.partial.*.json"))
     if not partial_files:
@@ -234,7 +245,7 @@ def merge_partial_group_files(folder: Path, final: bool) -> None:
 
 def _packed_group_hash(test_ids: List[str]) -> AllocGroupHash:
     """Return a deterministic ``0x``-prefixed id for a packed group."""
-    return AllocGroupHash.from_hash("\n".join(test_ids))
+    return AllocGroupHash.from_preimage("\n".join(test_ids))
 
 
 # The test id -> group hash index written next to the group files by

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -1,6 +1,5 @@
 """Pre-allocation group models for test fixture generation."""
 
-import hashlib
 import json
 import os
 from collections import defaultdict
@@ -14,7 +13,6 @@ from typing import (
     KeysView,
     List,
     Literal,
-    NamedTuple,
     Optional,
     Self,
     Set,
@@ -29,7 +27,7 @@ from execution_testing.base_types import (
     Hash,
 )
 from execution_testing.forks import Fork, TransitionFork
-from execution_testing.test_types import Alloc, Environment
+from execution_testing.test_types import Alloc, AllocGroupHash, Environment
 from execution_testing.test_types.chain_config_types import DEFAULT_CHAIN_ID
 
 from .blockchain import FixtureHeader
@@ -51,6 +49,7 @@ class PreAllocGroupBuilder(CamelModel):
             "groups only pack with groups carrying the same salt."
         ),
     )
+    group_hash: AllocGroupHash
     pre: Alloc
 
     def model_post_init(self, __context: Any) -> None:
@@ -96,6 +95,7 @@ class PreAllocGroupBuilder(CamelModel):
             fork=self.fork,
             chain_id=self.chain_id,
             group_salt=self.group_salt,
+            group_hash=self.group_hash,
             pre=self.pre.model_dump(),
             pre_account_count=self.get_pre_account_count(),
             test_count=self.get_test_count(),
@@ -202,25 +202,9 @@ def merge_partial_group_files(folder: Path) -> None:
             )
 
 
-def _environment_group_key(environment: Environment) -> str:
-    """
-    Return a stable string identifying a genesis environment.
-
-    Two groups can only share a client if they share a genesis block, so the
-    environment is part of every packing bucket. The canonical JSON dump
-    matches the equality semantics of `Environment` (which compares the
-    alias-keyed, none-excluded dump).
-    """
-    return json.dumps(
-        environment.model_dump(mode="json", by_alias=True, exclude_none=True),
-        sort_keys=True,
-    )
-
-
-def _packed_group_hash(test_ids: List[str]) -> str:
+def _packed_group_hash(test_ids: List[str]) -> AllocGroupHash:
     """Return a deterministic ``0x``-prefixed id for a packed group."""
-    digest = hashlib.sha256("\n".join(test_ids).encode("utf-8")).digest()
-    return f"0x{int.from_bytes(digest[:8], byteorder='big'):016x}"
+    return AllocGroupHash.from_hash("\n".join(test_ids))
 
 
 # The test id -> group hash index written next to the group files by
@@ -229,7 +213,7 @@ def _packed_group_hash(test_ids: List[str]) -> str:
 TEST_GROUP_INDEX_FILE = "test_group_index"
 
 
-class GroupIndexEntry(NamedTuple):
+class GroupIndexEntry(CamelModel):
     """
     A test's entry in the test id -> pre-alloc group index.
 
@@ -241,11 +225,49 @@ class GroupIndexEntry(NamedTuple):
     reconstructed by scanning group files.
     """
 
-    group_hash: str
-    phase1_hash: str | None
+    group_hash: AllocGroupHash
+    phase1_hash: AllocGroupHash | None
 
 
-def read_test_group_index(folder: Path) -> Dict[str, GroupIndexEntry]:
+class GroupIndexEntries(EthereumTestRootModel):
+    """File containing a test-id to GroupIndexEntry mapping."""
+
+    root: Dict[str, GroupIndexEntry] = Field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, file_path: Path) -> Self:
+        """Read an index from file."""
+        return cls.model_validate_json(file_path.read_text())
+
+    def to_file(self, file_path: Path) -> None:
+        """Write the index entries to a file."""
+        file_path.write_text(self.model_dump_json(by_alias=True, indent=2))
+
+    def __getitem__(self, item: str) -> GroupIndexEntry:
+        """Get an index entry."""
+        return self.root[item]
+
+    def __setitem__(self, item: str, value: GroupIndexEntry) -> None:
+        """Set an index entry."""
+        self.root[item] = value
+
+    def __iter__(self) -> Iterator[str]:  # type: ignore [override]
+        """Iterate over root dict."""
+        return iter(self.root)
+
+    def items(
+        self,
+    ) -> Generator[Tuple[str, GroupIndexEntry], None, None]:
+        """Get items from root dict."""
+        for key, value in self.root.items():
+            yield key, value
+
+    def get(self, key: str) -> GroupIndexEntry | None:
+        """Get item from root dict."""
+        return self.root.get(key)
+
+
+def read_test_group_index(folder: Path) -> GroupIndexEntries:
     """
     Map every test id to the pre-alloc group that contains it.
 
@@ -256,23 +278,23 @@ def read_test_group_index(folder: Path) -> Dict[str, GroupIndexEntry]:
     """
     index_file = folder / TEST_GROUP_INDEX_FILE
     if index_file.exists():
-        return {
-            test_id: GroupIndexEntry(entry["group"], entry["phase1"])
-            for test_id, entry in json.loads(index_file.read_text()).items()
-        }
-    index: Dict[str, GroupIndexEntry] = {}
+        return GroupIndexEntries.from_file(index_file)
+    index = GroupIndexEntries()
     for file in folder.glob("*.json"):
         data = json.loads(file.read_text())
         for test_id in data.get("testIds", []):
-            index[test_id] = GroupIndexEntry(file.stem, None)
+            assert isinstance(test_id, str)
+            index.root[test_id] = GroupIndexEntry(
+                group_hash=AllocGroupHash(file.stem), phase1_hash=None
+            )
     return index
 
 
 def packed_group_hash_for_test(
-    index: Dict[str, GroupIndexEntry],
+    index: GroupIndexEntries,
     test_id: str,
-    phase1_hash: str,
-) -> str:
+    phase1_hash: AllocGroupHash,
+) -> AllocGroupHash:
     """
     Return the packed group hash owning ``test_id``, verifying freshness.
 
@@ -283,7 +305,7 @@ def packed_group_hash_for_test(
     built from a different version of the test, so phase 2 would fill it
     against the wrong genesis.
     """
-    entry = index.get(test_id)
+    entry = index.root.get(test_id)
     if entry is None:
         raise ValueError(
             f"Test {test_id!r} was not assigned to any pre-allocation "
@@ -400,32 +422,31 @@ def pack_pre_alloc_groups(folder: Path) -> None:
         return
 
     builders = []
-    phase1_hash_by_test: Dict[str, str] = {}
+    phase1_hash_by_test: Dict[str, AllocGroupHash] = {}
     for file in files:
         builder = PreAllocGroupBuilder.model_validate_json(file.read_text())
         for test_id in builder.test_ids:
-            phase1_hash_by_test[test_id] = file.stem
+            phase1_hash_by_test[test_id] = AllocGroupHash(file.stem)
         builders.append(builder)
 
     genesis_buckets: Dict[
-        Tuple[str, int, str, str], List[PreAllocGroupBuilder]
+        Tuple[Fork | TransitionFork, int, str, str], List[PreAllocGroupBuilder]
     ] = defaultdict(list)
     for builder in builders:
-        genesis_buckets[
-            (
-                builder.fork.name(),
-                builder.chain_id,
-                builder.group_salt or "",
-                _environment_group_key(builder.environment),
-            )
-        ].append(builder)
+        key = (
+            builder.fork,
+            builder.chain_id,
+            builder.group_salt or "",
+            builder.environment.canonical_json(),
+        )
+        genesis_buckets[key].append(builder)
 
     # Drop the fine-grained files up front; the packed files written below are
     # named by content hash and never clash with the (now stale) originals.
     for file in files:
         file.unlink()
 
-    test_group_index: Dict[str, GroupIndexEntry] = {}
+    test_group_index = GroupIndexEntries()
     for genesis_key in sorted(genesis_buckets):
         bucket = genesis_buckets[genesis_key]
         reserved = _reserved_addresses(bucket)
@@ -443,6 +464,7 @@ def pack_pre_alloc_groups(folder: Path) -> None:
         for merged in packed.values():
             merged.test_ids.sort()
             packed_hash = _packed_group_hash(merged.test_ids)
+            merged.group_hash = packed_hash
             (folder / f"{packed_hash}.json").write_text(
                 merged.model_dump_json(
                     by_alias=True, exclude_none=True, indent=2
@@ -450,22 +472,10 @@ def pack_pre_alloc_groups(folder: Path) -> None:
             )
             for test_id in merged.test_ids:
                 test_group_index[test_id] = GroupIndexEntry(
-                    packed_hash, phase1_hash_by_test[test_id]
+                    group_hash=packed_hash,
+                    phase1_hash=phase1_hash_by_test[test_id],
                 )
-
-    (folder / TEST_GROUP_INDEX_FILE).write_text(
-        json.dumps(
-            {
-                test_id: {
-                    "group": entry.group_hash,
-                    "phase1": entry.phase1_hash,
-                }
-                for test_id, entry in test_group_index.items()
-            },
-            sort_keys=True,
-            indent=2,
-        )
-    )
+    test_group_index.to_file(folder / TEST_GROUP_INDEX_FILE)
 
 
 class PreAllocGroupBuilders(EthereumTestRootModel):
@@ -478,7 +488,9 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
     Iterating will fail if lazy_load is True.
     """
 
-    root: Dict[str, PreAllocGroupBuilder]
+    root: Dict[AllocGroupHash, PreAllocGroupBuilder] = Field(
+        default_factory=dict
+    )
 
     def to_folder(self, folder: Path, worker_id: Optional[str] = None) -> None:
         """
@@ -494,7 +506,7 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
     def add_test_pre(
         self,
         *,
-        pre_alloc_hash: str,
+        pre_alloc_hash: AllocGroupHash,
         test_id: str,
         fork: Fork | TransitionFork,
         chain_id: int,
@@ -525,6 +537,7 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
                 chain_id=chain_id,
                 environment=environment,
                 group_salt=group_salt,
+                group_hash=pre_alloc_hash,
                 pre=Alloc.merge(
                     Alloc.model_validate(
                         fork.transitions_to().pre_allocation_blockchain()
@@ -564,6 +577,7 @@ class GroupPreAlloc(Alloc):
 
     _cached_state_root: Hash | None = PrivateAttr(None)
     _model_dump_cache: ModelDumpCache | None = PrivateAttr(None)
+    _pre_alloc_group_hash: AllocGroupHash | None = PrivateAttr(None)
 
     def state_root(self) -> Hash:
         """On pre-alloc groups, which are normally very big, always cache."""
@@ -617,6 +631,16 @@ class GroupPreAlloc(Alloc):
         )
         return data
 
+    def get_alloc_grouping_hash(self) -> AllocGroupHash | None:
+        """
+        Return the grouping hash if the allocation belongs to a particular
+        group, otherwise `None`.
+
+        Method can be overloaded by other implementations of the Alloc to
+        return the appropriate group.
+        """
+        return self._pre_alloc_group_hash
+
 
 class PreAllocGroup(PreAllocGroupBuilder):
     """
@@ -637,6 +661,7 @@ class PreAllocGroup(PreAllocGroupBuilder):
         """
         super().model_post_init(__context)
         self.pre._cached_state_root = self.genesis.state_root
+        self.pre._pre_alloc_group_hash = self.group_hash
 
     @classmethod
     def from_file(cls, file: Path) -> Self:
@@ -653,7 +678,13 @@ class PreAllocGroup(PreAllocGroupBuilder):
         builder = PreAllocGroupBuilder.model_validate_json(data)
         built = builder.build()
         # Use cls.model_validate to ensure proper Self return type
-        return cls.model_validate(built.model_dump())
+        v = cls.model_validate(built.model_dump())
+        if file.stem != str(v.group_hash):
+            raise Exception(
+                "invalid group hash found inside file: "
+                f"file={file}, group_hash={v.group_hash}"
+            )
+        return v
 
 
 class PreAllocGroups(EthereumTestRootModel):
@@ -666,11 +697,13 @@ class PreAllocGroups(EthereumTestRootModel):
     Iterating will fail if lazy_load is True.
     """
 
-    root: Dict[str, PreAllocGroup | None]
+    root: Dict[AllocGroupHash, PreAllocGroup | None] = Field(
+        default_factory=dict
+    )
 
     _folder_source: Path | None = PrivateAttr(None)
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    def __setitem__(self, key: AllocGroupHash, value: Any) -> None:
         """Set item in root dict."""
         assert self._folder_source is None, (
             "Cannot set item in root dict after folder source is set"
@@ -685,18 +718,18 @@ class PreAllocGroups(EthereumTestRootModel):
             with open(fail_file) as f:
                 raise Alloc.CollisionError.from_json(json.loads(f.read()))
 
-        data: Dict[str, PreAllocGroup | None] = {}
+        data: Dict[AllocGroupHash, PreAllocGroup | None] = {}
         for file in folder.glob("*.json"):
             if lazy_load:
-                data[file.stem] = None
+                data[AllocGroupHash(file.stem)] = None
             else:
-                data[file.stem] = PreAllocGroup.from_file(file)
+                data[AllocGroupHash(file.stem)] = PreAllocGroup.from_file(file)
         instance = cls(root=data)
         if lazy_load:
             instance._folder_source = folder
         return instance
 
-    def __getitem__(self, item: str) -> PreAllocGroup:
+    def __getitem__(self, item: AllocGroupHash) -> PreAllocGroup:
         """Get item from root dict."""
         if self._folder_source is None:
             value = self.root[item]
@@ -711,11 +744,11 @@ class PreAllocGroups(EthereumTestRootModel):
             assert result is not None
             return result
 
-    def __iter__(self) -> Iterator[str]:  # type: ignore [override]
+    def __iter__(self) -> Iterator[AllocGroupHash]:  # type: ignore [override]
         """Iterate over root dict."""
         return iter(self.root)
 
-    def __contains__(self, item: str) -> bool:
+    def __contains__(self, item: AllocGroupHash) -> bool:
         """Check if item in root dict."""
         return item in self.root
 
@@ -723,7 +756,7 @@ class PreAllocGroups(EthereumTestRootModel):
         """Get length of root dict."""
         return len(self.root)
 
-    def keys(self) -> KeysView[str]:
+    def keys(self) -> KeysView[AllocGroupHash]:
         """Get keys from root dict."""
         return self.root.keys()
 
@@ -733,7 +766,9 @@ class PreAllocGroups(EthereumTestRootModel):
             assert value is not None, "Value is None"
             yield value
 
-    def items(self) -> Generator[Tuple[str, PreAllocGroup], None, None]:
+    def items(
+        self,
+    ) -> Generator[Tuple[AllocGroupHash, PreAllocGroup], None, None]:
         """Get items from root dict."""
         for key, value in self.root.items():
             assert value is not None, f"Value for key {key} is None"

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -26,6 +26,7 @@ from execution_testing.base_types import (
     CamelModel,
     EthereumTestRootModel,
     Hash,
+    ZeroPaddedHexNumber,
 )
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.test_types import Alloc, AllocGroupHash, Environment
@@ -45,7 +46,7 @@ class PreAllocGroupCommon(CamelModel):
         ..., description="Grouping environment for this test group"
     )
     fork: Fork | TransitionFork = Field(..., alias="network")
-    chain_id: int = DEFAULT_CHAIN_ID
+    chain_id: ZeroPaddedHexNumber = ZeroPaddedHexNumber(DEFAULT_CHAIN_ID)
     group_salt: str | None = Field(
         None,
         description=(

--- a/packages/testing/src/execution_testing/fixtures/tests/test_consume.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_consume.py
@@ -1,0 +1,66 @@
+"""Tests for the consume index file models."""
+
+import json
+
+from execution_testing.base_types import Hash
+from execution_testing.fixtures.consume import IndexFile
+
+# A fixture hash as an older framework version wrote it: serialized from a
+# number, so its two leading zero bytes are missing.
+LEGACY_FIXTURE_HASH = (
+    "0x511ecc977c8f0ea5e940b47f4faac9ff6f7b77b2bb82f4d94a369f4475d1463"
+)
+
+
+def _index_json(root_hash: str, fixture_hash: str) -> str:
+    """Return an index file holding a single test case."""
+    return json.dumps(
+        {
+            "root_hash": root_hash,
+            "created_at": "2025-10-09T22:01:49.594302",
+            "test_count": 1,
+            "forks": ["Prague"],
+            "fixture_formats": ["state_test"],
+            "test_cases": [
+                {
+                    "id": "tests/a.py::test_a",
+                    "json_path": "state_tests/a.json",
+                    "fixture_hash": fixture_hash,
+                    "fork": "Prague",
+                    "format": "state_test",
+                    "pre_hash": None,
+                }
+            ],
+        }
+    )
+
+
+def test_index_file_reads_legacy_hashes() -> None:
+    """
+    Load an index file written before its hashes were typed.
+
+    Those hashes were serialized from numbers, which drops leading zero
+    bytes and writes an unavailable root hash as ``0x0``, so reading one
+    back must pad rather than reject it.
+    """
+    index = IndexFile.model_validate_json(
+        _index_json(root_hash="0x0", fixture_hash=LEGACY_FIXTURE_HASH)
+    )
+
+    assert index.root_hash == Hash(0)
+
+    fixture_hash = index.test_cases[0].fixture_hash
+    assert len(fixture_hash) == 32
+    assert int(str(fixture_hash), 16) == int(LEGACY_FIXTURE_HASH, 16)
+
+
+def test_index_file_reads_full_width_hashes() -> None:
+    """Load an index file whose hashes already carry their zero bytes."""
+    full_width = str(Hash(int(LEGACY_FIXTURE_HASH, 16)))
+
+    index = IndexFile.model_validate_json(
+        _index_json(root_hash=full_width, fixture_hash=full_width)
+    )
+
+    assert index.root_hash == Hash(full_width)
+    assert index.test_cases[0].fixture_hash == Hash(full_width)

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -1,4 +1,4 @@
-"""Tests for conflict-aware packing of pre-allocation groups."""
+"""Tests for pre-allocation group building and conflict-aware packing."""
 
 import json
 from pathlib import Path
@@ -7,6 +7,7 @@ from typing import Dict
 import pytest
 
 from execution_testing.base_types import Account, Address
+from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.fixtures.pre_alloc_groups import (
     TEST_GROUP_INDEX_FILE,
     GroupIndexEntry,
@@ -15,7 +16,7 @@ from execution_testing.fixtures.pre_alloc_groups import (
     packed_group_hash_for_test,
     read_test_group_index,
 )
-from execution_testing.forks import Fork, Osaka, Prague
+from execution_testing.forks import Fork, Osaka, Prague, get_forks
 from execution_testing.test_types import Alloc, AllocGroupHash, Environment
 
 
@@ -528,3 +529,58 @@ def test_pack_isolates_disagreeing_shared_address(tmp_path: Path) -> None:
         "tests/b.py::test_b",
         "tests/c.py::test_c",
     ]
+
+
+def test_builder_genesis_carries_the_environment() -> None:
+    """
+    Every `Environment` field the genesis header shares reaches that header.
+
+    A final `PreAllocGroup` does not carry the `Environment` it was grouped
+    on, only the `genesis` header the builder derives from it, so this
+    mapping is the whole of what a consumer ends up seeing.
+
+    The fields to compare come from the two models, so one added to both is
+    covered without touching this test. Fields left `None` are skipped, and
+    the newest fork is used: `FixtureHeader.genesis` dumps the environment
+    with `exclude_none=True` and derives the rest itself, gated on the fork
+    (the empty block access list hash, for one).
+    """
+    fork = get_forks()[-1]
+    environment = Environment(
+        fee_recipient=0x1234,
+        prev_randao=0x5678,
+        extra_data=b"\x01\x02",
+        number=0,
+        timestamp=7,
+        difficulty=0,
+        gas_limit=0x123456,
+        base_fee_per_gas=99,
+        excess_blob_gas=0x20000,
+        blob_gas_used=0x10000,
+        parent_beacon_block_root=0xABC,
+        slot_number=42,
+    ).set_fork_requirements(fork)
+
+    genesis = (
+        PreAllocGroupBuilder(
+            test_ids=["tests/a.py::test_a"],
+            environment=environment,
+            fork=fork,
+            pre=Alloc(),
+        )
+        .build()
+        .genesis
+    )
+
+    carried = sorted(
+        field
+        for field in set(Environment.model_fields)
+        & set(FixtureHeader.model_fields)
+        if getattr(environment, field) is not None
+    )
+    assert carried, "no environment field reaches the genesis header"
+    for field in carried:
+        assert getattr(genesis, field) == getattr(environment, field), (
+            f"{field} did not reach the genesis header: "
+            f"{getattr(environment, field)} != {getattr(genesis, field)}"
+        )

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -16,12 +16,12 @@ from execution_testing.fixtures.pre_alloc_groups import (
     read_test_group_index,
 )
 from execution_testing.forks import Fork, Osaka, Prague
-from execution_testing.test_types import Alloc, Environment
+from execution_testing.test_types import Alloc, AllocGroupHash, Environment
 
 
 def _write_group(
     folder: Path,
-    stem: str,
+    stem: AllocGroupHash | int,
     test_id: str,
     pre: Dict[int, Account],
     *,
@@ -35,19 +35,20 @@ def _write_group(
         environment=environment,
         fork=fork,
         group_salt=group_salt,
+        group_hash=stem,
         pre=Alloc(
             {Address(address): account for address, account in pre.items()}
         ),
     )
-    (folder / f"{stem}.json").write_text(
+    (folder / f"{builder.group_hash}.json").write_text(
         builder.model_dump_json(by_alias=True, exclude_none=True, indent=2)
     )
 
 
-def _packed(folder: Path) -> Dict[str, dict]:
+def _packed(folder: Path) -> Dict[AllocGroupHash, dict]:
     """Load the packed group files by stem."""
     return {
-        file.stem: json.loads(file.read_text())
+        AllocGroupHash(file.stem): json.loads(file.read_text())
         for file in folder.glob("*.json")
     }
 
@@ -57,14 +58,14 @@ def test_pack_merges_non_conflicting_groups(tmp_path: Path) -> None:
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x2000: Account(balance=2)},
         environment=env,
@@ -90,14 +91,14 @@ def test_pack_keeps_conflicting_groups_apart(tmp_path: Path) -> None:
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x1000: Account(balance=2)},
         environment=env,
@@ -125,14 +126,14 @@ def test_pack_merges_identical_account_at_shared_address(
     shared = Account(balance=1, nonce=1)
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: shared, 0x2000: Account(balance=5)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x1000: shared, 0x3000: Account(balance=6)},
         environment=env,
@@ -147,14 +148,14 @@ def test_pack_separates_distinct_environments(tmp_path: Path) -> None:
     """Groups with different genesis environments never merge."""
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=Environment(),
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x2000: Account(balance=2)},
         environment=Environment(gas_limit=0x1000000),
@@ -173,14 +174,14 @@ def test_pack_respects_group_salt(tmp_path: Path) -> None:
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x2000: Account(balance=2)},
         environment=env,
@@ -188,7 +189,7 @@ def test_pack_respects_group_salt(tmp_path: Path) -> None:
     )
     _write_group(
         tmp_path,
-        "0x03",
+        3,
         "tests/c.py::test_c",
         {0x3000: Account(balance=3)},
         environment=env,
@@ -214,7 +215,7 @@ def test_pack_merges_groups_with_matching_salt(tmp_path: Path) -> None:
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
@@ -222,7 +223,7 @@ def test_pack_merges_groups_with_matching_salt(tmp_path: Path) -> None:
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x2000: Account(balance=2)},
         environment=env,
@@ -245,21 +246,21 @@ def test_pack_writes_test_group_index(tmp_path: Path) -> None:
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x2000: Account(balance=2)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x03",
+        3,
         "tests/c.py::test_c",
         {0x1000: Account(balance=3)},
         environment=env,
@@ -271,7 +272,7 @@ def test_pack_writes_test_group_index(tmp_path: Path) -> None:
     packed = _packed(tmp_path)
     assert TEST_GROUP_INDEX_FILE not in packed
     index = read_test_group_index(tmp_path)
-    assert sorted(index) == [
+    assert sorted(index.root) == [
         "tests/a.py::test_a",
         "tests/b.py::test_b",
         "tests/c.py::test_c",
@@ -279,9 +280,9 @@ def test_pack_writes_test_group_index(tmp_path: Path) -> None:
     for test_id, entry in index.items():
         assert test_id in packed[entry.group_hash]["testIds"]
     # Every entry records the test's fine-grained phase 1 hash.
-    assert index["tests/a.py::test_a"].phase1_hash == "0x01"
-    assert index["tests/b.py::test_b"].phase1_hash == "0x02"
-    assert index["tests/c.py::test_c"].phase1_hash == "0x03"
+    assert index["tests/a.py::test_a"].phase1_hash == AllocGroupHash(1)
+    assert index["tests/b.py::test_b"].phase1_hash == AllocGroupHash(2)
+    assert index["tests/c.py::test_c"].phase1_hash == AllocGroupHash(3)
 
 
 def test_read_test_group_index_falls_back_to_scanning(
@@ -291,23 +292,27 @@ def test_read_test_group_index_falls_back_to_scanning(
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x2000: Account(balance=2)},
         environment=env,
     )
 
     assert not (tmp_path / TEST_GROUP_INDEX_FILE).exists()
-    assert read_test_group_index(tmp_path) == {
-        "tests/a.py::test_a": GroupIndexEntry("0x01", None),
-        "tests/b.py::test_b": GroupIndexEntry("0x02", None),
+    assert read_test_group_index(tmp_path).root == {
+        "tests/a.py::test_a": GroupIndexEntry(
+            group_hash=AllocGroupHash(1), phase1_hash=None
+        ),
+        "tests/b.py::test_b": GroupIndexEntry(
+            group_hash=AllocGroupHash(2), phase1_hash=None
+        ),
     }
 
 
@@ -322,7 +327,7 @@ def test_packed_group_hash_lookup_validates_phase1_hash(
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
@@ -331,17 +336,17 @@ def test_packed_group_hash_lookup_validates_phase1_hash(
     index = read_test_group_index(tmp_path)
 
     packed_hash = packed_group_hash_for_test(
-        index, "tests/a.py::test_a", phase1_hash="0x01"
+        index, "tests/a.py::test_a", phase1_hash=AllocGroupHash(1)
     )
     assert packed_hash == index["tests/a.py::test_a"].group_hash
 
     with pytest.raises(ValueError, match="stale"):
         packed_group_hash_for_test(
-            index, "tests/a.py::test_a", phase1_hash="0xff"
+            index, "tests/a.py::test_a", phase1_hash=AllocGroupHash(0xFF)
         )
     with pytest.raises(ValueError, match="not assigned"):
         packed_group_hash_for_test(
-            index, "tests/b.py::test_b", phase1_hash="0x02"
+            index, "tests/b.py::test_b", phase1_hash=AllocGroupHash(2)
         )
 
 
@@ -352,19 +357,16 @@ def test_packed_group_hash_lookup_without_fingerprint(
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x1000: Account(balance=1)},
         environment=env,
     )
 
     index = read_test_group_index(tmp_path)
-    assert (
-        packed_group_hash_for_test(
-            index, "tests/a.py::test_a", phase1_hash="0xff"
-        )
-        == "0x01"
-    )
+    assert packed_group_hash_for_test(
+        index, "tests/a.py::test_a", phase1_hash=AllocGroupHash(0xFF)
+    ) == AllocGroupHash(1)
 
 
 def test_pack_is_deterministic(tmp_path: Path) -> None:
@@ -376,7 +378,7 @@ def test_pack_is_deterministic(tmp_path: Path) -> None:
         for i in range(6):
             _write_group(
                 folder,
-                f"0x0{i}",
+                i,
                 f"tests/t{i}.py::test_{i}",
                 {0x1000 + i: Account(balance=i)},
                 environment=env,
@@ -399,14 +401,14 @@ def test_pack_isolates_funded_precompile(tmp_path: Path) -> None:
     env = Environment()
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x02: Account(balance=1), 0x9000: Account(balance=1)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x9001: Account(balance=2)},
         environment=env,
@@ -440,7 +442,7 @@ def test_pack_isolates_fork_precompile_above_blanket_range(
         folder.mkdir()
         _write_group(
             folder,
-            "0x01",
+            1,
             "tests/a.py::test_a",
             {0x100: Account(balance=1)},
             environment=env,
@@ -448,7 +450,7 @@ def test_pack_isolates_fork_precompile_above_blanket_range(
         )
         _write_group(
             folder,
-            "0x02",
+            2,
             "tests/b.py::test_b",
             {0x2000: Account(balance=2)},
             environment=env,
@@ -468,9 +470,9 @@ def test_pack_merges_when_shared_address_agrees(tmp_path: Path) -> None:
     env = Environment()
     shared = Account(balance=1, nonce=1)
     for stem, test_id, private in [
-        ("0x01", "tests/a.py::test_a", 0xA000),
-        ("0x02", "tests/b.py::test_b", 0xB000),
-        ("0x03", "tests/c.py::test_c", 0xC000),
+        (1, "tests/a.py::test_a", 0xA000),
+        (2, "tests/b.py::test_b", 0xB000),
+        (3, "tests/c.py::test_c", 0xC000),
     ]:
         _write_group(
             tmp_path,
@@ -494,21 +496,21 @@ def test_pack_isolates_disagreeing_shared_address(tmp_path: Path) -> None:
     shared = Account(balance=1, nonce=1)
     _write_group(
         tmp_path,
-        "0x01",
+        1,
         "tests/a.py::test_a",
         {0x9000: shared, 0xA000: Account(balance=2)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x02",
+        2,
         "tests/b.py::test_b",
         {0x9000: shared, 0xB000: Account(balance=2)},
         environment=env,
     )
     _write_group(
         tmp_path,
-        "0x03",
+        3,
         "tests/c.py::test_c",
         {0xC000: Account(balance=2)},
         environment=env,

--- a/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_pre_alloc_groups.py
@@ -32,7 +32,7 @@ def _write_group(
     """Write a single fine-grained group file, as Phase 1 would."""
     builder = PreAllocGroupBuilder(
         test_ids=[test_id],
-        environment=environment,
+        environment=environment.set_fork_requirements(fork),
         fork=fork,
         group_salt=group_salt,
         group_hash=stem,

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1347,15 +1347,14 @@ class BlockchainTest(BaseTest):
         if fixture_format == BlockchainEngineXFixture:
             # For Engine X format, exclude pre (will be provided via shared
             # state) and prepare for state diff optimization
-            fixture_data.update(
-                {
-                    "post_state": alloc
-                    if self.include_full_post_state_in_output
-                    else None,
-                    "pre_hash": "",  # Will be set by BaseTestWrapper
-                }
-            )
-            fixture = BlockchainEngineXFixture(**fixture_data)
+            pre_alloc_group_hash = self.pre.get_alloc_grouping_hash()
+            if pre_alloc_group_hash is None:
+                raise ValueError(
+                    "Engine X fixtures require a pre-alloc group; was phase 1 "
+                    "run?"
+                )
+            fixture_data["pre_hash"] = pre_alloc_group_hash
+            fixture_data["post_state_diff"] = alloc.calculate_diff(self.pre)
         elif fixture_format == BlockchainEngineSyncFixture:
             # Sync fixture format
             assert genesis.header.block_hash != head_hash, (
@@ -1382,7 +1381,6 @@ class BlockchainTest(BaseTest):
                     else None,
                 }
             )
-            fixture = BlockchainEngineSyncFixture(**fixture_data)
         else:
             # Standard engine fixture
             fixture_data.update(
@@ -1393,7 +1391,7 @@ class BlockchainTest(BaseTest):
                     else None,
                 }
             )
-            fixture = BlockchainEngineFixture(**fixture_data)
+        fixture = fixture_format.format_class()(**fixture_data)
 
         return FillResult(
             fixture=fixture,

--- a/packages/testing/src/execution_testing/test_types/__init__.py
+++ b/packages/testing/src/execution_testing/test_types/__init__.py
@@ -1,6 +1,6 @@
 """Common definitions and types."""
 
-from .account_types import EOA, Alloc
+from .account_types import EOA, Alloc, AllocGroupHash
 from .blob_types import Blob
 from .block_access_list import (
     BalAccountAbsentValues,
@@ -65,6 +65,7 @@ __all__ = (
     "DETERMINISTIC_FACTORY_BYTECODE",
     "DETERMINISTIC_FACTORY_ADDRESS",
     "Alloc",
+    "AllocGroupHash",
     "AuthorizationTuple",
     "BalAccountAbsentValues",
     "BalAccountChange",

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -114,7 +114,7 @@ class AllocGroupHash(FixedSizeBytes[8]):  # type: ignore
     """Class that helps represent hashes used to group allocs."""
 
     @classmethod
-    def from_hash(cls, x: str | bytes) -> "AllocGroupHash":
+    def from_preimage(cls, x: str | bytes) -> "AllocGroupHash":
         """
         Perform a hash (sha256) then truncate the output to get the alloc
         hash.

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
+from hashlib import sha256
 from types import ModuleType
 from typing import (
     Any,
@@ -28,6 +29,7 @@ from spec256k1 import PrivateKey
 from execution_testing.base_types import (
     Account,
     Address,
+    FixedSizeBytes,
     Hash,
     HashInt,
     Number,
@@ -106,6 +108,31 @@ class EOA(Address):
     def copy(self) -> Self:
         """Return copy of the EOA."""
         return self.__class__(Address(self), key=self.key, nonce=self.nonce)
+
+
+class AllocGroupHash(FixedSizeBytes[8]):  # type: ignore
+    """Class that helps represent hashes used to group allocs."""
+
+    @classmethod
+    def from_hash(cls, x: str | bytes) -> "AllocGroupHash":
+        """
+        Perform a hash (sha256) then truncate the output to get the alloc
+        hash.
+        """
+        if isinstance(x, str):
+            x = x.encode("utf-8")
+        return cls(sha256(x).digest()[:8])
+
+    def __xor__(self, other: "int | AllocGroupHash") -> "AllocGroupHash":
+        """
+        Alloc hashes are usually combination of multiple inputs via
+        XOR operation.
+        """
+        if isinstance(other, int):
+            other = AllocGroupHash(other)
+        return AllocGroupHash(
+            bytes(a ^ b for a, b in zip(self, other, strict=True))
+        )
 
 
 class Alloc(BaseAlloc):
@@ -339,6 +366,57 @@ class Alloc(BaseAlloc):
                     account.check_alloc(address, got_account)
                 else:
                     raise Alloc.MissingAccountError(address=address)
+
+    def get_alloc_grouping_hash(self) -> AllocGroupHash | None:
+        """
+        Return the grouping hash if the allocation belongs to a particular
+        group, otherwise `None`.
+
+        Method can be overloaded by other implementations of the Alloc to
+        return the appropriate group.
+        """
+        return None
+
+    def calculate_diff(self, base_alloc: "Alloc") -> "Alloc":
+        """
+        Calculate the state difference between self and a base.
+
+        Returns an Alloc containing only the accounts that:
+        - Changed between base and self (balance, nonce, storage, code)
+        - Were created during test execution (new accounts)
+        - Were deleted during test execution (represented as None)
+
+        Args:
+            base_alloc: Genesis pre-allocation state
+
+        Returns:
+            Alloc containing only the state differences for efficient storage
+
+        """
+        diff: Dict[Address, Account | None] = {}
+
+        # Find all addresses that exist in either state
+        all_addresses = set(self.root.keys()) | set(base_alloc.root.keys())
+
+        for address in all_addresses:
+            genesis_account = base_alloc.root.get(address)
+            post_account = self.root.get(address)
+
+            # Account was deleted (exists in genesis but not in post)
+            if genesis_account is not None and post_account is None:
+                diff[address] = None
+
+            # Account was created (doesn't exist in genesis but exists in post)
+            elif genesis_account is None and post_account is not None:
+                diff[address] = post_account
+
+            # Account was modified (exists in both but different)
+            elif genesis_account != post_account:
+                diff[address] = post_account
+
+            # Account unchanged - don't include in diff
+
+        return Alloc(diff)
 
     # ------------------------------------------------------------------
     # PreState protocol implementation

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -1,6 +1,6 @@
 """Block-related types for Ethereum tests."""
 
-import hashlib
+import json
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Dict, Generic, List, Sequence
@@ -211,15 +211,18 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
 
         return self.copy(**updated_values)
 
-    def __hash__(self) -> int:
-        """Hashes the environment object."""
-        hash_dict = self.model_dump(exclude_none=True, by_alias=True)
+    def canonical_json(self) -> str:
+        """
+        Return the canonical JSON encoding of this model.
 
-        sorted_items = sorted(hash_dict.items())
-        hash_string = str(sorted_items)
-
-        digest = hashlib.sha256(hash_string.encode("utf-8")).digest()
-        return int.from_bytes(digest[:8], byteorder="big")
+        Keys are alias-cased and sorted, and unset fields are excluded, so
+        two equal models encode identically and the encoding is stable
+        across processes: usable as a grouping key or a hash pre-image.
+        """
+        return json.dumps(
+            self.model_dump(mode="json", by_alias=True, exclude_none=True),
+            sort_keys=True,
+        )
 
     def __eq__(self, other: object) -> bool:
         """Check if two environment objects are equal."""

--- a/tests/ported_static/conftest.py
+++ b/tests/ported_static/conftest.py
@@ -13,6 +13,7 @@ remove this skip list.
 from pathlib import Path
 
 import pytest
+from execution_testing.fixtures import BaseFixture, LabeledFixtureFormat
 from execution_testing.forks import Amsterdam
 
 _SKIP_LIST_PATH = Path(__file__).parent / "amsterdam_skip_list.txt"
@@ -22,21 +23,20 @@ _AMSTERDAM_SKIP_CASES: frozenset[str] = frozenset(
     if line.strip() and not line.lstrip().startswith("#")
 )
 
-# Fixture format suffixes pytest appends inside the parametrize id. These
-# must be stripped from the nodeid before substring-matching against the
-# skip list, because the skip list predates these suffixes.
-_FIXTURE_FORMAT_TOKENS: tuple[str, ...] = (
-    "-blockchain_test_engine_from_state_test",
-    "-blockchain_test_from_state_test",
-    "-blockchain_test_engine",
-    "-blockchain_test",
-    "-state_test",
-)
+
+def _fixture_format_tokens() -> tuple[str, ...]:
+    """
+    Return the fixture format suffixes pytest appends inside parametrize ids.
+    """
+    names = set(BaseFixture.formats) | set(
+        LabeledFixtureFormat.registered_labels
+    )
+    return tuple(f"-{name}" for name in sorted(names, key=len, reverse=True))
 
 
-def _normalize_nodeid(nodeid: str) -> str:
+def _normalize_nodeid(nodeid: str, tokens: tuple[str, ...]) -> str:
     """Strip pytest fixture-format suffixes to match the skip list format."""
-    for token in _FIXTURE_FORMAT_TOKENS:
+    for token in tokens:
         nodeid = nodeid.replace(token, "")
     return nodeid
 
@@ -48,6 +48,7 @@ def pytest_collection_modifyitems(
     skip_marker = pytest.mark.skip(
         reason="Ported static test gas limits not yet updated for EIP-8037"
     )
+    tokens = _fixture_format_tokens()
     for item in items:
         if "ported_static" not in item.nodeid:
             continue
@@ -59,7 +60,7 @@ def pytest_collection_modifyitems(
         # EIP-8037 breakage applies equally to its descendant forks.
         # Rewriting the item's fork token to Amsterdam's lets one list
         # cover them all.
-        normalized = _normalize_nodeid(item.nodeid).replace(
+        normalized = _normalize_nodeid(item.nodeid, tokens).replace(
             f"fork_{fork.name()}", "fork_Amsterdam"
         )
         for skip_case in _AMSTERDAM_SKIP_CASES:


### PR DESCRIPTION
### Description

Makes pre-allocation group packing optional, and replaces the untyped string hashes used across the pre-alloc group and fixture index machinery with fixed-size types.

**`--disable-optimistic-pre-alloc-grouping`**

New `fill` flag. Phase 1 skips the packing pass so groups stay fine-grained, and phase 2 then resolves a test's group by recomputing its hash directly instead of looking it up in the packed index. Packing stays the default.

**Typed group hashes**

- New `AllocGroupHash` (8-byte truncated sha256) replaces the `str`/`int` hashes that were assembled by hand in several places.
- `Environment.__hash__` is replaced by `Environment.canonical_json()`, so the grouping pre-image is an explicit canonical JSON encoding rather than a process-stable `__hash__` whose value was persisted as a folder name.
- `PreAllocGroupBuilder` carries its own `group_hash`, and `GroupPreAlloc.get_pre_alloc_grouping_hash()` lets an allocation report the group it belongs to.
- `GroupIndexEntry`/`GroupIndexEntries` are pydantic models; the test → group index is read and written through them instead of hand-rolled JSON.

**Engine X fixtures**

- `pre_hash` is set when the fixture is constructed, from the allocation's own group hash, rather than patched onto the model afterwards.
- `postStateDiff` was never populated: `post_state` is not a field of `BlockchainEngineXFixture`, so the filler's `hasattr(fixture, "post_state")` guard never fired. It is now computed in `BlockchainTest.make_hive_fixture` through the new `Alloc.calculate_diff()` (moved out of `filler.py`) and is a required field.

**Fixture index**

- `TestCaseBase.fixture_hash` and `IndexFile.root_hash` are `Hash` instead of `HexNumber`; `hasher` and `compare_fixtures` follow.
- `FixtureCollector` writes index entries through `TestCaseIndexFile` instead of an ad-hoc dict.
- `HashableItem.from_folder` no longer strips the first two characters of a hash unconditionally, which mis-parsed unprefixed `generatedTestHash` values into 31 bytes.

**Compatibility**

Group hashes change, so existing `pre_alloc` folders must be regenerated. Engine X fixtures and `.meta/index.json` files written by earlier versions no longer validate, since `postStateDiff` and `fixture_hash` are now required.

### Related Issues or PRs
N/A.

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN4XCZVSa0pCscxi731xCq22pBaoOy5qdwJ1iPsovPYdxuEqx4VoXxX-o&s=10)
