### PR TITLE
feat(tests): ECRECOVER that covers R == -G with u1 < u2 and u1 == u2

### DIFF
--- a/tests/frontier/precompiles/test_ecrecover.py
+++ b/tests/frontier/precompiles/test_ecrecover.py
@@ -236,6 +236,42 @@ from execution_testing.vm import Opcodes as Op
             ),
             id="u1_eq_neg_u2_R_eq_neg_G",
         ),
+        # u1 < u2 && R == -G
+        pytest.param(
+            bytes.fromhex(
+                "8641998106234453aa5f9d6a3178f4f7b812e00b817a776265dfdd31b93e29a9"
+            ),
+            bytes.fromhex(
+                "000000000000000000000000000000000000000000000000000000000000001c"
+            ),
+            bytes.fromhex(
+                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            ),
+            bytes.fromhex(
+                "f37cccfdf3b97758ab40c52b9d0e160e0537f9b65b9c51b2b3e502b62df02f30"
+            ),
+            bytes.fromhex(
+                "00000000000000000000000080c0dbf239224071c59dd8970ab9d542e3414ab2"
+            ),
+            id="u1_lt_u2_R_eq_neg_G",
+        ),
+        # u1 == u2 && R == -G, so the recovered point is the point at infinity
+        pytest.param(
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            ),
+            bytes.fromhex(
+                "000000000000000000000000000000000000000000000000000000000000001c"
+            ),
+            bytes.fromhex(
+                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            ),
+            bytes.fromhex(
+                "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"
+            ),
+            b"",
+            id="u1_eq_u2_R_eq_neg_G",
+        ),
         # 13u1 == u2 && R == -13G
         pytest.param(
             bytes.fromhex(


### PR DESCRIPTION
### Description

`R == -G` is the input class where the Shamir/interleaved-MSM precomputation `P + Q` (with `P = G`, `Q = R`) is the point at infinity. Implementations that special-case it reduce `u1*G + u2*R` to `(u1 - u2)*G`, which branches on the ordering of `u1` and `u2`.

Only `u1 > u2` was covered. Add the two neighbouring cases:

- `u1_lt_u2_R_eq_neg_G`: `u1 = 1`, `u2 = 2`, so the difference is negative and the recovered key is `-G`.
- `u1_eq_u2_R_eq_neg_G`: `u1 == u2`, so the recovered point is the point at infinity and the precompile returns empty.

### Related Issues or PRs

Fixes #3458

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
