### PR TITLE
test(test-execute): pin genesis commitment provider

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/tests/test_genesis.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/tests/test_genesis.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from execution_testing.base_types import Hash
+from execution_testing.base_types import (
+    Account,
+    Address,
+    Hash,
+    StateCommitment,
+)
 from execution_testing.forks import (
     BPO1,
     BPO2,
@@ -13,6 +18,7 @@ from execution_testing.forks import (
     BPO4,
     BPO5,
     Berlin,
+    BinaryTree,
     Byzantium,
     Cancun,
     Constantinople,
@@ -27,8 +33,14 @@ from execution_testing.forks import (
 from execution_testing.rpc import (
     ForkConfigBlobSchedule,
 )
+from execution_testing.test_types import Alloc
 
-from ..execute_types import ForkActivationTimes, Genesis, NetworkConfig
+from ..execute_types import (
+    ForkActivationTimes,
+    Genesis,
+    GenesisConfig,
+    NetworkConfig,
+)
 
 CURRENT_FILE = Path(realpath(__file__))
 CURRENT_FOLDER = CURRENT_FILE.parent
@@ -139,3 +151,37 @@ def test_genesis_parsing(
         f"Unexpected network config: {network_config}, "
         f"expected: {expected_network_config}"
     )
+
+
+def test_binary_tree_genesis_seeds_alloc_state_commitment() -> None:
+    """Genesis hashing must use the provider selected by the active fork."""
+    address = Address(0x100)
+    alloc = Alloc({address: Account(balance=1, storage={0: 1})})
+
+    mpt_alloc = alloc.model_copy(deep=True)
+    mpt_alloc.migrate_state_commitment(StateCommitment.MPT)
+    mpt_root = mpt_alloc.state_root()
+
+    genesis = Genesis(
+        config=GenesisConfig(
+            chain_id=1,
+            terminal_total_difficulty=0,
+            terminal_total_difficulty_passed=True,
+            fork_activation_times=ForkActivationTimes(root={BinaryTree: 0}),
+            blob_schedule={},
+        ),
+        alloc=alloc,
+        fee_recipient=Address(0),
+        difficulty=0,
+        extra_data=b"",
+        gas_limit=30_000_000,
+        nonce=0,
+        mixhash=Hash(0),
+        timestamp=0,
+        parent_hash=Hash(0),
+    )
+
+    assert genesis.config.fork() is BinaryTree
+    assert genesis.alloc.state_commitment() is StateCommitment.BINARY_TREE
+    assert genesis.alloc.state_root() != mpt_root
+    _ = genesis.hash

--- a/packages/testing/src/execution_testing/cli/tests/test_execute_genesis.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_execute_genesis.py
@@ -23,7 +23,7 @@ from execution_testing.forks import (
     get_development_forks,
 )
 from execution_testing.specs.blockchain import GENESIS_ENVIRONMENT_DEFAULTS
-from execution_testing.test_types import Environment
+from execution_testing.test_types import Alloc, Environment
 
 # ``build_genesis_header`` pins these two values instead of taking them
 # from the environment; mirror them so both builders receive equivalent
@@ -46,3 +46,20 @@ def test_execute_genesis_matches_fill_genesis(fork: Fork) -> None:
     fill_genesis = FixtureHeader.genesis(fork, env, pre_alloc.state_root())
     assert to_json(execute_genesis) == to_json(fill_genesis)
     assert execute_genesis.block_hash == fill_genesis.block_hash
+
+
+@pytest.mark.parametrize("fork", FORKS, ids=lambda fork: fork.name())
+def test_execute_genesis_uses_fork_state_commitment(fork: Fork) -> None:
+    """The execute genesis root must use the fork-selected commitment."""
+    pre_alloc, execute_genesis = build_genesis_header(fork)
+
+    # The commitment is private state and is intentionally absent from the
+    # serialized allocation. Reconstructing the same logical allocation gives
+    # this assertion an independent provider selection instead of reusing the
+    # provider already chosen by ``build_genesis_header``.
+    independent_pre = Alloc.model_validate(pre_alloc.model_dump())
+    independent_pre.migrate_state_commitment(
+        fork.transitions_from().state_commitment()
+    )
+
+    assert execute_genesis.state_root == independent_pre.state_root()


### PR DESCRIPTION
### Description

Addresses the remaining regression-coverage gap in #3251. The production MPT decoupling has already landed in #3279; this PR pins both execute-path boundaries that issue identified.

The existing execute/fill parity test could agree on the wrong root because it reused the allocation whose private commitment provider had already been selected by `build_genesis_header()`.

This adds independent assertions for both paths:

1. **Hive execute builder:** serialize and reconstruct the logical allocation, independently select the genesis fork's provider, compute the expected root, and compare it with the execute genesis header.
2. **eth_config genesis model:** construct a non-empty BinaryTree genesis allocation, independently compute its MPT contrast root, and prove model initialization selects PBT before the genesis hash is evaluated.

Genesis-header parity is therefore no longer sufficient by itself; each execute boundary must independently agree with the fork-selected commitment provider.

### Verification

- `uv run pytest -q packages/testing/src/execution_testing/cli/tests/test_execute_genesis.py packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/tests/test_genesis.py` — 42 passed
- Ruff check and format check — passed
- `git diff --check` — passed

### Scope

- test-only
- no duplicate state-commitment plumbing
- no MPT→PBT activation/migration machinery
- no mainnet fork behavior change

### Base

`projects/binary-trie` at `09d2088cf9f338e660cb04f948653baf544b7ba6`.