### PR TITLE
test(eip-8297): verify RPC state across cache invalidation

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/post_state.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/post_state.py
@@ -1,0 +1,101 @@
+"""RPC helpers for priming and verifying fixture post-state assertions."""
+
+from execution_testing.base_types import Hash
+from execution_testing.fixtures import PostVerifications
+from execution_testing.rpc import EthRPC
+
+from .exceptions import LoggedError
+
+
+def prime_post_verification_queries(
+    eth_rpc: EthRPC,
+    post_verifications: PostVerifications | None,
+) -> None:
+    """
+    Read every state field that will later be verified through JSON-RPC.
+
+    Priming the same RPC keys before block execution makes a client-side stale
+    state cache observable after the chain advances: the final verification
+    must return the post-state values rather than any value retained here.
+    """
+    if post_verifications is None:
+        return
+
+    for address, check in post_verifications.accounts.items():
+        if check is None:
+            # JSON-RPC cannot distinguish a nonexistent account from an empty
+            # account directly. Prime every observable account-level field so
+            # stale non-zero state can still be detected after execution.
+            eth_rpc.get_balance(address)
+            eth_rpc.get_transaction_count(address)
+            eth_rpc.get_code(address)
+            continue
+
+        if check.balance is not None:
+            eth_rpc.get_balance(address)
+        if check.nonce is not None:
+            eth_rpc.get_transaction_count(address)
+        if check.code is not None:
+            eth_rpc.get_code(address)
+        if check.storage is not None:
+            for key in check.storage:
+                eth_rpc.get_storage_at(address, Hash(int(key)))
+
+
+def verify_post_verification_queries(
+    eth_rpc: EthRPC,
+    post_verifications: PostVerifications | None,
+) -> None:
+    """Verify fill-time post-state assertions against the live client RPC."""
+    if post_verifications is None:
+        return
+
+    for address, check in post_verifications.accounts.items():
+        if check is None:
+            balance = eth_rpc.get_balance(address)
+            nonce = eth_rpc.get_transaction_count(address)
+            code = eth_rpc.get_code(address)
+            if balance != 0 or nonce != 0 or bytes(code) != b"":
+                raise LoggedError(
+                    f"Post-state RPC mismatch for {address}: expected "
+                    "nonexistent/empty account, got "
+                    f"balance={balance}, nonce={nonce}, "
+                    f"code=0x{bytes(code).hex()}"
+                )
+            continue
+
+        if check.balance is not None:
+            got_balance = eth_rpc.get_balance(address)
+            if got_balance != int(check.balance):
+                raise LoggedError(
+                    f"Post-state RPC balance mismatch for {address}: "
+                    f"expected {int(check.balance)}, got {got_balance}"
+                )
+
+        if check.nonce is not None:
+            got_nonce = eth_rpc.get_transaction_count(address)
+            if got_nonce != int(check.nonce):
+                raise LoggedError(
+                    f"Post-state RPC nonce mismatch for {address}: "
+                    f"expected {int(check.nonce)}, got {got_nonce}"
+                )
+
+        if check.code is not None:
+            got_code = eth_rpc.get_code(address)
+            if bytes(got_code) != bytes(check.code):
+                raise LoggedError(
+                    f"Post-state RPC code mismatch for {address}: "
+                    f"expected 0x{bytes(check.code).hex()}, "
+                    f"got 0x{bytes(got_code).hex()}"
+                )
+
+        if check.storage is not None:
+            for key, expected_value in check.storage.items():
+                got_value = eth_rpc.get_storage_at(address, Hash(int(key)))
+                got_int = int.from_bytes(bytes(got_value), byteorder="big")
+                if got_int != int(expected_value):
+                    raise LoggedError(
+                        f"Post-state RPC storage mismatch for {address} at "
+                        f"slot {Hash(int(key))}: expected "
+                        f"{int(expected_value)}, got {got_int}"
+                    )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -38,6 +38,10 @@ from ..helpers.exceptions import (
     GenesisBlockMismatchExceptionError,
     LoggedError,
 )
