### PR TITLE
refactor(spec-specs): add `OPCODE_SELFBALANCE`, `OPCODE_TLOAD` and `OPCODE_TSTORE`

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -226,6 +226,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[ExecutionGas] = BASE
     OPCODE_RETURNDATASIZE: Final[ExecutionGas] = BASE
     OPCODE_CHAINID: Final[ExecutionGas] = BASE
+    OPCODE_SELFBALANCE: Final[ExecutionGas] = FAST_STEP
     OPCODE_BASEFEE: Final[ExecutionGas] = BASE
     OPCODE_BLOBBASEFEE: Final[ExecutionGas] = BASE
     OPCODE_SLOTNUM: Final[ExecutionGas] = BASE

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -524,7 +524,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/arrow_glacier/vm/gas.py
+++ b/src/ethereum/forks/arrow_glacier/vm/gas.py
@@ -135,6 +135,7 @@ class GasCosts:
     OPCODE_DIFFICULTY: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/environment.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/berlin/vm/gas.py
+++ b/src/ethereum/forks/berlin/vm/gas.py
@@ -136,6 +136,7 @@ class GasCosts:
     OPCODE_DIFFICULTY: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/berlin/vm/instructions/environment.py
+++ b/src/ethereum/forks/berlin/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -160,6 +160,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -167,6 +168,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/bpo1/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/bpo1/vm/instructions/storage.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/storage.py
@@ -147,7 +147,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -174,7 +174,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -160,6 +160,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -167,6 +168,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/bpo2/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/bpo2/vm/instructions/storage.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/storage.py
@@ -144,7 +144,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -171,7 +171,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -160,6 +160,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -167,6 +168,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/bpo3/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/bpo3/vm/instructions/storage.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/storage.py
@@ -144,7 +144,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -171,7 +171,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -160,6 +160,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -167,6 +168,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/bpo4/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/bpo4/vm/instructions/storage.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/storage.py
@@ -147,7 +147,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -174,7 +174,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -160,6 +160,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -167,6 +168,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/bpo5/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/bpo5/vm/instructions/storage.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/storage.py
@@ -147,7 +147,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -174,7 +174,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/cancun/vm/gas.py
+++ b/src/ethereum/forks/cancun/vm/gas.py
@@ -145,6 +145,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -152,6 +153,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/cancun/vm/instructions/environment.py
+++ b/src/ethereum/forks/cancun/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/cancun/vm/instructions/storage.py
+++ b/src/ethereum/forks/cancun/vm/instructions/storage.py
@@ -147,7 +147,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -174,7 +174,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/gray_glacier/vm/gas.py
+++ b/src/ethereum/forks/gray_glacier/vm/gas.py
@@ -135,6 +135,7 @@ class GasCosts:
     OPCODE_DIFFICULTY: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/gray_glacier/vm/instructions/environment.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/istanbul/vm/gas.py
+++ b/src/ethereum/forks/istanbul/vm/gas.py
@@ -133,6 +133,7 @@ class GasCosts:
     OPCODE_DIFFICULTY: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/environment.py
@@ -495,7 +495,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/london/vm/gas.py
+++ b/src/ethereum/forks/london/vm/gas.py
@@ -135,6 +135,7 @@ class GasCosts:
     OPCODE_DIFFICULTY: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/london/vm/instructions/environment.py
+++ b/src/ethereum/forks/london/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/muir_glacier/vm/gas.py
+++ b/src/ethereum/forks/muir_glacier/vm/gas.py
@@ -133,6 +133,7 @@ class GasCosts:
     OPCODE_DIFFICULTY: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/environment.py
@@ -495,7 +495,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -160,6 +160,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -167,6 +168,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/osaka/vm/instructions/environment.py
+++ b/src/ethereum/forks/osaka/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/osaka/vm/instructions/storage.py
+++ b/src/ethereum/forks/osaka/vm/instructions/storage.py
@@ -142,7 +142,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -169,7 +169,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/paris/vm/gas.py
+++ b/src/ethereum/forks/paris/vm/gas.py
@@ -135,6 +135,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_DUP: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/paris/vm/instructions/environment.py
+++ b/src/ethereum/forks/paris/vm/instructions/environment.py
@@ -513,7 +513,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -155,6 +155,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_BLOBBASEFEE: Final[Uint] = BASE
     OPCODE_BLOBHASH: Final[Uint] = Uint(3)
@@ -162,6 +163,8 @@ class GasCosts:
     OPCODE_PUSH0: Final[Uint] = BASE
     OPCODE_DUP: Final[Uint] = VERY_LOW
     OPCODE_SWAP: Final[Uint] = VERY_LOW
