### PR TITLE
feat(tests): EIP-8037 - pin gas on the unasserted child-halt spill tests

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -263,8 +263,12 @@ def test_reservoir_restored_after_child_spill_and_halt(
     parent; the spilled gas stays burned (re-classified as execution).
     The parent does two SSTOREs: the first drains the recovered
     reservoir, the second spills from the parent's own `gas_left`.
+    The receipt pins the halted child's whole budget as consumed, so
+    a credit of the burned spill back to the parent is caught.
     """
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    child_budget = 500_000
 
     # Child does two SSTOREs then halts
     child = pre.deploy_contract(
@@ -272,15 +276,20 @@ def test_reservoir_restored_after_child_spill_and_halt(
     )
 
     parent_storage = Storage()
-    parent = pre.deploy_contract(
-        code=(
-            Op.POP(Op.CALL(gas=500_000, address=child))
-            # First SSTORE drains the recovered reservoir; second
-            # SSTORE spills from parent's gas_left (gas_limit_cap is
-            # large enough to absorb it).
-            + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.SSTORE(parent_storage.store_next(1), 1)
-        ),
+    parent_code = (
+        Op.POP(Op.CALL(gas=child_budget, address=child))
+        # First SSTORE drains the recovered reservoir; second
+        # SSTORE spills from parent's gas_left (gas_limit_cap is
+        # large enough to absorb it).
+        + Op.SSTORE(parent_storage.store_next(1), 1)
+        + Op.SSTORE(parent_storage.store_next(1), 1)
+    )
+    parent = pre.deploy_contract(code=parent_code)
+
+    # The halted child burns its whole budget. The parent's own sets
+    # and their state gas are inside `gas_cost`.
+    expected_cumulative = (
+        intrinsic_cost + parent_code.gas_cost(fork) + child_budget
     )
 
     # Reservoir = 1 SSTORE's worth of state gas — child will spill
@@ -288,6 +297,9 @@ def test_reservoir_restored_after_child_spill_and_halt(
         to=parent,
         state_gas_reservoir=sstore_state_gas,
         sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
     )
 
     post = {parent: Account(storage=parent_storage)}

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1952,12 +1952,14 @@ def test_create2_failed_deposit_refunds_storage_state_gas(
     """
     Test a failed CREATE2 deposit refunds the init's storage-slot state gas.
 
-    Total gas used is independent of `slots`, so a client that drops the
-    slot refund diverges for `slots >= 1`; `slots == 0` is the negative
-    control.
+    Total state gas refunded is independent of `slots`, so a client
+    that drops the slot refund diverges for `slots >= 1` and
+    `slots == 0` is the negative control. The receipt pins the init
+    frame's whole 63/64 share as burned, slot spills included.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
 
     # init: write `slots` new storage slots, then trigger a deposit failure
     init_code = Bytecode()
@@ -1971,21 +1973,50 @@ def test_create2_failed_deposit_refunds_storage_state_gas(
         init_code += Op.RETURN(0, fork.max_code_size())
     mstore_value, size = init_code_at_high_bytes(init_code)
 
-    storage = Storage()
-    factory = pre.deploy_contract(
-        code=(
-            Op.MSTORE(0, mstore_value)
-            + Op.SSTORE(
-                storage.store_next(0, "create2_failed"),
-                Op.CREATE2(value=0, offset=0, size=size, salt=0),
-            )
-        ),
+    create_call = Op.CREATE2(
+        value=0, offset=0, size=size, salt=0, init_code_size=size
     )
+    storage = Storage()
+    factory_create_code = (
+        Op.MSTORE(0, mstore_value, new_memory_size=32) + create_call
+    )
+    factory_post_create_code = (
+        # Store the CREATE2 result (0 on failure): a cold 0 -> 0 no-op.
+        Op.PUSH1(storage.store_next(0, "create2_failed"))
+        + Op.SSTORE.with_metadata(original_value=0, new_value=0)(
+            unchecked=True
+        )
+    )
+    factory = pre.deploy_contract(
+        code=factory_create_code + factory_post_create_code,
+    )
+
+    # Simulate the runtime gas: the whole-cap gas limit leaves no
+    # reservoir, so every state charge spills from `gas_left` and the
+    # failed deposit burns the init frame's whole share regardless of
+    # `slots` or `fail_mode`.
+    sim_gas_left = (
+        gas_limit_cap
+        - intrinsic_cost
+        - factory_create_code.execution_cost(fork)
+    )
+    # CREATE2's new-account state gas spills wholly from gas_left and
+    # refills there when the create fails.
+    new_account_state_gas = create_call.state_cost(fork)
+    sim_gas_left -= new_account_state_gas
+    # 63/64 retention: the factory keeps gas_left // 64.
+    sim_gas_left = sim_gas_left // 64
+    sim_gas_left += new_account_state_gas
+    sim_gas_left -= factory_post_create_code.execution_cost(fork)
+    expected_cumulative = gas_limit_cap - sim_gas_left
 
     tx = Transaction(
         to=factory,
         gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_cumulative,
+        ),
     )
 
     state_test(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -26,6 +26,7 @@ from execution_testing import (
     Op,
     Storage,
     Transaction,
+    TransactionReceipt,
 )
 
 from .spec import ref_spec_8037
@@ -115,28 +116,30 @@ def test_multi_block_mixed_state_operations(
 
     This mixed scenario tests that `receipt_gas_used` is consistent
     across different state gas paths within a multi-block chain.
+    Every receipt pins its cumulative gas, so a mis-credited spill
+    on any path breaks the fill.
     """
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    child_budget = 500_000
 
-    reverting_child = pre.deploy_contract(
-        code=(Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.REVERT(0, 0)),
-    )
-    halting_child = pre.deploy_contract(
-        code=(Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.INVALID),
-    )
+    reverting_child_code = Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.REVERT(0, 0)
+    reverting_child = pre.deploy_contract(code=reverting_child_code)
+    halting_child_code = Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.INVALID
+    halting_child = pre.deploy_contract(code=halting_child_code)
 
     all_contracts = []
     all_storages = []
 
     # Simple SSTOREs from reservoir
     block1_txs = []
-    for _ in range(2):
+    for i in range(2):
         storage = Storage()
-        contract = pre.deploy_contract(
-            code=(Op.SSTORE(storage.store_next(1), 1)),
-        )
+        code = Op.SSTORE(storage.store_next(1), 1)
+        contract = pre.deploy_contract(code=code)
         all_contracts.append(contract)
         all_storages.append(storage)
+        tx_gas_used = intrinsic_cost + code.gas_cost(fork)
         block1_txs.append(
             Transaction(
                 to=contract,
@@ -144,26 +147,29 @@ def test_multi_block_mixed_state_operations(
                 max_priority_fee_per_gas=1,
                 max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
+                expected_receipt=TransactionReceipt(
+                    cumulative_gas_used=(i + 1) * tx_gas_used,
+                ),
             )
         )
 
     # Child spill + revert
     block2_txs = []
-    for _ in range(2):
+    for i in range(2):
         storage = Storage()
-        parent = pre.deploy_contract(
-            code=(
-                Op.POP(
-                    Op.CALL(
-                        gas=500_000,
-                        address=reverting_child,
-                    )
-                )
-                + Op.SSTORE(storage.store_next(1), 1)
-            ),
-        )
+        parent_code = Op.POP(
+            Op.CALL(gas=child_budget, address=reverting_child)
+        ) + Op.SSTORE(storage.store_next(1), 1)
+        parent = pre.deploy_contract(code=parent_code)
         all_contracts.append(parent)
         all_storages.append(storage)
+        # The reverted child refunds its state gas and returns its
+        # unspent budget, so only its execution gas is consumed.
+        tx_gas_used = (
+            intrinsic_cost
+            + parent_code.gas_cost(fork)
+            + reverting_child_code.execution_cost(fork)
+        )
         block2_txs.append(
             Transaction(
                 to=parent,
@@ -171,26 +177,26 @@ def test_multi_block_mixed_state_operations(
                 max_priority_fee_per_gas=1,
                 max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
+                expected_receipt=TransactionReceipt(
+                    cumulative_gas_used=(i + 1) * tx_gas_used,
+                ),
             )
         )
 
     # Child spill + exceptional halt
     block3_txs = []
-    for _ in range(2):
+    for i in range(2):
         storage = Storage()
-        parent = pre.deploy_contract(
-            code=(
-                Op.POP(
-                    Op.CALL(
-                        gas=500_000,
-                        address=halting_child,
-                    )
-                )
-                + Op.SSTORE(storage.store_next(1), 1)
-            ),
-        )
+        parent_code = Op.POP(
+            Op.CALL(gas=child_budget, address=halting_child)
+        ) + Op.SSTORE(storage.store_next(1), 1)
+        parent = pre.deploy_contract(code=parent_code)
         all_contracts.append(parent)
         all_storages.append(storage)
+        # The halted child burns its whole budget, spill included.
+        tx_gas_used = (
+            intrinsic_cost + parent_code.gas_cost(fork) + child_budget
+        )
         block3_txs.append(
             Transaction(
                 to=parent,
@@ -198,6 +204,9 @@ def test_multi_block_mixed_state_operations(
                 max_priority_fee_per_gas=1,
                 max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
+                expected_receipt=TransactionReceipt(
+                    cumulative_gas_used=(i + 1) * tx_gas_used,
+                ),
             )
         )
 


### PR DESCRIPTION
### Description

Pin exact receipt gas for three EIP-8037 scenarios that previously asserted only storage state. The new assertions ensure state gas spilled from a child frame into execution gas remains burned when that frame halts exceptionally, while the state-gas reservoir is restored correctly.

- `test_reservoir_restored_after_child_spill_and_halt` charges the halted child's full forwarded budget plus the caller's own execution and state-gas costs.
- `test_multi_block_mixed_state_operations` pins cumulative receipts for reservoir-funded SSTOREs, child spill-and-revert, and child spill-and-halt transactions across three blocks.
- `test_create2_failed_deposit_refunds_storage_state_gas` pins the failed init frame's full 63/64 share for EIP-3541 rejection and code-deposit OOG, proving the result is independent of the number of reverted storage slots.

The gas calculations use fork-aware bytecode cost helpers and the transaction intrinsic-cost calculator rather than hard-coded schedule values.

### Related Issues or PRs

#3423


### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title matches the target squash commit message.


