### PR TITLE
perf(test-client-cli): skip redundant BAL hash

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -41,7 +41,6 @@ from execution_testing.test_types import (
     Transaction,
     Withdrawal,
 )
-from execution_testing.test_types.block_access_list import BlockAccessList
 from execution_testing.test_types.receipt_types import TransactionReceipt
 
 from .cli_types import (
@@ -167,6 +166,11 @@ class ClientBackend:
     """Raw datadir head, set by the fill-stateful plugin pre-session."""
     start_block: Dict[str, Any] | None
     """Client head after global pre-run setup; per-test chains off this."""
+
+    # An engine ``ExecutionPayload`` carries the BAL body but not its hash, so
+    # the hash in our ``Result`` is EEST's own derivation from that body --
+    # not an independent attestation to verify against.
+    attests_block_access_list_hash: ClassVar[bool] = False
 
     # t8n-compatibility stubs — fill's filler reads these on the backend.
     opcode_count: OpcodeCount | None = None
@@ -513,9 +517,13 @@ class ClientBackend:
         block_access_list_hash: Hash | None = None
         bal_rlp = getattr(built_payload, "block_access_list", None)
         if bal_rlp is not None:
-            block_access_list_hash = Hash(
-                BlockAccessList.from_rlp(bal_rlp).rlp.keccak256()
-            )
+            # Hash the client's own bytes. Decoding them into a
+            # ``BlockAccessList`` only to re-encode and hash that would yield a
+            # different value whenever the client's RLP is non-canonical --
+            # silently replacing what the client committed to -- and on a
+            # BAL-heavy block the round trip costs more than the whole block's
+            # execution.
+            block_access_list_hash = Hash(bal_rlp.keccak256())
 
         return Result(
             state_root=built_payload.state_root,

--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -167,9 +167,6 @@ class ClientBackend:
     start_block: Dict[str, Any] | None
     """Client head after global pre-run setup; per-test chains off this."""
 
-    # An engine ``ExecutionPayload`` carries the BAL body but not its hash, so
-    # the hash in our ``Result`` is EEST's own derivation from that body --
-    # not an independent attestation to verify against.
     attests_block_access_list_hash: ClassVar[bool] = False
 
     # t8n-compatibility stubs — fill's filler reads these on the backend.
@@ -517,12 +514,8 @@ class ClientBackend:
         block_access_list_hash: Hash | None = None
         bal_rlp = getattr(built_payload, "block_access_list", None)
         if bal_rlp is not None:
-            # Hash the client's own bytes. Decoding them into a
-            # ``BlockAccessList`` only to re-encode and hash that would yield a
-            # different value whenever the client's RLP is non-canonical --
-            # silently replacing what the client committed to -- and on a
-            # BAL-heavy block the round trip costs more than the whole block's
-            # execution.
+            # Hash the client's own bytes: a re-encode of the decoded BAL
+            # would diverge whenever the client's RLP is non-canonical.
             block_access_list_hash = Hash(bal_rlp.keccak256())
 
         return Result(

--- a/packages/testing/src/execution_testing/client_clis/filler_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/filler_backend.py
@@ -18,7 +18,7 @@ fill's perspective.
 callers continue to work unchanged.
 """
 
-from typing import List, Protocol, runtime_checkable
+from typing import ClassVar, List, Protocol, runtime_checkable
 
 from execution_testing.exceptions import ExceptionMapper
 
@@ -42,6 +42,22 @@ class FillerBackend(Protocol):
     Maps backend-specific errors to EEST transaction/block exceptions.
     ``exception_mapper.reliable`` indicates whether the mapping is trusted
     for test assertions (t8n: True; live-client: typically False).
+    """
+
+    attests_block_access_list_hash: ClassVar[bool]
+    """
+    Whether ``Result.block_access_list_hash`` is an *independent* attestation
+    of the EIP-7928 BAL hash, i.e. computed by the backend rather than derived
+    by EEST from the BAL body the backend returned.
+
+    True for ``TransitionTool``: t8n reports the hash from the spec's own
+    ``hash_block_access_list``, so comparing it against EEST's re-encoding of
+    the decoded BAL cross-checks two implementations.
+
+    False for ``ClientBackend``: an engine ``ExecutionPayload`` carries the BAL
+    *body* but no hash, so EEST derives the hash itself. Verifying that against
+    a second derivation from the same bytes is vacuous, and the round trip it
+    requires dominates stateful fill time on BAL-heavy blocks.
     """
 
     def evaluate(

--- a/packages/testing/src/execution_testing/client_clis/filler_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/filler_backend.py
@@ -46,18 +46,10 @@ class FillerBackend(Protocol):
 
     attests_block_access_list_hash: ClassVar[bool]
     """
-    Whether ``Result.block_access_list_hash`` is an *independent* attestation
-    of the EIP-7928 BAL hash, i.e. computed by the backend rather than derived
-    by EEST from the BAL body the backend returned.
-
-    True for ``TransitionTool``: t8n reports the hash from the spec's own
-    ``hash_block_access_list``, so comparing it against EEST's re-encoding of
-    the decoded BAL cross-checks two implementations.
-
-    False for ``ClientBackend``: an engine ``ExecutionPayload`` carries the BAL
-    *body* but no hash, so EEST derives the hash itself. Verifying that against
-    a second derivation from the same bytes is vacuous, and the round trip it
-    requires dominates stateful fill time on BAL-heavy blocks.
+    Whether ``Result.block_access_list_hash`` is computed by the backend
+    rather than derived by EEST from the BAL body the backend returned
+    (t8n: True; live-client: False, since an engine ``ExecutionPayload``
+    carries the body but no hash).
     """
 
     def evaluate(

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -207,6 +207,9 @@ class TransitionTool(EthereumCLI):
     supports_opcode_count: ClassVar[bool] = False
     supports_xdist: ClassVar[bool] = True
     supports_blob_params: ClassVar[bool] = False
+    # t8n computes the BAL hash itself (spec ``hash_block_access_list``), so it
+    # is worth cross-checking against EEST's own re-encoding of the BAL.
+    attests_block_access_list_hash: ClassVar[bool] = True
     fork_name_map: ClassVar[Dict[str, str]] = {}
 
     @abstractmethod

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -207,8 +207,6 @@ class TransitionTool(EthereumCLI):
     supports_opcode_count: ClassVar[bool] = False
     supports_xdist: ClassVar[bool] = True
     supports_blob_params: ClassVar[bool] = False
-    # t8n computes the BAL hash itself (spec ``hash_block_access_list``), so it
-    # is worth cross-checking against EEST's own re-encoding of the BAL.
     attests_block_access_list_hash: ClassVar[bool] = True
     fork_name_map: ClassVar[Dict[str, str]] = {}
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1016,15 +1016,23 @@ class BlockchainTest(BaseTest):
                 "provided by the transition tool"
             )
 
-            computed_block_access_list_hash = Hash(t8n_bal.rlp.keccak256())
-            assert (
-                computed_block_access_list_hash
-                == header.block_access_list_hash
-            ), (
-                "Block access list hash in header does not match the "
-                f"computed hash from BAL: {header.block_access_list_hash} "
-                f"!= {computed_block_access_list_hash}"
-            )
+            # Only meaningful when the backend attested the hash itself: then
+            # this cross-checks the backend's hash against EEST's re-encoding
+            # of the decoded BAL. When the backend does not (a client returns
+            # the BAL body only, so the header hash below is already EEST's
+            # derivation from these same bytes), the comparison is `a == a` and
+            # the re-encode it needs is the single most expensive step of a
+            # stateful fill.
+            if t8n.attests_block_access_list_hash:
+                computed_block_access_list_hash = Hash(t8n_bal.rlp.keccak256())
+                assert (
+                    computed_block_access_list_hash
+                    == header.block_access_list_hash
+                ), (
+                    "Block access list hash in header does not match the "
+                    f"computed hash from BAL: {header.block_access_list_hash} "
+                    f"!= {computed_block_access_list_hash}"
+                )
 
         if block.rlp_modifier is not None:
             # Modify any parameter specified in the `rlp_modifier` after

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1016,13 +1016,6 @@ class BlockchainTest(BaseTest):
                 "provided by the transition tool"
             )
 
-            # Only meaningful when the backend attested the hash itself: then
-            # this cross-checks the backend's hash against EEST's re-encoding
-            # of the decoded BAL. When the backend does not (a client returns
-            # the BAL body only, so the header hash below is already EEST's
-            # derivation from these same bytes), the comparison is `a == a` and
-            # the re-encode it needs is the single most expensive step of a
-            # stateful fill.
             if t8n.attests_block_access_list_hash:
                 computed_block_access_list_hash = Hash(t8n_bal.rlp.keccak256())
                 assert (


### PR DESCRIPTION
### Description
Don't calculate the BAL hash if it is not necessary. (written with LLM)

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
