### PR TITLE
feat(tests): EIP-7702 - precompile calls from a delegated frame

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
@@ -519,6 +519,73 @@ def test_call_to_precompile_in_pointer_context(
     )
 
 
+@pytest.mark.with_all_call_opcodes
+@pytest.mark.valid_from("Prague")
+def test_precompile_call_from_delegated_frame(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+) -> None:
+    """
+    Tx -> entry contract -> delegated authority -> precompile.
+
+    Being reached through a delegation must not stop the frame from calling a
+    precompile directly, for any of the call opcodes.
+    """
+    storage: Storage = Storage()
+
+    identity_precompile = 0x04
+    # Identity echoes its input, so a precompile that did not run is visible
+    # as empty return data instead of only as a gas difference.
+    precompile_input = 0xC0FFEE
+
+    delegation_target = pre.deploy_contract(
+        code=Op.MSTORE(0, precompile_input)
+        + Op.SSTORE(
+            storage.store_next(1, "call_result"),
+            call_opcode(
+                address=identity_precompile,
+                args_offset=0,
+                args_size=32,
+                ret_offset=32,
+                ret_size=32,
+            ),
+        )
+        + Op.SSTORE(
+            storage.store_next(32, "returndatasize"), Op.RETURNDATASIZE
+        )
+        + Op.SSTORE(
+            storage.store_next(precompile_input, "returned_data"),
+            Op.MLOAD(32),
+        )
+        + Op.STOP
+    )
+
+    authority = pre.fund_eoa()
+    entry_contract = pre.deploy_contract(
+        code=Op.CALL(address=authority) + Op.STOP
+    )
+
+    tx = Transaction(
+        to=entry_contract,
+        sender=pre.fund_eoa(),
+        authorization_list=[
+            AuthorizationTuple(
+                address=delegation_target,
+                nonce=0,
+                signer=authority,
+            )
+        ],
+    )
+
+    post = {authority: Account(storage=storage)}
+    state_test(
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
 @pytest.mark.with_all_precompiles
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("sender_delegated", [True, False])


### PR DESCRIPTION
### Description

Parametrize the direct precompile call made by a frame that was entered through a 7702 delegation over CALL, CALLCODE, DELEGATECALL and STATICCALL; only the CALL variant was covered before.

The frame calls the identity precompile and stores the call result, RETURNDATASIZE and the echoed word, so the precompile's execution is pinned by its output rather than only by a gas difference, which keeps the observable meaningful under STATICCALL.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.