### PR TITLE
fix(tests): clear rlp_modifier when building inclusion-list variants

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1396,6 +1396,8 @@ class BlockchainTest(BaseTest):
                     block.expected_inclusion_list_satisfied = False
                 if block.header_verify:
                     block.header_verify = None
+                if block.rlp_modifier:
+                    block.rlp_modifier = None
                 if block.expected_gas_used:
                     block.expected_gas_used = None
                 if block.expected_block_access_list:


### PR DESCRIPTION
### Description

The inclusion-list variant in `BlockchainTest.make_fixture` moves the last transaction of the last block out of the block body and into the inclusion list. It then clears the expectations derived from that transaction:

```python
block.inclusion_list_txs.append(block.txs.pop())
...
if block.header_verify:
    block.header_verify = None
if block.expected_gas_used:
    block.expected_gas_used = None
if block.expected_block_access_list:
    block.expected_block_access_list = None
```

`rlp_modifier` is not cleared, but it belongs to the same group. It force-writes header fields onto the built block *after* the transition tool has run:

```python
if block.rlp_modifier is not None:
    header = block.rlp_modifier.apply(header)
```

and tests compute it from the pre-move transaction list. In `tests/cancun/eip4844_blobs/test_blob_txs.py`:

```python
@pytest.fixture
def rlp_modifier(expected_blob_gas_used):
    """Header fields to modify on the output block in the BlockchainTest."""
    if expected_blob_gas_used == Header.EMPTY_FIELD:
        return None
    return Header(blob_gas_used=expected_blob_gas_used)
```

So the moved transaction keeps contributing `blob_gas_used` to the header even though it no longer executes in the block.

The same block-rewriting logic elsewhere in this file already clears `rlp_modifier` alongside `header_verify` and friends, so this brings the inclusion-list path in line with it.

### Concrete example

From `tests-focil-devnet@v0.2.0`, `blockchain_tests_engine/for_bogota/cancun/eip4844_blobs/blob_txs/insufficient_balance_blob_tx_combinations.json`, comparing the plain and inclusion-list variants of the same parametrisation (`blobs_per_tx_(1,)` / `exact_balance_minus_1`):

| | block txs | `blobVersionedHashes` | header `blobGasUsed` |
|---|---|---|---|
| `blockchain_test_engine` | 1 | 1 | `0x20000` (131072) |
| `blockchain_test_engine_inclusion_list` | 0 | 0 | `0x20000` (131072) |

`blobGasUsed` must equal `GAS_PER_BLOB * <blobs in the block>`. In the inclusion-list variant the block carries no transactions and the payload declares no versioned hashes, so the only consistent value is `0`; the header claims `131072`. The fixture contradicts itself independently of any consumer — `gasUsed` (`0x0`) and `receiptsRoot` (the empty-trie root) were both recomputed correctly, only the `rlp_modifier`-forced field was not.

Across that release, 126 inclusion-list fixtures carry a `blobGasUsed` that disagrees with their own `blobVersionedHashes` count. All of them come from `tests/cancun/eip4844_blobs/test_blob_txs.py`, the file that defines the `rlp_modifier` fixture above.

I was not able to re-fill Bogota fixtures locally to confirm the regenerated output, so the change is offered on the strength of the code path and the arithmetic above; a fill run would be worth doing before merge.

### Related Issues or PRs

N/A.

### Checklist

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static` — I ran `ruff check` and `ruff format --check` on the changed file (both clean) but not the full `just static` suite, so please let CI be the judge.
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Red_Panda_%2824986761703%29.jpg/640px-Red_Panda_%2824986761703%29.jpg)

