### PR TITLE
fix(test-cli): ignore tests/json_loader and tests/spec_tools during collection

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
@@ -16,3 +16,5 @@ addopts =
     -p execution_testing.cli.pytest_commands.plugins.help.help
     -m eip_version_check
     --tb short
+    --ignore tests/json_loader
+    --ignore tests/spec_tools


### PR DESCRIPTION
### Description

`check_eip_versions` collects `tests/json_loader` and `tests/spec_tools`, whose items carry a `fork` parameter but no spec type format, and then crashes during collection. It is the same failure #3450 fixed for `fill` and `execute`:

```
INTERNALERROR> ValueError: No spec type format found in the test item.
```

`pytest-fill.ini`, `pytest-execute.ini` and `pytest-execute-hive.ini` all ignore both directories. `pytest-check-eip-versions.ini` has never carried an `--ignore` line and also sets `testpaths = tests/`, so it is the one config that still reaches them.

Toggling each ignore and reading the collected count puts 938 items in scope, 630 under `tests/json_loader` and 308 under `tests/spec_tools`. Nothing is lost by skipping them: `is_test_for_an_eip` matches `eip\d{1,4}` against the module path, so neither directory can produce an `EIPSpecTestItem`. With the two ignores, `check_eip_versions --collect-only` goes from an abort to `44384/189010 tests collected`.

On master the same run then dies a second time in the `tests/json_loader` teardown with a `KeyError`, which #3460 guards. The two are independent; this one fixes the command on its own.

### Related Issues or PRs

Follows #3450, which made the same fix for the other three configs.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

```
   ,__,
   (oo)
   (__)
```
