### PR TITLE
feat(ci): test `execute`, `consume` and `check_eip_versions` via collect-only

### DIFF
--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -6,12 +6,16 @@ on:
       - "forks/**"
     paths:
       - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/**"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/**"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini"
       - "packages/testing/src/execution_testing/rpc/**"
       - ".github/workflows/hive-execute.yaml"
       - ".github/actions/start-hive-dev/**"
   pull_request:
     paths:
       - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/**"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/**"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini"
       - "packages/testing/src/execution_testing/rpc/**"
       - ".github/workflows/hive-execute.yaml"
       - ".github/actions/start-hive-dev/**"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -167,6 +167,41 @@ jobs:
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  execute-collect:
+    runs-on: ubuntu-latest
+    needs: static
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-uv
+        with:
+          python-version: "3.14"
+      - name: Collect the full test tree via the execute plugins
+        run: just execute-collect
+
+  consume-collect:
+    runs-on: ubuntu-latest
+    needs: static
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-uv
+        with:
+          python-version: "3.14"
+      - name: Collect the consume test cases of a mini fixture set
+        run: just consume-collect
+
+  check-eip-versions-collect:
+    runs-on: ubuntu-latest
+    needs: static
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-uv
+        with:
+          python-version: "3.14"
+      - name: Collect the EIP version checks
+        run: just check-eip-versions-collect
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
   spec-tools:
     runs-on: ubuntu-latest
     needs: static

--- a/Justfile
+++ b/Justfile
@@ -226,6 +226,64 @@ json-loader *args: (_tmp "json-loader")
         "$@" \
         tests/json_loader
 
+# Collect (without running) the full test tree via the execute remote and execute hive plugin stacks
+[group('integration tests')]
+execute-collect:
+    #!/usr/bin/env bash
+    # Assert a sane collected-test floor: guards against a silent pass if
+    # collection shrinks drastically or yields only placeholder items.
+    set -euo pipefail
+    summary_floor='^[0-9]{4,}(/[0-9]+)? tests collected'
+    uv run execute remote \
+        --collect-only -q \
+        --fork "{{ latest_fork }}" \
+        --rpc-endpoint http://127.0.0.1:1 \
+        --rpc-seed-key 0x0000000000000000000000000000000000000000000000000000000000000001 \
+        --rpc-chain-id 1 \
+        | tee /dev/stderr | tail -n 3 | grep -qE "$summary_floor"
+    uv run execute hive \
+        --collect-only -q \
+        --fork "{{ latest_fork }}" \
+        | tee /dev/stderr | tail -n 3 | grep -qE "$summary_floor"
+
+# Collect (without running) the EIP version checks over the full test tree
+[group('integration tests')]
+check-eip-versions-collect:
+    #!/usr/bin/env bash
+    # Assert a sane collected-test floor: guards against a silent pass if
+    # collection shrinks drastically or yields only placeholder items.
+    set -euo pipefail
+    export GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token)}"
+    uv run check_eip_versions \
+        --collect-only -q \
+        | tee /dev/stderr | tail -n 3 \
+        | grep -qE '^[0-9]{4,}(/[0-9]+)? tests collected'
+
+# Collect (without running) the consume test cases of a freshly filled mini fixture set
+[group('integration tests')]
+consume-collect: (_tmp "consume-collect")
+    #!/usr/bin/env bash
+    # Assert exact collected-test counts for the 16-case DUP1..DUP16 fill:
+    # an empty parametrization (e.g. a missing fixture format) collects a
+    # single placeholder item and exits 0, so counts must be checked.
+    set -euo pipefail
+    fixtures="{{ output_dir }}/consume-collect/fixtures"
+    uv run fill \
+        --fork "{{ latest_fork }}" \
+        --generate-all-formats \
+        --output="$fixtures" \
+        --clean \
+        -q \
+        tests/frontier/opcodes/test_dup.py
+    uv run consume engine --collect-only -q --input "$fixtures" \
+        | tee /dev/stderr | grep -q '^16 tests collected'
+    uv run consume rlp --collect-only -q --input "$fixtures" \
+        | tee /dev/stderr | grep -q '^16 tests collected'
+    uv run consume enginex --collect-only -q --input "$fixtures" \
+        | tee /dev/stderr | grep -q '^16 tests collected'
+    uv run consume direct --collect-only -q --input "$fixtures" \
+        | tee /dev/stderr | grep -q '^32 tests collected'
+
 # Run the spec-tools tests (lint and new-fork tooling)
 [group('integration tests')]
 spec-tools *args: (_tmp "spec-tools")

--- a/Justfile
+++ b/Justfile
@@ -263,9 +263,6 @@ check-eip-versions-collect:
 [group('integration tests')]
 consume-collect: (_tmp "consume-collect")
     #!/usr/bin/env bash
-    # Assert exact collected-test counts for the 16-case DUP1..DUP16 fill:
-    # an empty parametrization (e.g. a missing fixture format) collects a
-    # single placeholder item and exits 0, so counts must be checked.
     set -euo pipefail
     fixtures="{{ output_dir }}/consume-collect/fixtures"
     uv run fill \
@@ -275,14 +272,12 @@ consume-collect: (_tmp "consume-collect")
         --clean \
         -q \
         tests/frontier/opcodes/test_dup.py
-    uv run consume engine --collect-only -q --input "$fixtures" \
-        | tee /dev/stderr | grep -q '^16 tests collected'
-    uv run consume rlp --collect-only -q --input "$fixtures" \
-        | tee /dev/stderr | grep -q '^16 tests collected'
-    uv run consume enginex --collect-only -q --input "$fixtures" \
-        | tee /dev/stderr | grep -q '^16 tests collected'
-    uv run consume direct --collect-only -q --input "$fixtures" \
-        | tee /dev/stderr | grep -q '^32 tests collected'
+    for consume_command in engine rlp enginex direct; do
+        uv run consume "$consume_command" \
+            --collect-only -q \
+            -o empty_parameter_set_mark=fail_at_collect \
+            --input "$fixtures"
+    done
 
 # Run the spec-tools tests (lint and new-fork tooling)
 [group('integration tests')]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/pytest_hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/pytest_hive.py
@@ -43,18 +43,30 @@ from typing import Any, Generator, List
 
 import pytest
 from filelock import FileLock
-from hive.client import ClientRole
+from hive.client import ClientRole, ClientType
 from hive.simulation import Simulation
 from hive.testing import HiveTest, HiveTestResult, HiveTestSuite
 
 from execution_testing.logging import get_logger
 
+from ..shared.helpers import is_help_or_collectonly_mode
 from .hive_info import ClientFile, HiveInfo
 
 logger = get_logger(__name__)
 
 
 def pytest_configure(config: pytest.Config) -> None:  # noqa: D103
+    if is_help_or_collectonly_mode(config):
+        # Collection does not require a live hive simulator; provide a
+        # placeholder client so client-parametrized tests still collect.
+        config.hive_execution_clients = [  # type: ignore[attr-defined]
+            ClientType(
+                name="collect-only",
+                version="",
+                meta={"roles": [ClientRole.ExecutionClient.value]},
+            )
+        ]
+        return
     hive_simulator_url = config.getoption("hive_simulator")
     if hive_simulator_url is None:
         pytest.exit(


### PR DESCRIPTION
### Description

Add cheap collect-only CI guards for our pytest commands. This would have caught the collection crash behind #3438 (fixed in #3450).

- `pytest_hive`: This also allows `--collect-only` with hive simulators w/o actually having to connect to a hive dev backend.
- New `just execute-collect`: collect the full `tests/` tree via both the `execute remote` and `execute hive` plugin stacks (this reproduces the #3438 crash without the fix in #3450). Asserts a collected-count floor so a drastic silent shrink also fails.
- New `just consume-collect`: fill a mini fixture set (`test_dup.py`, 16 cases, all formats), then collect it via `consume engine/rlp/enginex/direct` with exact-count assertions: an empty parametrization (e.g. a missing fixture format) collects a single placeholder item and exits 0, so counts must be checked. Notably, `consume enginex` currently has no CI coverage at all: its `hive-consume.yaml` matrix rows are commented out.
- New `just check-eip-versions-collect`: collect the EIP version checks over the full `tests/` tree with the same collected-count floor. This is the guard for the failure mode fixed in #3461 (verified: it exits non-zero with #3461's parent commit, passes with the fix).
- Run the three recipes as jobs in `test.yaml` on every PR.
- `hive-execute.yaml`: also trigger on changes to the shared plugins and `pytest-execute.ini`, both of which the E2E consumes.

### Related Issues or PRs

Related to #3438; requires #3450 and #3461 (both merged).

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

```
 /\_/\
( o.o )
 > ^ <
```
