### PR TITLE
chore(client-clis): map reth BAL slot-miss rejection

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -120,7 +120,8 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"block access list hash mismatch|"
             r"BAL rejection: FinalHashMismatch|"
-            r"Bal error: Account .* not found in BAL"
+            r"Bal error: Account .* not found in BAL|"
+            r"Bal error: Slot .* not found in BAL for account .*"
         ),
         BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
             r"block access list item cost exceeds gas limit"


### PR DESCRIPTION
Maps Reth's `Bal error: Slot ... not found in BAL for account ...` message to `INVALID_BLOCK_ACCESS_LIST`.

This aligns strict exception matching with the existing missing-account rule and covers the missing-storage read/write cases observed in Glamsterdam Hive.