### PR TITLE
refactor(client-clis): map geth empty system contract rejection to `SYSTEM_CONTRACT_EMPTY`

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -108,6 +108,7 @@ class GethExceptionMapper(ExceptionMapper):
             "invalid number of versionedHashes"
         ),
         BlockException.INVALID_REQUESTS: "invalid requests hash",
+        BlockException.SYSTEM_CONTRACT_EMPTY: "empty system contract",
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             "system call failed to execute:"
         ),


### PR DESCRIPTION
### Description

Adds the missing `BlockException.SYSTEM_CONTRACT_EMPTY` entry to `GethExceptionMapper`.

Since ethereum/go-ethereum#35514 geth rejects a block whose request system call targets a codeless contract with

```
failed to process builder deposit queue: empty system contract: no code at 0x0000bFF46984e3725691FA540a8C7589300D8282
```

(same wording for the builder exit, withdrawal and consolidation queues). The mapper had no entry for it, so under strict exception matching the four `test_builder_{deposit,exit}_contract_deployment[...deploy_after_fork-*]` cases fail for geth on hive with

```
Undefined exception message: expected exception: "BlockException.SYSTEM_CONTRACT_EMPTY", returned exception: "failed to process builder deposit queue: empty system contract: no code at 0x0000bFF4…" (mapper: "GethExceptionMapper")
```

see e.g. https://hive.ethpandaops.io/#/test/glamsterdam-quick/1787871380-41935bc78ffdbd1459c0d93df12c7ece. Every other client mapper already carries an equivalent entry; nimbus only passes because hive runs it with `--disable-strict-exception-matching`.

Verified locally that `GethExceptionMapper().message_to_exception(...)` now yields `[SYSTEM_CONTRACT_EMPTY]` for the deposit, exit and withdrawal queue messages.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static` (ruff check + format on the changed file)
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![cat](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/640px-Cat_November_2010-1a.jpg)

https://claude.ai/code/session_015PPcN9JS3yMPYWCYqusrEm
