### PR TITLE
fix(client-clis): map frame transaction rejections in the Nethermind mapper

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -422,8 +422,91 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.INVALID_CHAINID: (
             r"InvalidTxChainId|Signature is invalid."
         ),
+        # `Transaction \d+ is not valid: <cause>` is the wrapper the client
+        # puts around any payload transaction that fails to RLP-decode, so
+        # this entry alone cannot tell one decode failure from another. It is
+        # kept broad because the mapper is additive: a fixture passes when its
+        # expected exception is among those matched, and the entries below
+        # supply the discriminating labels for the causes that have one.
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: (
             r"Transaction \d+ is not valid"
+        ),
+        # Frame transaction static constraints: frame count, mode, flags,
+        # value placement, atomic batch, expiry verifier, signature entry
+        # structure, nonce and blob fields.
+        TransactionException.TYPE_6_INVALID_FRAME_FORMAT: (
+            r"frame transaction must contain between 1 and 64 frames"
+            r"|frame transaction sender must be set"
+            r"|frame mode must be DEFAULT, VERIFY, SENDER, or POST_TX"
+            r"|POST_TX frames must form a trailing suffix of the frame list"
+            r"|POST_TX frames are not enabled"
+            r"|frame flags must not use reserved bits"
+            r"|frame value is only allowed in SENDER mode"
+            r"|frames allowed to approve execution must target the sender"
+            r"|the last frame must not have the atomic batch flag set"
+            r"|the atomic batch flag must not be set on a VERIFY frame"
+            r"|the atomic batch flag must not be set on a POST_TX frame"
+            r"|an atomic batch frame must not be followed by a VERIFY frame"
+            r"|an atomic batch frame must not be followed by a POST_TX frame"
+            r"|frames belonging to an atomic batch must not carry approval"
+            r" scope"
+            r"|total frame gas must not exceed 2\^64 - 1"
+            r"|expiry verifier frame must have zero flags, zero value, and"
+            r" 8-byte data"
+            r"|at most one expiry verifier frame is allowed"
+            r"|unknown signature scheme"
+            r"|ARBITRARY signatures must not name a signer"
+            r"|signature msg must be empty or a 32-byte digest"
+            r"|explicit signature msg must not be the zero digest"
+            r"|max fee per blob gas must be 0 when there are no blob hashes"
+            r"|keyed nonces are not enabled"
+            r"|legacy nonce is not allowed"
+            r"|malformed nonce key set"
+            r"|at most 16 recent root references are allowed"
+            r"|frame transaction SECP256K1 signer does not match the"
+            r" recovered address"
+            r"|frame transaction P256 signer does not match the public key"
+            # Decode-time rejections of a frame field too wide or too long
+            # for its type, which the fixtures also file as format failures.
+            # Generic decoder wordings carrying no frame context, so they
+            # widen the label rather than pinpoint it.
+            r"|Expected a sequence prefix to be in the range of <192, 255>"
+            r"|Unexpected length of integer value"
+            r"|Unexpected RLP prefix"
+            r"|Collection count"
+            r"|An RLP limit exceeded"
+        ),
+        # Signature entries that fail protocol validation. Disjoint from the
+        # format set above, which files a signer not matching the recovered
+        # key as a format failure rather than a signature failure.
+        TransactionException.TYPE_6_INVALID_SIGNATURE: (
+            r"frame transaction has an invalid signature"
+            r"|frame transaction signature has the wrong length"
+            r"|frame transaction signature must use a 0/1 recovery id and a"
+            r" canonical low s value"
+            r"|frame transaction P256 signature must be canonical with a low"
+            r" s value"
+            r"|frame transaction P256 signatures require the secp256r1"
+            r" precompile"
+        ),
+        # A well-formed, correctly signed transaction that frame execution
+        # then invalidates. Never a bare "frame": that would also catch the
+        # format and signature wordings above.
+        TransactionException.TYPE_6_INVALID_FRAME_EXECUTION: (
+            r"VERIFY frame reverted"
+            r"|validation prefix frame reverted"
+            r"|SENDER frame before execution approval"
+            r"|never set a payer"
+        ),
+        # A fee field wider than 32 bytes trips the decoder length guard,
+        # which names neither the field nor the transaction type, so both fee
+        # labels take the same pattern. The second wording is the same guard
+        # with the client trace logging enabled.
+        TransactionException.GASPRICE_OVERFLOW: (
+            r"Collection count|An RLP limit exceeded"
+        ),
+        TransactionException.PRIORITY_OVERFLOW: (
+            r"Collection count|An RLP limit exceeded"
         ),
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"BlockBlobGasExceeded: A block cannot have more than "
@@ -433,8 +516,17 @@ class NethermindExceptionMapper(ExceptionMapper):
             r"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ "
             r"exceeded MaxBlobGas per transaction=\d+"
         ),
