### PR TITLE
fix(eip-8141): account block execution gas before refund

### DIFF
--- a/src/ethereum/forks/amsterdam/frame_processing.py
+++ b/src/ethereum/forks/amsterdam/frame_processing.py
@@ -287,22 +287,33 @@ def process_frame_transaction(
     payer = frame_context.payer
     assert payer is not None
 
+    tx_unused_gas = Uint(tx_output.gas_left) + Uint(tx_output.state_gas_left)
     settlement = settle_frame_transaction_gas(
         frame_context.standard_gas_limit,
         tx_env.calldata_floor,
-        Uint(tx_output.gas_left) + Uint(tx_output.state_gas_left),
+        tx_unused_gas,
         tx_output.refund_counter,
         StateGas(Uint(tx_output.state_gas_used)),
     )
-    # The payer pays for exactly the capacity the transaction occupies
-    # across both dimensions.
+    # The payer-facing gas remains post-refund.
     gas_used = Uint(settlement.execution_gas_used) + Uint(
         settlement.state_gas_used
     )
 
+    # EIP-7778 keeps storage refunds out of block gas accounting. The
+    # state dimension is already net; only execution is reconstructed
+    # from pre-refund usage and held to the calldata floor.
+    gas_used_before_refund = frame_context.standard_gas_limit - tx_unused_gas
+    block_execution_gas_used = ExecutionGas(
+        max(
+            gas_used_before_refund - Uint(settlement.state_gas_used),
+            tx_env.calldata_floor,
+        )
+    )
+
     disburse_frame_gas_fees(block_env, tx_env, gas_used)
 
-    block_output.block_gas_used += settlement.execution_gas_used
+    block_output.block_gas_used += block_execution_gas_used
     block_output.block_state_gas_used += settlement.state_gas_used
     block_output.blob_gas_used += calculate_total_blob_gas(tx)
 

--- a/src/ethereum/forks/amsterdam/frame_processing.py
+++ b/src/ethereum/forks/amsterdam/frame_processing.py
@@ -295,29 +295,14 @@ def process_frame_transaction(
         tx_output.refund_counter,
         StateGas(Uint(tx_output.state_gas_used)),
     )
-    # The payer-facing gas remains post-refund.
-    gas_used = Uint(settlement.execution_gas_used) + Uint(
-        settlement.state_gas_used
-    )
 
-    # EIP-7778 keeps storage refunds out of block gas accounting. The
-    # state dimension is already net; only execution is reconstructed
-    # from pre-refund usage and held to the calldata floor.
-    gas_used_before_refund = frame_context.standard_gas_limit - tx_unused_gas
-    block_execution_gas_used = ExecutionGas(
-        max(
-            gas_used_before_refund - Uint(settlement.state_gas_used),
-            tx_env.calldata_floor,
-        )
-    )
+    disburse_frame_gas_fees(block_env, tx_env, settlement.gas_used)
 
-    disburse_frame_gas_fees(block_env, tx_env, gas_used)
-
-    block_output.block_gas_used += block_execution_gas_used
+    block_output.block_gas_used += settlement.execution_gas_used
     block_output.block_state_gas_used += settlement.state_gas_used
     block_output.blob_gas_used += calculate_total_blob_gas(tx)
 
-    block_output.cumulative_gas_used += gas_used
+    block_output.cumulative_gas_used += settlement.gas_used
     receipt = make_frame_receipt(
         tx,
         payer,

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -1406,11 +1406,14 @@ def settle_transaction_gas(
 @dataclass
 class FrameTransactionGasSettlement:
     """
-    Settled per-dimension gas for a finished frame transaction.
+    Settled gas amounts for a finished frame transaction.
 
-    Hold only the two block-accounted dimensions; their sum is the
-    transaction's `gas_used`, derived by the caller.
+    Hold the payer-facing total alongside the two block-accounted
+    dimensions so the caller does not have to reconstruct settlement.
     """
+
+    gas_used: Uint
+    """Total gas charged to the payer, after refund and floor."""
 
     execution_gas_used: ExecutionGas
     """Execution gas the transaction contributes to the block total."""
@@ -1437,17 +1440,20 @@ def settle_frame_transaction_gas(
       ([EIP-3529]) — state gas refills bypass the cap by design: a
       refill reverses a charge for state that was never durably
       created, and has already reduced the owning frame's receipt, and
-      with it the pre-refund usage; and
-    - the execution dimension, as the post-refund usage less the final
-      attributed state gas, held to the calldata floor ([EIP-7623]).
-      The floor binds the execution dimension alone, so — unlike the
-      regular flow — a floor-bound transaction pays the floor plus its
-      state gas in full.
+      with it the pre-refund usage;
+    - the payer-facing execution dimension, as the post-refund usage
+      less the final attributed state gas, held to the calldata floor
+      ([EIP-7623]); and
+    - the block-accounted execution dimension, as the pre-refund usage
+      less the final attributed state gas, held to the same floor.
+      Storage refunds therefore reduce what the payer pays without
+      reducing block execution gas ([EIP-7778]).
 
-    The refund cap of a state-dominated transaction can exceed its
-    intrinsic cost plus execution usage, driving the subtraction
-    negative, so it is computed in plain integers before the floor
-    clamps it.
+    The floor binds the execution dimension alone, so a floor-bound
+    transaction pays the floor plus its state gas in full. The refund
+    cap of a state-dominated transaction can exceed its intrinsic cost
+    plus execution usage, driving the payer-facing subtraction negative,
+    so it is computed in plain integers before the floor clamps it.
 
     Parameters
     ----------
@@ -1470,10 +1476,11 @@ def settle_frame_transaction_gas(
     Returns
     -------
     settlement : `FrameTransactionGasSettlement`
-        The settled per-dimension gas.
+        The settled gas amounts.
 
     [EIP-3529]: https://eips.ethereum.org/EIPS/eip-3529
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+    [EIP-7778]: https://eips.ethereum.org/EIPS/eip-7778
 
     """
     gas_used_before_refund = standard_gas_limit - tx_unused_gas
@@ -1482,7 +1489,7 @@ def settle_frame_transaction_gas(
     )
     gas_used_after_refund = gas_used_before_refund - applied_refund
 
-    execution_gas_used = ExecutionGas(
+    payer_execution_gas_used = ExecutionGas(
         Uint(
             max(
                 int(gas_used_after_refund) - int(tx_state_gas),
@@ -1490,7 +1497,14 @@ def settle_frame_transaction_gas(
             )
         )
     )
+    block_execution_gas_used = ExecutionGas(
+        max(
+            gas_used_before_refund - Uint(tx_state_gas),
+            calldata_floor,
+        )
+    )
     return FrameTransactionGasSettlement(
-        execution_gas_used=execution_gas_used,
+        gas_used=Uint(payer_execution_gas_used) + Uint(tx_state_gas),
+        execution_gas_used=block_execution_gas_used,
         state_gas_used=tx_state_gas,
     )

--- a/tests/amsterdam/eip8141_frame_transactions/spec.py
+++ b/tests/amsterdam/eip8141_frame_transactions/spec.py
@@ -14,7 +14,7 @@ class ReferenceSpec:
 
 
 ref_spec_8141 = ReferenceSpec(
-    "EIPS/eip-8141.md", "3ceef8d37092c5b13a614746dbce5b1fc3c2dfab"
+    "EIPS/eip-8141.md", "7d1c8bfb945cbb53479217df3bf1da67b3aa445b"
 )
 
 

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -212,7 +212,9 @@ def test_storage_refund_settlement(
         if floor_case == "below_post_refund":
             found_floor_case = calldata_floor < gas_used_after_refund
         elif floor_case == "between":
-            found_floor_case = gas_used_after_refund < calldata_floor < gas_used_before_refund
+            found_floor_case = (
+                gas_used_after_refund < calldata_floor < gas_used_before_refund
+            )
         else:
             assert floor_case == "above_pre_refund"
             found_floor_case = gas_used_before_refund < calldata_floor

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -2,11 +2,10 @@
 Transaction-level gas settlement tests for
 [EIP-8141: Frame Transaction](https://eips.ethereum.org/EIPS/eip-8141).
 
-A frame transaction's `gas_used` is the sum of its two block-accounted
-dimensions: the execution dimension — the post-refund usage held to
-the EIP-7623 calldata floor — plus the final attributed state gas.
-Blocks receive the settlement dimensions directly, so a storage refund
-lowers the block's execution counter along with the payer's charge.
+A frame transaction's payer-facing `gas_used` is the post-refund execution
+usage held to the EIP-7623 calldata floor plus final attributed state gas.
+Block accounting keeps the same state dimension but counts execution before
+storage refunds, as required by EIP-7778.
 """
 
 import pytest
@@ -134,11 +133,11 @@ def test_storage_refund_settlement(
     """
     Settle a frame transaction that clears a pre-existing storage slot.
 
-    The EIP-3529 refund reduces the payer's charge and — because a
-    frame transaction contributes its settlement dimensions to the
-    block directly — the block's execution gas counter equally, pinned
-    through the header. Clearing durable state consumes no state gas,
-    so the frame declares none.
+    The EIP-3529 refund reduces the payer's charge, while EIP-7778 keeps
+    the refunded execution gas counted toward the block gas limit. The
+    receipt therefore reports post-refund cumulative gas and the block
+    header reports pre-refund gas. Clearing durable state consumes no
+    state gas, so the frame declares none.
     """
     sender = pre.fund_eoa()
     clear = Op.SSTORE(
@@ -216,5 +215,5 @@ def test_storage_refund_settlement(
             sender: Account(nonce=1),
             worker: Account(storage={SLOT: 0}),
         },
-        blockchain_test_header_verify=Header(gas_used=gas_used),
+        blockchain_test_header_verify=Header(gas_used=gas_used_before_refund),
     )

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -125,18 +125,35 @@ def test_calldata_floor_with_state_gas(
     )
 
 
+@pytest.mark.parametrize(
+    "calldata_padding_length,floor_case",
+    [
+        pytest.param(0, "below_post_refund", id="post_refund_above_floor"),
+        pytest.param(
+            768,
+            "between",
+            id="floor_between_pre_and_post_refund",
+        ),
+        pytest.param(
+            1024,
+            "above_pre_refund",
+            id="floor_above_pre_refund",
+        ),
+    ],
+)
 def test_storage_refund_settlement(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    calldata_padding_length: int,
+    floor_case: str,
 ) -> None:
     """
     Settle a frame transaction that clears a pre-existing storage slot.
 
-    The EIP-3529 refund reduces the payer's charge, while EIP-7778 keeps
-    the refunded execution gas counted toward the block gas limit. The
-    receipt therefore reports post-refund cumulative gas and the block
-    header reports pre-refund gas. Clearing durable state consumes no
+    The three cases pin both settlement clamps around the calldata floor:
+    payer-facing gas uses post-refund execution while block execution gas
+    remains pre-refund under EIP-7778. Clearing durable state consumes no
     state gas, so the frame declares none.
     """
     sender = pre.fund_eoa()
@@ -164,10 +181,12 @@ def test_storage_refund_settlement(
                 target=worker,
                 gas_limit=REFUND_WORKER_GAS,
                 state_gas_limit=0,
+                data=b"\x00" * calldata_padding_length,
             ),
         ],
     )
-    # Materialize the signature bytes the intrinsic cost charges for.
+    # Materialize the signature bytes the intrinsic cost and calldata
+    # floor charge for.
     tx.sign()
     assert tx.frames is not None and tx.signatures is not None
 
@@ -187,11 +206,25 @@ def test_storage_refund_settlement(
     refund = worker_code.refund(fork)
     # The premise of the test: the refund applies uncapped.
     assert 0 < refund <= gas_used_before_refund // 5
-    gas_used = gas_used_before_refund - refund
+    gas_used_after_refund = gas_used_before_refund - refund
+    calldata_floor = fork.frame_transaction_data_floor_cost_calculator()(
+        frames=tx.frames, signatures=tx.signatures
+    )
+
+    if floor_case == "below_post_refund":
+        assert calldata_floor < gas_used_after_refund
+    elif floor_case == "between":
+        assert gas_used_after_refund < calldata_floor < gas_used_before_refund
+    else:
+        assert floor_case == "above_pre_refund"
+        assert gas_used_before_refund < calldata_floor
+
+    payer_gas_used = max(gas_used_after_refund, calldata_floor)
+    block_gas_used = max(gas_used_before_refund, calldata_floor)
 
     tx.expected_receipt = TransactionReceipt(
         payer=sender,
-        cumulative_gas_used=gas_used,
+        cumulative_gas_used=payer_gas_used,
         frame_receipts=[
             FrameReceipt(
                 status=Spec.STATUS_SUCCESS,
@@ -215,5 +248,5 @@ def test_storage_refund_settlement(
             sender: Account(nonce=1),
             worker: Account(storage={SLOT: 0}),
         },
-        blockchain_test_header_verify=Header(gas_used=gas_used_before_refund),
+        blockchain_test_header_verify=Header(gas_used=block_gas_used),
     )

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -177,6 +177,7 @@ def test_storage_refund_settlement(
     for _ in range(num_iterations):
         tx = Transaction(
             sender=sender,
+            nonce=0,
             frames=[
                 verify_frame(),
                 default_frame(

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -212,11 +212,7 @@ def test_storage_refund_settlement(
         if floor_case == "below_post_refund":
             found_floor_case = calldata_floor < gas_used_after_refund
         elif floor_case == "between":
-            found_floor_case = (
-                gas_used_after_refund
-                < calldata_floor
-                < gas_used_before_refund
-            )
+            found_floor_case = gas_used_after_refund < calldata_floor < gas_used_before_refund
         else:
             assert floor_case == "above_pre_refund"
             found_floor_case = gas_used_before_refund < calldata_floor

--- a/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_gas_settlement.py
@@ -126,26 +126,17 @@ def test_calldata_floor_with_state_gas(
 
 
 @pytest.mark.parametrize(
-    "calldata_padding_length,floor_case",
+    "floor_case",
     [
-        pytest.param(0, "below_post_refund", id="post_refund_above_floor"),
-        pytest.param(
-            768,
-            "between",
-            id="floor_between_pre_and_post_refund",
-        ),
-        pytest.param(
-            1024,
-            "above_pre_refund",
-            id="floor_above_pre_refund",
-        ),
+        pytest.param("below_post_refund", id="post_refund_above_floor"),
+        pytest.param("between", id="floor_between_pre_and_post_refund"),
+        pytest.param("above_pre_refund", id="floor_above_pre_refund"),
     ],
 )
 def test_storage_refund_settlement(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    calldata_padding_length: int,
     floor_case: str,
 ) -> None:
     """
@@ -173,51 +164,73 @@ def test_storage_refund_settlement(
     worker_code = padding + clear + Op.STOP
     worker = pre.deploy_contract(code=worker_code, storage={SLOT: 1})
 
-    tx = Transaction(
-        sender=sender,
-        frames=[
-            verify_frame(),
-            default_frame(
-                target=worker,
-                gas_limit=REFUND_WORKER_GAS,
-                state_gas_limit=0,
-                data=b"\x00" * calldata_padding_length,
-            ),
-        ],
-    )
-    # Materialize the signature bytes the intrinsic cost and calldata
-    # floor charge for.
-    tx.sign()
-    assert tx.frames is not None and tx.signatures is not None
-
     verify_gas = default_code_frame_gas(fork, target_warm=True)
     frame_execution_gas = fork.frame_entry_gas_calculator()() + (
         worker_code.execution_cost(fork)
     )
-    gas_used_before_refund = (
-        fork.frame_transaction_intrinsic_cost_calculator()(
-            frames=tx.frames,
-            signatures=tx.signatures,
-            return_cost_deducted_prior_execution=True,
-        )
-        + verify_gas
-        + frame_execution_gas
-    )
-    refund = worker_code.refund(fork)
-    # The premise of the test: the refund applies uncapped.
-    assert 0 < refund <= gas_used_before_refund // 5
-    gas_used_after_refund = gas_used_before_refund - refund
-    calldata_floor = fork.frame_transaction_data_floor_cost_calculator()(
-        frames=tx.frames, signatures=tx.signatures
-    )
 
-    if floor_case == "below_post_refund":
-        assert calldata_floor < gas_used_after_refund
-    elif floor_case == "between":
-        assert gas_used_after_refund < calldata_floor < gas_used_before_refund
-    else:
-        assert floor_case == "above_pre_refund"
-        assert gas_used_before_refund < calldata_floor
+    data = b""
+    bytes_to_add_per_iteration = b"\x00" * 16
+    num_iterations = 200
+    found_floor_case = False
+
+    for _ in range(num_iterations):
+        tx = Transaction(
+            sender=sender,
+            frames=[
+                verify_frame(),
+                default_frame(
+                    target=worker,
+                    gas_limit=REFUND_WORKER_GAS,
+                    state_gas_limit=0,
+                    data=data,
+                ),
+            ],
+        )
+        # Materialize the signature bytes the intrinsic cost and calldata
+        # floor charge for.
+        tx.sign()
+        assert tx.frames is not None and tx.signatures is not None
+
+        gas_used_before_refund = (
+            fork.frame_transaction_intrinsic_cost_calculator()(
+                frames=tx.frames,
+                signatures=tx.signatures,
+                return_cost_deducted_prior_execution=True,
+            )
+            + verify_gas
+            + frame_execution_gas
+        )
+        refund = worker_code.refund(fork)
+        # The premise of the test: the refund applies uncapped.
+        assert 0 < refund <= gas_used_before_refund // 5
+        gas_used_after_refund = gas_used_before_refund - refund
+        calldata_floor = fork.frame_transaction_data_floor_cost_calculator()(
+            frames=tx.frames, signatures=tx.signatures
+        )
+
+        if floor_case == "below_post_refund":
+            found_floor_case = calldata_floor < gas_used_after_refund
+        elif floor_case == "between":
+            found_floor_case = (
+                gas_used_after_refund
+                < calldata_floor
+                < gas_used_before_refund
+            )
+        else:
+            assert floor_case == "above_pre_refund"
+            found_floor_case = gas_used_before_refund < calldata_floor
+
+        if found_floor_case:
+            break
+
+        data += bytes_to_add_per_iteration
+
+    if not found_floor_case:
+        raise ValueError(
+            f"Could not find calldata for {floor_case} in "
+            f"{num_iterations} iterations."
+        )
 
     payer_gas_used = max(gas_used_after_refund, calldata_floor)
     block_gas_used = max(gas_used_before_refund, calldata_floor)


### PR DESCRIPTION
### Description

Fix EIP-8141 frame-transaction block gas accounting so storage refunds reduce payer-facing gas without reducing block execution gas, as required by EIP-7778.

The payer and receipt remain post-refund. At the block-processing boundary:

- payer fee and receipt cumulative gas: post-refund
- block execution gas: pre-refund
- block state gas: net after state-gas refills
- the calldata floor is applied independently to the payer-facing and block-accounted totals

### Reviewer-requested changes incorporated

Current head: `ce7e32f8f7ac6e7cbdfaf87779b787c6f4e40406`.

All three items from `@gurukamath`'s review are incorporated:

1. `tests/amsterdam/eip8141_frame_transactions/spec.py` is pinned to merged EIP update commit `7d1c8bfb945cbb53479217df3bf1da67b3aa445b`.
2. Payer-facing `gas_used` is derived inside `settle_frame_transaction_gas` and carried by `FrameTransactionGasSettlement` rather than reconstructed inline in `process_frame_transaction`.
3. `test_storage_refund_settlement` covers all three calldata-floor orderings: post-refund above floor, floor between pre/post refund, and floor above pre-refund.

The two inline review threads have been answered and resolved, and re-review has been requested. No acceptance claim is being made before that review completes.

### Verification state

The earlier focused validation (`9 passed`, Ruff check/format check, and `git diff --check`) predates the final reviewer-requested refinements and is preserved as prior evidence rather than represented as exact-current-head CI.

On current head, the upstream fork-triggered `render`, `Python Specification`, and `Build Docs` workflow runs are all `action_required`; they require upstream authorization before they can execute. There is therefore no author-side CI action remaining on this head.

### Base

`eips/amsterdam/eip-8141` at `6798542ebd017b683b688489d770bf206c8bd3ba`.