+from ..helpers.post_state import (
+    prime_post_verification_queries,
+    verify_post_verification_queries,
+)
 from ..helpers.rejected_blocks import (
     BlockRejectionTracker,
     verify_block_rejection,
@@ -126,6 +130,9 @@ def test_blockchain_via_engine(
         # pre-alloc group, so later tests skip the redundant getBlockByNumber
         # round-trip; per-test clients get a fresh id each test and re-verify.
         genesis_verified_clients.add(client.id)
+
+    with timing_data.time("Prime post-state RPC cache"):
+        prime_post_verification_queries(eth_rpc, fixture.post_verifications)
 
     with timing_data.time("Payloads execution") as total_payload_timing:
         logger.info(
@@ -231,3 +238,6 @@ def test_blockchain_via_engine(
                                 f"{PayloadStatusEnum.VALID}, got {status}"
                             )
         logger.info("All payloads processed successfully.")
+
+    with timing_data.time("Verify post-state RPC cache"):
+        verify_post_verification_queries(eth_rpc, fixture.post_verifications)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_post_state_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_post_state_rpc.py
@@ -1,0 +1,79 @@
+"""Tests for live-client RPC post-state verification."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from execution_testing.base_types import Address, Hash
+from execution_testing.fixtures import AccountCheck, PostVerifications
+from execution_testing.rpc import EthRPC
+
+from ..simulators.helpers.exceptions import LoggedError
+from ..simulators.helpers.post_state import (
+    prime_post_verification_queries,
+    verify_post_verification_queries,
+)
+
+ADDRESS = Address(0x1234)
+
+
+def _rpc_with_expected_state() -> Mock:
+    """Return an EthRPC-shaped mock with one deterministic account state."""
+    rpc = Mock(spec=EthRPC)
+    rpc.get_balance.return_value = 7
+    rpc.get_transaction_count.return_value = 3
+    rpc.get_code.return_value = b"\x60\x00"
+    rpc.get_storage_at.return_value = Hash(2)
+    return rpc
+
+
+def _post_verifications() -> PostVerifications:
+    """Return checks spanning every state field observable through RPC."""
+    return PostVerifications(
+        accounts={
+            ADDRESS: AccountCheck(
+                nonce=3,
+                balance=7,
+                code=b"\x60\x00",
+                storage={1: 2},
+            )
+        }
+    )
+
+
+def test_prime_reads_exact_fields_that_will_be_verified() -> None:
+    """Priming touches each checked RPC key without asserting its old value."""
+    rpc = _rpc_with_expected_state()
+
+    prime_post_verification_queries(rpc, _post_verifications())
+
+    rpc.get_balance.assert_called_once_with(ADDRESS)
+    rpc.get_transaction_count.assert_called_once_with(ADDRESS)
+    rpc.get_code.assert_called_once_with(ADDRESS)
+    rpc.get_storage_at.assert_called_once_with(ADDRESS, Hash(1))
+
+
+def test_verify_accepts_live_state_matching_fill_assertions() -> None:
+    """All explicitly asserted post-state fields must match the live client."""
+    rpc = _rpc_with_expected_state()
+
+    verify_post_verification_queries(rpc, _post_verifications())
+
+
+def test_verify_rejects_stale_storage_cache_value() -> None:
+    """A stale storage value returned after execution fails verification."""
+    rpc = _rpc_with_expected_state()
+    rpc.get_storage_at.return_value = Hash(1)
+
+    with pytest.raises(LoggedError, match="storage mismatch"):
+        verify_post_verification_queries(rpc, _post_verifications())
+
+
+def test_verify_rejects_observable_state_for_deleted_account() -> None:
+    """A deleted account must not expose stale balance, nonce, or code."""
+    rpc = _rpc_with_expected_state()
+    rpc.get_balance.return_value = 1
+    post = PostVerifications(accounts={ADDRESS: None})
+
+    with pytest.raises(LoggedError, match="nonexistent/empty account"):
+        verify_post_verification_queries(rpc, post)

--- a/tests/binary_tree/eip8297_partitioned_binary_tree/test_cache_invalidation.py
+++ b/tests/binary_tree/eip8297_partitioned_binary_tree/test_cache_invalidation.py
@@ -1,0 +1,88 @@
+"""Cache-invalidation stress coverage for the EIP-8297 BinaryTree fork."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Op,
+    Transaction,
+)
+
+from .spec import ref_spec_8297
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8297.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8297.version
+
+pytestmark = [pytest.mark.valid_from("BinaryTree"), pytest.mark.slow]
+
+CACHE_INVALIDATION_HORIZON = 128
+SLOT = 0
+INITIAL_VALUE = 1
+MID_VALUE = 2
+FINAL_VALUE = 3
+
+_WRITE_CODE = Op.SSTORE(SLOT, Op.CALLDATALOAD(0)) + Op.STOP
+
+
+def _word(value: int) -> bytes:
+    """Encode one calldata word for the cache-stress writer contract."""
+    return value.to_bytes(32, byteorder="big")
+
+
+def test_rpc_state_after_cache_invalidation_horizon(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Keep one storage key alive across a 128-block cache horizon and mutate it
+    on both sides of that boundary.
+
+    The account starts at ``1`` in genesis, changes to ``2`` in block 1,
+    remains untouched through block 128, and changes to ``3`` in block 129.
+    When the generated engine fixture includes ``postVerifications``, the Hive
+    engine consumer primes this exact storage RPC at genesis and verifies it
+    again after the final forkchoice update. A stale state/RPC cache returning
+    either the genesis value or the pre-flush value therefore fails even when
+    block execution and state-root validation themselves succeeded.
+
+    ``BinaryTree`` currently commits through PBT from genesis. This test
+    exercises the post-flip cache horizon available on the branch today; it
+    deliberately does not pretend to model the future MPT-to-PBT activation
+    boundary.
+    """
+    contract = pre.deploy_contract(
+        code=_WRITE_CODE,
+        storage={SLOT: INITIAL_VALUE},
+    )
+    sender = pre.fund_eoa()
+
+    first_write = Block(
+        txs=[
+            Transaction(
+                sender=sender,
+                to=contract,
+                data=_word(MID_VALUE),
+            )
+        ]
+    )
+    quiet_blocks = [Block() for _ in range(CACHE_INVALIDATION_HORIZON - 1)]
+    post_horizon_write = Block(
+        txs=[
+            Transaction(
+                sender=sender,
+                to=contract,
+                data=_word(FINAL_VALUE),
+            )
+        ]
+    )
+
+    blocks = [first_write, *quiet_blocks, post_horizon_write]
+    assert len(blocks) == CACHE_INVALIDATION_HORIZON + 1
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={contract: Account(storage={SLOT: FINAL_VALUE})},
+    )


### PR DESCRIPTION
### Description

Advances #3333 by making stale state-RPC reads observable without encoding any client's private cache implementation. This PR does not close the future MPT→PBT transition case because the target branch does not yet implement that activation boundary.

When `postVerifications` are present, the Engine consumer now uses the fill-time assertions as a live RPC oracle:

- before payload execution, read the exact balance, nonce, code, and storage keys that will be verified, priming any client-side cache;
- execute payloads and advance forkchoice normally;
- read the same fields again and require them to match the fill-time post-state assertions.

The BinaryTree fixture crosses the 128-block horizon from #3333: one slot starts at `1`, changes to `2` in block 1, remains untouched through block 128, then changes to `3` in block 129. A stale genesis or pre-flush value fails even when block execution and the committed state root succeed.

### Transition boundary

`projects/binary-trie` currently runs PBT from genesis. The fixture therefore exercises cache churn on the available PBT provider, not an MPT-backed cache surviving an actual flip. When a real activation fixture exists, the same RPC oracle can observe that transition-specific failure without client hooks.

The oracle remains opt-in through the existing `--post-verifications` fill flag.

### Verification

- `uv run pytest -q packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_post_state_rpc.py` — 4 passed
- `uv run fill -q tests/binary_tree/eip8297_partitioned_binary_tree/test_cache_invalidation.py --fork BinaryTree --clean -n 0` — 2 passed
- Ruff check and format check — passed
- `git diff --check` — passed

### Base

`projects/binary-trie` at `09d2088cf9f338e660cb04f948653baf544b7ba6`.