### PR TITLE
bug(test-base-types): Conversion methods use `ValueError`

### DIFF
--- a/packages/testing/src/execution_testing/base_types/conversions.py
+++ b/packages/testing/src/execution_testing/base_types/conversions.py
@@ -12,7 +12,7 @@ NumberConvertible: TypeAlias = str | bytes | SupportsBytes | int
 def to_bytes(input_bytes: BytesConvertible) -> bytes:
     """Convert multiple types into bytes."""
     if input_bytes is None:
-        raise Exception("Cannot convert `None` input to bytes")
+        raise ValueError("Cannot convert `None` input to bytes")
 
     if isinstance(input_bytes, str):
         # We can have a hex representation of bytes with spaces for readability
@@ -52,7 +52,7 @@ def to_fixed_size_bytes(
         )
     input_bytes = to_bytes(input_bytes)
     if len(input_bytes) > size:
-        raise Exception(
+        raise ValueError(
             f"input is too large for fixed size bytes: {input_bytes.hex()}, "
             f" {len(input_bytes)} > {size}"
         )
@@ -61,7 +61,7 @@ def to_fixed_size_bytes(
             return input_bytes.rjust(size, b"\x00")
         if right_padding:
             return input_bytes.ljust(size, b"\x00")
-        raise Exception(
+        raise ValueError(
             f"input is too small for fixed size bytes: "
             f"{len(input_bytes)} < {size}\n"
             "Use `left_padding=True` or `right_padding=True` to allow padding."
@@ -84,4 +84,4 @@ def to_number(input_number: NumberConvertible) -> int:
         input_number, SupportsBytes
     ):
         return int.from_bytes(input_number, byteorder="big")
-    raise Exception("invalid type for `number`")
+    raise ValueError("invalid type for `number`")


### PR DESCRIPTION
### Description

Fixes a minor long-standing issue with the conversion methods: Pydantic catches `ValueError` as a validation issue, whereas a bare `Exception` is bubbled up all the way to the caller.

This change makes it possible to use unions where one of the types fails the validation due to a `ValueError` in the conversion method, while the other type succeeds at it.

Found during implementation of [EIP-7668](https://github.com/ethereum/execution-specs/tree/eips/amsterdam/eip-7668).

### Related Issues or PRs
N/A.

### Checklist
- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.diamondpet.com/wp-content/uploads/2024/01/fluffy-siberian-cat-sitting-outside-in-snow-012324.jpg)