+        # A frame transaction reports the per-transaction gas cap against its
+        # own reservation rather than through the shared prefix.
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
-            r"TxGasLimitCapExceeded:"
+            r"TxGasLimitCapExceeded:|exceeds the transaction gas cap of"
+        ),
+        # Reached only when gas limit * price (+ value) overflows, never on a
+        # plain balance shortfall. The client composes this onto its
+        # insufficient-funds wording, so both labels match and the fixture
+        # picks the one it named.
+        TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW: (
+            r"required balance exceeds 256 bits"
         ),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (
             r"HeaderExcessBlobGasMismatch: Excess blob gas in header "

--- a/packages/testing/src/execution_testing/client_clis/tests/test_nethermind_exception_mapper.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_nethermind_exception_mapper.py
@@ -1,0 +1,133 @@
+"""Tests for the frame transaction entries in NethermindExceptionMapper."""
+
+from typing import List, Set, Tuple
+
+import pytest
+
+from execution_testing.client_clis.clis.nethermind import (
+    NethermindExceptionMapper,
+)
+from execution_testing.exceptions import (
+    ExceptionBase,
+    TransactionException,
+    UndefinedException,
+)
+
+FORMAT = TransactionException.TYPE_6_INVALID_FRAME_FORMAT
+SIGNATURE = TransactionException.TYPE_6_INVALID_SIGNATURE
+EXECUTION = TransactionException.TYPE_6_INVALID_FRAME_EXECUTION
+TYPE_6 = {FORMAT, SIGNATURE, EXECUTION}
+
+# One client wording per rule, verbatim from the client's own rejection
+# message constants.
+FRAME_MESSAGES: List[Tuple[str, TransactionException]] = [
+    ("frame transaction must contain between 1 and 64 frames", FORMAT),
+    ("frame transaction sender must be set", FORMAT),
+    ("frame mode must be DEFAULT, VERIFY, SENDER, or POST_TX", FORMAT),
+    ("POST_TX frames must form a trailing suffix of the frame list", FORMAT),
+    ("POST_TX frames are not enabled", FORMAT),
+    ("frame flags must not use reserved bits", FORMAT),
+    ("frame value is only allowed in SENDER mode", FORMAT),
+    ("frames allowed to approve execution must target the sender", FORMAT),
+    ("the last frame must not have the atomic batch flag set", FORMAT),
+    ("the atomic batch flag must not be set on a VERIFY frame", FORMAT),
+    ("the atomic batch flag must not be set on a POST_TX frame", FORMAT),
+    ("an atomic batch frame must not be followed by a VERIFY frame", FORMAT),
+    ("an atomic batch frame must not be followed by a POST_TX frame", FORMAT),
+    (
+        "frames belonging to an atomic batch must not carry approval scope",
+        FORMAT,
+    ),
+    ("total frame gas must not exceed 2^64 - 1", FORMAT),
+    (
+        "expiry verifier frame must have zero flags, zero value, and 8-byte "
+        "data",
+        FORMAT,
+    ),
+    ("at most one expiry verifier frame is allowed", FORMAT),
+    ("unknown signature scheme", FORMAT),
+    ("ARBITRARY signatures must not name a signer", FORMAT),
+    ("signature msg must be empty or a 32-byte digest", FORMAT),
+    (
+        "frame transaction signature msg must be empty or a 32-byte digest",
+        FORMAT,
+    ),
+    ("explicit signature msg must not be the zero digest", FORMAT),
+    ("max fee per blob gas must be 0 when there are no blob hashes", FORMAT),
+    ("keyed nonces are not enabled", FORMAT),
+    ("legacy nonce is not allowed", FORMAT),
+    ("malformed nonce key set", FORMAT),
+    ("at most 16 recent root references are allowed", FORMAT),
+    (
+        "frame transaction SECP256K1 signer does not match the recovered "
+        "address",
+        FORMAT,
+    ),
+    ("frame transaction P256 signer does not match the public key", FORMAT),
+    ("frame transaction has an invalid signature", SIGNATURE),
+    ("frame transaction signature has the wrong length", SIGNATURE),
+    (
+        "frame transaction signature must use a 0/1 recovery id and a "
+        "canonical low s value",
+        SIGNATURE,
+    ),
+    (
+        "frame transaction P256 signature must be canonical with a low s "
+        "value",
+        SIGNATURE,
+    ),
+    (
+        "frame transaction P256 signatures require the secp256r1 precompile",
+        SIGNATURE,
+    ),
+    ("VERIFY frame reverted", EXECUTION),
+    ("validation prefix frame reverted", EXECUTION),
+    ("SENDER frame before execution approval", EXECUTION),
+    ("frame transaction never set a payer", EXECUTION),
+    ("frame transaction validation prefix never set a payer", EXECUTION),
+]
+
+
+def matched(message: str) -> Set[ExceptionBase]:
+    """Return the exceptions the mapper reports for a client message."""
+    exceptions = NethermindExceptionMapper().message_to_exception(message)
+    assert not isinstance(exceptions, UndefinedException), message
+    return set(exceptions)
+
+
+@pytest.mark.parametrize(
+    "message, expected", FRAME_MESSAGES, ids=[m for m, _ in FRAME_MESSAGES]
+)
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_frame_message_maps_to_exactly_one_type_6_exception(
+    message: str, expected: TransactionException, wrapped: bool
+) -> None:
+    """
+    Each client wording maps to its own label and to neither of the other two.
+
+    A fixture naming one label has to fail when the client rejected for
+    another, so the format, signature and execution sets must stay pairwise
+    disjoint under the mapper's substring and regex matching. `wrapped` covers
+    the `Transaction <n> is not valid: <cause>` form the client uses for
+    payload transactions.
+    """
+    if wrapped:
+        message = f"Transaction 0 is not valid: {message}"
+    exceptions = matched(message)
+    assert expected in exceptions
+    assert exceptions & TYPE_6 == {expected}
+
+
+@pytest.mark.parametrize(
+    "substring",
+    sorted(
+        value
+        for exception, value in (
+            NethermindExceptionMapper.mapping_substring.items()
+        )
+        if exception not in TYPE_6
+    ),
+)
+def test_no_type_6_label_on_unrelated_messages(substring: str) -> None:
+    """No frame label leaks onto a message belonging to another exception."""
+    assert not matched(substring) & TYPE_6


### PR DESCRIPTION
## What

`NethermindExceptionMapper` gains the `TYPE_6_*` frame transaction entries, plus four other wordings that were unmapped or mislabelled.

## Why

In the hive `frames` group's last completed Nethermind run (2026-08-23, `eels/consume-engine`, filter `.*fork_Bogota.*`) the client scored **24872/24944**. Of the 72 failures, **59 are this file**: 47 named a `TYPE_6_*` exception with no entry, 9 resolved to `TYPE_3_TX_WITH_FULL_BLOBS` instead of the expected label, 2 were an unmapped `GAS_LIMIT_EXCEEDS_MAXIMUM`, and 1 resolved to `INSUFFICIENT_ACCOUNT_FUNDS` where `GASLIMIT_PRICE_PRODUCT_OVERFLOW` was expected.

The 9 show what the missing entries cost:

```
got:      "[TransactionException.TYPE_3_TX_WITH_FULL_BLOBS] Transaction 0 is not valid:
           Expected a sequence prefix to be in the range of <192, 255> and got 147"
expected: "TransactionException.TYPE_6_INVALID_FRAME_FORMAT"
```

That is not a type-3 transaction and carries no blobs. `Transaction <n> is not valid: <cause>` is the wrapper the client puts around *any* payload transaction that fails to RLP-decode, and the existing pattern `r"Transaction \d+ is not valid"` matches the wrapper while discarding the `<cause>` that identifies the failure — so every decode failure came back labelled type-3.

## What this changes

Three frame entries, grouped to match the exceptions' own docstrings: `TYPE_6_INVALID_FRAME_FORMAT` (the static frame constraints, plus decode-time rejections of a field too wide or long for its type), `TYPE_6_INVALID_SIGNATURE` (a signature entry failing protocol validation), and `TYPE_6_INVALID_FRAME_EXECUTION` (a well-formed, signed transaction that frame execution then invalidates).

Three more the catch-all was swallowing: `GASPRICE_OVERFLOW` / `PRIORITY_OVERFLOW` (a fee field wider than 32 bytes trips the decoder's length guard, which names neither field nor type, so both take the same pattern), `GAS_LIMIT_EXCEEDS_MAXIMUM` (a frame transaction reports the cap against its own reservation, needing a second wording), and `GASLIMIT_PRICE_PRODUCT_OVERFLOW` (composed onto the insufficient-funds wording, which is why it resolved only to `INSUFFICIENT_ACCOUNT_FUNDS`).

Every fragment is taken from the client's own rejection-message constants rather than from log samples, so it cannot drift against the wording.

## Why this is safe

`ExceptionMapper.message_to_exception` returns a **list**, and `ExceptionWithMessage.__contains__` passes a fixture when its expected exception is among those matched. The mapping is additive: an entry can only widen what a message resolves to, never remove a label a passing fixture depends on.

## Verification

`test_nethermind_exception_mapper.py` locks the invariant that matters: the three frame labels must stay pairwise disjoint under substring and regex matching, so a fixture naming one fails when the client rejected for another. In particular never a bare `"frame"`, which would catch `"validation prefix frame reverted"`. Over 39 wordings, in both bare and wrapped forms, it asserts each maps to its own label and neither of the other two, and that no frame label leaks onto the mapper's other 36 messages. 114 assertions pass here; 78 fail against the branch point. `just static` is clean.

The decode fragments sit outside the invariant deliberately: they are generic decoder wordings with no frame context, so they also match unrelated decode failures. Given additive matching that only widens `TYPE_6_INVALID_FRAME_FORMAT`; narrowing them needs frame context in the decoder's messages, which is a client-side change.

## Left for maintainers: the catch-all itself

This does **not** narrow `TYPE_3_TX_WITH_FULL_BLOBS`. Its docstring describes one specific decode failure, but the pattern matches the wrapper around all of them, so a fixture expecting it passes even when the client rejected for an unrelated reason — a false green. Narrowing it **can** turn currently-green fixtures red, and I have not enumerated the full set it legitimately matches, so I left it alone and documented what it does. Happy to follow up if you would like it tightened.

## Notes

- Targets `devnets/frames/0` rather than `forks/amsterdam`, since the `TYPE_6_*` members exist only there. The mapper file is byte-identical on both branches, so this forward-ports cleanly.
- No fixtures are refilled and no spec behaviour changes; this is message mapping only.
- Of the run's remaining 13 failures, 12 were client-side and are fixed; 1 is unrelated to this file.
