### PR TITLE
test(eip-8297): preserve provider state across reorg branches

### DIFF
--- a/tests/binary_trie/test_reorg_transition.py
+++ b/tests/binary_trie/test_reorg_transition.py
@@ -1,0 +1,123 @@
+"""
+Reorg coverage for the EIP-8297 MPT -> PBT state-tree flip.
+
+The activation block is the first block whose post-state is committed by the
+PBT; its parent is still MPT-committed. EIP-8347 therefore requires both trees
+to remain available through the transition window so an unfinalized reorg can
+cross the boundary safely.
+
+These tests pin the reference-state invariant directly: advancing a PBT branch
+must not consume or mutate the retained MPT parent, and post-flip branches must
+be discardable back to a common PBT parent rather than "undone" in place.
+"""
+
+from ethereum_types.bytes import Bytes20, Bytes32
+from ethereum_types.numeric import U256, Uint
+
+from ethereum.state import EMPTY_CODE_HASH, Account, BlockDiff
+from ethereum.state_mpt import State as MptState
+from ethereum.state_mpt import set_account as mpt_set_account
+from ethereum.state_mpt import set_storage as mpt_set_storage
+from ethereum.state_mpt import state_root as mpt_state_root
+from ethereum.state_pbt import State as PbtState
+from ethereum.state_pbt import apply_changes_to_state as pbt_apply_changes
+from ethereum.state_pbt import state_root as pbt_state_root
+
+from .transition import pbt_from_mpt_snapshot
+
+ADDRESS = Bytes20(b"\xaa" * 20)
+SLOT = Bytes32((1).to_bytes(32, "big"))
+
+
+def _account() -> Account:
+    """Return a small live account used on both sides of the flip."""
+    return Account(
+        nonce=Uint(0),
+        balance=U256(1_000),
+        code_hash=EMPTY_CODE_HASH,
+    )
+
+
+def _mpt_parent() -> MptState:
+    """Build the last MPT-committed state before PBT activation."""
+    state = MptState()
+    mpt_set_account(state, ADDRESS, _account())
+    mpt_set_storage(state, ADDRESS, SLOT, U256(1))
+    return state
+
+
+def _copy_pbt_state(state: PbtState) -> PbtState:
+    """Copy a PBT layer so sibling branches share no mutable mappings."""
+    return PbtState(
+        _accounts=dict(state._accounts),
+        _storage={
+            address: dict(slots) for address, slots in state._storage.items()
+        },
+        _code_store=dict(state._code_store),
+    )
+
+
+def _storage_write(value: int) -> BlockDiff:
+    """Return a block diff that writes the test slot."""
+    return BlockDiff(storage_changes={ADDRESS: {SLOT: U256(value)}})
+
+
+def test_reorg_across_activation_retains_mpt_parent() -> None:
+    """
+    Discard a PBT activation branch and rebuild from the MPT parent.
+
+    Branch A crosses the activation boundary and advances the new tree. A
+    reorg then selects a competing activation block. The safe operation is to
+    discard A and construct branch B from the still-retained MPT parent; no
+    reverse write against the PBT is required and the MPT commitment remains
+    byte-identical throughout.
+    """
+    mpt_parent = _mpt_parent()
+    parent_root = mpt_state_root(mpt_parent)
+
+    branch_a = pbt_from_mpt_snapshot(mpt_parent)
+    activation_root = pbt_state_root(branch_a)
+    pbt_apply_changes(branch_a, _storage_write(2))
+    branch_a_root = pbt_state_root(branch_a)
+
+    # Crossing into PBT and advancing it must not consume the MPT parent.
+    assert mpt_state_root(mpt_parent) == parent_root
+    assert mpt_parent.get_storage(ADDRESS, SLOT) == U256(1)
+
+    # Reorg across the flip: throw away branch A and re-cross activation from
+    # the retained MPT parent with a competing block.
+    branch_b = pbt_from_mpt_snapshot(mpt_parent)
+    assert pbt_state_root(branch_b) == activation_root
+    pbt_apply_changes(branch_b, _storage_write(3))
+    branch_b_root = pbt_state_root(branch_b)
+
+    assert branch_a_root != branch_b_root
+    assert branch_a.get_storage(ADDRESS, SLOT) == U256(2)
+    assert branch_b.get_storage(ADDRESS, SLOT) == U256(3)
+    assert mpt_state_root(mpt_parent) == parent_root
+
+
+def test_post_flip_reorg_discards_pbt_branch_layers() -> None:
+    """
+    Reorg between two PBT branches without mutating their common parent.
+
+    EIP-8347 records post-values rather than reversible writes, so rollback is
+    modeled by discarding branch layers to the common ancestor and replaying
+    the replacement branch. Both siblings start from an identical copied PBT
+    parent and diverge independently.
+    """
+    common_parent = pbt_from_mpt_snapshot(_mpt_parent())
+    pbt_apply_changes(common_parent, _storage_write(4))
+    common_root = pbt_state_root(common_parent)
+
+    branch_a = _copy_pbt_state(common_parent)
+    branch_b = _copy_pbt_state(common_parent)
+
+    pbt_apply_changes(branch_a, _storage_write(5))
+    pbt_apply_changes(branch_b, _storage_write(6))
+
+    assert pbt_state_root(common_parent) == common_root
+    assert common_parent.get_storage(ADDRESS, SLOT) == U256(4)
+    assert pbt_state_root(branch_a) != pbt_state_root(branch_b)
+    assert branch_a.get_storage(ADDRESS, SLOT) == U256(5)
+    assert branch_b.get_storage(ADDRESS, SLOT) == U256(6)

