### PR TITLE
fix(specs,tests): widen a frame transaction's chain id to 256 bits

### DIFF
--- a/src/ethereum/forks/amsterdam/exceptions.py
+++ b/src/ethereum/forks/amsterdam/exceptions.py
@@ -4,7 +4,7 @@ Exceptions specific to this fork.
 
 from typing import TYPE_CHECKING, Final
 
-from ethereum_types.numeric import U64, Uint
+from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.exceptions import InvalidBlock, InvalidTransaction
 
@@ -20,7 +20,7 @@ class WrongChainIdError(InvalidTransaction):
     [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
     """
 
-    def __init__(self, expected: U64, actual: U64):
+    def __init__(self, expected: U64, actual: U64 | U256):
         super().__init__(f"expected chain_id `{expected}` but got `{actual}`")
         self.expected = expected
         self.actual = actual

--- a/src/ethereum/forks/amsterdam/transactions/__init__.py
+++ b/src/ethereum/forks/amsterdam/transactions/__init__.py
@@ -883,12 +883,18 @@ def check_nonce(tx: Transaction, sender_nonce: Uint) -> None:
         raise NonceMismatchError("nonce too high")
 
 
-def chain_id(tx: Transaction) -> None | U64:
+def chain_id(tx: Transaction) -> None | U64 | U256:
     """
     Extract the chain identifier from a transaction. See [EIP-155].
 
+    [`FrameTransaction`][f] widens the field to [`U256`][u], so callers must
+    not assume the result fits in a [`U64`][v].
+
     [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
-    """
+    [f]: ref:ethereum.forks.amsterdam.transactions.frame_transaction.FrameTransaction
+    [u]: ref:ethereum_types.numeric.U256
+    [v]: ref:ethereum_types.numeric.U64
+    """  # noqa: E501
     if isinstance(tx, LegacyTransaction):
         if tx.v == 27 or tx.v == 28:
             return None

--- a/src/ethereum/forks/amsterdam/transactions/frame_transaction.py
+++ b/src/ethereum/forks/amsterdam/transactions/frame_transaction.py
@@ -390,7 +390,7 @@ class FrameTransaction:
     [EIP-8141]: https://eips.ethereum.org/EIPS/eip-8141
     """
 
-    chain_id: U64
+    chain_id: U256
     """
     The ID of the chain on which this transaction is executed.
     """

--- a/src/ethereum_spec_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/loaders/transaction_loader.py
@@ -41,10 +41,21 @@ class TransactionLoad:
     def __init__(self, raw: Any, fork: Any) -> None:
         self.raw = raw
         self.fork = fork
+        self.tx_cls: Any = None
 
-    def json_to_chain_id(self) -> U64:
-        """Get chain ID for the transaction."""
-        return hex_to_u64(self.raw.get("chainId", "0x01"))
+    def json_to_chain_id(self) -> U64 | U256:
+        """
+        Get chain ID for the transaction.
+
+        Frame transactions widen the field to 256 bits; every other
+        type keeps the 64 bits of [EIP-155].
+
+        [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
+        """
+        raw_chain_id = self.raw.get("chainId", "0x01")
+        if self.tx_cls is getattr(self.fork, "FrameTransaction", None):
+            return hex_to_u256(raw_chain_id)
+        return hex_to_u64(raw_chain_id)
 
     def json_to_nonce(self) -> U256:
         """Get the nonce for the transaction."""
@@ -237,6 +248,7 @@ class TransactionLoad:
         """
         Extract all the transaction parameters from the json file.
         """
+        self.tx_cls = tx_cls
         parameters = []
         for field in fields(tx_cls):
             parameters.append(getattr(self, f"json_to_{field.name}")())

--- a/tests/amsterdam/eip8141_frame_transactions/test_admission_validity.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_admission_validity.py
@@ -59,6 +59,21 @@ ADMISSION_CASES = [
         None,
         id="max_cost_within_bound",
     ),
+    pytest.param(
+        # A frame transaction's chain id is a 256-bit field, so a value
+        # too wide for the 64-bit field of every other transaction type
+        # still decodes and is rejected for naming another chain.
+        dict(chain_id=2**64),
+        TransactionException.INVALID_CHAINID,
+        id="chain_id_above_64_bits",
+        marks=pytest.mark.exception_test,
+    ),
+    pytest.param(
+        dict(chain_id=2**256 - 1),
+        TransactionException.INVALID_CHAINID,
+        id="chain_id_at_256_bit_maximum",
+        marks=pytest.mark.exception_test,
+    ),
 ]
 """
 Field-level variations of a minimal frame transaction, each with the

--- a/tests/json_loader/test_transaction_codec.py
+++ b/tests/json_loader/test_transaction_codec.py
@@ -1,5 +1,6 @@
-"""Test that decode_transaction handles legacy transactions as bytes."""
+"""Test that decode_transaction handles transactions given as bytes."""
 
+import pytest
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
@@ -7,6 +8,10 @@ from ethereum_types.numeric import U256, Uint
 from ethereum.forks.amsterdam.transactions import (
     LegacyTransaction,
     decode_transaction,
+)
+from ethereum.forks.amsterdam.transactions.frame_transaction import (
+    FrameTransaction,
+    TransactionFees,
 )
 from ethereum.state import Address
 
@@ -28,3 +33,38 @@ def test_decode_legacy_from_bytes() -> None:
     assert encoded[0] >= 0xC0
     assert decode_transaction(encoded) == tx
     assert decode_transaction(tx) is tx
+
+
+def frame_transaction(chain_id: U256) -> FrameTransaction:
+    """Build a frame transaction carrying the given chain id."""
+    return FrameTransaction(
+        chain_id=chain_id,
+        nonce=U256(0),
+        sender=Address(b"\x00" * 20),
+        frames=(),
+        signatures=(),
+        fees=TransactionFees(
+            max_priority_fee_per_gas=Uint(0),
+            max_fee_per_gas=Uint(0),
+            max_fee_per_blob_gas=U256(0),
+        ),
+        blob_versioned_hashes=(),
+    )
+
+
+@pytest.mark.parametrize("chain_id", [U256(1), U256(2**64), U256(2**256 - 1)])
+def test_decode_frame_chain_id_is_256_bits(chain_id: U256) -> None:
+    """
+    Decode a frame transaction whose chain id needs more than the 64
+    bits every other transaction type allows.
+
+    [EIP-8141] bounds the field at `2**256`, so a wide chain id decodes
+    and is rejected later for naming another chain, rather than failing
+    to decode at all.
+
+    [EIP-8141]: https://eips.ethereum.org/EIPS/eip-8141
+    """
+    tx = frame_transaction(chain_id)
+    encoded = Bytes(b"\x06" + rlp.encode(tx))
+
+    assert decode_transaction(encoded) == tx


### PR DESCRIPTION
### Description

[EIP-8141](https://eips.ethereum.org/EIPS/eip-8141) bounds a frame transaction's chain id with `assert tx.chain_id < 2**256`, but `FrameTransaction` declares the field as `U64`, so `rlp.decode_to` rejects anything wider than eight bytes:

```
DecodingError: cannot decode into `FrameTransaction`
	because cannot decode field `FrameTransaction.chain_id`
	because expected at most 8 but got 9
```

A narrowing of the assertion to `2**64` was proposed in ethereum/EIPs#12223 and rejected: chain ids are valid up to `2**256 - 1`, so the field should not be bounded below that. This aligns the reference implementation with that ruling.

The change is behaviour-preserving for every in-range chain id — RLP encodes a `U256` and a `U64` of the same value identically, so no existing fixture changes. What it changes is *where* an out-of-range value is rejected: a chain id of `2**64` now decodes and fails the `check_transaction` chain-id comparison with `WrongChainIdError`, instead of failing to decode. `2**256` still fails to decode, matching the EIP's bound.

Coherence fixes that come with the widening:

- `chain_id(tx)` returns `None | U64 | U256`; the comparison against `block_env.chain_id` is numeric across the two widths, so `WrongChainIdError` fires as before. Its `actual` parameter widens to match.
- `TransactionLoad.json_to_chain_id` used `hex_to_u64` unconditionally and raised `OverflowError` on a wide value. It now selects the width from the resolved transaction class, so only frame transactions widen.

Two tests pin the boundary, which nothing covered before:

- `tests/json_loader/test_transaction_codec.py` decodes a frame transaction at `1`, `2**64` and `2**256 - 1`. Reverting the annotation fails the latter two with `DecodingError` and leaves the rest passing.
- `tests/amsterdam/eip8141_frame_transactions/test_admission_validity.py` adds `chain_id_above_64_bits` and `chain_id_at_256_bit_maximum`, both expecting `TransactionException.INVALID_CHAINID`. Their `txbytes` carry a 9-byte and a 32-byte chain-id item, so a client that stops at the decoder rejects them for the wrong reason.

Checks run: `typecheck`, `lint`, `format-check`, `spellcheck`, `deadcode`, `lint-spec`, `lock-check` (all of `just static` except `lint-actions`, which needs a binary not available here and covers no changed file). `just` itself is not installed locally, so each recipe was run as its underlying `uv run` command. Also `uv run fill --from Bogota --until Bogota tests/amsterdam/eip8141_frame_transactions/` (715 passed) and `uv run pytest tests/json_loader` (58 passed, 2 skipped).

### Related Issues or PRs

ethereum/EIPs#12223.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A cat](https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg)
