### PR TITLE
feat(ci): split the devnet release fill across fork ranges through Bogota

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -23,9 +23,8 @@ benchmark_fast:
   feature_only: true
 
 # Shared entry for all `<feat>-devnet` releases; matched by `-devnet` suffix.
-# devnets/frames/0: fill the full suite at the Bogota pseudo-fork.
-# `--fork` (not `--until`) because the build-matrix splitter has no Bogota
-# in its FORK_ORDER.
+# devnets/frames/0: fill every fork through the Bogota pseudo-fork, split
+# across the fork ranges so the fill parallelizes.
 devnet:
   evm-type: eels
-  fill-params: --fork=Bogota --generate-all-formats
+  fill-params: --until=Bogota --generate-all-formats

--- a/.github/configs/fork-ranges.yaml
+++ b/.github/configs/fork-ranges.yaml
@@ -16,3 +16,6 @@
 - label: amsterdam
   from: Amsterdam
   until: Amsterdam
+- label: bogota
+  from: Bogota
+  until: Bogota

--- a/.github/scripts/generate_build_matrix.py
+++ b/.github/scripts/generate_build_matrix.py
@@ -65,6 +65,7 @@ FORK_ORDER = [
     "BPO4",
     "BPO5",
     "Amsterdam",
+    "Bogota",
 ]
 
 FORK_INDEX = {name: i for i, name in enumerate(FORK_ORDER)}
@@ -140,31 +141,43 @@ def validate_inputs(feature: str, version: str, branch: str, evm: str) -> None:
             )
 
 
-def parse_until_fork(fill_params: str) -> str | None:
+def parse_fork_bounds(fill_params: str) -> tuple[str | None, str | None]:
     """
-    Extract the `--until` value from fill-params.
+    Extract the ``--from``/``--until`` forks from fill-params.
 
-    Return `None` when `--fork` is used instead (single-fork
-    feature that should not be split).
+    Return ``(None, None)`` when ``--fork`` is used instead (single-fork
+    feature that should not be split).  Either element may be ``None``
+    when the corresponding flag is absent.
     """
     if re.search(r"--fork\b", fill_params):
-        return None
-    m = re.search(r"--until[=\s]+(\S+)", fill_params)
-    return m.group(1) if m else None
+        return None, None
+    m_from = re.search(r"--from[=\s]+(\S+)", fill_params)
+    m_until = re.search(r"--until[=\s]+(\S+)", fill_params)
+    return (
+        m_from.group(1) if m_from else None,
+        m_until.group(1) if m_until else None,
+    )
 
 
-def applicable_ranges(fork_ranges: list[dict], until_fork: str) -> list[dict]:
+def applicable_ranges(
+    fork_ranges: list[dict], from_fork: str | None, until_fork: str
+) -> list[dict]:
     """
-    Return fork ranges whose `from` is at or before *until_fork*.
+    Return fork ranges overlapping ``[from_fork, until_fork]``.
 
-    Clamp the last applicable range's `until` to *until_fork* so we
-    never fill beyond the feature's declared boundary.
+    A range is applicable when it intersects the feature's declared
+    ``--from``/``--until`` boundary; its ends are clamped so we never
+    fill outside that boundary.  When ``from_fork`` is ``None`` the
+    lower bound defaults to the earliest fork.
     """
+    lower = FORK_INDEX[from_fork] if from_fork else 0
     limit = FORK_INDEX[until_fork]
     result = []
     for r in fork_ranges:
-        if FORK_INDEX[r["from"]] <= limit:
+        if FORK_INDEX[r["from"]] <= limit and FORK_INDEX[r["until"]] >= lower:
             entry = dict(r)
+            if FORK_INDEX[r["from"]] < lower:
+                entry["from"] = from_fork
             if FORK_INDEX[r["until"]] > limit:
                 entry["until"] = until_fork
             result.append(entry)
@@ -182,9 +195,9 @@ def build_matrix(
     the combine step.  Unsplit features produce a single entry with
     empty labels.
     """
-    until = parse_until_fork(feature["fill-params"])
+    from_fork, until = parse_fork_bounds(feature["fill-params"])
     if until and fork_ranges:
-        ranges = applicable_ranges(fork_ranges, until)
+        ranges = applicable_ranges(fork_ranges, from_fork, until)
         if len(ranges) > 1:
             build = [
                 {


### PR DESCRIPTION
### Description

Cherry-picks the focil branch's build-matrix Bogota support (`Bogota` in `FORK_ORDER` plus `--from`/`--until` range bounds), adds a `bogota` fork range, and flips the shared `devnet` feature entry from `--fork=Bogota` to `--until=Bogota`.

Release fills split into six parallel range jobs (`pre-shanghai` through `bogota`) instead of one monolithic job, and the release now carries fixtures for every fork through Bogota, matching the glamsterdam devnet release shape. The hive frames workflows filter to `fork_Bogota`, so consumed coverage is unchanged. Applies from the next `frames-devnet` release, `v0.1.0` was filled single-job.

Verified: the matrix generator emits the six ranges for `frames-devnet`, and `fill --from=Bogota --until=Bogota --collect-only` collects the 8141 suite.

### Related Issues or PRs

#3415

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.