### PR TITLE
feat(tests): EIP-8037 - consume spilled state gas along a halt chain

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -1034,6 +1034,66 @@ def test_top_level_failure_spilled_state_gas(
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "gas_limit",
+    [
+        pytest.param(150_000, id="gas_150k"),
+        pytest.param(200_000, id="gas_200k"),
+        pytest.param(300_000, id="gas_300k"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_spilled_state_gas_consumed_across_halt_chain(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_limit: int,
+) -> None:
+    """
+    Verify spilled state gas stays consumed along a chain of halting frames.
+
+    A self-`DELEGATECALL`ing contract writes `NOT(storage[slot])`, so set and
+    clear alternate down the shared-storage call stack and the reservoir is
+    recycled instead of drained once. Each frame reuses the value it wrote as
+    a `CALL`'s `args_size`, so the frames that set the slot halt on the
+    memory-size overflow while the frames that cleared it re-enter the
+    contract, interleaving halting and surviving frames. Every halt must burn
+    its spill rather than credit it back to the caller's reservoir, so the
+    top-level halt charges the whole gas limit.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    # Below the cap, so the reservoir starts empty and every set spills.
+    assert gas_limit < gas_limit_cap
+
+    slot = 0
+    value_offset = 0
+    contract = pre.deploy_contract(
+        code=(
+            # Memory is per-frame, so each frame keeps the value it wrote
+            # and reuses it below as the CALL's args_size.
+            Op.MSTORE(value_offset, Op.NOT(Op.SLOAD(slot)))
+            + Op.SSTORE(slot, Op.MLOAD(value_offset))
+            + Op.POP(Op.DELEGATECALL(address=Op.ADDRESS))
+            # An all-ones args_size overflows the memory-size calculation
+            # and halts the frame. A zero one, in a frame that cleared the
+            # slot, re-enters the contract and spawns further frames.
+            + Op.POP(
+                Op.CALL(address=Op.ADDRESS, args_size=Op.MLOAD(value_offset))
+            )
+        ),
+    )
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_limit),
+    )
+
+    state_test(pre=pre, post={contract: Account(storage={})}, tx=tx)
+
+
 def _build_call_chain(
     pre: Alloc,
     frame_bodies: list[Bytecode],

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -1035,11 +1035,11 @@ def test_top_level_failure_spilled_state_gas(
 
 
 @pytest.mark.parametrize(
-    "gas_limit",
+    "descent_frames",
     [
-        pytest.param(150_000, id="gas_150k"),
-        pytest.param(200_000, id="gas_200k"),
-        pytest.param(300_000, id="gas_300k"),
+        pytest.param(2, id="descent_frames_2"),
+        pytest.param(4, id="descent_frames_4"),
+        pytest.param(8, id="descent_frames_8"),
     ],
 )
 @pytest.mark.valid_from("EIP8037")
@@ -1047,7 +1047,7 @@ def test_spilled_state_gas_consumed_across_halt_chain(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    gas_limit: int,
+    descent_frames: int,
 ) -> None:
     """
     Verify spilled state gas stays consumed along a chain of halting frames.
@@ -1061,28 +1061,35 @@ def test_spilled_state_gas_consumed_across_halt_chain(
     its spill rather than credit it back to the caller's reservoir, so the
     top-level halt charges the whole gas limit.
     """
+    slot = 0
+    value_offset = 0
+    code = (
+        # Memory is per-frame, so each frame keeps the value it wrote
+        # and reuses it below as the CALL's args_size.
+        Op.MSTORE(value_offset, Op.NOT(Op.SLOAD(slot)))
+        + Op.SSTORE(slot, Op.MLOAD(value_offset))
+        + Op.POP(Op.DELEGATECALL(address=Op.ADDRESS))
+        # An all-ones args_size overflows the memory-size calculation
+        # and halts the frame. A zero one, in a frame that cleared the
+        # slot, re-enters the contract and spawns further frames.
+        + Op.POP(Op.CALL(address=Op.ADDRESS, args_size=Op.MLOAD(value_offset)))
+    )
+    contract = pre.deploy_contract(code=code)
+
+    # One fresh spilled set plus a descent budget in static frame
+    # costs. Clear credits recycle the reservoir for deeper sets, and
+    # warm frames cost less than the static sum, so the descent runs
+    # past the budget. Fork-derived so the depth regimes survive
+    # repricings.
+    gas_limit = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + Op.SSTORE(new_value=1).state_cost(fork)
+        + descent_frames * code.execution_cost(fork)
+    )
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     # Below the cap, so the reservoir starts empty and every set spills.
     assert gas_limit < gas_limit_cap
-
-    slot = 0
-    value_offset = 0
-    contract = pre.deploy_contract(
-        code=(
-            # Memory is per-frame, so each frame keeps the value it wrote
-            # and reuses it below as the CALL's args_size.
-            Op.MSTORE(value_offset, Op.NOT(Op.SLOAD(slot)))
-            + Op.SSTORE(slot, Op.MLOAD(value_offset))
-            + Op.POP(Op.DELEGATECALL(address=Op.ADDRESS))
-            # An all-ones args_size overflows the memory-size calculation
-            # and halts the frame. A zero one, in a frame that cleared the
-            # slot, re-enters the contract and spawns further frames.
-            + Op.POP(
-                Op.CALL(address=Op.ADDRESS, args_size=Op.MLOAD(value_offset))
-            )
-        ),
-    )
 
     tx = Transaction(
         to=contract,


### PR DESCRIPTION
### Description

State gas that spills into a frame's execution gas must be consumed when that frame halts exceptionally. The suite guards this at single spill points, but never along a chain of halting frames that recycles one reservoir.

A self-DELEGATECALLing contract writes NOT(storage[slot]), so set and clear alternate down the shared-storage call stack. Each frame reuses the value it wrote as a CALL's args_size, so the frames that set the slot halt on the memory-size overflow while the frames that cleared it return normally. The top-level halt then charges the whole gas limit, asserted over three gas limits below the transaction gas limit cap so the reservoir starts empty and every set spills.

### Related Issues or PRs

https://github.com/NethermindEth/nethermind/issues/12964
Found by evmone-fuzz.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
