### PR TITLE
fix(evm-tools): accept empty hex transaction values

### DIFF
--- a/packages/testing/src/execution_testing/evm_tools/t8n/cli.py
+++ b/packages/testing/src/execution_testing/evm_tools/t8n/cli.py
@@ -116,23 +116,27 @@ def _parse_ommers_from_env_json(env_json: Any, fork: Any) -> List[Ommer]:
 
 def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Drop fields that the testing ``Transaction`` model rejects.
+    Normalize JSON inputs that the testing ``Transaction`` model rejects.
 
-    Three boundary mismatches to smooth over:
+    Four boundary mismatches to smooth over:
 
-    1. ``yParity`` on authorization tuples. The testing
+    1. An empty hexadecimal transaction value. Some legacy state tests
+       encode zero as ``0x``, while the testing ``HexNumber`` requires at
+       least one digit. Normalize it to the accepted numeric ``0x0``
+       representation.
+    2. ``yParity`` on authorization tuples. The testing
        ``AuthorizationTuple`` serializer emits both ``v`` and
        ``yParity`` (they are guaranteed equal — see the model's
        ``duplicate_v_as_y_parity``), but its validator binds only
        ``v`` and treats ``yParity`` as an extra-forbidden field.
-    2. ``secretKey`` on an already-signed tx. The testing
+    3. ``secretKey`` on an already-signed tx. The testing
        ``Transaction`` retains the private key after auto-signing in
        ``model_post_init``, so the dump still carries ``secretKey``
        alongside the populated ``v``/``r``/``s``. On re-validation
        the model rejects the pair with
        ``InvalidSignaturePrivateKeyError``. Strip ``secretKey``
        whenever ``v`` is set (i.e. the tx is already signed).
-    3. A tx with no signature material at all. Filled state tests
+    4. A tx with no signature material at all. Filled state tests
        store a tx whose signature is deliberately invalid without
        ``v``/``r``/``s`` or ``secretKey`` (the fixture format cannot
        express explicit signature values), expecting the fork to
@@ -140,6 +144,8 @@ def _normalize_tx_json(tx: Dict[str, Any]) -> Dict[str, Any]:
        would make ``Transaction.rlp`` try to auto-sign a key-less tx
        and die on an assertion.
     """
+    if tx.get("value") == "0x":
+        tx["value"] = "0x0"
     auth_list = tx.get("authorizationList")
     if isinstance(auth_list, list):
         tx["authorizationList"] = [

--- a/packages/testing/src/execution_testing/evm_tools/tests/test_statetest.py
+++ b/packages/testing/src/execution_testing/evm_tools/tests/test_statetest.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from execution_testing.base_types import Hash
+from execution_testing.base_types import EmptyTrieRoot, Hash
 from execution_testing.evm_tools import statetest
 from execution_testing.evm_tools.statetest import (
     StateTest,
@@ -23,7 +23,12 @@ from execution_testing.test_types import Environment
 pytestmark = pytest.mark.evm_tools
 
 
-def _test_case(*, env: dict[str, Any], post_hash: str) -> StateTestCase:
+def _test_case(
+    *,
+    env: dict[str, Any],
+    post_hash: str,
+    transaction_value: str = "0x0",
+) -> StateTestCase:
     """Create a minimal state test case."""
     return StateTestCase(
         path="test.json",
@@ -39,7 +44,7 @@ def _test_case(*, env: dict[str, Any], post_hash: str) -> StateTestCase:
         transaction={
             "data": ["0x"],
             "gasLimit": ["0x5208"],
-            "value": ["0x0"],
+            "value": [transaction_value],
         },
     )
 
@@ -79,6 +84,23 @@ def test_run_test_case_translates_previous_hash(
         "blockHashes": {"0": previous_hash},
         "withdrawals": [],
     }
+
+
+def test_run_test_case_accepts_empty_hex_value() -> None:
+    """Treat the legacy empty hexadecimal transaction value as zero."""
+    test_case = _test_case(
+        env={
+            "currentBaseFee": "0x7",
+            "currentRandom": "0x" + "00" * 32,
+        },
+        post_hash="0x",
+        transaction_value="0x",
+    )
+
+    with ForkCache() as fork_cache:
+        result = run_test_case(test_case, fork_cache)
+
+    assert result.state_root == Hash(EmptyTrieRoot)
 
 
 def test_run_one_formats_state_root_once(


### PR DESCRIPTION
## Summary

Treat `"0x"` as zero when it appears as a state-test transaction `value`.

This keeps the EELS state-test runner compatible with goevmlab-generated and other legacy state-test inputs. The syntax also appears in ethereum/legacyTests fillers, [here's an example](https://github.com/ethereum/legacyTests/blob/1f581b8ccdc4c63acf5f2c5c1b155c690c32a8eb/src/LegacyTests/Constantinople/GeneralStateTestsFiller/stPreCompiledContracts2/modexp_0_0_0_25000Filler.json#L90-L92).

## Related Issues/PRs

This is a small fix complementary to[#3409](https://github.com/ethereum/execution-specs/pull/3409), covering the remaining case from [Holiman's comment](https://github.com/ethereum/execution-specs/pull/3409#issuecomment-5379434726). The stricter transaction parsing was introduced by [#2924](https://github.com/ethereum/execution-specs/pull/2924).

## Testing

- `uv run pytest -q packages/testing/src/execution_testing/evm_tools/tests/test_statetest.py`
- `just test-tests`
- `just static`


<img width="443" height="552" alt="image" src="https://github.com/user-attachments/assets/885fa1ca-e63f-4ab0-a4be-e18ba63bd0d3" />
