### PR TITLE
fix(consume): map Reth BAL gas limit rejection

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -121,6 +121,9 @@ class RethExceptionMapper(ExceptionMapper):
             r"block access list hash mismatch|"
             r"BAL rejection: FinalHashMismatch"
         ),
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            r"block access list item cost exceeds gas limit"
+        ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"block access list hash mismatch|"
             r"BAL rejection: FinalHashMismatch"


### PR DESCRIPTION
Backports the Reth BAL gas-limit rejection mapping from #3371 to `devnets/glamsterdam/8`.

Without this mapping, strict exception matching fails even though Reth correctly rejects the block.