### PR TITLE
feat(spec-specs,tests): pin the EIP-8141 approval context across batches and reverts

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions/frame_transaction.py
+++ b/src/ethereum/forks/amsterdam/transactions/frame_transaction.py
@@ -652,6 +652,21 @@ def validate_frame_transaction(
                     "atomic batches cannot contain verify frames"
                 )
 
+        # Approval scope is disallowed on every frame of an atomic
+        # batch, including its terminating frame. A frame belongs to a
+        # batch when it or its predecessor carries the flag. Keeping the
+        # approval context constant across a batch means unrolling one
+        # can never withdraw an execution approval that later SENDER
+        # frames rely on, and whether the transaction sets a payer never
+        # depends on a batch outcome.
+        in_batch = FrameFlag.ATOMIC_BATCH in frame.flags or (
+            index > 0 and FrameFlag.ATOMIC_BATCH in tx.frames[index - 1].flags
+        )
+        if in_batch and frame.flags & APPROVE_SCOPE_MASK != FrameFlag(0):
+            raise InvalidFrameError(
+                "atomic batch frames cannot carry approval scope"
+            )
+
         if frame.mode == FrameMode.VERIFY and frame.to == EXPIRY_VERIFIER:
             if has_expiry_verifier_frame:
                 raise InvalidFrameError("multiple expiry verifier frames")

