### PR TITLE
perf(test-type): cache ecrecover and optimize function calls to ecrecover

### DIFF
--- a/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
@@ -1,6 +1,6 @@
 """Test suite for transaction signing and serialization."""
 
-from typing import Tuple
+from typing import Any, Tuple
 
 import pytest
 from spec256k1 import PublicKey
@@ -11,6 +11,25 @@ from .. import transaction_types
 from ..account_types import EOA
 from ..transaction_types import Transaction
 from ..utils import keccak256
+
+SIGNING_KEY = Hash(bytes(range(1, 33)))
+OTHER_KEY = Hash(bytes(range(33, 65)))
+
+
+def signable_transaction(**kwargs: Any) -> Transaction:
+    """Return a minimal legacy transaction ready to be signed."""
+    return Transaction(ty=0, gas_limit=21_000, nonce=0, **kwargs)
+
+
+def recover_sender(tx: Transaction) -> Address:
+    """Recover the sender of a signed transaction from its signature."""
+    public_key = PublicKey.from_signature_and_message(
+        tx.signature_bytes,
+        tx.rlp_signing_bytes().keccak256(),
+    )
+    return Address(
+        keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
+    )
 
 
 @pytest.mark.parametrize(
@@ -305,87 +324,55 @@ def test_gas_limit_none_alias_is_unset(alias: str) -> None:
     assert tx.gas_limit == 21_000
 
 
-class TestSenderDerivation:
+def test_derived_sender_matches_recovery() -> None:
+    """The derived sender equals the one recovered from the signature."""
+    signed = signable_transaction(
+        secret_key=SIGNING_KEY
+    ).with_signature_and_sender()
+    assert signed.sender == recover_sender(signed)
+
+
+def test_known_sender_skips_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sender holding the signing key is reused as-is."""
+
+    def unexpected_recovery(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError(
+            "recovered the public key even though the sender was known"
+        )
+
+    monkeypatch.setattr(
+        transaction_types.PublicKey,
+        "from_signature_and_message",
+        unexpected_recovery,
+    )
+    sender = EOA(key=SIGNING_KEY)
+    signed = signable_transaction(sender=sender).with_signature_and_sender()
+    assert signed.sender == sender
+
+
+@pytest.mark.parametrize(
+    "sender",
+    [
+        pytest.param(EOA(key=OTHER_KEY), id="holds_another_key"),
+        pytest.param(EOA(address=0x1234), id="keyless"),
+    ],
+)
+def test_sender_without_the_signing_key_is_derived(sender: EOA) -> None:
+    """A sender that does not hold the signing key is not trusted."""
+    tx = signable_transaction(sender=sender, secret_key=SIGNING_KEY)
+    assert tx.with_signature_and_sender().sender == EOA(key=SIGNING_KEY)
+
+
+def test_reassigned_sender_does_not_override_the_signer() -> None:
     """
-    Tests for deriving the sender without recovering it from the signature.
+    A sender reassigned after construction is not trusted.
 
-    Recovering the public key from the signature costs more than the signing
-    itself, and the signer's address is usually already known. These tests pin
-    the equivalence and, importantly, the case where the declared sender is
-    *not* the signer.
+    `validate_assignment=True` lets `sender` be replaced while
+    `secret_key` keeps the original key.
     """
-
-    KEY_A = Hash(bytes(range(1, 33)))
-    KEY_B = Hash(bytes(range(33, 65)))
-
-    def _tx(self, **kwargs: object) -> Transaction:
-        return Transaction(ty=0, gas_limit=21_000, nonce=0, **kwargs)
-
-    def test_derived_sender_matches_recovery(self) -> None:
-        """
-        Deriving from the private key must equal recovering from the signature.
-
-        This is the property the whole change rests on: the signature was
-        produced by `secret_key`, so recovery can only return that key.
-        """
-        signed = self._tx(secret_key=self.KEY_A).with_signature_and_sender()
-
-        recovered = PublicKey.from_signature_and_message(
-            signed.signature_bytes,
-            signed.rlp_signing_bytes().keccak256(),
-        )
-        expected = Address(
-            keccak256(recovered.format(compressed=False)[1:])[32 - 20 :]
-        )
-        assert signed.sender == expected
-
-    def test_known_sender_is_reused_without_a_public_key_operation(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """
-        When the declared sender holds the signing key, no public-key
-        operation may happen at all -- that is the point of the fast path.
-        """
-        sender = EOA(key=self.KEY_A)
-
-        def _boom(*_args: object, **_kwargs: object) -> object:
-            raise AssertionError(
-                "recovered the public key even though the sender was known"
-            )
-
-        monkeypatch.setattr(
-            transaction_types.PublicKey, "from_signature_and_message", _boom
-        )
-        signed = self._tx(sender=sender).with_signature_and_sender()
-        assert signed.sender == sender
-
-    def test_reassigned_sender_does_not_override_the_signer(self) -> None:
-        """
-        A sender that does not hold the signing key must not be trusted.
-
-        `Transaction` sets `validate_assignment=True`, so `sender` can be
-        reassigned after construction while `secret_key` keeps the original
-        key. Trusting `sender` here would emit a transaction whose `sender`
-        field contradicts its own signature.
-        """
-        signer = EOA(key=self.KEY_A)
-        other = EOA(key=self.KEY_B)
-        assert signer != other
-
-        tx = self._tx(sender=signer)
-        assert tx.secret_key == self.KEY_A, "secret_key comes from sender.key"
-        tx.sender = other  # allowed: validate_assignment
-
-        signed = tx.with_signature_and_sender()
-        assert signed.sender == signer, (
-            "the signer must win, not the sender field"
-        )
-
-    def test_keyless_sender_falls_back_to_derivation(self) -> None:
-        """`EOA.key` is optional, so a keyless sender must not be trusted."""
-        keyless = EOA(address=0x1234)
-        assert keyless.key is None
-
-        tx = self._tx(sender=keyless, secret_key=self.KEY_A)
-        signed = tx.with_signature_and_sender()
-        assert signed.sender == EOA(key=self.KEY_A)
+    tx = signable_transaction(sender=EOA(key=SIGNING_KEY))
+    assert tx.secret_key == SIGNING_KEY
+    tx.sender = EOA(key=OTHER_KEY)
+    assert tx.with_signature_and_sender().sender == EOA(key=SIGNING_KEY)

--- a/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
@@ -376,3 +376,15 @@ def test_reassigned_sender_does_not_override_the_signer() -> None:
     assert tx.secret_key == SIGNING_KEY
     tx.sender = EOA(key=OTHER_KEY)
     assert tx.with_signature_and_sender().sender == EOA(key=SIGNING_KEY)
+
+
+def test_mismatched_sender_address_is_trusted() -> None:
+    """
+    An `EOA` whose address does not derive from its key is taken as-is.
+    """
+    inconsistent = EOA(address=0x1234, key=SIGNING_KEY)
+    signed = signable_transaction(
+        sender=inconsistent
+    ).with_signature_and_sender()
+    assert signed.sender == inconsistent
+    assert signed.sender != recover_sender(signed)

--- a/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_transactions.py
@@ -3,10 +3,14 @@
 from typing import Tuple
 
 import pytest
+from spec256k1 import PublicKey
 
-from execution_testing.base_types import AccessList, Hash
+from execution_testing.base_types import AccessList, Address, Hash
 
+from .. import transaction_types
+from ..account_types import EOA
 from ..transaction_types import Transaction
+from ..utils import keccak256
 
 
 @pytest.mark.parametrize(
@@ -299,3 +303,89 @@ def test_gas_limit_none_alias_is_unset(alias: str) -> None:
     tx = Transaction.model_validate({alias: None})
     assert "gas_limit" not in tx.model_fields_set
     assert tx.gas_limit == 21_000
+
+
+class TestSenderDerivation:
+    """
+    Tests for deriving the sender without recovering it from the signature.
+
+    Recovering the public key from the signature costs more than the signing
+    itself, and the signer's address is usually already known. These tests pin
+    the equivalence and, importantly, the case where the declared sender is
+    *not* the signer.
+    """
+
+    KEY_A = Hash(bytes(range(1, 33)))
+    KEY_B = Hash(bytes(range(33, 65)))
+
+    def _tx(self, **kwargs: object) -> Transaction:
+        return Transaction(ty=0, gas_limit=21_000, nonce=0, **kwargs)
+
+    def test_derived_sender_matches_recovery(self) -> None:
+        """
+        Deriving from the private key must equal recovering from the signature.
+
+        This is the property the whole change rests on: the signature was
+        produced by `secret_key`, so recovery can only return that key.
+        """
+        signed = self._tx(secret_key=self.KEY_A).with_signature_and_sender()
+
+        recovered = PublicKey.from_signature_and_message(
+            signed.signature_bytes,
+            signed.rlp_signing_bytes().keccak256(),
+        )
+        expected = Address(
+            keccak256(recovered.format(compressed=False)[1:])[32 - 20 :]
+        )
+        assert signed.sender == expected
+
+    def test_known_sender_is_reused_without_a_public_key_operation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        When the declared sender holds the signing key, no public-key
+        operation may happen at all -- that is the point of the fast path.
+        """
+        sender = EOA(key=self.KEY_A)
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError(
+                "recovered the public key even though the sender was known"
+            )
+
+        monkeypatch.setattr(
+            transaction_types.PublicKey, "from_signature_and_message", _boom
+        )
+        signed = self._tx(sender=sender).with_signature_and_sender()
+        assert signed.sender == sender
+
+    def test_reassigned_sender_does_not_override_the_signer(self) -> None:
+        """
+        A sender that does not hold the signing key must not be trusted.
+
+        `Transaction` sets `validate_assignment=True`, so `sender` can be
+        reassigned after construction while `secret_key` keeps the original
+        key. Trusting `sender` here would emit a transaction whose `sender`
+        field contradicts its own signature.
+        """
+        signer = EOA(key=self.KEY_A)
+        other = EOA(key=self.KEY_B)
+        assert signer != other
+
+        tx = self._tx(sender=signer)
+        assert tx.secret_key == self.KEY_A, "secret_key comes from sender.key"
+        tx.sender = other  # allowed: validate_assignment
+
+        signed = tx.with_signature_and_sender()
+        assert signed.sender == signer, (
+            "the signer must win, not the sender field"
+        )
+
+    def test_keyless_sender_falls_back_to_derivation(self) -> None:
+        """`EOA.key` is optional, so a keyless sender must not be trusted."""
+        keyless = EOA(address=0x1234)
+        assert keyless.key is None
+
+        tx = self._tx(sender=keyless, secret_key=self.KEY_A)
+        signed = tx.with_signature_and_sender()
+        assert signed.sender == EOA(key=self.KEY_A)

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -728,15 +728,34 @@ class Transaction(
         signing_hash = self.rlp_signing_bytes().keccak256()
 
         # Sign the bytes
-        signature_bytes = PrivateKey(self.secret_key).sign_recoverable(
-            signing_hash
-        )
-        public_key = PublicKey.from_signature_and_message(
-            signature_bytes, signing_hash
-        )
+        signing_key = PrivateKey(self.secret_key)
+        signature_bytes = signing_key.sign_recoverable(signing_hash)
 
-        sender = keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
-        updated_values["sender"] = Address(sender)
+        # The sender is the account belonging to `secret_key`, whichever route
+        # is taken below. Recovering it from the signature -- the previous
+        # approach -- costs more than the signing itself (47 us against 40 us),
+        # and a benchmark fill signs tens of thousands of transfers per block.
+        if self.sender is not None and self.sender.key == self.secret_key:
+            # The declared sender holds the signing key, so its address is
+            # already known and no public-key operation is needed at all.
+            # `model_post_init` sets `secret_key` from `sender.key` when a
+            # transaction is to be signed, which makes this the common case.
+            #
+            # The key comparison is what makes this safe: `sender` is
+            # reassignable (`validate_assignment=True`) and `EOA.key` may be
+            # `None`, so a sender that does not hold the signing key must not
+            # be trusted -- it would yield a transaction whose `sender` field
+            # contradicts its own signature.
+            updated_values["sender"] = self.sender
+        else:
+            # Either no sender, or one that does not hold the signing key.
+            # Derive the address from the private key: the same public key
+            # recovery would return, since the signature was produced by this
+            # key, but one point multiplication (28 us) instead of a recovery.
+            public_key = signing_key.public_key
+            updated_values["sender"] = Address(
+                keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
+            )
 
         v, r, s = (
             signature_bytes[64],

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -731,27 +731,15 @@ class Transaction(
         signing_key = PrivateKey(self.secret_key)
         signature_bytes = signing_key.sign_recoverable(signing_hash)
 
-        # The sender is the account belonging to `secret_key`, whichever route
-        # is taken below. Recovering it from the signature -- the previous
-        # approach -- costs more than the signing itself (47 us against 40 us),
-        # and a benchmark fill signs tens of thousands of transfers per block.
+        # The key comparison is what makes reusing `sender` safe: it is
+        # reassignable and `EOA.key` may be `None`, so a sender that does not
+        # hold the signing key would contradict its own signature.
         if self.sender is not None and self.sender.key == self.secret_key:
-            # The declared sender holds the signing key, so its address is
-            # already known and no public-key operation is needed at all.
-            # `model_post_init` sets `secret_key` from `sender.key` when a
-            # transaction is to be signed, which makes this the common case.
-            #
-            # The key comparison is what makes this safe: `sender` is
-            # reassignable (`validate_assignment=True`) and `EOA.key` may be
-            # `None`, so a sender that does not hold the signing key must not
-            # be trusted -- it would yield a transaction whose `sender` field
-            # contradicts its own signature.
             updated_values["sender"] = self.sender
         else:
-            # Either no sender, or one that does not hold the signing key.
-            # Derive the address from the private key: the same public key
-            # recovery would return, since the signature was produced by this
-            # key, but one point multiplication (28 us) instead of a recovery.
+            # The address the public key recovery would return, since the
+            # signature was produced by this key, but derived with one point
+            # multiplication instead.
             public_key = signing_key.public_key
             updated_values["sender"] = Address(
                 keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]


### PR DESCRIPTION
### Description
`ecrecover` is a rather expensive function to recover public keys from signature components. We are currently using methods which are rather "high level" but partially calculate certain things twice. This also adds a cache check to see if the sender was already recovered before.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
