### PR TITLE
fix(test-focil): omit inclusion list result for invalid payloads

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -595,7 +595,11 @@ class BuiltBlock(CamelModel):
             if self.block_access_list
             else None,
             inclusion_list_transactions=self.inclusion_list_txs,
-            inclusion_list_satisfied=self.inclusion_list_satisfied,
+            inclusion_list_satisfied=(
+                self.inclusion_list_satisfied
+                if self.expected_exception is None
+                else None
+            ),
             execution_payload_modifier=self.engine_payload_modifier(),
             validation_error=self.expected_exception,
             error_code=self.engine_api_error_code,

--- a/packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py
@@ -1,0 +1,58 @@
+"""Regression tests for Engine API inclusion-list payload metadata."""
+
+from typing import Any
+
+import pytest
+
+from execution_testing.fixtures.blockchain import FixtureEngineNewPayload
+
+from ..blockchain import BuiltBlock
+
+
+@pytest.mark.parametrize(
+    "validation_error,inclusion_list_satisfied,expected",
+    [
+        pytest.param(None, True, True, id="valid-satisfied"),
+        pytest.param(None, False, False, id="valid-unsatisfied"),
+        pytest.param(object(), True, None, id="invalid-satisfied"),
+        pytest.param(object(), False, None, id="invalid-unsatisfied"),
+    ],
+)
+def test_inclusion_list_result_only_emitted_for_valid_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    validation_error: object | None,
+    inclusion_list_satisfied: bool,
+    expected: bool | None,
+) -> None:
+    """Invalid payload fixtures must carry a null inclusion-list result."""
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    def capture(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        FixtureEngineNewPayload,
+        "from_fixture_header",
+        staticmethod(capture),
+    )
+
+    block = BuiltBlock.model_construct(
+        fork=object(),
+        header=object(),
+        txs=[],
+        withdrawals=None,
+        requests=None,
+        block_access_list=None,
+        inclusion_list_txs=None,
+        inclusion_list_satisfied=inclusion_list_satisfied,
+        expected_exception=validation_error,
+        engine_api_error_code=None,
+        rlp_modifier=None,
+        engine_new_payload_block_access_list=None,
+        engine_new_payload_slot_number=None,
+    )
+
+    assert block.get_fixture_engine_new_payload() is sentinel
+    assert captured["inclusion_list_satisfied"] is expected


### PR DESCRIPTION
### Description

Fixes #3436.

Engine API payload metadata only has a meaningful `inclusionListSatisfied` result when the payload itself is valid. The FOCIL filler previously carried the transition-tool result into `engine_newPayload` fixtures even when the same `BuiltBlock` was marked invalid.

`BuiltBlock.get_fixture_engine_new_payload()` now:

- preserves `True` and `False` for valid payloads;
- emits `None` for invalid payloads, as the Engine API requires.

The focused regression covers all four valid/invalid and satisfied/unsatisfied combinations.

### Verification

- `uv run pytest -q packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py` — 4 passed
- Ruff check and format check — passed
- `git diff --check` — passed

### Scope

- no change to inclusion-list evaluation
- no change to valid-payload metadata
- no production fork behavior change

### Base

`devnets/focil/0` at `23b0358c3513c8d22324faea66b41cec4b0b6446`.