### PR TITLE
fix(spec-specs): tolerate a missing fork cache at json_loader teardown

### DIFF
--- a/tests/json_loader/conftest.py
+++ b/tests/json_loader/conftest.py
@@ -213,8 +213,11 @@ def pytest_sessionstart(session: Session) -> None:
 def pytest_sessionfinish(session: Session, exitstatus: int) -> None:
     """Clean up the fork cache at session finish."""
     del exitstatus
-    session.stash[fork_cache_key].__exit__()
-    del session.stash[fork_cache_key]
+    # Unless this directory is named on the command line, the file is
+    # registered after session start has fired, so the stash can be empty.
+    if fork_cache_key in session.stash:
+        session.stash[fork_cache_key].__exit__()
+        del session.stash[fork_cache_key]
 
 
 def pytest_collect_file(

--- a/tests/json_loader/test_conftest.py
+++ b/tests/json_loader/test_conftest.py
@@ -1,0 +1,42 @@
+"""Tests for the session teardown hook in this directory's conftest."""
+
+from types import SimpleNamespace
+from typing import cast
+
+from execution_testing.evm_tools.t8n import ForkCache
+from pytest import Session, Stash
+
+from .conftest import pytest_sessionfinish
+from .stash_keys import fork_cache_key
+
+
+class RecordingForkCache:
+    """Fork cache stand-in that records whether it was closed."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __exit__(self, *args: object, **kwargs: object) -> None:
+        """Record the close."""
+        self.closed = True
+
+
+def test_session_finish_closes_the_stored_fork_cache() -> None:
+    """Close the cache the session start hook stored, and drop the key."""
+    cache = RecordingForkCache()
+    stash = Stash()
+    stash[fork_cache_key] = cast(ForkCache, cache)
+
+    pytest_sessionfinish(cast(Session, SimpleNamespace(stash=stash)), 0)
+
+    assert cache.closed
+    assert fork_cache_key not in stash
+
+
+def test_session_finish_tolerates_a_missing_fork_cache() -> None:
+    """Return quietly when the session start hook stored no cache."""
+    stash = Stash()
+
+    pytest_sessionfinish(cast(Session, SimpleNamespace(stash=stash)), 0)
+
+    assert fork_cache_key not in stash


### PR DESCRIPTION
### Description

`tests/json_loader/conftest.py` closes a fork cache in `pytest_sessionfinish` that its own `pytest_sessionstart` may never have created. pytest registers a directory's conftest before session start only when that directory is named on the command line; reached by collection it arrives after, so the start hook here never runs while the finish hook still does.

Any run over `tests/` that does not name `tests/json_loader` hits it. The test passes, the session then dies in teardown, prints no summary and exits 1:

```
$ uv run pytest tests -k test_decode_max_withdrawal_amount
.                                                          [100%]Traceback (most recent call last):
...
KeyError: <_pytest.stash.StashKey object at 0x10de06440>
$ echo $?
1
```

Guarding the read matches the `stash.get(key, None)` reads in `plugins/forks/forks.py` and `plugins/consume/simulators/helpers/test_tracker.py`. The same command then reports `1 passed, 18066 deselected` and exits 0.

`test_conftest.py` covers both directions: reverting the guard fails the empty-stash test with the same `KeyError`, and deleting the teardown body outright fails the other on `assert cache.closed`.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

```
   |\---/|
   | o_o |
    \_^_/
```
