### PR TITLE
feat(spec-specs,tests): dispatch a precompile a VERIFY frame targets

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/frame_interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/frame_interpreter.py
@@ -392,8 +392,9 @@ def execute_frame(
     at frame entry, from its own execution gas budget, before
     anything else: resolving the target's code is how the protocol
     dispatches the frame. A `VERIFY` frame whose resolved target has
-    no code then runs the protocol default code instead of an EVM. As
-    with an ordinary `CALL`, a caller that cannot cover the
+    no code then runs the protocol default code instead of an EVM,
+    unless that target is a precompile, which dispatches in every
+    mode. As with an ordinary `CALL`, a caller that cannot cover the
     transferred value reverts the frame, consuming the gas charged so
     far.
 
@@ -458,6 +459,7 @@ def execute_frame(
     target_account = get_account(tx_state, resolved_target)
     if (
         frame.mode == FrameMode.VERIFY
+        and resolved_target not in PRE_COMPILED_CONTRACTS
         and target_account.code_hash == EMPTY_CODE_HASH
     ):
         try:

--- a/tests/amsterdam/eip8141_frame_transactions/spec.py
+++ b/tests/amsterdam/eip8141_frame_transactions/spec.py
@@ -14,7 +14,7 @@ class ReferenceSpec:
 
 
 ref_spec_8141 = ReferenceSpec(
-    "EIPS/eip-8141.md", "b6b6f1cea0085e357bc80fb553d41896ac2a7fd0"
+    "EIPS/eip-8141.md", "3ceef8d37092c5b13a614746dbce5b1fc3c2dfab"
 )
 
 

--- a/tests/amsterdam/eip8141_frame_transactions/test_target_resolution.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_target_resolution.py
@@ -2,13 +2,14 @@
 Target resolution tests for
 [EIP-8141: Frame Transaction](https://eips.ethereum.org/EIPS/eip-8141).
 
-Only a `VERIFY` frame's codeless target runs the default code; every
-other frame runs a top-level call, which dispatches a precompile by
-address and follows an EIP-7702 designation. Each case pins the
-resolution through the frame receipt's `gas_used`.
+A frame runs a top-level call, which dispatches a precompile by
+address and follows an EIP-7702 designation; the default code is left
+to a `VERIFY` frame whose codeless target is no precompile. Each case
+pins the resolution through the frame receipt's `gas_used`.
 """
 
-from typing import Dict, Optional
+from functools import partial
+from typing import Callable, Dict, Optional
 
 import pytest
 from execution_testing import (
@@ -18,6 +19,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Fork,
+    Frame,
     FrameReceipt,
     FrameSignature,
     Op,
@@ -50,6 +52,12 @@ IDENTITY = Address(0x04)
 BN254_ADD = Address(0x06)
 """The `BN254_ADD` precompile, which rejects a point off the curve."""
 
+P256VERIFY = Address(0x100)
+"""The `P256VERIFY` precompile, which sits above the low precompiles."""
+
+IN_THE_GAP = Address(0x12)
+"""Codeless address between the low precompiles and `P256VERIFY`."""
+
 OFF_THE_CURVE = b"\xff" * 128
 """`BN254_ADD` input that is not a pair of curve points."""
 
@@ -76,6 +84,7 @@ def identity_gas(fork: Fork, data: bytes) -> int:
     [
         pytest.param(Spec.MODE_DEFAULT, id="default_mode"),
         pytest.param(Spec.MODE_SENDER, id="sender_mode"),
+        pytest.param(Spec.MODE_VERIFY, id="verify_mode"),
     ],
 )
 @pytest.mark.parametrize(
@@ -96,15 +105,23 @@ def test_precompile_target(
     """
     Execute the precompile a frame targets, charging the frame its
     input-dependent gas on top of the warm frame-entry access.
+
+    A `VERIFY` frame dispatches it too, rather than reading the empty
+    code hash a precompile account carries as the default code's cue.
     """
     sender = pre.fund_eoa()
-    frame = default_frame if mode == Spec.MODE_DEFAULT else sender_frame
+    builders: Dict[int, Callable[..., Frame]] = {
+        Spec.MODE_DEFAULT: default_frame,
+        Spec.MODE_SENDER: sender_frame,
+        # Only the default code approves, and the precompile displaces it.
+        Spec.MODE_VERIFY: partial(verify_frame, flags=Spec.APPROVE_NONE),
+    }
 
     tx = Transaction(
         sender=sender,
         frames=[
             verify_frame(),
-            frame(target=IDENTITY, data=data),
+            builders[mode](target=IDENTITY, data=data),
         ],
         expected_receipt=TransactionReceipt(
             payer=sender,
@@ -160,20 +177,15 @@ def test_precompile_target_rejecting_its_input(
 
 
 @pytest.mark.exception_test
-def test_verify_frame_precompile_target(
+def test_verify_frame_precompile_rejecting_its_input(
     state_test: StateTestFiller,
     pre: Alloc,
 ) -> None:
     """
-    Reject a frame transaction whose `VERIFY` frame targets a
-    precompile: the target's empty code hash routes the frame to the
-    default code, which reverts because no signature entry can resolve
-    to a precompile address.
-
-    The first frame approves both execution and payment, so the
-    approvals do not depend on the frame under test. Dispatching the
-    precompile instead would leave every approval in place and make the
-    transaction valid, rather than rejecting it for a missing approval.
+    Reject the transaction whose `VERIFY` frame targets a precompile
+    that rejects its input: the dispatched precompile halts the frame,
+    and a failed `VERIFY` frame invalidates the transaction where a
+    `DEFAULT` frame's failure stays its own.
     """
     sender = pre.fund_eoa()
 
@@ -181,7 +193,76 @@ def test_verify_frame_precompile_target(
         sender=sender,
         frames=[
             verify_frame(),
-            verify_frame(flags=Spec.APPROVE_NONE, target=IDENTITY),
+            verify_frame(
+                flags=Spec.APPROVE_NONE,
+                target=BN254_ADD,
+                data=OFF_THE_CURVE,
+            ),
+        ],
+        error=TransactionException.TYPE_6_INVALID_FRAME_EXECUTION,
+    )
+
+    # The rejected transaction leaves the sender's nonce untouched.
+    state_test(pre=pre, tx=tx, post={sender: Account(nonce=0)})
+
+
+def test_verify_frame_target_above_the_precompile_gap(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Dispatch `P256VERIFY` for the `VERIFY` frame that targets it: the
+    exact set of active precompiles routes the frame, not an address
+    range that stops below the gap separating it from the rest.
+    """
+    sender = pre.fund_eoa()
+    entry_gas = fork.frame_entry_gas_calculator()(target_warm=True)
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(),
+            verify_frame(flags=Spec.APPROVE_NONE, target=P256VERIFY),
+        ],
+        expected_receipt=TransactionReceipt(
+            payer=sender,
+            frame_receipts=[
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=entry_gas
+                    + fork.gas_costs().PRECOMPILE_P256VERIFY,
+                ),
+            ],
+        ),
+    )
+
+    state_test(pre=pre, tx=tx, post={sender: Account(nonce=1)})
+
+
+@pytest.mark.exception_test
+def test_verify_frame_target_inside_the_precompile_gap(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Run the default code for a `VERIFY` frame targeting a codeless
+    address in the gap below `P256VERIFY`: the default code reverts on
+    the frame's empty approval scope, rejecting the transaction. An
+    address range spanning the gap would dispatch instead and accept
+    it.
+    """
+    sender = pre.fund_eoa()
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(),
+            verify_frame(flags=Spec.APPROVE_NONE, target=IN_THE_GAP),
         ],
         error=TransactionException.TYPE_6_INVALID_FRAME_EXECUTION,
     )


### PR DESCRIPTION
### Description

[EIP-8141][eip] now dispatches a precompile frame target unconditionally:

> - If `resolved_target` is an active precompile at the current fork, the frame dispatches it as an ordinary call would.
> - Otherwise, if `resolved_target` code hash is empty, i.e. `0xc5d2...a470`, execute the logic described in default code.

There is no mode condition, so a `VERIFY` frame dispatches a precompile too. A `VERIFY` frame already runs as a static call and only a `SENDER` frame may carry non-zero value, so a precompile there is pure computation with no state effect — which is why this was preferred over banning a precompile target in `VERIFY`.

`execute_frame` decided the default code from the resolved target's code hash alone, and a precompile account carries the empty code hash that decision keys on. A `VERIFY` frame targeting a precompile therefore ran the default code and never dispatched it. The default code is now left to a `VERIFY` frame whose codeless target is no precompile.

On the test side, `VERIFY` folds into the mode parametrization of `test_precompile_target`, and `test_verify_frame_precompile_target` — which encoded the old rejection — is dropped as superseded. The first frame approves both execution and payment, so routing the frame under test to the default code instead reverts it and rejects the transaction: with the reference change reverted, exactly the nine new `verify_mode` cases fail with `VERIFY frame reverted`, and nothing else moves.

`test_verify_frame_delegated_to_precompile_target` is unaffected: a designated target is not codeless, so it never reached the default-code branch.

### Pinning the edges of the precompile set

The new condition consults an exact set, and the spec's "active precompile at the current fork" is not a contiguous address range: `P256VERIFY` sits at `0x100`, above a gap that starts at `0x12`. Two cases pin those edges, one on each side of the gap, and each is load-bearing on its own — replacing the set membership with an approximating address range fails that case and only that case:

| Reference change | Fails | Rest of the suite |
| --- | --- | --- |
| Range `0x01..=0x11`, stopping below the gap | `test_verify_frame_target_above_the_precompile_gap` (3) | 568 pass |
| Range `0x01..=0x100`, spanning the gap | `test_verify_frame_target_inside_the_precompile_gap` (3) | 568 pass |

Neither was caught by the suite before these cases were added. The positive and negative directions of the condition were already pinned: dropping it fails the nine `verify_mode` cases plus the `P256VERIFY` case, and inverting it fails 285 cases across the directory, since every leading `verify_frame()` resolves to the codeless sender and depends on the default code to approve.

These fill for `Bogota` only, so the precompile set does not vary across the forks under test.

### Numbers

`eip8141_frame_transactions` fills 571 cases, all passing (559 before this PR; 565 before the two boundary cases).

`just` was not available locally, so every `just static` recipe was run individually and is clean: `mypy`, `ethereum-spec-lint`, `codespell`, `vulture`, `actionlint`, `uv lock --check`, `ruff format --check`, `ruff check`.

[eip]: https://github.com/ethereum/EIPs/pull/12157

### Related Issues or PRs

Follows #3047, which implemented EIP-8141 on this branch.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Red_Panda.JPG/960px-Red_Panda.JPG)
