### PR TITLE
feat(specs,tests): charge a frame target's access at frame entry

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/bogota/eip_8141.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/bogota/eip_8141.py
@@ -71,9 +71,10 @@ class EIP8141(BaseFork):
         Add the frame instruction gas costs.
 
         `SIGDATACOPY` follows the `CALLDATACOPY` shape: the opcode
-        instance must carry copy-size and memory-size metadata. The
-        remaining frame instructions — `FRAMEDATACOPY` and `APPROVE` —
-        stay unmapped.
+        instance must carry copy-size and memory-size metadata.
+        `APPROVE` follows the `REVERT` shape: only its return-data
+        region's memory expansion is charged. The remaining frame
+        instruction — `FRAMEDATACOPY` — stays unmapped.
         """
         gas_costs = cls.gas_costs()
         memory_expansion_calculator = cls.memory_expansion_gas_calculator()
@@ -87,6 +88,9 @@ class EIP8141(BaseFork):
             Opcodes.SIGDATACOPY: cls._with_memory_expansion(
                 cls._with_data_copy(gas_costs.VERY_LOW, gas_costs),
                 memory_expansion_calculator,
+            ),
+            Opcodes.APPROVE: cls._with_memory_expansion(
+                0, memory_expansion_calculator
             ),
         }
 

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -5965,6 +5965,7 @@ class Opcodes(Opcode, Enum):
         pushed_stack_items=0,
         kwargs=["offset", "size", "scope"],
         terminating=True,
+        metadata={"new_memory_size": 0, "old_memory_size": 0},
     )
     """
     APPROVE(offset, size, scope)

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -361,7 +361,6 @@ def restore_frame_context(
 def attempt_approval(
     tx_env: TransactionEnvironment,
     scope: FrameFlag,
-    accessed_addresses: Set[Address],
 ) -> bool:
     """
     Attempt an `APPROVE` of `scope` on behalf of the executing frame's
@@ -374,11 +373,9 @@ def attempt_approval(
     set, that execution is approved (by this same scope or earlier),
     and that the resolved target can cover the transaction's maximum
     cost; it increments the sender's nonce and collects the maximum
-    cost from the resolved target, which becomes the payer. Collecting
-    the maximum cost warms the payer like any protocol-touched
-    account, in the caller's active warm set so the warmth shares the
-    approval's rollback fate; an execution-only approval touches no
-    payer balance and warms nothing.
+    cost from the resolved target, which becomes the payer. The payer
+    needs no warming here: it is the frame's resolved target, whose
+    access the frame charged and warmed at frame entry.
 
     When incrementing the nonce creates the sender account, the
     account creation is charged from the executing frame's state gas
@@ -437,7 +434,6 @@ def attempt_approval(
             U256(Uint(payer_balance) - frame_context.max_cost),
         )
         frame_context.payer = resolved_target
-        accessed_addresses.add(resolved_target)
 
     return True
 

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -383,11 +383,13 @@ def attempt_approval(
     When incrementing the nonce creates the sender account, the
     account creation is charged from the executing frame's state gas
     pool immediately before the increment. A pool that cannot cover
-    the charge halts the frame exceptionally — the halt's rollback
-    discards every approval effect.
+    the charge halts the current call frame exceptionally — the halt's
+    rollback discards every approval effect, including an execution
+    approval this same call already recorded.
 
     Return whether the approval was granted; a refusal reverts the
-    requesting frame.
+    requesting call frame, which is the frame itself only when the
+    protocol default code is the caller.
     """
     frame_context = tx_env.frame_context
     assert frame_context is not None

--- a/src/ethereum/forks/amsterdam/vm/frame_interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/frame_interpreter.py
@@ -250,37 +250,24 @@ def create_evm_from_frame(
     frame: Frame,
     resolved_target: Address,
     gas_meter: GasMeter,
-    warm_addresses: Set[Address],
-    warm_storage_keys: Set[Tuple[Address, Bytes32]],
+    accessed_addresses: Set[Address],
+    accessed_storage_keys: Set[Tuple[Address, Bytes32]],
 ) -> Evm:
     """
     Build a frame's top-level EVM.
 
-    The frame starts warm with the coinbase, the precompiles, and the
-    journal shared across frames — not its caller, and not its target:
-    the target's warm or cold access is charged here, within the
-    frame's own execution gas budget, as is the access for resolving
-    an EIP-7702 delegation. A value transfer reviving a dead account
-    is charged to the frame's state gas pool, after the caller's
-    balance check and before the frame's code executes. A charge
-    exceeding either budget raises instead of building the EVM,
-    failing the frame.
+    The access sets arrive from `execute_frame`, which seeded them
+    from the journal shared across frames and charged the resolved
+    target's warm or cold access into them at frame entry. Charged
+    here are the frame's remaining entry costs: the access for
+    resolving an EIP-7702 delegation, from the frame's own execution
+    gas budget, and the state gas for a value transfer reviving a
+    dead account — after the caller's balance check and before the
+    frame's code executes. A charge exceeding either budget raises
+    instead of building the EVM, failing the frame.
     """
     frame_context = tx_env.frame_context
     assert frame_context is not None
-
-    ## Warm up the access sets
-    accessed_addresses: Set[Address] = set(warm_addresses)
-    accessed_addresses.add(block_env.coinbase)
-    accessed_addresses.update(PRE_COMPILED_CONTRACTS.keys())
-    accessed_storage_keys = set(warm_storage_keys)
-
-    ## Resolve dispatch and charge its state-dependent costs
-    if resolved_target in accessed_addresses:
-        charge_gas_from_meter(gas_meter, GasCosts.WARM_ACCESS)
-    else:
-        charge_gas_from_meter(gas_meter, GasCosts.COLD_ACCOUNT_ACCESS)
-        accessed_addresses.add(resolved_target)
 
     if frame.value > U256(0) and not is_account_alive(
         tx_env.state, resolved_target
@@ -336,16 +323,17 @@ def create_evm_from_frame(
 def execute_default_verify_code(
     tx_env: TransactionEnvironment,
     frame: Frame,
-    warm_addresses: Set[Address],
 ) -> FrameStatus:
     """
     Execute the protocol default code of a `VERIFY` frame whose
     resolved target has no code, returning the frame's status.
 
-    The default code consumes no execution gas. It can consume state
-    gas through `APPROVE`, when incrementing the nonce creates the
-    sender account; a pool that cannot cover that charge raises,
-    halting the frame exceptionally.
+    The default code draws no execution gas of its own: the frame's
+    only execution charge is the resolved target's access, taken by
+    `execute_frame` at frame entry. It can consume state gas through
+    `APPROVE`, when incrementing the nonce creates the sender
+    account; a pool that cannot cover that charge raises, halting the
+    frame exceptionally.
 
     The default code approves the scope allowed by the frame's flags,
     provided the transaction carries an authorizing secp256k1
@@ -385,7 +373,7 @@ def execute_default_verify_code(
     if frame_context.resolved_signers[signature_index] != resolved_target:
         return FrameStatus.FAILURE
 
-    if not attempt_approval(tx_env, allowed_scope, warm_addresses):
+    if not attempt_approval(tx_env, allowed_scope):
         return FrameStatus.FAILURE
 
     return FrameStatus.SUCCESS
@@ -400,10 +388,14 @@ def execute_frame(
     """
     Run a single frame as a top-level call and reduce its outcome.
 
-    A `VERIFY` frame whose resolved target has no code runs the
-    protocol default code instead of an EVM. As with an ordinary
-    `CALL`, a caller that cannot cover the transferred value reverts
-    the frame before it executes, consuming no gas.
+    Every frame is charged its resolved target's warm or cold access
+    at frame entry, from its own execution gas budget, before
+    anything else: resolving the target's code is how the protocol
+    dispatches the frame. A `VERIFY` frame whose resolved target has
+    no code then runs the protocol default code instead of an EVM. As
+    with an ordinary `CALL`, a caller that cannot cover the
+    transferred value reverts the frame, consuming the gas charged so
+    far.
 
     The frame's receipt reports its usage of both gas dimensions at
     frame exit: the execution gas its meter consumed — the whole
@@ -413,9 +405,9 @@ def execute_frame(
     here at frame entry, so its receipt reports zero state gas.
 
     On success the frame's accesses are committed back to the
-    journal's warm sets; a failed frame's accesses are discarded with
-    its EVM, so nothing it touched stays warm. The default code runs
-    without an EVM and warms in the journal's set directly.
+    journal's warm sets — the resolved target included, which is what
+    keeps a payer warm for later frames — and a failed frame's
+    accesses are discarded, so nothing it touched stays warm.
     """
     frame_context = tx_env.frame_context
     assert frame_context is not None
@@ -428,6 +420,40 @@ def execute_frame(
     # receipts are undone with it.
     entry_snapshot = copy_frame_context(tx_env)
     state_budget = Uint(frame.gas_limits.state)
+    execution_budget = Uint(frame.gas_limits.execution)
+
+    gas_meter = GasMeter(
+        gas_left=ExecutionGas(execution_budget),
+        reservoir=None,
+    )
+
+    ## Warm up the frame's access sets
+    accessed_addresses: Set[Address] = set(journal.warm_addresses)
+    accessed_addresses.add(block_env.coinbase)
+    accessed_addresses.update(PRE_COMPILED_CONTRACTS.keys())
+    accessed_storage_keys = set(journal.warm_storage_keys)
+
+    ## Charge the resolved target's access
+    try:
+        if resolved_target in accessed_addresses:
+            charge_gas_from_meter(gas_meter, GasCosts.WARM_ACCESS)
+        else:
+            charge_gas_from_meter(gas_meter, GasCosts.COLD_ACCOUNT_ACCESS)
+            accessed_addresses.add(resolved_target)
+    except ExceptionalHalt:
+        # The target's access exceeded the frame's execution budget:
+        # the frame halts exceptionally, consuming the budget whole.
+        # Nothing else has been charged, so there is nothing to
+        # restore.
+        return FrameOutcome(
+            receipt=FrameReceipt(
+                status=FrameStatus.FAILURE,
+                gas_used=GasUsed(execution=execution_budget, state=Uint(0)),
+                logs=(),
+            ),
+            refund_counter=0,
+            accounts_to_delete=set(),
+        )
 
     target_account = get_account(tx_state, resolved_target)
     if (
@@ -435,9 +461,7 @@ def execute_frame(
         and target_account.code_hash == EMPTY_CODE_HASH
     ):
         try:
-            status = execute_default_verify_code(
-                tx_env, frame, journal.warm_addresses
-            )
+            status = execute_default_verify_code(tx_env, frame)
         except ExceptionalHalt:
             # `APPROVE` could not cover the sender-creation state
             # charge: the frame halts exceptionally with no approval
@@ -447,7 +471,7 @@ def execute_frame(
                 receipt=FrameReceipt(
                     status=FrameStatus.FAILURE,
                     gas_used=GasUsed(
-                        execution=Uint(frame.gas_limits.execution),
+                        execution=execution_budget,
                         state=Uint(0),
                     ),
                     logs=(),
@@ -455,11 +479,13 @@ def execute_frame(
                 refund_counter=0,
                 accounts_to_delete=set(),
             )
+        if status == FrameStatus.SUCCESS:
+            journal.warm_addresses.update(accessed_addresses)
         return FrameOutcome(
             receipt=FrameReceipt(
                 status=status,
                 gas_used=GasUsed(
-                    execution=Uint(0),
+                    execution=execution_budget - Uint(gas_meter.gas_left),
                     state=state_budget - Uint(frame_context.state_gas_left),
                 ),
                 logs=(),
@@ -474,17 +500,15 @@ def execute_frame(
             return FrameOutcome(
                 receipt=FrameReceipt(
                     status=FrameStatus.FAILURE,
-                    gas_used=GasUsed(execution=Uint(0), state=Uint(0)),
+                    gas_used=GasUsed(
+                        execution=execution_budget - Uint(gas_meter.gas_left),
+                        state=Uint(0),
+                    ),
                     logs=(),
                 ),
                 refund_counter=0,
                 accounts_to_delete=set(),
             )
-
-    gas_meter = GasMeter(
-        gas_left=ExecutionGas(Uint(frame.gas_limits.execution)),
-        reservoir=None,
-    )
 
     try:
         evm = create_evm_from_frame(
@@ -493,8 +517,8 @@ def execute_frame(
             frame,
             resolved_target,
             gas_meter,
-            journal.warm_addresses,
-            journal.warm_storage_keys,
+            accessed_addresses,
+            accessed_storage_keys,
         )
     except ExceptionalHalt:
         # The frame's entry charges exceeded its own budgets: the
@@ -504,7 +528,7 @@ def execute_frame(
             receipt=FrameReceipt(
                 status=FrameStatus.FAILURE,
                 gas_used=GasUsed(
-                    execution=Uint(frame.gas_limits.execution),
+                    execution=execution_budget,
                     state=Uint(0),
                 ),
                 logs=(),
@@ -522,7 +546,7 @@ def execute_frame(
         restore_frame_context(tx_env, entry_snapshot)
 
     gas_used = GasUsed(
-        execution=Uint(frame.gas_limits.execution) - Uint(gas_meter.gas_left),
+        execution=execution_budget - Uint(gas_meter.gas_left),
         state=state_budget - Uint(frame_context.state_gas_left),
     )
     if evm.error is None:

--- a/src/ethereum/forks/amsterdam/vm/instructions/frame.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/frame.py
@@ -43,13 +43,14 @@ def approve(evm: Evm) -> None:
     transaction-scoped approval context based on the scope operand.
 
     The memory region designated by the offset and length operands
-    becomes the frame's return data, following `RETURN` semantics —
-    only the memory expansion is charged. A refused approval — an
-    `ADDRESS` other than the frame's resolved target, a scope outside
-    the frame's allowed flags, or a failed precondition — reverts the
-    frame instead. The approval's writes deliberately bypass the
-    `VERIFY` static restriction: only `APPROVE` may mutate state
-    there.
+    becomes the call frame's return data, following `RETURN`
+    semantics — only the memory expansion is charged. A refused
+    approval — an `ADDRESS` other than the frame's resolved target, a
+    scope outside the frame's allowed flags, or a failed precondition
+    — reverts the current call frame, not the whole frame: a caller
+    that handles the revert carries on. The approval's writes
+    deliberately bypass the `VERIFY` static restriction: only
+    `APPROVE` may mutate state there.
     """
     # STACK
     offset = pop(evm.stack)

--- a/src/ethereum/forks/amsterdam/vm/instructions/frame.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/frame.py
@@ -75,9 +75,7 @@ def approve(evm: Evm) -> None:
     # A scope with bits beyond the approval mask is never allowed.
     if scope & ~U256(APPROVE_SCOPE_MASK) != U256(0):
         raise Revert
-    if not attempt_approval(
-        evm.tx_env, FrameFlag(Uint(scope)), evm.accessed_addresses
-    ):
+    if not attempt_approval(evm.tx_env, FrameFlag(Uint(scope))):
         raise Revert
 
     evm.output = Bytes(memory_read_bytes(evm.memory, offset, length))

--- a/tests/amsterdam/eip8141_frame_transactions/helpers.py
+++ b/tests/amsterdam/eip8141_frame_transactions/helpers.py
@@ -2,9 +2,23 @@
 
 from typing import Any, Dict
 
-from execution_testing import Frame
+from execution_testing import Fork, Frame
 
 from .spec import Spec
+
+
+def default_code_frame_gas(fork: Fork, *, target_warm: bool) -> int:
+    """
+    Return the execution gas a frame running the protocol default code
+    reports in its receipt.
+
+    The default code draws no execution gas of its own, so the frame's
+    only charge is its resolved target's access at frame entry, warm or
+    cold per `target_warm`. A frame that resolves to the transaction
+    sender finds it warm, the sender seeding every frame's warm set; a
+    frame targeting a sponsor usually does not.
+    """
+    return fork.frame_entry_gas_calculator()(target_warm=target_warm)
 
 
 def verify_frame(**overrides: Any) -> Frame:

--- a/tests/amsterdam/eip8141_frame_transactions/spec.py
+++ b/tests/amsterdam/eip8141_frame_transactions/spec.py
@@ -14,7 +14,7 @@ class ReferenceSpec:
 
 
 ref_spec_8141 = ReferenceSpec(
-    "EIPS/eip-8141.md", "0603514569547869ae2531a4e5b2b62875888db3"
+    "EIPS/eip-8141.md", "b6b6f1cea0085e357bc80fb553d41896ac2a7fd0"
 )
 
 

--- a/tests/amsterdam/eip8141_frame_transactions/test_block_access_lists.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_block_access_lists.py
@@ -36,7 +36,7 @@ from execution_testing import (
 from tests.frontier.precompiles.spec import Spec as EcrecoverSpec
 from tests.osaka.eip7951_p256verify_precompiles.spec import Spec as Spec7951
 
-from .helpers import sender_frame, verify_frame
+from .helpers import default_code_frame_gas, sender_frame, verify_frame
 from .signature_helpers import P256_SIGNATURE, p256_entry
 from .spec import Spec, ref_spec_8141
 
@@ -297,7 +297,10 @@ def test_bal_unaffordable_designation_absent(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(status=Spec.STATUS_FAILURE, gas_used=frame_gas),
             ],
         ),
@@ -377,8 +380,10 @@ def test_bal_sponsored_payer_and_sender(
     tx.sign()
     assert tx.frames is not None and tx.signatures is not None
 
-    # The two VERIFY frames run the protocol default code, which
-    # consumes no gas; the SENDER frame charges its cold target's
+    # The two VERIFY frames run the protocol default code, whose only
+    # execution charge is their target's access at entry: warm for the
+    # sender the first frame resolves to, cold for the sponsor the
+    # second one names. The SENDER frame charges its cold target's
     # access at entry and then runs the storage write.
     sponsored_gas_used = (
         fork.frame_transaction_intrinsic_cost_calculator()(
@@ -386,6 +391,8 @@ def test_bal_sponsored_payer_and_sender(
             signatures=tx.signatures,
             return_cost_deducted_prior_execution=True,
         )
+        + default_code_frame_gas(fork, target_warm=True)
+        + default_code_frame_gas(fork, target_warm=False)
         + fork.frame_entry_gas_calculator()()
         + target_code.gas_cost(fork)
     )

--- a/tests/amsterdam/eip8141_frame_transactions/test_frame_transactions.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_frame_transactions.py
@@ -15,6 +15,7 @@ from execution_testing import (
     Alloc,
     Bytes,
     Conditional,
+    Fork,
     Frame,
     FrameReceipt,
     FrameSignature,
@@ -25,6 +26,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
+from .helpers import default_code_frame_gas
 from .spec import Spec, ref_spec_8141
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
@@ -461,12 +463,14 @@ def test_frame_revert_discards_the_approval_it_granted(
 def test_refused_approval_reverts_only_its_call_frame(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
     inner_attempts_approval: bool,
 ) -> None:
     """
     A refused `APPROVE` reverts the call frame that issued it, not the
     whole frame: its caller observes a failed call and runs on to a
-    successful frame.
+    successful frame, and the receipt keeps the refused call's gas
+    consumed.
 
     The `plain_return` case is the control, replacing the inner
     `APPROVE` with a bare `STOP`, so that the recorded call outcome
@@ -477,22 +481,32 @@ def test_refused_approval_reverts_only_its_call_frame(
     # The frame carries no approval flags, so any scope it attempts to
     # approve lies outside its own and is refused. Targeting a
     # non-sender is not an option: a frame flagged to approve execution
-    # must resolve to the sender to be statically valid.
-    inner = (
+    # must resolve to the sender to be statically valid. The inner code
+    # runs via `DELEGATECALL`, which preserves `ADDRESS`, so the
+    # refusal comes from the scope alone — and both executed paths stay
+    # straight-line, so the receipt pins the frame's exact gas.
+    inner_code = (
         Op.APPROVE(0, 0, Spec.APPROVE_EXECUTION)
         if inner_attempts_approval
         else Op.STOP
     )
-    # Calldata distinguishes the invocations: the frame supplies some,
-    # the self-call supplies none.
-    outer = Op.SSTORE(
-        SLOT_CALL_OUTCOME, Op.CALL(gas=Op.GAS, address=Op.ADDRESS)
+    inner = pre.deploy_contract(code=inner_code)
+    target_code = Op.SSTORE(
+        SLOT_CALL_OUTCOME,
+        Op.DELEGATECALL(gas=Op.GAS, address=inner),
+        new_value=0 if inner_attempts_approval else 1,
     ) + Op.SSTORE(SLOT_EXECUTED, 1)
-    target = pre.deploy_contract(
-        code=Conditional(
-            condition=Op.CALLDATASIZE, if_true=outer, if_false=inner
-        )
+    target = pre.deploy_contract(code=target_code)
+
+    # The refused call's gas stays consumed: the frame reports its
+    # target's cold entry access, the outer code, and the inner code
+    # the revert cut short.
+    frame_gas = (
+        fork.frame_entry_gas_calculator()()
+        + target_code.execution_cost(fork)
+        + inner_code.execution_cost(fork)
     )
+    fresh_write_state_cost = Op.SSTORE(SLOT_EXECUTED, 1).state_cost(fork)
 
     tx = Transaction(
         sender=sender,
@@ -504,14 +518,23 @@ def test_refused_approval_reverts_only_its_call_frame(
             Frame(
                 mode=Spec.MODE_DEFAULT,
                 target=target,
-                data=Bytes(b"\x01"),
             ),
         ],
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, logs=[]),
-                FrameReceipt(status=Spec.STATUS_SUCCESS),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    logs=[],
+                ),
+                # The control's outcome write creates a second slot.
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=frame_gas,
+                    state_gas_used=fresh_write_state_cost
+                    * (1 if inner_attempts_approval else 2),
+                ),
             ],
         ),
     )

--- a/tests/amsterdam/eip8141_frame_transactions/test_frame_transactions.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_frame_transactions.py
@@ -39,6 +39,9 @@ pytestmark = pytest.mark.valid_from("Bogota")
 SLOT_EXECUTED = 0x01
 """Storage slot used by target contracts to record execution."""
 
+SLOT_CALL_OUTCOME = 0x02
+"""Storage slot used by target contracts to record a nested call's success."""
+
 
 def test_transfer_with_default_code(
     state_test: StateTestFiller,
@@ -443,6 +446,86 @@ def test_frame_revert_discards_the_approval_it_granted(
         post={
             sender: Account(
                 storage={SLOT_EXECUTED: 0 if frame_reverts else 1}
+            ),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "inner_attempts_approval",
+    [
+        pytest.param(True, id="refused_approval"),
+        pytest.param(False, id="plain_return"),
+    ],
+)
+def test_refused_approval_reverts_only_its_call_frame(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    inner_attempts_approval: bool,
+) -> None:
+    """
+    A refused `APPROVE` reverts the call frame that issued it, not the
+    whole frame: its caller observes a failed call and runs on to a
+    successful frame.
+
+    The `plain_return` case is the control, replacing the inner
+    `APPROVE` with a bare `STOP`, so that the recorded call outcome
+    attributes to the refusal rather than to the nested call itself.
+    """
+    sender = pre.fund_eoa()
+
+    # The frame carries no approval flags, so any scope it attempts to
+    # approve lies outside its own and is refused. Targeting a
+    # non-sender is not an option: a frame flagged to approve execution
+    # must resolve to the sender to be statically valid.
+    inner = (
+        Op.APPROVE(0, 0, Spec.APPROVE_EXECUTION)
+        if inner_attempts_approval
+        else Op.STOP
+    )
+    # Calldata distinguishes the invocations: the frame supplies some,
+    # the self-call supplies none.
+    outer = Op.SSTORE(
+        SLOT_CALL_OUTCOME, Op.CALL(gas=Op.GAS, address=Op.ADDRESS)
+    ) + Op.SSTORE(SLOT_EXECUTED, 1)
+    target = pre.deploy_contract(
+        code=Conditional(
+            condition=Op.CALLDATASIZE, if_true=outer, if_false=inner
+        )
+    )
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            Frame(
+                mode=Spec.MODE_VERIFY,
+                flags=Spec.APPROVE_EXECUTION_AND_PAYMENT,
+            ),
+            Frame(
+                mode=Spec.MODE_DEFAULT,
+                target=target,
+                data=Bytes(b"\x01"),
+            ),
+        ],
+        expected_receipt=TransactionReceipt(
+            payer=sender,
+            frame_receipts=[
+                FrameReceipt(status=Spec.STATUS_SUCCESS, logs=[]),
+                FrameReceipt(status=Spec.STATUS_SUCCESS),
+            ],
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={
+            sender: Account(nonce=1),
+            target: Account(
+                storage={
+                    SLOT_CALL_OUTCOME: 0 if inner_attempts_approval else 1,
+                    SLOT_EXECUTED: 1,
+                }
             ),
         },
     )

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -23,7 +23,11 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .helpers import default_frame, verify_frame
+from .helpers import (
+    default_code_frame_gas,
+    default_frame,
+    verify_frame,
+)
 from .spec import Spec, ref_spec_8141
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
@@ -78,7 +82,12 @@ def test_calldata_floor_with_state_gas(
         frames=[
             # The floor must dominate the settlement anchor, so every
             # budget the anchor sums is kept to what execution needs.
-            verify_frame(gas_limit=0, state_gas_limit=0),
+            # The verifying frame needs its entry access and nothing
+            # more: the default code itself draws no execution gas.
+            verify_frame(
+                gas_limit=default_code_frame_gas(fork, target_warm=True),
+                state_gas_limit=0,
+            ),
             default_frame(
                 target=worker,
                 gas_limit=FLOOR_WORKER_GAS,
@@ -163,6 +172,7 @@ def test_storage_refund_settlement(
     tx.sign()
     assert tx.frames is not None and tx.signatures is not None
 
+    verify_gas = default_code_frame_gas(fork, target_warm=True)
     frame_execution_gas = fork.frame_entry_gas_calculator()() + (
         worker_code.execution_cost(fork)
     )
@@ -172,6 +182,7 @@ def test_storage_refund_settlement(
             signatures=tx.signatures,
             return_cost_deducted_prior_execution=True,
         )
+        + verify_gas
         + frame_execution_gas
     )
     refund = worker_code.refund(fork)
@@ -184,7 +195,9 @@ def test_storage_refund_settlement(
         cumulative_gas_used=gas_used,
         frame_receipts=[
             FrameReceipt(
-                status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                status=Spec.STATUS_SUCCESS,
+                gas_used=verify_gas,
+                state_gas_used=0,
             ),
             # The receipt reports pre-refund execution gas; the refund
             # applies only at transaction settlement.

--- a/tests/amsterdam/eip8141_frame_transactions/test_state_gas.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_state_gas.py
@@ -28,7 +28,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .helpers import default_frame, verify_frame
+from .helpers import default_code_frame_gas, default_frame, verify_frame
 from .spec import Spec, ref_spec_8141
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
@@ -108,7 +108,9 @@ def test_same_frame_refill(
             payer=sender,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
@@ -198,7 +200,9 @@ def test_cross_frame_refill(
             payer=sender,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 # The owner's attribution is gone: the refill returned
                 # its charge at settlement.
@@ -289,7 +293,9 @@ def test_state_gas_exhaustion(
             payer=sender,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 receipt,
             ],
@@ -316,8 +322,8 @@ def test_approve_creates_sender(
 
     Incrementing the nonce creates the sender account, and `APPROVE`
     charges the account creation to the approving frame's state gas
-    pool — here inside the payer's protocol default code, which
-    consumes no execution gas at all.
+    pool — here inside the payer's protocol default code, whose only
+    execution charge is the payer's cold access at frame entry.
     """
     sender = pre.fund_eoa(amount=0)
     payer = pre.fund_eoa()
@@ -340,11 +346,13 @@ def test_approve_creates_sender(
             payer=payer,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
-                    gas_used=0,
+                    gas_used=default_code_frame_gas(fork, target_warm=False),
                     state_gas_used=fork.gas_costs().NEW_ACCOUNT,
                 ),
             ],
@@ -473,7 +481,9 @@ def test_refill_after_intermediate_modification(
             payer=sender,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 # The creation's attribution is gone: the third
                 # frame's refill returned it at settlement.
@@ -593,7 +603,9 @@ def test_batch_unroll_restores_refilled_receipt(
             payer=sender,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 # The unroll restored the refill the batch frame
                 # applied to this receipt.
@@ -700,7 +712,9 @@ def test_frame_revert_restores_refilled_receipt(
             payer=sender,
             frame_receipts=[
                 FrameReceipt(
-                    status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                    state_gas_used=0,
                 ),
                 # The revert restored the refill the failing frame
                 # applied to this receipt.

--- a/tests/amsterdam/eip8141_frame_transactions/test_target_resolution.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_target_resolution.py
@@ -53,6 +53,9 @@ BN254_ADD = Address(0x06)
 OFF_THE_CURVE = b"\xff" * 128
 """`BN254_ADD` input that is not a pair of curve points."""
 
+SLOT_CREATED = 0x01
+"""Storage slot a worker contract creates."""
+
 
 def identity_gas(fork: Fork, data: bytes) -> int:
     """
@@ -419,6 +422,79 @@ def test_frame_entry_gas_boundary(
     )
 
     state_test(pre=pre, tx=tx, post={sender: Account(nonce=1)})
+
+
+def test_entry_charge_halt_unrolls_batch(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Halt a mid-batch frame on its entry access charge.
+
+    The halt unrolls the batch like any other frame failure: the
+    executed frame keeps its status and execution gas with its state
+    gas zeroed, the halting frame forfeits its whole budget, and the
+    terminator is skipped.
+    """
+    sender = pre.fund_eoa()
+    halting_target = pre.fund_eoa(amount=1)
+
+    worker_code = Op.SSTORE(SLOT_CREATED, 1)
+    worker = pre.deploy_contract(code=worker_code)
+
+    # Both frame targets are fresh, so each entry access is cold.
+    entry_gas = fork.frame_entry_gas_calculator()()
+    worker_gas = entry_gas + worker_code.execution_cost(fork)
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(),
+            default_frame(
+                flags=Spec.ATOMIC_BATCH_FLAG,
+                target=worker,
+                gas_limit=worker_gas,
+                state_gas_limit=worker_code.state_cost(fork),
+            ),
+            default_frame(
+                flags=Spec.ATOMIC_BATCH_FLAG,
+                target=halting_target,
+                gas_limit=entry_gas - 1,
+            ),
+            default_frame(target=worker, gas_limit=worker_gas),
+        ],
+        expected_receipt=TransactionReceipt(
+            payer=sender,
+            frame_receipts=[
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
+                # The unroll zeroes the executed frame's state gas and
+                # keeps its execution gas.
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=worker_gas,
+                    state_gas_used=0,
+                ),
+                FrameReceipt(
+                    status=Spec.STATUS_FAILURE, gas_used=entry_gas - 1
+                ),
+                FrameReceipt(status=Spec.STATUS_SKIPPED, gas_used=0),
+            ],
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={
+            sender: Account(nonce=1),
+            # The unroll discarded the worker's write.
+            worker: Account(storage={SLOT_CREATED: 0}),
+        },
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/amsterdam/eip8141_frame_transactions/test_target_resolution.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_target_resolution.py
@@ -16,8 +16,10 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    Bytes,
     Fork,
     FrameReceipt,
+    FrameSignature,
     Op,
     StateTestFiller,
     Transaction,
@@ -25,7 +27,12 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .helpers import default_frame, sender_frame, verify_frame
+from .helpers import (
+    default_code_frame_gas,
+    default_frame,
+    sender_frame,
+    verify_frame,
+)
 from .spec import Spec, ref_spec_8141
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
@@ -99,7 +106,10 @@ def test_precompile_target(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=identity_gas(fork, data),
@@ -114,6 +124,7 @@ def test_precompile_target(
 def test_precompile_target_rejecting_its_input(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Fail the frame whose targeted precompile rejects its input: the
@@ -130,7 +141,10 @@ def test_precompile_target_rejecting_its_input(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_FAILURE,
                     gas_used=DEFAULT_FRAME_GAS_LIMIT,
@@ -216,7 +230,10 @@ def test_delegated_target_entry_charge(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 *warming_receipts,
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
@@ -299,7 +316,10 @@ def test_dead_target_entry_charge(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 expected_frame,
             ],
         ),
@@ -331,7 +351,10 @@ def test_delegated_to_precompile_target(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=entry_gas(delegated=True, delegation_warm=True),
@@ -341,6 +364,143 @@ def test_delegated_to_precompile_target(
     )
 
     state_test(pre=pre, tx=tx, post={sender: Account(nonce=1)})
+
+
+@pytest.mark.parametrize(
+    "affordable",
+    [
+        pytest.param(True, id="affordable"),
+        pytest.param(False, id="one_gas_short"),
+    ],
+)
+def test_frame_entry_gas_boundary(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    affordable: bool,
+) -> None:
+    """
+    Run a frame budgeted exactly its target's entry access, and one
+    budgeted a single gas less.
+
+    The target holds no code, so the entry access is the whole of the
+    frame's execution: at the exact budget the frame succeeds having
+    spent all of it, and one gas short it halts exceptionally,
+    forfeiting the budget. A `DEFAULT` frame's failure is its own, so
+    the transaction stays valid either way.
+    """
+    sender = pre.fund_eoa()
+    target = pre.fund_eoa(amount=1)
+
+    entry_gas = fork.frame_entry_gas_calculator()()
+    budget = entry_gas if affordable else entry_gas - 1
+    expected_frame_receipt = (
+        FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=entry_gas)
+        if affordable
+        else FrameReceipt(status=Spec.STATUS_FAILURE, gas_used=budget)
+    )
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(),
+            default_frame(target=target, gas_limit=budget),
+        ],
+        expected_receipt=TransactionReceipt(
+            payer=sender,
+            frame_receipts=[
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
+                expected_frame_receipt,
+            ],
+        ),
+    )
+
+    state_test(pre=pre, tx=tx, post={sender: Account(nonce=1)})
+
+
+@pytest.mark.parametrize(
+    "affordable",
+    [
+        pytest.param(True, id="affordable"),
+        pytest.param(
+            False, id="one_gas_short", marks=pytest.mark.exception_test
+        ),
+    ],
+)
+def test_default_code_entry_gas_shortfall(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    affordable: bool,
+) -> None:
+    """
+    Approve payment through a sponsor's protocol default code with the
+    sponsor's entry access barely affordable, and one gas short of it.
+
+    The entry access is charged before the frame is dispatched, so the
+    frame one gas short halts before the default code is evaluated: no
+    approval is granted, and a failed `VERIFY` frame invalidates the
+    transaction. The affordable case is the control that attributes the
+    rejection to the entry charge rather than to the sponsorship shape
+    — the same frame, one gas richer, approves and binds the payer.
+    """
+    sender = pre.fund_eoa()
+    payer = pre.fund_eoa()
+
+    # The transaction touches the sponsor nowhere else, so its frame
+    # pays the cold access.
+    entry_gas = fork.frame_entry_gas_calculator()()
+    budget = entry_gas if affordable else entry_gas - 1
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(flags=Spec.APPROVE_EXECUTION),
+            verify_frame(
+                flags=Spec.APPROVE_PAYMENT, target=payer, gas_limit=budget
+            ),
+        ],
+        signatures=[
+            FrameSignature(scheme=Spec.SCHEME_SECP256K1, signer=Bytes(sender)),
+            FrameSignature(
+                scheme=Spec.SCHEME_SECP256K1,
+                signer=Bytes(payer),
+                secret_key=payer.key,
+            ),
+        ],
+        error=(
+            None
+            if affordable
+            else TransactionException.TYPE_6_INVALID_FRAME_EXECUTION
+        ),
+        expected_receipt=(
+            TransactionReceipt(
+                payer=payer,
+                frame_receipts=[
+                    FrameReceipt(
+                        status=Spec.STATUS_SUCCESS,
+                        gas_used=default_code_frame_gas(
+                            fork, target_warm=True
+                        ),
+                    ),
+                    FrameReceipt(
+                        status=Spec.STATUS_SUCCESS, gas_used=entry_gas
+                    ),
+                ],
+            )
+            if affordable
+            else None
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={sender: Account(nonce=1 if affordable else 0)},
+    )
 
 
 def test_verify_frame_delegated_to_precompile_target(
@@ -372,7 +532,10 @@ def test_verify_frame_delegated_to_precompile_target(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=entry_gas(delegated=True, delegation_warm=True),

--- a/tests/amsterdam/eip8141_frame_transactions/test_value_transfer.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_value_transfer.py
@@ -19,6 +19,7 @@ from execution_testing import (
     Bytes,
     Fork,
     FrameReceipt,
+    FrameSignature,
     Hash,
     StateTestFiller,
     Transaction,
@@ -27,7 +28,11 @@ from execution_testing import (
     keccak256,
 )
 
-from .helpers import sender_frame, verify_frame
+from .helpers import (
+    default_code_frame_gas,
+    sender_frame,
+    verify_frame,
+)
 from .spec import Spec, ref_spec_8141
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
@@ -101,6 +106,7 @@ def test_value_transfer(
         value_frame = sender_frame(value=TRANSFER_VALUE)
         entry_gas = fork.frame_entry_gas_calculator()(target_warm=True)
         logs = []
+    verify_gas = default_code_frame_gas(fork, target_warm=True)
 
     tx = Transaction(
         sender=sender,
@@ -126,17 +132,19 @@ def test_value_transfer(
         signatures=tx.signatures,
         sender=sender,
     )
-    # The frames run no code beyond the target's entry access, so the
+    # Neither frame runs code beyond its target's entry access, so the
     # floor may bind; both anchors carry the value transfer cost, so
     # the pin exercises it either way.
-    gas_used = max(intrinsic + entry_gas, calldata_floor)
+    gas_used = max(intrinsic + verify_gas + entry_gas, calldata_floor)
 
     tx.expected_receipt = TransactionReceipt(
         payer=sender,
         cumulative_gas_used=gas_used,
         frame_receipts=[
             FrameReceipt(
-                status=Spec.STATUS_SUCCESS, gas_used=0, state_gas_used=0
+                status=Spec.STATUS_SUCCESS,
+                gas_used=verify_gas,
+                state_gas_used=0,
             ),
             FrameReceipt(
                 status=Spec.STATUS_SUCCESS,
@@ -152,3 +160,67 @@ def test_value_transfer(
         post[recipient] = Account(balance=1 + TRANSFER_VALUE)
 
     state_test(pre=pre, tx=tx, post=post)
+
+
+def test_value_transfer_exceeding_balance(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Transfer more value than the sender holds, with a sponsor paying.
+
+    The balance check happens after the target's access is charged, so
+    the reverting frame's receipt reports that access rather than
+    nothing. A sponsor pays the gas, keeping the shortfall a property
+    of the sender's balance alone, and a `SENDER` frame's failure
+    leaves the transaction valid.
+    """
+    sender = pre.fund_eoa(amount=TRANSFER_VALUE)
+    payer = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=1)
+
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(flags=Spec.APPROVE_EXECUTION),
+            verify_frame(flags=Spec.APPROVE_PAYMENT, target=payer),
+            sender_frame(target=recipient, value=TRANSFER_VALUE + 1),
+        ],
+        signatures=[
+            FrameSignature(scheme=Spec.SCHEME_SECP256K1, signer=Bytes(sender)),
+            FrameSignature(
+                scheme=Spec.SCHEME_SECP256K1,
+                signer=Bytes(payer),
+                secret_key=payer.key,
+            ),
+        ],
+        expected_receipt=TransactionReceipt(
+            payer=payer,
+            frame_receipts=[
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=False),
+                ),
+                FrameReceipt(
+                    status=Spec.STATUS_FAILURE,
+                    gas_used=fork.frame_entry_gas_calculator()(),
+                    state_gas_used=0,
+                    logs=[],
+                ),
+            ],
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={
+            sender: Account(nonce=1, balance=TRANSFER_VALUE),
+            recipient: Account(balance=1),
+        },
+    )

--- a/tests/amsterdam/eip8141_frame_transactions/test_warmth.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_warmth.py
@@ -37,7 +37,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .helpers import verify_frame
+from .helpers import default_code_frame_gas, verify_frame
 from .spec import Spec, ref_spec_8141
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
@@ -178,7 +178,12 @@ def test_sender_is_warm(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                # The verifying frame resolves to the sender, so its
+                # entry charge is the warm access.
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=probe.frame_gas,
@@ -223,7 +228,10 @@ def test_coinbase_is_warm(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=probe.frame_gas,
@@ -338,7 +346,10 @@ def test_frame_target_entry_charge(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 *[
                     FrameReceipt(status=status, gas_used=gas)
                     for status, gas in expected
@@ -417,7 +428,10 @@ def test_warmth_carry_to_next_frame(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(status=warmer_status, gas_used=warmer_gas),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
@@ -447,9 +461,11 @@ def test_payer_warm_after_default_code_payment_approval(
     Measure a `BALANCE` of the payer in the frame after a sponsored
     payment approval through the payer's protocol default code.
 
-    Collecting the maximum cost warms the payer like any
-    protocol-touched account — also on the default code path, which
-    runs without an EVM and warms in the journal directly.
+    The payer needs no warming rule of its own: it is the resolved
+    target of the frame that approves payment, so that frame charges
+    the payer's access at entry — a cold one, the transaction having
+    touched the sponsor nowhere else — and commits the warmth to the
+    journal shared across frames when it succeeds.
     """
     sender = pre.fund_eoa()
     payer = pre.fund_eoa()
@@ -474,8 +490,14 @@ def test_payer_warm_after_default_code_payment_approval(
         expected_receipt=TransactionReceipt(
             payer=payer,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=False),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=probe.frame_gas,
@@ -534,7 +556,10 @@ def test_origin_warmth_by_frame_mode(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,
                     gas_used=fork.gas_costs().COLD_ACCOUNT_ACCESS
@@ -642,7 +667,10 @@ def test_warmth_from_inner_call(
         expected_receipt=TransactionReceipt(
             payer=sender,
             frame_receipts=[
-                FrameReceipt(status=Spec.STATUS_SUCCESS, gas_used=0),
+                FrameReceipt(
+                    status=Spec.STATUS_SUCCESS,
+                    gas_used=default_code_frame_gas(fork, target_warm=True),
+                ),
                 FrameReceipt(status=outer_status, gas_used=outer_gas),
                 FrameReceipt(
                     status=Spec.STATUS_SUCCESS,


### PR DESCRIPTION
### Description

- EIP-8141 revision `b3e8cad3` ([EIPs #12211](https://github.com/ethereum/EIPs/pull/12211)) moves the resolved target's warm or cold access to frame entry — before the balance check and before dispatch — so `execute_frame` takes the charge, every default-code frame receipt reports it instead of zero, and the payer's warming rule from #12113 falls out as redundant; 

- Revision `b6b6f1ce` ([EIPs #12212](https://github.com/ethereum/EIPs/pull/12212)) rescopes every `APPROVE` failure from the frame to the current call frame, which the implementation already did — `process_call` catches `Revert` and `ExceptionalHalt` inside the call frame and restores the frame context — so only three docstrings changed, one test now pins the distinction, and the `ReferenceSpec` moves to `b6b6f1ce` rather than the current tip, whose #12157 precompile arm belongs to #3407.


### Related Issues or PRs
#2829

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