--- a/tests/amsterdam/eip8141_frame_transactions/test_frame_transactions.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_frame_transactions.py
@@ -14,6 +14,7 @@ from execution_testing import (
     Account,
     Alloc,
     Bytes,
+    Conditional,
     Frame,
     FrameReceipt,
     FrameSignature,
@@ -363,4 +364,98 @@ def test_verify_frame_reverts(
         pre=pre,
         tx=tx,
         post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "frame_reverts",
+    [
+        pytest.param(
+            True,
+            id="reverts",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(False, id="returns"),
+    ],
+)
+def test_frame_revert_discards_the_approval_it_granted(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    frame_reverts: bool,
+) -> None:
+    """
+    A frame that reverts discards the approval context it granted.
+
+    `APPROVE` exits its own call context, so a frame cannot approve and
+    then revert directly. A nested call back into the frame's target can:
+    the inner call approves and returns, and the outer frame decides
+    afterwards whether to revert.
+
+    The nonce increment and the `max_cost` collection that `APPROVE`
+    performed roll back with the frame's state, so `payer` and
+    `sender_approved` have to go with them. Keeping them does not merely
+    leak an approval, it produces a free transaction: the payer stays
+    bound, the transaction is valid, and fees settle against an account
+    whose escrow was rolled back.
+
+    The `returns` case is the control, and is what makes the `reverts`
+    case meaningful: the same nested `APPROVE`, with the outer invocation
+    returning instead. It must be accepted with the payer bound, which
+    pins that the approval really was granted from the nested call --
+    otherwise the `reverts` case would be rejected for having never
+    approved at all, and would pass against an implementation that keeps
+    the approval.
+    """
+    # The frame's target must be `tx.sender` for the approval scopes, so
+    # both invocations run the sender's code. Calldata distinguishes them:
+    # the frame supplies some, the self-call supplies none.
+    outer = Op.SSTORE(SLOT_EXECUTED, 1) + Op.CALL(
+        gas=Op.GAS, address=Op.ADDRESS
+    )
+    outer += Op.REVERT(0, 0) if frame_reverts else Op.STOP
+    sender_code = Conditional(
+        condition=Op.CALLDATASIZE,
+        if_true=outer,
+        # `APPROVE` exits this call context, returning control to `outer`.
+        if_false=Op.APPROVE(0, 0, Spec.APPROVE_EXECUTION_AND_PAYMENT),
+    )
+    sender = pre.deploy_contract(code=sender_code, balance=10**18)
+
+    tx = Transaction(
+        sender=sender,
+        nonce=1,
+        frames=[
+            Frame(
+                mode=Spec.MODE_DEFAULT,
+                flags=Spec.APPROVE_EXECUTION_AND_PAYMENT,
+                target=sender,
+                gas_limit=400_000,
+                data=Bytes(b"\x01"),
+            ),
+        ],
+        # Discarding the approval leaves the only frame's transaction with
+        # no payer, so it is rejected.
+        error=(
+            TransactionException.TYPE_6_INVALID_FRAME_EXECUTION
+            if frame_reverts
+            else None
+        ),
+        expected_receipt=(
+            None
+            if frame_reverts
+            else TransactionReceipt(
+                payer=sender,
+                frame_receipts=[FrameReceipt(status=Spec.STATUS_SUCCESS)],
+            )
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={
+            sender: Account(
+                storage={SLOT_EXECUTED: 0 if frame_reverts else 1}
+            ),
+        },
     )

--- a/tests/amsterdam/eip8141_frame_transactions/test_static_validity.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_static_validity.py
@@ -315,6 +315,48 @@ FRAME_CASES = [
         id="atomic_batch_of_default_frames",
     ),
     pytest.param(
+        # Approval scope is disallowed on every frame of a batch. This is
+        # the flagged member; `atomic_batch_of_default_frames` above is the
+        # same shape without the scope, and is valid.
+        [
+            verify_frame(),
+            default_frame(flags=Spec.ATOMIC_BATCH_FLAG | Spec.APPROVE_PAYMENT),
+            default_frame(),
+        ],
+        TransactionException.TYPE_6_INVALID_FRAME_FORMAT,
+        id="approval_scope_on_flagged_batch_frame",
+        marks=pytest.mark.exception_test,
+    ),
+    pytest.param(
+        # The terminating frame carries no flag of its own but still
+        # belongs to the batch, so the same rule applies to it. Without
+        # this case an implementation that only checks flagged frames
+        # passes, and the approval context is no longer constant across
+        # the batch.
+        [
+            verify_frame(),
+            default_frame(flags=Spec.ATOMIC_BATCH_FLAG),
+            default_frame(flags=Spec.APPROVE_PAYMENT),
+        ],
+        TransactionException.TYPE_6_INVALID_FRAME_FORMAT,
+        id="approval_scope_on_batch_terminating_frame",
+        marks=pytest.mark.exception_test,
+    ),
+    pytest.param(
+        # A frame after the batch has ended is unaffected: the terminator
+        # closed the batch, so this frame is outside it. Pins the rule's
+        # upper boundary, so an implementation cannot satisfy the two cases
+        # above by rejecting approval scope on any frame following a batch.
+        [
+            verify_frame(),
+            default_frame(flags=Spec.ATOMIC_BATCH_FLAG),
+            default_frame(),
+            default_frame(flags=Spec.APPROVE_PAYMENT),
+        ],
+        None,
+        id="approval_scope_after_batch_terminator",
+    ),
+    pytest.param(
         # Each frame's gas limit fits into 64 bits, but the total
         # frame gas must as well.
         [


### PR DESCRIPTION
### Description

Implements EIP-8141 revision [`9c915ee49`](https://github.com/ethereum/EIPs/commit/9c915ee49), which #3047 predates.

**Approval scope on atomic-batch frames** — spec + tests.

- A frame is in a batch when it or its predecessor carries `ATOMIC_BATCH_FLAG`; no such frame may carry approval scope.
- This keeps the approval context constant across a batch, so unrolling one cannot withdraw an approval that later `SENDER` frames rely on.
- Cases: the flagged member, the terminating frame (no flag of its own, still in the batch), and a frame after the terminator (outside it, stays valid).

**A reverting frame discards the approval it granted** — tests only; the spec already does this.

- `APPROVE` exits its own call context, but a nested call back into the frame's target can approve and return, leaving the outer frame free to revert.
- Keeping `payer` bound while the `max_cost` collection rolls back yields a free transaction.
- Paired with a returning control case, which must be accepted with the payer bound.

Filled with `--fork Bogota`: the 559 tests in `tests/amsterdam/eip8141_frame_transactions/` pass, and the three static cases fail without the validation rule added here.

### Related Issues or PRs

Follows #3047.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
