### PR TITLE
refactor(test-benchmark): migrate benchmark suite to devnet-8

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -1,7 +1,7 @@
 benchmark:
   impl: geth
   repo: ethereum/go-ethereum
-  ref: glamsterdam-devnet-7
+  ref: glamsterdam-devnet-8
   evm-bin: evm
   xdist: auto
 eels:

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -107,13 +107,20 @@ def test_codecopy(
 
 @pytest.mark.repricing
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
-@pytest.mark.parametrize("code_size", [0, 32, 256, 1024, 24576])
+@pytest.mark.parametrize(
+    "code_size",
+    [0, 32, 256, 1024, pytest.param(None, id="code_size_max")],
+)
 def test_codecopy_benchmark(
     benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
     mem_size: int,
-    code_size: int,
+    code_size: int | None,
 ) -> None:
     """Benchmark CODECOPY with varying memory and code size config."""
+    if code_size is None:
+        code_size = fork.max_code_size()
+
     setup = Op.MSTORE8(mem_size, 0xFF) if mem_size > 0 else Bytecode()
 
     attack_block = Op.CODECOPY(Op.PUSH0, Op.PUSH0, code_size)
@@ -128,17 +135,21 @@ def test_codecopy_benchmark(
     )
 
 
-@pytest.mark.repricing(copied_size=512)
+@pytest.mark.repricing(copy_size=512)
 @pytest.mark.parametrize(
     "copy_size",
-    [0, 32, 256, 512, 1024],
+    [0, 32, 256, 512, 1024, pytest.param(None, id="copy_size_max")],
 )
 def test_extcodecopy_warm(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
-    copy_size: int,
+    fork: Fork,
+    copy_size: int | None,
 ) -> None:
     """Benchmark EXTCODECOPY instruction."""
+    if copy_size is None:
+        copy_size = fork.max_code_size()
+
     copied_contract_address = pre.deploy_contract(
         code=Op.JUMPDEST * copy_size,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -110,15 +110,32 @@ def test_contract_calling_many_addresses(
         "access_list": access_list if access_warm else None,
     }
 
-    total_iterations = (
-        sum(
+    stipend = fork.call_value_stipend() if value_transfer else 0
+
+    state_bound = bool(
+        code.state_gas_cost_by_iteration_count(fork=fork, iteration_count=1)
+    )
+
+    if fixed_opcode_count is not None:
+        total_iterations = int(fixed_opcode_count * 1000)
+    else:
+        packing_budget = gas_benchmark_value
+        if stipend and not state_bound:
+            per_iteration = code.tx_execution_gas_cost_by_iteration_count(
+                fork=fork, iteration_count=2, **tx_kwargs
+            ) - code.tx_execution_gas_cost_by_iteration_count(
+                fork=fork, iteration_count=1, **tx_kwargs
+            )
+            packing_budget = (
+                gas_benchmark_value
+                * per_iteration
+                // (per_iteration - stipend)
+            )
+        total_iterations = sum(
             code.tx_iterations_by_gas_limit(
-                fork=fork, gas_limit=gas_benchmark_value, **tx_kwargs
+                fork=fork, gas_limit=packing_budget, **tx_kwargs
             )
         )
-        if fixed_opcode_count is None
-        else int(fixed_opcode_count * 1000)
-    )
 
     if total_iterations == 0:
         pytest.skip(
@@ -127,29 +144,17 @@ def test_contract_calling_many_addresses(
 
     with TestPhaseManager.execution():
         sender = pre.fund_eoa()
-        if fixed_opcode_count is not None:
-            exec_txs = list(
-                code.transactions_by_total_iteration_count(
-                    fork=fork,
-                    total_iterations=total_iterations,
-                    sender=sender,
-                    to=contract_address,
-                    **tx_kwargs,
-                )
+        exec_txs = list(
+            code.transactions_by_total_iteration_count(
+                fork=fork,
+                total_iterations=total_iterations,
+                sender=sender,
+                to=contract_address,
+                **tx_kwargs,
             )
-        else:
-            exec_txs = list(
-                code.transactions_by_gas_limit(
-                    fork=fork,
-                    gas_limit=gas_benchmark_value,
-                    sender=sender,
-                    to=contract_address,
-                    **tx_kwargs,
-                )
-            )
+        )
         total_gas_cost = sum(tx.gas_cost for tx in exec_txs)
-        if value_transfer:
-            total_gas_cost -= fork.gas_costs().CALL_STIPEND * total_iterations
+        total_gas_cost -= stipend * total_iterations
 
     post = {
         Address(start_addr + i): Account(balance=transfer_amount)

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -112,30 +112,67 @@ def test_contract_calling_many_addresses(
 
     stipend = fork.call_value_stipend() if value_transfer else 0
 
-    state_bound = bool(
-        code.state_gas_cost_by_iteration_count(fork=fork, iteration_count=1)
-    )
+    def packing_budget() -> int:
+        """
+        Return the gas budget to size the transactions against.
+
+        Every iteration is charged the call stipend but gets it back
+        unused, so the block consumes less than it is charged; raising the
+        budget by that ratio lands the block on the target. The stipend
+        only comes back out of the execution dimension, so a block bounded
+        by the state dimension needs no adjustment.
+        """
+        state_bound = code.state_gas_cost_by_iteration_count(
+            fork=fork, iteration_count=1
+        )
+        if not stipend or state_bound:
+            return gas_benchmark_value
+        per_iteration = code.tx_execution_gas_cost_by_iteration_count(
+            fork=fork, iteration_count=2, **tx_kwargs
+        ) - code.tx_execution_gas_cost_by_iteration_count(
+            fork=fork, iteration_count=1, **tx_kwargs
+        )
+        return gas_benchmark_value * per_iteration // (per_iteration - stipend)
 
     if fixed_opcode_count is not None:
         total_iterations = int(fixed_opcode_count * 1000)
     else:
-        packing_budget = gas_benchmark_value
-        if stipend and not state_bound:
-            per_iteration = code.tx_execution_gas_cost_by_iteration_count(
-                fork=fork, iteration_count=2, **tx_kwargs
-            ) - code.tx_execution_gas_cost_by_iteration_count(
-                fork=fork, iteration_count=1, **tx_kwargs
-            )
-            packing_budget = (
-                gas_benchmark_value
-                * per_iteration
-                // (per_iteration - stipend)
-            )
         total_iterations = sum(
             code.tx_iterations_by_gas_limit(
-                fork=fork, gas_limit=packing_budget, **tx_kwargs
+                fork=fork, gas_limit=packing_budget(), **tx_kwargs
             )
         )
+
+    def block_gas(iterations: int) -> int:
+        """Return the block gas the iterations land, per gas dimension."""
+        execution = 0
+        state = 0
+        start_iteration = 0
+        for iteration_count in code.tx_iterations_by_total_iteration_count(
+            fork=fork, total_iterations=iterations, **tx_kwargs
+        ):
+            execution += code.tx_execution_gas_cost_by_iteration_count(
+                fork=fork,
+                iteration_count=iteration_count,
+                start_iteration=start_iteration,
+                **tx_kwargs,
+            )
+            state += code.state_gas_cost_by_iteration_count(
+                fork=fork, iteration_count=iteration_count
+            )
+            start_iteration += iteration_count
+        # The block header carries the larger dimension only (EIP-8037),
+        # and the unused stipend comes back out of the execution one.
+        return max(execution - stipend * iterations, state)
+
+    # The raised packing budget inflates the per-transaction intrinsic gas
+    # too, which earns no stipend back, so the block can overshoot the
+    # target by up to one iteration.
+    while (
+        total_iterations > 0
+        and block_gas(total_iterations) > gas_benchmark_value
+    ):
+        total_iterations -= 1
 
     if total_iterations == 0:
         pytest.skip(

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -313,18 +313,6 @@ def test_ether_transfers_to_precompile(
     )
 
 
-@pytest.fixture
-def total_cost_floor_per_token(fork: Fork) -> int:
-    """Total cost floor per token (EIP-7623)."""
-    return fork.gas_costs().TX_DATA_TOKEN_FLOOR
-
-
-@pytest.fixture
-def total_cost_standard_per_token(fork: Fork) -> int:
-    """Standard cost per token (EIP-7623)."""
-    return fork.gas_costs().TX_DATA_TOKEN_STANDARD
-
-
 def calldata_generator(
     gas_amount: int,
     zero_byte: int,
@@ -423,119 +411,77 @@ def test_block_full_access_list_and_data(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     intrinsic_cost: int,
-    total_cost_standard_per_token: int,
     fork: Fork,
     gas_benchmark_value: int,
     tx_gas_limit: int,
 ) -> None:
     """
-    Test a block with access lists (60% gas) and calldata (40% gas) using
-    random mixed bytes.
-    """
-    # Skip if EIP-7934 block RLP size limit would be exceeded
-    block_rlp_limit = fork.block_rlp_size_limit()
-    if block_rlp_limit:
-        pytest.skip(
-            "Test skipped: EIP-7934 block RLP size limit might be exceeded"
-        )
+    Test a block whose gas goes entirely into transaction payload.
 
+    Every transaction carries an access list plus one calldata byte per
+    access-list byte, and runs no code, so its whole gas limit is
+    intrinsic gas.
+    """
+    access_address = Address("0x1234567890123456789012345678901234567890")
+    intrinsic_calculator = fork.transaction_intrinsic_cost_calculator()
+    calldata_gas_calculator = fork.calldata_gas_calculator()
     iteration_count = math.ceil(gas_benchmark_value / tx_gas_limit)
 
-    gas_remaining = gas_benchmark_value
-    total_gas_used = 0
+    gas_available = gas_benchmark_value
+    block_rlp_limit = fork.block_rlp_size_limit()
+    if block_rlp_limit:
+        # A payload never costs less than its data floor, so the floor
+        # rate of the cheapest byte bounds the block's byte count.
+        gas_available = min(
+            gas_available,
+            int(block_rlp_limit * 0.99)
+            * calldata_gas_calculator(data=b"\x00", floor=True)
+            + iteration_count * intrinsic_cost,
+        )
+    budget = gas_available // iteration_count
 
-    txs = []
-    for _ in range(iteration_count):
-        gas_available = min(tx_gas_limit, gas_remaining) - intrinsic_cost
+    # One unit is a storage key plus its own length in calldata bytes.
+    # A key alone already costs its data-floor tokens, which bounds how
+    # many units can fit.
+    bytes_per_key = len(Hash(0))
+    max_units = budget // calldata_gas_calculator(data=Hash(0), floor=True)
+    keys = [Hash(i) for i in range(max_units)]
+    calldata_pool = random.Random(42).randbytes(bytes_per_key * max_units)
 
-        # Split available gas: 60% for access lists, 40% for calldata
-        gas_for_access_list = int(gas_available * 0.6)
-        gas_for_calldata = int(gas_available * 0.4)
-
-        # Access list gas costs from fork's gas_costs
-        gas_costs = fork.gas_costs()
-        gas_per_address = gas_costs.TX_ACCESS_LIST_ADDRESS
-        gas_per_storage_key = gas_costs.TX_ACCESS_LIST_STORAGE_KEY
-
-        # Calculate number of storage keys we can fit
-        gas_after_address = gas_for_access_list - gas_per_address
-        num_storage_keys = gas_after_address // gas_per_storage_key
-
-        # Create access list with 1 address and many storage keys
-        access_address = Address("0x1234567890123456789012345678901234567890")
-        storage_keys = []
-        for i in range(num_storage_keys):
-            # Generate random-looking storage keys
-            storage_keys.append(Hash(i))
-
-        access_list = [
-            AccessList(
-                address=access_address,
-                storage_keys=storage_keys,
-            )
-        ]
-
-        # Calculate calldata with 29% of gas for zero bytes and 71% for
-        # non-zero bytes
-        # Token accounting: tokens_in_calldata = zero_bytes + 4 *
-        # non_zero_bytes
-        # We want to split the gas budget:
-        # - 29% of gas_for_calldata for zero bytes
-        # - 71% of gas_for_calldata for non-zero bytes
-
-        max_tokens_in_calldata = (
-            gas_for_calldata // total_cost_standard_per_token
+    def payload_cost(units: int) -> int:
+        return intrinsic_calculator(
+            calldata=calldata_pool[: bytes_per_key * units],
+            access_list=[
+                AccessList(address=access_address, storage_keys=keys[:units])
+            ],
         )
 
-        # Calculate how many tokens to allocate to each type
-        tokens_for_zero_bytes = int(max_tokens_in_calldata * 0.29)
-        tokens_for_non_zero_bytes = (
-            max_tokens_in_calldata - tokens_for_zero_bytes
+    # Largest payload whose intrinsic cost still fits the budget.
+    low, high = 0, max_units
+    while low < high:
+        mid = (low + high + 1) // 2
+        if payload_cost(mid) <= budget:
+            low = mid
+        else:
+            high = mid - 1
+
+    tx_gas = payload_cost(low)
+    txs = [
+        Transaction(
+            to=pre.fund_eoa(amount=0),
+            data=calldata_pool[: bytes_per_key * low],
+            gas_limit=tx_gas,
+            sender=pre.fund_eoa(),
+            access_list=[
+                AccessList(address=access_address, storage_keys=keys[:low])
+            ],
         )
-
-        # Convert tokens to actual byte counts
-        # Zero bytes: 1 token per byte
-        # Non-zero bytes: 4 tokens per byte
-        num_zero_bytes = tokens_for_zero_bytes  # 1 token = 1 zero byte
-        num_non_zero_bytes = (
-            tokens_for_non_zero_bytes // 4
-        )  # 4 tokens = 1 non-zero byte
-
-        # Create calldata with mixed bytes
-        calldata = bytearray()
-
-        # Add zero bytes
-        calldata.extend(b"\x00" * num_zero_bytes)
-
-        # Add non-zero bytes (random values from 0x01 to 0xff)
-        rng = random.Random(42)  # For reproducibility
-        for _ in range(num_non_zero_bytes):
-            calldata.append(rng.randint(1, 255))
-
-        # Shuffle the bytes to mix zero and non-zero bytes
-        calldata_list = list(calldata)
-        rng.shuffle(calldata_list)
-        shuffled_calldata = bytes(calldata_list)
-
-        txs.append(
-            Transaction(
-                to=pre.fund_eoa(amount=0),
-                data=shuffled_calldata,
-                gas_limit=gas_available + intrinsic_cost,
-                sender=pre.fund_eoa(),
-                access_list=access_list,
-            )
-        )
-
-        gas_remaining -= gas_for_access_list + intrinsic_cost
-        total_gas_used += fork.transaction_intrinsic_cost_calculator()(
-            calldata=shuffled_calldata,
-            access_list=access_list,
-        )
+        for _ in range(iteration_count)
+    ]
 
     benchmark_test(
         blocks=[Block(txs=txs)],
-        expected_benchmark_gas_used=total_gas_used,
+        expected_benchmark_gas_used=tx_gas * iteration_count,
     )
 
 

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -1,5 +1,6 @@
 """Benchmark different transaction types."""
 
+import bisect
 import math
 import random
 from dataclasses import dataclass
@@ -410,7 +411,6 @@ def test_block_full_data(
 def test_block_full_access_list_and_data(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
-    intrinsic_cost: int,
     fork: Fork,
     gas_benchmark_value: int,
     tx_gas_limit: int,
@@ -418,35 +418,64 @@ def test_block_full_access_list_and_data(
     """
     Test a block whose gas goes entirely into transaction payload.
 
-    Every transaction carries an access list plus one calldata byte per
-    access-list byte, and runs no code, so its whole gas limit is
-    intrinsic gas.
+    Every transaction carries an access list plus calldata, and runs no
+    code, so its whole gas limit is intrinsic gas.
     """
-    access_address = Address("0x1234567890123456789012345678901234567890")
+    access_address = pre.fund_eoa()
     intrinsic_calculator = fork.transaction_intrinsic_cost_calculator()
     calldata_gas_calculator = fork.calldata_gas_calculator()
-    iteration_count = math.ceil(gas_benchmark_value / tx_gas_limit)
 
-    gas_available = gas_benchmark_value
+    def unit_gas(byte_count: int, units: int) -> int:
+        """Return the gas one more key plus its calldata bytes adds."""
+
+        def cost(count: int) -> int:
+            return intrinsic_calculator(
+                calldata=b"\xff" * byte_count * count,
+                access_list=[
+                    AccessList(
+                        address=access_address,
+                        storage_keys=[Hash(i) for i in range(count)],
+                    )
+                ],
+            )
+
+        return cost(units + 1) - cost(units)
+
+    byte_gas = calldata_gas_calculator(data=b"\xff")
+    byte_floor_gas = calldata_gas_calculator(data=b"\xff", floor=True)
+    key_gas = unit_gas(0, 1)
+
+    bytes_per_key = len(Hash(0))
+    if byte_floor_gas > byte_gas:
+        # Pairing each key with the byte count where the floor dimension
+        # overtakes the execution one carries the most calldata per gas.
+        # The key's floor share is measured over a whole transaction,
+        # below which the fixed base decides which dimension binds.
+        byte_step = byte_floor_gas - byte_gas
+        floor_bound_bytes = key_gas // byte_step + 1
+        key_floor_gas = (
+            unit_gas(floor_bound_bytes, tx_gas_limit // key_gas)
+            - floor_bound_bytes * byte_floor_gas
+        )
+        bytes_per_key = (key_gas - key_floor_gas) // byte_step
+
+    gas_per_unit = key_gas + bytes_per_key * byte_gas
+    total_units = gas_benchmark_value // gas_per_unit
     block_rlp_limit = fork.block_rlp_size_limit()
     if block_rlp_limit:
-        # A payload never costs less than its data floor, so the floor
-        # rate of the cheapest byte bounds the block's byte count.
-        gas_available = min(
-            gas_available,
-            int(block_rlp_limit * 0.99)
-            * calldata_gas_calculator(data=b"\x00", floor=True)
-            + iteration_count * intrinsic_cost,
+        # Each unit adds its calldata bytes plus its RLP-encoded storage
+        # key, which carries a one-byte length prefix.
+        bytes_per_unit = bytes_per_key + len(Hash(0)) + 1
+        total_units = min(
+            total_units, int(block_rlp_limit * 0.99) // bytes_per_unit
         )
-    budget = gas_available // iteration_count
 
-    # One unit is a storage key plus its own length in calldata bytes.
-    # A key alone already costs its data-floor tokens, which bounds how
-    # many units can fit.
-    bytes_per_key = len(Hash(0))
-    max_units = budget // calldata_gas_calculator(data=Hash(0), floor=True)
-    keys = [Hash(i) for i in range(max_units)]
-    calldata_pool = random.Random(42).randbytes(bytes_per_key * max_units)
+    keys = [Hash(i) for i in range(total_units)]
+    # A zero byte is charged the cheaper standard rate, which would make a
+    # payload's cost depend on which slice of the pool it takes.
+    pool = random.Random(42).randbytes(bytes_per_key * total_units)
+    calldata_pool = bytes(byte or 1 for byte in pool)
+    unit_counts = range(min(tx_gas_limit // gas_per_unit, total_units) + 1)
 
     def payload_cost(units: int) -> int:
         return intrinsic_calculator(
@@ -456,32 +485,42 @@ def test_block_full_access_list_and_data(
             ],
         )
 
-    # Largest payload whose intrinsic cost still fits the budget.
-    low, high = 0, max_units
-    while low < high:
-        mid = (low + high + 1) // 2
-        if payload_cost(mid) <= budget:
-            low = mid
-        else:
-            high = mid - 1
-
-    tx_gas = payload_cost(low)
-    txs = [
-        Transaction(
-            to=pre.fund_eoa(amount=0),
-            data=calldata_pool[: bytes_per_key * low],
-            gas_limit=tx_gas,
-            sender=pre.fund_eoa(),
-            access_list=[
-                AccessList(address=access_address, storage_keys=keys[:low])
-            ],
+    min_tx_gas = payload_cost(1)
+    gas_remaining = gas_benchmark_value
+    units_used = 0
+    txs = []
+    while gas_remaining >= min_tx_gas and units_used < total_units:
+        units = min(
+            bisect.bisect_right(
+                unit_counts, min(tx_gas_limit, gas_remaining), key=payload_cost
+            )
+            - 1,
+            total_units - units_used,
         )
-        for _ in range(iteration_count)
-    ]
+        unit_end = units_used + units
+        tx_gas = payload_cost(units)
+        txs.append(
+            Transaction(
+                to=pre.fund_eoa(amount=0),
+                data=calldata_pool[
+                    bytes_per_key * units_used : bytes_per_key * unit_end
+                ],
+                gas_limit=tx_gas,
+                sender=pre.fund_eoa(),
+                access_list=[
+                    AccessList(
+                        address=access_address,
+                        storage_keys=keys[units_used:unit_end],
+                    )
+                ],
+            )
+        )
+        gas_remaining -= tx_gas
+        units_used = unit_end
 
     benchmark_test(
         blocks=[Block(txs=txs)],
-        expected_benchmark_gas_used=tx_gas * iteration_count,
+        expected_benchmark_gas_used=gas_benchmark_value - gas_remaining,
     )
 
 

--- a/tests/benchmark/helper/delegation.py
+++ b/tests/benchmark/helper/delegation.py
@@ -33,6 +33,7 @@ def build_delegated_storage_setup(
     pre: Alloc,
     fork: Fork,
     tx_gas_limit: int,
+    block_gas_budget: int,
     needs_init: bool,
     num_target_slots: int,
     initializer_code: IteratingBytecode,
@@ -89,8 +90,9 @@ def build_delegated_storage_setup(
             )
         )
 
-        # Pack init transactions into blocks
-        blocks.extend(pack_transactions_into_blocks(init_txs, tx_gas_limit))
+        blocks.extend(
+            pack_transactions_into_blocks(init_txs, block_gas_budget)
+        )
 
     # Final block: Authorize to executor
     blocks.append(
@@ -128,25 +130,33 @@ def delegate_with_calldata(
     The delegated code determines what happens with the calldata.
     The authority nonce is incremented in-place.
     """
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
-        calldata=bytes(calldata),
-        authorization_list_or_count=1,
+    authorization = AuthorizationTuple(
+        chain_id=0,
+        address=address,
+        nonce=authority.nonce,
+        signer=authority,
     )
-    gas_limit = intrinsic_gas + 500_000
+    top_frame_kwargs: dict = {
+        "recipient_type": RecipientType.DELEGATION_7702,
+        "authorizations": [authorization],
+    }
+    buffer_gas = 500_000
+    gas_limit = (
+        fork.transaction_intrinsic_cost_calculator()(
+            calldata=bytes(calldata),
+            authorization_list_or_count=1,
+        )
+        + fork.transaction_top_frame_gas_calculator()(**top_frame_kwargs)
+        + fork.transaction_top_frame_state_gas(**top_frame_kwargs)
+        + buffer_gas
+    )
     tx = Transaction(
         gas_limit=gas_limit,
         to=authority,
         value=0,
         data=calldata,
         sender=pre.fund_eoa(),
-        authorization_list=[
-            AuthorizationTuple(
-                chain_id=0,
-                address=address,
-                nonce=authority.nonce,
-                signer=authority,
-            ),
-        ],
+        authorization_list=[authorization],
     )
     authority.nonce = Number(authority.nonce + 1)
     return tx
@@ -198,8 +208,12 @@ def run_bloated_eoa_benchmark(
             txs = tx_generator(sender)
         else:
             gas_available = gas_benchmark_value
-            intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
-            while gas_available >= intrinsic_gas:
+            minimum_tx_gas = fork.transaction_intrinsic_cost_calculator()(
+                recipient_type=RecipientType.DELEGATION_7702
+            ) + fork.transaction_top_frame_gas_calculator()(
+                recipient_type=RecipientType.DELEGATION_7702
+            )
+            while gas_available >= minimum_tx_gas:
                 tx_gas = min(gas_available, tx_gas_limit)
                 txs.append(
                     Transaction(

--- a/tests/benchmark/helper/storage.py
+++ b/tests/benchmark/helper/storage.py
@@ -149,6 +149,7 @@ def build_sequential_storage_init(
     pre: Alloc,
     fork: Fork,
     tx_gas_limit: int,
+    block_gas_budget: int,
     authority: EOA,
     storage_init_ranges: list[StorageInitRange],
 ) -> list[Block]:
@@ -201,7 +202,7 @@ def build_sequential_storage_init(
         )
 
     blocks: list[Block] = [Block(txs=[auth_tx])]
-    blocks.extend(pack_transactions_into_blocks(init_txs, tx_gas_limit))
+    blocks.extend(pack_transactions_into_blocks(init_txs, block_gas_budget))
     return blocks
 
 

--- a/tests/benchmark/helper/transactions.py
+++ b/tests/benchmark/helper/transactions.py
@@ -10,6 +10,7 @@ from execution_testing import (
     Fork,
     Hash,
     Transaction,
+    TransactionWithCost,
 )
 
 from .enums import CacheStrategy
@@ -109,30 +110,35 @@ def build_cache_strategy_blocks(
 
 def pack_transactions_into_blocks(
     transactions: list[Transaction],
-    gas_limit: int,
+    block_gas_budget: int,
 ) -> list[Block]:
     """
-    Pack transactions into blocks without exceeding gas_limit per block.
+    Pack transactions into blocks without exceeding block_gas_budget.
 
-    Greedily add transactions to the current block until adding another
-    would exceed the gas limit, then start a new block.
+    A block's gas occupancy is the maximum across the independent
+    EIP-8037 gas dimensions rather than their sum, so the execution and
+    state dimensions are accumulated separately.
     """
-    if not transactions:
-        return []
-
     blocks: list[Block] = []
     current_txs: list[Transaction] = []
-    current_gas = 0
+    execution_gas = 0
+    state_gas = 0
 
     for tx in transactions:
-        tx_gas_limit = tx.gas_limit
-        if current_gas + tx_gas_limit > gas_limit and current_txs:
+        if isinstance(tx, TransactionWithCost):
+            tx_execution, tx_state = tx.execution_cost, tx.state_cost
+        else:
+            tx_execution, tx_state = int(tx.gas_limit), 0
+        occupancy = max(execution_gas + tx_execution, state_gas + tx_state)
+        if occupancy > block_gas_budget and current_txs:
             blocks.append(Block(txs=current_txs))
             current_txs = []
-            current_gas = 0
+            execution_gas = 0
+            state_gas = 0
 
         current_txs.append(tx)
-        current_gas += tx_gas_limit
+        execution_gas += tx_execution
+        state_gas += tx_state
 
     if current_txs:
         blocks.append(Block(txs=current_txs))

--- a/tests/benchmark/stateful/bloatnet/test_call.py
+++ b/tests/benchmark/stateful/bloatnet/test_call.py
@@ -102,7 +102,7 @@ def test_call_value_to_empty(
 
     expected_gas_used = (
         sum(tx.gas_cost for tx in txs)
-        - fork.gas_costs().CALL_STIPEND * total_iterations
+        - fork.call_value_stipend() * total_iterations
     )
 
     benchmark_test(

--- a/tests/benchmark/stateful/bloatnet/test_sload.py
+++ b/tests/benchmark/stateful/bloatnet/test_sload.py
@@ -41,15 +41,17 @@ from tests.benchmark.helper.storage import (
     initializer_calldata_generator,
 )
 
+LOOP_GAS_THRESHOLD = 0xFFFF
+
 
 def _max_sloads_per_tx(tx_gas_limit: int, fork: Fork) -> int:
     """
     Conservative upper bound on cold SLOADs that fit in a max-gas tx.
 
-    Derived from the cold SLOAD cost (EIP-2929: 2100 gas) and used by
-    the bloated SLOAD benchmarks both as the inter-tx offset stride
-    (to keep consecutive txs' SLOAD ranges disjoint) and as the
-    per-target storage pre-load count.
+    Derived from the fork's cold `SLOAD` cost (`COLD_STORAGE_ACCESS`)
+    and used by the bloated SLOAD benchmarks both as the inter-tx
+    offset stride (to keep consecutive txs' SLOAD ranges disjoint) and
+    as the per-target storage pre-load count.
     """
     cold_sload_cost = Op.SLOAD(key_warm=False).gas_cost(fork)
     return tx_gas_limit // cold_sload_cost
@@ -172,6 +174,7 @@ def test_sload_benchmark(
             pre=pre,
             fork=fork,
             tx_gas_limit=tx_gas_limit,
+            block_gas_budget=gas_benchmark_value,
             needs_init=storage_keys_pre_set,
             num_target_slots=num_target_slots,
             initializer_code=initializer_code,
@@ -278,7 +281,7 @@ def test_sload_bloated(
                 + Op.PUSH1(1)  # [1, index]
                 + Op.ADD  # [index+1]
             ),
-            condition=Op.GT(Op.GAS, 0xFFFF),
+            condition=Op.GT(Op.GAS, LOOP_GAS_THRESHOLD),
         )
         + Op.PUSH0  # [0, index+1]
         + Op.SSTORE  # s[0] = index+1
@@ -332,15 +335,19 @@ def test_sload_bloated_prefetch_miss(
     runs them sequentially to propagate state changes — forcing
     every tx's prewarm scope to restart from pre-block state.
     """
-    # Runtime: read old offset from slot 0, write new offset from
-    # calldata to slot 0, then SLOAD sequentially from old offset.
-    runtime_code = (
-        Op.SLOAD(Op.PUSH0)
-        + Op.SSTORE(Op.PUSH0, Op.CALLDATALOAD(Op.PUSH0))
-        + While(
-            body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
-            condition=Op.GT(Op.GAS, 0xFFFF),
-        )
+    plant_code = Op.SLOAD(Op.PUSH0, key_warm=False) + Op.SSTORE(
+        Op.PUSH0,
+        Op.CALLDATALOAD(Op.PUSH0),
+        key_warm=True,
+        original_value=0,
+        current_value=0,
+        new_value=1,
+    )
+    # Read the old offset from slot 0, write the new offset from
+    # calldata to slot 0, then SLOAD sequentially from the old offset.
+    runtime_code = plant_code + While(
+        body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
+        condition=Op.GT(Op.GAS, LOOP_GAS_THRESHOLD),
     )
 
     authority = pre.stub_eoa(token_name)
@@ -372,6 +379,13 @@ def test_sload_bloated_prefetch_miss(
     base_offset = max_sloads_per_tx if existing_slots else START_SLOT
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
         calldata=b"\xff" * 32,
+        recipient_type=RecipientType.DELEGATION_7702,
+    ) + fork.transaction_top_frame_gas_calculator()(
+        recipient_type=RecipientType.DELEGATION_7702
+    )
+
+    plant_tx_gas = (
+        intrinsic_gas + plant_code.gas_cost(fork) + LOOP_GAS_THRESHOLD
     )
 
     # senders_iter yields one sender per tx (fresh per call in
@@ -384,14 +398,10 @@ def test_sload_bloated_prefetch_miss(
     gas_available = gas_benchmark_value
     txs: list[Transaction] = []
 
-    # First transaction: minimal gas, only writes the initial
-    # offset. Gas limit ensures remaining gas after the SLOAD +
-    # SSTORE setup falls below the 0xFFFF loop threshold so the
-    # SLOAD loop does not run. This tx's job is to change slot 0
-    # inside the benchmark block so every subsequent max-gas tx
-    # reads an offset the prefetcher's pre-block snapshot does
-    # not see, achieving a 100% prefetch miss rate on max-gas txs.
-    first_tx_gas = min(gas_available, intrinsic_gas + 30_000)
+    # This tx's job is to change slot 0 inside the benchmark block so
+    # every subsequent max-gas tx reads an offset the prefetcher's
+    # pre-block snapshot does not see, achieving a 100% miss rate.
+    first_tx_gas = min(gas_available, plant_tx_gas)
     sender = next(senders_iter)
     senders.append(sender)
     txs.append(
@@ -407,7 +417,7 @@ def test_sload_bloated_prefetch_miss(
     # Subsequent transactions: max gas, each shifts the offset
     # so the next transaction SLOADs from a different range.
     tx_index = 1
-    while gas_available >= intrinsic_gas:
+    while gas_available >= plant_tx_gas:
         tx_gas = min(gas_available, tx_gas_limit)
         new_offset = base_offset + tx_index * max_sloads_per_tx
         sender = next(senders_iter)
@@ -516,7 +526,7 @@ def test_sload_bloated_multi_contract(
         + Op.SLOAD(Op.PUSH0)
         + While(
             body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
-            condition=Op.GT(Op.GAS, 0xFFFF),
+            condition=Op.GT(Op.GAS, LOOP_GAS_THRESHOLD),
         )
         + Op.PUSH0
         + Op.SSTORE
@@ -538,7 +548,7 @@ def test_sload_bloated_multi_contract(
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     # Minimum per-tx gas ensuring the SLOAD loop runs at least one
     # iteration so every target satisfies storage_reads=[base_offset]:
-    # intrinsic + CALL + offset_holder + setup + 0xFFFF loop threshold
+    # intrinsic + CALL + offset_holder + setup + loop threshold
     # + one iteration + final SSTORE, with buffer.
     min_tx_gas = intrinsic_gas + 130_000
 

--- a/tests/benchmark/stateful/bloatnet/test_sload.py
+++ b/tests/benchmark/stateful/bloatnet/test_sload.py
@@ -378,8 +378,9 @@ def test_sload_bloated_prefetch_miss(
     # SLOAD range is completely disjoint from the actual range.
     base_offset = max_sloads_per_tx if existing_slots else START_SLOT
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
-        calldata=b"\xff" * 32,
+        calldata=Hash(base_offset),
         recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
     ) + fork.transaction_top_frame_gas_calculator()(
         recipient_type=RecipientType.DELEGATION_7702
     )

--- a/tests/benchmark/stateful/bloatnet/test_sstore.py
+++ b/tests/benchmark/stateful/bloatnet/test_sstore.py
@@ -376,6 +376,7 @@ def test_sstore_variants(
             pre=pre,
             fork=fork,
             tx_gas_limit=tx_gas_limit,
+            block_gas_budget=gas_benchmark_value,
             needs_init=initial_value != 0,
             num_target_slots=num_target_slots,
             initializer_code=initializer_code,
@@ -493,7 +494,8 @@ def test_sstore_dirty_transitions(
 
     Variants:
 
-    - oscillation: X→0→X→0, alternates clean (2900) and dirty (100)
+    - oscillation: X→0→X→0, alternates a clean change (slot access plus
+      `STORAGE_WRITE`) with a dirty one (slot access only)
     - triple_write_restore: X→B→C→X, all SSTORE branches
     - mass_clear: X→0, maximum per-slot refund generation
     """
@@ -539,6 +541,7 @@ def test_sstore_dirty_transitions(
             pre=pre,
             fork=fork,
             tx_gas_limit=tx_gas_limit,
+            block_gas_budget=gas_benchmark_value,
             needs_init=initial_value != 0,
             num_target_slots=num_target_slots,
             initializer_code=initializer_code,

--- a/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
+++ b/tests/benchmark/stateful/eip7928_block_level_access_lists/helpers.py
@@ -243,6 +243,7 @@ def run_bal_benchmark(
                     pre=pre,
                     fork=fork,
                     tx_gas_limit=tx_gas_limit,
+                    block_gas_budget=sum(plan.gas_limits),
                     authority=authority,
                     storage_init_ranges=storage_init_ranges,
                 )


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Makes `tests/benchmark/` devnet-8 ready.

- Bumps the benchmark EVM pin to `glamsterdam-devnet-8`.
- Fixes loop and transaction sizing that assumed devnet-7 gas values, so the affected benchmarks fill their gas target again.
- Revives `test_block_full_access_list_and_data`, which was skipped on every fork with an EIP-7934 block RLP size limit.
- Derives the remaining hardcoded gas amounts and docstring values from the fork.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

issue #3375

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
