### PR TITLE
feat(tests): expand create collision matrix and add balance-only cases

### DIFF
--- a/tests/frontier/create/test_create_collision.py
+++ b/tests/frontier/create/test_create_collision.py
@@ -27,6 +27,11 @@ pytestmark = [
     pytest.mark.pre_alloc_mutable,
 ]
 
+CORRECT_INITCODE = Initcode(
+    deploy_code=Op.STOP,
+    initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),
+)
+
 # Every account shape where creation must abort under EIP-684: the
 # product of nonce, code, storage and balance with non-empty code or
 # nonce. Cells with zero nonce and empty code are excluded: with
@@ -37,13 +42,13 @@ pytestmark = [
 # instead of code or nonce; cells with non-empty storage also check
 # that the aborted creation neither wipes the storage nor runs the
 # initcode, which would zero slot 0x01 in the correct-initcode case.
-COLLISION_ACCOUNT_PARAMS = [
-    pytest.param(
+COLLISION_ACCOUNT_CASES = [
+    (
         nonce,
         code,
         storage,
         balance,
-        id=(
+        (
             f"nonce_{nonce}-"
             f"{'code' if code else 'no_code'}-"
             f"{'storage' if storage else 'no_storage'}-"
@@ -57,17 +62,33 @@ COLLISION_ACCOUNT_PARAMS = [
     if nonce != 0 or code != b""
 ]
 
-CORRECT_INITCODE = Initcode(
-    deploy_code=Op.STOP,
-    initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),
-)
+INITCODE_CASES = [
+    (CORRECT_INITCODE, "correct-initcode", False),
+    (Op.REVERT(0, 0), "revert-initcode", True),
+    (Op.MSTORE(0xFFFFFFFFFFFFFFFFFFFFFFFFFFF, 1), "oog-initcode", True),
+]
 
-INITCODE_PARAMS = [
-    pytest.param(CORRECT_INITCODE, id="correct-initcode"),
-    pytest.param(Op.REVERT(0, 0), id="revert-initcode"),
+# Preserve the reverting and out-of-gas initcode coverage for the two
+# original ported account shapes. The successful initcode is the probe
+# that distinguishes a missed collision for every additional shape.
+ORIGINAL_COLLISION_ACCOUNT_IDS = {
+    "nonce_0-code-storage-balance_0",
+    "nonce_1-no_code-no_storage-balance_0",
+}
+
+COLLISION_PARAMS = [
     pytest.param(
-        Op.MSTORE(0xFFFFFFFFFFFFFFFFFFFFFFFFFFF, 1), id="oog-initcode"
-    ),
+        nonce,
+        code,
+        storage,
+        balance,
+        initcode,
+        id=f"{initcode_id}-{account_id}",
+    )
+    for initcode, initcode_id, original_accounts_only in INITCODE_CASES
+    for nonce, code, storage, balance, account_id in COLLISION_ACCOUNT_CASES
+    if not original_accounts_only
+    or account_id in ORIGINAL_COLLISION_ACCOUNT_IDS
 ]
 
 PORTED_FROM = pytest.mark.ported_from(
@@ -81,10 +102,9 @@ PORTED_FROM = pytest.mark.ported_from(
 
 @PORTED_FROM
 @pytest.mark.parametrize(
-    "collision_nonce,collision_code,collision_storage,collision_balance",
-    COLLISION_ACCOUNT_PARAMS,
+    "collision_nonce,collision_code,collision_storage,collision_balance,initcode",
+    COLLISION_PARAMS,
 )
-@pytest.mark.parametrize("initcode", INITCODE_PARAMS)
 @pytest.mark.with_all_contract_creating_tx_types
 @pytest.mark.eels_base_coverage
 def test_create_tx_collision(
@@ -146,10 +166,9 @@ def test_create_tx_collision(
 
 @PORTED_FROM
 @pytest.mark.parametrize(
-    "collision_nonce,collision_code,collision_storage,collision_balance",
-    COLLISION_ACCOUNT_PARAMS,
+    "collision_nonce,collision_code,collision_storage,collision_balance,initcode",
+    COLLISION_PARAMS,
 )
-@pytest.mark.parametrize("initcode", INITCODE_PARAMS)
 @pytest.mark.parametrize(
     "opcode",
     [

--- a/tests/frontier/create/test_create_collision.py
+++ b/tests/frontier/create/test_create_collision.py
@@ -23,7 +23,7 @@ from execution_testing import (
 
 pytestmark = [
     pytest.mark.valid_from("Frontier"),
-    # We need to modify the pre-alloc to include the collision
+    # We need to modify the pre-alloc to include the target account
     pytest.mark.pre_alloc_mutable,
 ]
 

--- a/tests/frontier/create/test_create_collision.py
+++ b/tests/frontier/create/test_create_collision.py
@@ -1,6 +1,7 @@
 """
 Test collision in CREATE/CREATE2 account creation, where the existing
-account has non-empty code or nonce (EIP-684).
+account has non-empty code or nonce (EIP-684), and that an account
+with only a balance is deployable.
 """
 
 from typing import Dict
@@ -22,41 +23,68 @@ from execution_testing import (
 
 pytestmark = [
     pytest.mark.valid_from("Frontier"),
-    pytest.mark.ported_from(
-        [
-            "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stSStoreTest/InitCollisionFiller.json",
-            "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stSStoreTest/InitCollisionNonZeroNonceFiller.json",
-        ],
-        pr=["https://github.com/ethereum/execution-spec-tests/pull/636"],
-    ),
-    pytest.mark.parametrize(
-        "collision_nonce,collision_code,collision_storage",
-        [
-            pytest.param(0, b"\0", {0x01: 0x01}, id="non-empty-code"),
-            pytest.param(1, b"", {}, id="non-empty-nonce"),
-        ],
-    ),
-    pytest.mark.parametrize(
-        "initcode",
-        [
-            pytest.param(
-                Initcode(
-                    deploy_code=Op.STOP,
-                    initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),
-                ),
-                id="correct-initcode",
-            ),
-            pytest.param(Op.REVERT(0, 0), id="revert-initcode"),
-            pytest.param(
-                Op.MSTORE(0xFFFFFFFFFFFFFFFFFFFFFFFFFFF, 1), id="oog-initcode"
-            ),
-        ],
-    ),
     # We need to modify the pre-alloc to include the collision
     pytest.mark.pre_alloc_mutable,
 ]
 
+# Every account shape where creation must abort under EIP-684: the
+# product of nonce, code, storage and balance with non-empty code or
+# nonce. Cells with zero nonce and empty code are excluded: with
+# non-empty storage the behavior is undefined in protocol (EIP-7610
+# was declined for inclusion in Glamsterdam), and with empty storage
+# the account is deployable (see the balance-only tests). Cells with
+# empty storage catch clients that incorrectly abort on storage
+# instead of code or nonce; cells with non-empty storage also check
+# that the aborted creation neither wipes the storage nor runs the
+# initcode, which would zero slot 0x01 in the correct-initcode case.
+COLLISION_ACCOUNT_PARAMS = [
+    pytest.param(
+        nonce,
+        code,
+        storage,
+        balance,
+        id=(
+            f"nonce_{nonce}-"
+            f"{'code' if code else 'no_code'}-"
+            f"{'storage' if storage else 'no_storage'}-"
+            f"balance_{balance}"
+        ),
+    )
+    for nonce in (0, 1)
+    for code in (b"", b"\0")
+    for storage in ({}, {0x01: 0x01})
+    for balance in (0, 1)
+    if nonce != 0 or code != b""
+]
 
+CORRECT_INITCODE = Initcode(
+    deploy_code=Op.STOP,
+    initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),
+)
+
+INITCODE_PARAMS = [
+    pytest.param(CORRECT_INITCODE, id="correct-initcode"),
+    pytest.param(Op.REVERT(0, 0), id="revert-initcode"),
+    pytest.param(
+        Op.MSTORE(0xFFFFFFFFFFFFFFFFFFFFFFFFFFF, 1), id="oog-initcode"
+    ),
+]
+
+PORTED_FROM = pytest.mark.ported_from(
+    [
+        "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stSStoreTest/InitCollisionFiller.json",
+        "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stSStoreTest/InitCollisionNonZeroNonceFiller.json",
+    ],
+    pr=["https://github.com/ethereum/execution-spec-tests/pull/636"],
+)
+
+
+@PORTED_FROM
+@pytest.mark.parametrize(
+    "collision_nonce,collision_code,collision_storage,collision_balance",
+    COLLISION_ACCOUNT_PARAMS,
+)
+@pytest.mark.parametrize("initcode", INITCODE_PARAMS)
 @pytest.mark.with_all_contract_creating_tx_types
 @pytest.mark.eels_base_coverage
 def test_create_tx_collision(
@@ -66,6 +94,7 @@ def test_create_tx_collision(
     collision_nonce: int,
     collision_code: bytes,
     collision_storage: Dict[int, int],
+    collision_balance: int,
     initcode: Bytecode,
     fork: Fork,
 ) -> None:
@@ -89,6 +118,7 @@ def test_create_tx_collision(
         nonce=collision_nonce,
         code=collision_code,
         storage=collision_storage,
+        balance=collision_balance,
     )
 
     expected_block_access_list = None
@@ -106,6 +136,7 @@ def test_create_tx_collision(
                 nonce=collision_nonce,
                 code=collision_code,
                 storage=collision_storage,
+                balance=collision_balance,
             ),
         },
         tx=tx,
@@ -113,6 +144,12 @@ def test_create_tx_collision(
     )
 
 
+@PORTED_FROM
+@pytest.mark.parametrize(
+    "collision_nonce,collision_code,collision_storage,collision_balance",
+    COLLISION_ACCOUNT_PARAMS,
+)
+@pytest.mark.parametrize("initcode", INITCODE_PARAMS)
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -129,6 +166,7 @@ def test_create_opcode_collision(
     collision_nonce: int,
     collision_code: bytes,
     collision_storage: Dict[int, int],
+    collision_balance: int,
     initcode: Bytecode,
 ) -> None:
     """
@@ -187,6 +225,7 @@ def test_create_opcode_collision(
         nonce=collision_nonce,
         code=collision_code,
         storage=collision_storage,
+        balance=collision_balance,
     )
 
     state_test(
@@ -196,8 +235,106 @@ def test_create_opcode_collision(
                 nonce=collision_nonce,
                 code=collision_code,
                 storage=collision_storage,
+                balance=collision_balance,
             ),
             gas_limiter_address: Account(storage={0x01: 0x00}),
+        },
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_contract_creating_tx_types
+def test_create_tx_balance_only_target(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx_type: int,
+) -> None:
+    """
+    Test that a contract creation transaction succeeds when the target
+    address has only a balance: an account with zero nonce, no code and
+    no storage is not a collision (EIP-684).
+    """
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        ty=tx_type,
+        to=None,
+        data=CORRECT_INITCODE,
+        protected=False,
+    )
+
+    created_contract_address = tx.created_contract
+
+    pre[created_contract_address] = Account(balance=1)
+
+    state_test(
+        pre=pre,
+        post={
+            created_contract_address: Account(
+                balance=1,
+                code=CORRECT_INITCODE.deploy_code,
+                storage={0x00: 0x01},
+            ),
+        },
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.CREATE,
+        pytest.param(
+            Op.CREATE2, marks=pytest.mark.valid_from("Constantinople")
+        ),
+    ],
+)
+def test_create_opcode_balance_only_target(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+) -> None:
+    """
+    Test that a contract creation opcode succeeds when the target
+    address has only a balance: an account with zero nonce, no code and
+    no storage is not a collision (EIP-684).
+    """
+    initcode = CORRECT_INITCODE
+    assert len(initcode) <= 32
+    contract_creator_code = (
+        # Stores the created address, which is non-zero on success.
+        Op.MSTORE(0, Op.PUSH32(bytes(initcode).ljust(32, b"\0")))
+        + Op.SSTORE(0x01, opcode(value=0, offset=0, size=len(initcode)))
+        + Op.STOP
+    )
+    contract_creator_address = pre.deploy_contract(contract_creator_code)
+
+    created_contract_address = compute_create_address(
+        address=contract_creator_address,
+        nonce=1,
+        salt=0,
+        initcode=initcode,
+        opcode=opcode,
+    )
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract_creator_address,
+        protected=False,
+    )
+
+    pre[created_contract_address] = Account(balance=1)
+
+    state_test(
+        pre=pre,
+        post={
+            created_contract_address: Account(
+                balance=1,
+                code=CORRECT_INITCODE.deploy_code,
+                storage={0x00: 0x01},
+            ),
+            contract_creator_address: Account(
+                storage={0x01: created_contract_address}
+            ),
         },
         tx=tx,
     )

--- a/tests/frontier/create/test_create_collision.py
+++ b/tests/frontier/create/test_create_collision.py
@@ -169,19 +169,11 @@ def test_create_tx_collision(
     "collision_nonce,collision_code,collision_storage,collision_balance,initcode",
     COLLISION_PARAMS,
 )
-@pytest.mark.parametrize(
-    "opcode",
-    [
-        Op.CREATE,
-        pytest.param(
-            Op.CREATE2, marks=pytest.mark.valid_from("Constantinople")
-        ),
-    ],
-)
+@pytest.mark.with_all_create_opcodes
 def test_create_opcode_collision(
     state_test: StateTestFiller,
     pre: Alloc,
-    opcode: Op,
+    create_opcode: Op,
     collision_nonce: int,
     collision_code: bytes,
     collision_storage: Dict[int, int],
@@ -199,7 +191,9 @@ def test_create_opcode_collision(
         # this runs out of gas, and every other fork jumps to a non-JUMPDEST.
         Op.MSTORE(0, Op.PUSH32(bytes(initcode).ljust(32, b"\0")))
         + Op.JUMPI(
-            condition=Op.ISZERO(opcode(value=0, offset=0, size=len(initcode))),
+            condition=Op.ISZERO(
+                create_opcode(value=0, offset=0, size=len(initcode))
+            ),
             pc=0,
         )
         + Op.STOP
@@ -231,7 +225,7 @@ def test_create_opcode_collision(
         nonce=1,
         salt=0,
         initcode=initcode,
-        opcode=opcode,
+        opcode=create_opcode,
     )
 
     tx = Transaction(
@@ -298,19 +292,11 @@ def test_create_tx_balance_only_target(
     )
 
 
-@pytest.mark.parametrize(
-    "opcode",
-    [
-        Op.CREATE,
-        pytest.param(
-            Op.CREATE2, marks=pytest.mark.valid_from("Constantinople")
-        ),
-    ],
-)
+@pytest.mark.with_all_create_opcodes
 def test_create_opcode_balance_only_target(
     state_test: StateTestFiller,
     pre: Alloc,
-    opcode: Op,
+    create_opcode: Op,
 ) -> None:
     """
     Test that a contract creation opcode succeeds when the target
@@ -322,7 +308,7 @@ def test_create_opcode_balance_only_target(
     contract_creator_code = (
         # Stores the created address, which is non-zero on success.
         Op.MSTORE(0, Op.PUSH32(bytes(initcode).ljust(32, b"\0")))
-        + Op.SSTORE(0x01, opcode(value=0, offset=0, size=len(initcode)))
+        + Op.SSTORE(0x01, create_opcode(value=0, offset=0, size=len(initcode)))
         + Op.STOP
     )
     contract_creator_address = pre.deploy_contract(contract_creator_code)
@@ -332,7 +318,7 @@ def test_create_opcode_balance_only_target(
         nonce=1,
         salt=0,
         initcode=initcode,
-        opcode=opcode,
+        opcode=create_opcode,
     )
 
     tx = Transaction(

--- a/tests/frontier/create/test_create_collision.py
+++ b/tests/frontier/create/test_create_collision.py
@@ -27,6 +27,10 @@ pytestmark = [
     pytest.mark.pre_alloc_mutable,
 ]
 
+# The prefix makes any initcode execution visible in storage: it adds
+# slot 0x00, the witness that creation ran in the balance-only tests,
+# and zeroes slot 0x01, which the collision tests pre-seed on some
+# account shapes. On a correct collision abort neither write happens.
 CORRECT_INITCODE = Initcode(
     deploy_code=Op.STOP,
     initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),


### PR DESCRIPTION
### Description
Expand the create collision tests to the full parameter matrix of nonce, code, storage and balance for all cases where EIP-684 defines an abort. The new no-storage cells catch a client that incorrectly aborts on storage instead of code or nonce. Cells with zero nonce and empty code are excluded at param generation: with non-empty storage the behavior is undefined in protocol (EIP-7610 was declined for Glamsterdam), with empty storage the account is deployable.

Also add balance-only success tests for the deployable case, for creation transactions and for the CREATE and CREATE2 opcodes: an account with only a balance is not a collision, creation must succeed and the balance is kept.

Filled locally at Frontier, Paris, Cancun and Amsterdam, all pass, re-verified after rebasing onto `forks/amsterdam` once #3417 merged.

### Related Issues or PRs
Implements the coverage expansion requested in the review of #3417 ([comment 1](https://github.com/ethereum/execution-specs/pull/3417#discussion_r3841725645), [comment 2](https://github.com/ethereum/execution-specs/pull/3417#discussion_r3841749201)).

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

```text
   /\_/\
  ( o.o )    no collisions,
   > ^ <     only deployments
  /|   |\
 (_|___|_)
```
