### PR TITLE
refactor(test-benchmark): tidy SSTORE storage benchmark

### DIFF
--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -98,7 +98,7 @@ def create_storage_initializer() -> IteratingBytecode:
 
     storage[i] = i for i in [index, index + num).
 
-    Returns: (bytecode, loop_cost, overhead)
+    Return an IteratingBytecode with the initialization loop.
     """
     prefix = (
         Op.CALLDATALOAD(0)  # [index]
@@ -137,7 +137,7 @@ def create_benchmark_executor(
     - CALLDATA[0..32] start slot (index)
     - CALLDATA[32..64] slot count (num)
 
-    Returns: (bytecode, loop_cost, overhead)
+    Return an IteratingBytecode with the benchmark execution loop.
     """
     prefix = (
         Op.CALLDATALOAD(0)  # [index]

--- a/tests/benchmark/helper/enums.py
+++ b/tests/benchmark/helper/enums.py
@@ -5,7 +5,7 @@ from enum import Enum, auto
 from execution_testing import TxOutcome
 
 
-class StorageAction:
+class StorageAction(Enum):
     """Enum for storage actions."""
 
     READ = auto()


### PR DESCRIPTION
### Description

Make StorageAction a proper Enum instead of a plain class holding bare auto() sentinels (which only worked by object identity), and fix the stale "Returns: (bytecode, loop_cost, overhead)" docstrings in create_storage_initializer / create_benchmark_executor, which return a single IteratingBytecode.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