+    OPCODE_TLOAD: Final[Uint] = WARM_ACCESS
+    OPCODE_TSTORE: Final[Uint] = WARM_ACCESS
 
     # Dynamic Opcodes
     OPCODE_RETURNDATACOPY_BASE: Final[Uint] = VERY_LOW

--- a/src/ethereum/forks/prague/vm/instructions/environment.py
+++ b/src/ethereum/forks/prague/vm/instructions/environment.py
@@ -515,7 +515,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.

--- a/src/ethereum/forks/prague/vm/instructions/storage.py
+++ b/src/ethereum/forks/prague/vm/instructions/storage.py
@@ -147,7 +147,7 @@ def tload(evm: Evm) -> None:
     key = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TLOAD)
 
     # OPERATION
     value = get_transient_storage(
@@ -174,7 +174,7 @@ def tstore(evm: Evm) -> None:
     new_value = pop(evm.stack)
 
     # GAS
-    charge_gas(evm, GasCosts.WARM_ACCESS)
+    charge_gas(evm, GasCosts.OPCODE_TSTORE)
     if evm.message.is_static:
         raise WriteInStaticContext
     set_transient_storage(

--- a/src/ethereum/forks/shanghai/vm/gas.py
+++ b/src/ethereum/forks/shanghai/vm/gas.py
@@ -136,6 +136,7 @@ class GasCosts:
     OPCODE_PREVRANDAO: Final[Uint] = BASE
     OPCODE_RETURNDATASIZE: Final[Uint] = BASE
     OPCODE_CHAINID: Final[Uint] = BASE
+    OPCODE_SELFBALANCE: Final[Uint] = FAST_STEP
     OPCODE_BASEFEE: Final[Uint] = BASE
     OPCODE_PUSH: Final[Uint] = VERY_LOW
     OPCODE_PUSH0: Final[Uint] = BASE

--- a/src/ethereum/forks/shanghai/vm/instructions/environment.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/environment.py
@@ -513,7 +513,7 @@ def self_balance(evm: Evm) -> None:
     pass
 
     # GAS
-    charge_gas(evm, GasCosts.FAST_STEP)
+    charge_gas(evm, GasCosts.OPCODE_SELFBALANCE)
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.


### PR DESCRIPTION
### Description

Every opcode in `GasCosts` has its own `OPCODE_*` alias for whatever constant it charges. `OPCODE_ADD = VERY_LOW`, `OPCODE_POP = BASE` and so on. SELFBALANCE, TLOAD and TSTORE were the three exceptions. This adds the missing aliases and points the handlers at them.

**SELFBALANCE** charged `GasCosts.FAST_STEP` directly in every fork that has the opcode. That is Istanbul onwards, so 17 forks.

I put the new constant straight after `OPCODE_CHAINID`. CHAINID is 0x46 and SELFBALANCE is 0x47 so that keeps opcode order, and it groups the two opcodes Istanbul added. The same slot is free in all 17 forks so `PatchHygiene` sees no reordering.

Worth noting that `FAST_STEP` is used in exactly one place in the whole tree and that place is `self_balance`. It is also only defined from Istanbul on, so it arrived with the opcode. It is `GasFastStep` from EIP-1884.

**TLOAD and TSTORE** already have constants in `amsterdam`. Cancun through bpo5 did not, and still charged `GasCosts.WARM_ACCESS` directly. This adds them to those eight forks.

I used the alias form the issue proposes rather than copying the amsterdam literals, and I left amsterdam alone. The reason is that the amsterdam literals came in with EIP-8038, which reprices state access. Transient storage is not persistent state, so pinning TLOAD and TSTORE to a literal there stops them moving with that repricing. Cancun through bpo5 have no EIP-8038, and EIP-1153 defines both opcodes as costing a warm storage read, so `WARM_ACCESS` is the honest thing to alias in those forks. Happy to switch them to literals if you would rather have one form everywhere.

Applying all of this to every fork is what #2396 did when it added the opcode gas constants in the first place.

Istanbul and Muir Glacier had to move together. `GlacierForksHygiene` only lets a Glacier fork differ from the one before it in the difficulty block.

Gas does not change anywhere. SELFBALANCE stays at 5. TLOAD and TSTORE stay at 100.

### What I ran

- `just lint-spec` clean
- `just spec-tools` 22 passed
- `just fill` across the CI matrix. Frontier to Paris 18620 passed. Shanghai to Cancun 14631. Prague 14420. Osaka 15220. Amsterdam 19987. Nothing failed.
- `just fill tests/ported_static/stSelfBalance/` 28 passed, including `test_self_balance_gas_cost`
- ruff lint and format, vulture, codespell and mypy over `src/ethereum/forks/` all clean
- Checked every fork to confirm each handler charges its new constant and that the values still come out as 5 and 100

### Related Issues or PRs

Fixes #2911.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