--- a/tests/binary_trie/transition.py
+++ b/tests/binary_trie/transition.py
@@ -1,0 +1,41 @@
+"""
+State-tree transition helpers used by binary-tree reorg tests.
+
+The production MPT -> PBT migration requires the verified snapshot and
+preimage machinery described by EIP-8347. The in-memory EELS MPT already
+retains those original account and storage keys in ``Trie._data``, so tests
+can model the activation boundary deterministically without pretending to
+implement snapshot distribution or BAL replay.
+
+The conversion deliberately copies every mutable mapping. The MPT snapshot
+therefore remains usable after the returned PBT state advances, which is the
+property a reorg across the activation boundary depends on.
+"""
+
+from ethereum import state_mpt, state_pbt
+
+
+def pbt_from_mpt_snapshot(state: state_mpt.State) -> state_pbt.State:
+    """
+    Return a PBT state cloned from an in-memory MPT snapshot.
+
+    Storage without a live account is omitted, matching the PBT embedding
+    rule that storage belongs to an account. The source MPT state is never
+    mutated or aliased through a mutable mapping.
+    """
+    accounts = {
+        address: account
+        for address, account in state._main_trie._data.items()
+        if account is not None
+    }
+    storage = {
+        address: dict(trie._data)
+        for address, trie in state._storage_tries.items()
+        if address in accounts and trie._data
+    }
+
+    return state_pbt.State(
+        _accounts=dict(accounts),
+        _storage=storage,
+        _code_store=dict(state._code_store),
+    )


### PR DESCRIPTION
### Description

Advances #3334 at the reference-state layer. This PR does not close the client-level transition issue.

The current `projects/binary-trie` branch commits through PBT from genesis and has no MPT→PBT activation machinery. A normal blockchain fixture therefore cannot honestly execute a reorg across the future flip. This test-only harness pins the provider invariant that such a fixture will depend on:

- clone the in-memory MPT snapshot into an independently mutable PBT state;
- advance one PBT activation branch without consuming or mutating the retained MPT parent;
- discard that branch and rebuild a competing PBT branch from the same MPT parent;
- discard post-flip sibling layers back to an unchanged common PBT parent.

### Boundary

This does not implement EIP-8347 snapshot distribution, dual-check verification, BAL replay, client persistence, forkchoice, or snap-sync behavior. Closing #3334 still requires a real activation fork and a client-facing reorg fixture. This PR preserves the narrower reference-state prerequisite without simulating missing production machinery.

### Verification

- `uv run pytest -q tests/binary_trie/test_reorg_transition.py` — 2 passed
- Ruff check and format check — passed
- `git diff --check` — passed

### Base

`projects/binary-trie` at `09d2088cf9f338e660cb04f948653baf544b7ba6`.