### PR TITLE
fix(test-evm-tools): restore state test compatibility

### DIFF
--- a/packages/testing/src/execution_testing/evm_tools/statetest/__init__.py
+++ b/packages/testing/src/execution_testing/evm_tools/statetest/__init__.py
@@ -108,10 +108,10 @@ def run_test_case(
     from .. import create_parser
 
     env = deepcopy(test_case.env)
-    try:
-        env["blockHashes"] = {"0": env["previousHash"]}
-    except KeyError:
-        env["blockHashes"] = {}
+    previous_hash = env.pop("previousHash", None)
+    env["blockHashes"] = (
+        {"0": previous_hash} if previous_hash is not None else {}
+    )
     env["withdrawals"] = []
 
     alloc = deepcopy(test_case.pre)
@@ -276,25 +276,26 @@ class StateTest:
                 t8n_extra=t8n_extra,
                 output_basedir=sys.stderr,
             )
+            state_root = result.state_root.hex()
 
             # Always output the state root on stderr (even with tracing
             # disabled) for the holiman/goevmlab integration.
             json.dump(
-                {"stateRoot": "0x" + result.state_root.hex()},
+                {"stateRoot": state_root},
                 sys.stderr,
             )
             sys.stderr.write("\n")
 
             passed = hex_to_bytes(test_case.post["hash"]) == result.state_root
             result_dict = {
-                "stateRoot": "0x" + result.state_root.hex(),
+                "stateRoot": state_root,
                 "fork": test_case.fork_name,
                 "name": test_case.key,
                 "pass": passed,
             }
 
             if not passed:
-                actual = result.state_root.hex()
+                actual = state_root[2:]
                 expected = test_case.post["hash"][2:]
                 result_dict["error"] = (
                     f"post state root mismatch: got {actual}, want {expected}"

--- a/packages/testing/src/execution_testing/evm_tools/tests/test_statetest.py
+++ b/packages/testing/src/execution_testing/evm_tools/tests/test_statetest.py
@@ -1,0 +1,138 @@
+"""Tests for general state test execution."""
+
+import argparse
+import json
+from io import StringIO
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from execution_testing.base_types import Hash
+from execution_testing.evm_tools import statetest
+from execution_testing.evm_tools.statetest import (
+    StateTest,
+    run_test_case,
+)
+from execution_testing.evm_tools.statetest import (
+    TestCase as StateTestCase,
+)
+from execution_testing.evm_tools.t8n import ForkCache
+from execution_testing.test_types import Environment
+
+pytestmark = pytest.mark.evm_tools
+
+
+def _test_case(*, env: dict[str, Any], post_hash: str) -> StateTestCase:
+    """Create a minimal state test case."""
+    return StateTestCase(
+        path="test.json",
+        key="test_case",
+        index=0,
+        fork_name="Shanghai",
+        post={
+            "hash": post_hash,
+            "indexes": {"data": 0, "gas": 0, "value": 0},
+        },
+        pre={},
+        env=env,
+        transaction={
+            "data": ["0x"],
+            "gasLimit": ["0x5208"],
+            "value": ["0x0"],
+        },
+    )
+
+
+def test_run_test_case_translates_previous_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Translate legacy `previousHash` without passing it to t8n."""
+    previous_hash = Hash(1).hex()
+    test_case = _test_case(env={"previousHash": previous_hash}, post_hash="0x")
+    captured_input: dict[str, Any] = {}
+    expected_result = object()
+
+    def fake_build_t8n(
+        options: argparse.Namespace,
+        in_file: StringIO,
+        fork_cache: ForkCache,
+    ) -> SimpleNamespace:
+        captured_input.update(json.load(in_file))
+        Environment.model_validate(captured_input["env"])
+        return SimpleNamespace(
+            run_state_test=lambda: None,
+            result=expected_result,
+        )
+
+    monkeypatch.setattr(
+        statetest,
+        "build_t8n_from_cli_options",
+        fake_build_t8n,
+    )
+
+    with ForkCache() as fork_cache:
+        result = run_test_case(test_case, fork_cache)
+
+    assert result is expected_result
+    assert captured_input["env"] == {
+        "blockHashes": {"0": previous_hash},
+        "withdrawals": [],
+    }
+
+
+def test_run_one_formats_state_root_once(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Emit one `0x` prefix while keeping mismatch hashes unprefixed."""
+    state_root = Hash("0x" + "11" * 32)
+    expected_root = "0x" + "00" * 32
+    test_case = _test_case(env={}, post_hash=expected_root)
+    out_file = StringIO()
+    state_test = StateTest(
+        argparse.Namespace(
+            file=None,
+            json=False,
+            memory=True,
+            stack=True,
+            return_data=True,
+        ),
+        out_file,
+        StringIO(),
+    )
+    state_test.supported_forks = ("shanghai",)
+
+    def fake_read_test_cases(_path: str) -> list[StateTestCase]:
+        return [test_case]
+
+    def fake_run_test_case(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(state_root=state_root)
+
+    monkeypatch.setattr(
+        statetest,
+        "read_test_cases",
+        fake_read_test_cases,
+    )
+    monkeypatch.setattr(
+        statetest,
+        "run_test_case",
+        fake_run_test_case,
+    )
+
+    assert state_test.run_one(test_case.path, ForkCache()) == 0
+
+    assert json.loads(capsys.readouterr().err) == {
+        "stateRoot": state_root.hex()
+    }
+    assert json.loads(out_file.getvalue()) == [
+        {
+            "stateRoot": state_root.hex(),
+            "fork": "Shanghai",
+            "name": "test_case",
+            "pass": False,
+            "error": (
+                f"post state root mismatch: got {'11' * 32}, want {'00' * 32}"
+            ),
+        }
+    ]


### PR DESCRIPTION

### Description

Restores the `statetest` compatibility output used by goevmlab and other legacy GeneralStateTests consumers.

`stateRoot` is now emitted with exactly one `0x` prefix on stdout and stderr. The mismatch message keeps its established unprefixed `got` and `want` values. The adapter also consumes the legacy `previousHash` field when translating it to `blockHashes`, preventing the stricter `Environment` model from rejecting otherwise supported fixtures.

The duplicate prefix came from treating `Hash.hex()` like Python's `bytes.hex()`: the testing `Hash` implementation already includes `0x`, so manually prepending another prefix produced `0x0x...`. Separately, `previousHash` was copied to `blockHashes` but left in the input object.

Focused unit tests cover both compatibility paths.

Validation:

- The focused regression module passes: 2 passed. As a negative control, both tests fail against the pre-fix adapter with the reported `0x0x...` output and `previousHash` validation error.
- The full testing-package suite passes: 2,048 passed, 29 skipped, 4 xfailed, and 2 xpassed.
- `just static` passes, including mypy over 4,270 source files, Ruff, vulture, execution-spec lint, actionlint, codespell, formatting, and lock checks.

### Related Issues or PRs

Fixes #3400.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![One prefix is plenty](https://cataas.com/cat/says/one%20prefix%20is%20plenty?fontSize=40&fontColor=white)

