### PR TITLE
fix(test-execute): ignore tests/spec_tools during collection

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -21,4 +21,4 @@ addopts =
     --dist load
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
     --ignore tests/json_loader
-    --ignore tests/evm_tools
+    --ignore tests/spec_tools

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -23,4 +23,4 @@ addopts =
     --dist load
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
     --ignore tests/json_loader
-    --ignore tests/evm_tools
+    --ignore tests/spec_tools

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -20,7 +20,7 @@ addopts =
     --dist loadgroup
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
     --ignore tests/json_loader
-    --ignore tests/evm_tools
+    --ignore tests/spec_tools
 # these customizations require the pytest-custom-report plugin
 report_passed_verbose = FILLED
 report_xpassed_verbose = XFILLED


### PR DESCRIPTION
### Description

PR #3307 moved `tests/evm_tools/test_*.py` to `tests/spec_tools/`, but the fill and execute pytest configs still ignored the old path. `execute` collects these plain unit tests, gives them a `fork` parameter via the autouse `pre` fixture, and then crashes during collection because they have no spec type format:

```
INTERNALERROR> ValueError: No spec type format found in the test item.
```

This is what stopped the eels/execute simulator runs on the glamsterdam Hive dashboard. Update the stale `--ignore tests/evm_tools` entries to `--ignore tests/spec_tools`.

Note: this also needs to reach `devnets/glamsterdam/8` for the dashboard to recover.

### Related Issues or PRs

Fixes #3438:
- #3438

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

```
 (\ /)
 ( .c.)
 o(")(")
```
