### PR TITLE
chore(doc): add EIP-8163 EXTENSION opcode to the EVM lists

### DIFF
--- a/lists/evm/pending-opcodes.md
+++ b/lists/evm/pending-opcodes.md
@@ -11,6 +11,7 @@ next or subsequent hard fork.
 |   0x5C   | TLOAD           | Transient data load                             | [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)                          |
 |   0x5D   | TSTORE          | Transient data store                            | [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)                          |
 |   0x5E   | MCOPY           | Memory copy                                     | [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656)                          |
+|   0xAE   | EXTENSION       | Extension prefix for non-Ethereum-L1 EVM chains | [EIP-8163](https://eips.ethereum.org/EIPS/eip-8163)                          |
 |   0xD0   | DATALOAD        | Loads data from EOF data section, via stack     | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
 |   0xD1   | DATALOADN       | Loads data from EOF data section, via immediate | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
 |   0xD2   | DATASIZE        | Size of the EOF data section                    | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
@@ -222,7 +223,7 @@ scheduled or accepted) are in *italics*.
 | 0xAB   |                  |                         |                  |                                                                                |
 | 0xAC   |                  |                         |                  |                                                                                |
 | 0xAD   |                  |                         |                  |                                                                                |
-| 0xAE   |                  |                         |                  |                                                                                |
+| *0xAE* | *EXTENSION*      | *System*                | *Bogota*         | *[EIP-8163](https://eips.ethereum.org/EIPS/eip-8163)*                          |
 | 0xAF   |                  |                         |                  |                                                                                |
 | 0xB0   |                  |                         |                  |                                                                                |
 | 0xB1   |                  |                         |                  |                                                                                |

--- a/lists/evm/proposed-opcodes.md
+++ b/lists/evm/proposed-opcodes.md
@@ -79,3 +79,4 @@ unshipped EIPs, even withdrawn and non-viable proposals.
 | [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                    | 0xEC   | EOFCREATE          | Create from EOF contained initcode                                           |
 | [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                    | 0xED   | TXCREATE           | Create from transaction contained initcode (removed from EIP-7620)           |
 | [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                    | 0xEE   | RETURNCONTRACT     | Contract to be created, references EOF data                                  |
+| [EIP-8163](https://eips.ethereum.org/EIPS/eip-8163)                    | 0xAE   | EXTENSION          | Extension prefix for non-Ethereum-L1 EVM chains                              |


### PR DESCRIPTION
### Description

Adds `EIP-8163: Reserve `EXTENSION (0xae)` opcode` to pending and proposed opcodes (PFI'd for Bogota).

I'll follow with some spec tests shortly

### Related Issues or PRs

N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/8/81/Rinden-Springspinne_M%C3%A4nnchen.jpg?utm_source=commons.wikimedia.org&utm_campaign=index&utm_content=original)
