### PR TITLE
test(spec-specs): add unit tests for get_last_256_block_hashes

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -214,7 +214,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/arrow_glacier/fork.py
+++ b/src/ethereum/forks/arrow_glacier/fork.py
@@ -134,7 +134,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/berlin/fork.py
+++ b/src/ethereum/forks/berlin/fork.py
@@ -128,7 +128,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/bpo1/fork.py
+++ b/src/ethereum/forks/bpo1/fork.py
@@ -177,7 +177,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/bpo2/fork.py
+++ b/src/ethereum/forks/bpo2/fork.py
@@ -177,7 +177,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/bpo3/fork.py
+++ b/src/ethereum/forks/bpo3/fork.py
@@ -177,7 +177,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/bpo4/fork.py
+++ b/src/ethereum/forks/bpo4/fork.py
@@ -177,7 +177,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/bpo5/fork.py
+++ b/src/ethereum/forks/bpo5/fork.py
@@ -177,7 +177,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/byzantium/fork.py
+++ b/src/ethereum/forks/byzantium/fork.py
@@ -123,7 +123,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/cancun/fork.py
+++ b/src/ethereum/forks/cancun/fork.py
@@ -151,7 +151,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/constantinople/fork.py
+++ b/src/ethereum/forks/constantinople/fork.py
@@ -123,7 +123,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/dao_fork/fork.py
+++ b/src/ethereum/forks/dao_fork/fork.py
@@ -129,7 +129,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/frontier/fork.py
+++ b/src/ethereum/forks/frontier/fork.py
@@ -117,7 +117,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/gray_glacier/fork.py
+++ b/src/ethereum/forks/gray_glacier/fork.py
@@ -134,7 +134,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/homestead/fork.py
+++ b/src/ethereum/forks/homestead/fork.py
@@ -117,7 +117,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/istanbul/fork.py
+++ b/src/ethereum/forks/istanbul/fork.py
@@ -123,7 +123,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/london/fork.py
+++ b/src/ethereum/forks/london/fork.py
@@ -136,7 +136,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/muir_glacier/fork.py
+++ b/src/ethereum/forks/muir_glacier/fork.py
@@ -123,7 +123,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/osaka/fork.py
+++ b/src/ethereum/forks/osaka/fork.py
@@ -177,7 +177,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/paris/fork.py
+++ b/src/ethereum/forks/paris/fork.py
@@ -127,7 +127,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/prague/fork.py
+++ b/src/ethereum/forks/prague/fork.py
@@ -170,7 +170,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/shanghai/fork.py
+++ b/src/ethereum/forks/shanghai/fork.py
@@ -127,7 +127,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/spurious_dragon/fork.py
+++ b/src/ethereum/forks/spurious_dragon/fork.py
@@ -121,7 +121,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/src/ethereum/forks/tangerine_whistle/fork.py
+++ b/src/ethereum/forks/tangerine_whistle/fork.py
@@ -117,7 +117,6 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
 
     """
     recent_blocks = chain.blocks[-255:]
-    # TODO: This function has not been tested rigorously
     if len(recent_blocks) == 0:
         return []
 

--- a/tests/json_loader/test_get_last_256_block_hashes.py
+++ b/tests/json_loader/test_get_last_256_block_hashes.py
@@ -70,68 +70,20 @@ def _expected_hashes(block_hashes: List[Hash32]) -> List[Hash32]:
     return block_hashes[-256:]
 
 
-def test_empty_chain() -> None:
-    """Return no hashes when the chain has no blocks."""
-    chain, hashes = _make_chain(0)
-    assert hashes == []
-    assert get_last_256_block_hashes(chain) == []
-
-
-def test_one_block() -> None:
-    """Include the genesis parent and the only block hash."""
-    chain, hashes = _make_chain(1)
-    result = get_last_256_block_hashes(chain)
-    assert result == [ZERO_HASH, hashes[0]]
-    assert result[-1] == _header_hash(chain.blocks[-1].header)
-
-
 @pytest.mark.parametrize(
     "length",
     [
-        pytest.param(2, id="two_blocks"),
-        pytest.param(254, id="less_than_256"),
-        pytest.param(255, id="exactly_255"),
-        pytest.param(256, id="exactly_256"),
-        pytest.param(257, id="more_than_256"),
+        pytest.param(0, id="empty_chain"),
+        pytest.param(1, id="one_block"),
+        pytest.param(255, id="last_untruncated_length"),
+        pytest.param(256, id="first_truncation"),
+        pytest.param(257, id="genesis_hash_dropped"),
     ],
 )
 def test_hash_window(length: int) -> None:
-    """Match length, order, and the keccak of the latest header."""
+    """Match the expected window and the keccak of the latest header."""
     chain, hashes = _make_chain(length)
     result = get_last_256_block_hashes(chain)
-    expected = _expected_hashes(hashes)
-
-    assert result == expected
-    assert len(result) == min(length + 1, 256)
-    assert result[-1] == _header_hash(chain.blocks[-1].header)
-    if length >= 2:
-        assert result[-2] == chain.blocks[-1].header.parent_hash
-        assert result[-2] == _header_hash(chain.blocks[-2].header)
-
-
-def test_window_drops_oldest_after_256() -> None:
-    """Drop the genesis hash once 257 blocks are on the chain."""
-    chain_256, hashes_256 = _make_chain(256)
-    chain_257, hashes_257 = _make_chain(257)
-
-    result_256 = get_last_256_block_hashes(chain_256)
-    result_257 = get_last_256_block_hashes(chain_257)
-
-    assert result_256 == hashes_256
-    assert result_256[0] == hashes_256[0]
-    assert ZERO_HASH not in result_256
-    assert result_257 == hashes_257[-256:]
-    assert result_257[0] == hashes_257[1]
-    assert hashes_257[0] not in result_257
-
-
-def test_hashes_are_in_increasing_block_number_order() -> None:
-    """Keep older hashes before newer hashes."""
-    chain, hashes = _make_chain(257)
-    result = get_last_256_block_hashes(chain)
-    for index in range(len(result) - 1):
-        older = result[index]
-        newer = result[index + 1]
-        older_number = hashes.index(older)
-        newer_number = hashes.index(newer)
-        assert older_number < newer_number
+    assert result == _expected_hashes(hashes)
+    if length > 0:
+        assert result[-1] == _header_hash(chain.blocks[-1].header)

--- a/tests/json_loader/test_get_last_256_block_hashes.py
+++ b/tests/json_loader/test_get_last_256_block_hashes.py
@@ -1,0 +1,137 @@
+"""Unit tests for Frontier ``get_last_256_block_hashes``."""
+
+from typing import List, Tuple
+
+import pytest
+from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes8, Bytes32
+from ethereum_types.numeric import U64, U256, Uint
+
+from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.forks.frontier.blocks import Block, Header
+from ethereum.forks.frontier.fork import BlockChain, get_last_256_block_hashes
+from ethereum.forks.frontier.fork_types import Bloom
+from ethereum.state import Address
+from ethereum.state_mpt import State
+
+ZERO_HASH = Hash32(b"\0" * 32)
+EMPTY_BLOOM = Bloom(b"\0" * 256)
+EMPTY_OMMERS_HASH = keccak256(rlp.encode(()))
+
+
+def _header_hash(header: Header) -> Hash32:
+    """Return ``keccak256(rlp(header))``."""
+    return Hash32(keccak256(rlp.encode(header)))
+
+
+def _make_header(parent_hash: Hash32, number: int) -> Header:
+    """Return a dummy Frontier header unique for ``number``."""
+    return Header(
+        parent_hash=parent_hash,
+        ommers_hash=EMPTY_OMMERS_HASH,
+        coinbase=Address(b"\0" * 20),
+        state_root=ZERO_HASH,
+        transactions_root=ZERO_HASH,
+        receipt_root=ZERO_HASH,
+        bloom=EMPTY_BLOOM,
+        difficulty=Uint(1),
+        number=Uint(number),
+        gas_limit=Uint(1),
+        gas_used=Uint(0),
+        timestamp=U256(number),
+        extra_data=number.to_bytes(2, "big"),
+        mix_digest=Bytes32(b"\0" * 32),
+        nonce=Bytes8(b"\0" * 8),
+    )
+
+
+def _make_chain(length: int) -> Tuple[BlockChain, List[Hash32]]:
+    """Build a linked dummy chain of ``length`` blocks."""
+    blocks: List[Block] = []
+    hashes: List[Hash32] = []
+    parent_hash = ZERO_HASH
+    for number in range(length):
+        header = _make_header(parent_hash, number)
+        block_hash = _header_hash(header)
+        blocks.append(Block(header=header, transactions=(), ommers=()))
+        hashes.append(block_hash)
+        parent_hash = block_hash
+    chain = BlockChain(blocks=blocks, state=State(), chain_id=U64(1))
+    return chain, hashes
+
+
+def _expected_hashes(block_hashes: List[Hash32]) -> List[Hash32]:
+    """Return the expected window: oldest first, at most 256 hashes."""
+    count = len(block_hashes)
+    if count == 0:
+        return []
+    if count < 256:
+        return [ZERO_HASH, *block_hashes]
+    return block_hashes[-256:]
+
+
+def test_empty_chain() -> None:
+    """Return no hashes when the chain has no blocks."""
+    chain, hashes = _make_chain(0)
+    assert hashes == []
+    assert get_last_256_block_hashes(chain) == []
+
+
+def test_one_block() -> None:
+    """Include the genesis parent and the only block hash."""
+    chain, hashes = _make_chain(1)
+    result = get_last_256_block_hashes(chain)
+    assert result == [ZERO_HASH, hashes[0]]
+    assert result[-1] == _header_hash(chain.blocks[-1].header)
+
+
+@pytest.mark.parametrize(
+    "length",
+    [
+        pytest.param(2, id="two_blocks"),
+        pytest.param(254, id="less_than_256"),
+        pytest.param(255, id="exactly_255"),
+        pytest.param(256, id="exactly_256"),
+        pytest.param(257, id="more_than_256"),
+    ],
+)
+def test_hash_window(length: int) -> None:
+    """Match length, order, and the keccak of the latest header."""
+    chain, hashes = _make_chain(length)
+    result = get_last_256_block_hashes(chain)
+    expected = _expected_hashes(hashes)
+
+    assert result == expected
+    assert len(result) == min(length + 1, 256)
+    assert result[-1] == _header_hash(chain.blocks[-1].header)
+    if length >= 2:
+        assert result[-2] == chain.blocks[-1].header.parent_hash
+        assert result[-2] == _header_hash(chain.blocks[-2].header)
+
+
+def test_window_drops_oldest_after_256() -> None:
+    """Drop the genesis hash once 257 blocks are on the chain."""
+    chain_256, hashes_256 = _make_chain(256)
+    chain_257, hashes_257 = _make_chain(257)
+
+    result_256 = get_last_256_block_hashes(chain_256)
+    result_257 = get_last_256_block_hashes(chain_257)
+
+    assert result_256 == hashes_256
+    assert result_256[0] == hashes_256[0]
+    assert ZERO_HASH not in result_256
+    assert result_257 == hashes_257[-256:]
+    assert result_257[0] == hashes_257[1]
+    assert hashes_257[0] not in result_257
+
+
+def test_hashes_are_in_increasing_block_number_order() -> None:
+    """Keep older hashes before newer hashes."""
+    chain, hashes = _make_chain(257)
+    result = get_last_256_block_hashes(chain)
+    for index in range(len(result) - 1):
+        older = result[index]
+        newer = result[index + 1]
+        older_number = hashes.index(older)
+        newer_number = hashes.index(newer)
+        assert older_number < newer_number


### PR DESCRIPTION
### Description
Adds direct unit tests for Frontier `get_last_256_block_hashes` (empty / 1 / <256 / 255 / 256 / 257 blocks, hash order, most-recent keccak). EEST BLOCKHASH tests go through t8n and do not exercise this helper. Asked in `#el-testing` before starting.

TODO removed only on Frontier for now; other forks still have the copy.

### Related Issues or PRs
N/A.

### Checklist
- [x] Ran fast static checks to avoid CI fails: `just static`
- [x] PR title has the form `<type>(<area>): <title>`

### Cute Animal Picture
![cat](https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?auto=format&fit=crop&w=640)