### PR TITLE
fix(test-forks): report tests dropped by validity markers and by generation

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -49,6 +49,8 @@ logger = get_logger(__name__)
 # Session-scoped cache for the lazily-computed unsupported-fork set
 # (see `get_unsupported_forks`).
 unsupported_forks_key: StashKey[FrozenSet[Fork | TransitionFork]] = StashKey()
+# Tests generation never parametrized, node id -> why.
+unparametrized_key: StashKey[Dict[str, str]] = StashKey()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -1268,6 +1270,12 @@ def fork_markers(
     ]
 
 
+def _record_unparametrized(metafunc: Metafunc, reason: str) -> None:
+    """Note a test that generation is about to drop without parametrizing."""
+    stash = metafunc.config.stash.setdefault(unparametrized_key, {})
+    stash[metafunc.definition.nodeid] = reason
+
+
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Pytest hook used to dynamically generate test cases."""
     test_name = metafunc.function.__name__
@@ -1293,6 +1301,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
     pytest_params: List[Any]
     if not test_fork_set:
+        _record_unparametrized(
+            metafunc, "its markers enable it for no fork at all"
+        )
         if metafunc.config.getoption("verbose") >= 2:
             pytest_params = [
                 pytest.param(
@@ -1321,6 +1332,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     intersection_set -= get_unsupported_forks(metafunc.config)
 
     if not intersection_set:
+        _record_unparametrized(
+            metafunc, "no selected fork is in its validity range"
+        )
         if metafunc.config.getoption("verbose") >= 2:
             pytest_params = [
                 pytest.param(
@@ -1722,3 +1736,13 @@ def pytest_collection_modifyitems(
             if config.option.verbose >= 2:
                 for item in validity_deselected:
                     writer.line(f"    {item.nodeid}")
+
+    # These never became items, so no deselection hook can carry them.
+    unparametrized = config.stash.get(unparametrized_key, {})
+    if unparametrized and config.option.verbose >= 0:
+        writer = config.get_terminal_writer()
+        writer.line("")
+        writer.sep("-", f"{len(unparametrized)} not parametrized for any fork")
+        if config.option.verbose >= 2:
+            for nodeid, reason in sorted(unparametrized.items()):
+                writer.line(f"  {nodeid}: {reason}")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -1619,6 +1619,9 @@ def pytest_collection_modifyitems(
     deselected: List[pytest.Item] = []
     # function name -> (reason, total, deselected_count)
     filter_stats: Dict[str, Tuple[str, int, int]] = {}
+    validity_deselected: List[pytest.Item] = []
+    # function name -> deselected_count
+    validity_stats: Dict[str, int] = {}
 
     for i, item in enumerate(items):
         params = _get_item_params(item)
@@ -1666,6 +1669,9 @@ def pytest_collection_modifyitems(
 
         if fork not in valid_fork_set:
             items_to_remove.append(i)
+            validity_deselected.append(item)
+            fn_name = item.nodeid.split("[")[0]
+            validity_stats[fn_name] = validity_stats.get(fn_name, 0) + 1
 
     # Fail if a filter_combinations predicate eliminated every case
     # for a test function — the predicate is almost certainly wrong.
@@ -1697,4 +1703,22 @@ def pytest_collection_modifyitems(
                     writer.line(f"  {fn_name}: {dc} deselected ({reason})")
             if config.option.verbose >= 2:
                 for item in deselected:
+                    writer.line(f"    {item.nodeid}")
+
+    if validity_deselected:
+        config.hook.pytest_deselected(items=validity_deselected)
+        if config.option.verbose >= 0:
+            # Fork-less items skip the check, so the tally cannot say "all".
+            surviving = {item.nodeid.split("[")[0] for item in items}
+            writer = config.get_terminal_writer()
+            writer.line("")
+            writer.sep(
+                "-",
+                f"{len(validity_deselected)} deselected by validity markers",
+            )
+            for fn_name, dc in sorted(validity_stats.items()):
+                gone = "" if fn_name in surviving else " (no cases left)"
+                writer.line(f"  {fn_name}: {dc} deselected{gone}")
+            if config.option.verbose >= 2:
+                for item in validity_deselected:
                     writer.line(f"    {item.nodeid}")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -346,6 +346,32 @@ def test_param_level_valid_from(state_test, value):
 """
 
 
+def generate_param_level_all_excluded_test() -> str:
+    """Generate a test whose every param names a later fork."""
+    return """
+import pytest
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(
+            True,
+            id="from_paris",
+            marks=pytest.mark.valid_from("Paris"),
+        ),
+        pytest.param(
+            False,
+            id="from_shanghai",
+            marks=pytest.mark.valid_from("Shanghai"),
+        ),
+    ],
+)
+@pytest.mark.state_test_only
+def test_all_params_excluded(state_test, value):
+    pass
+"""
+
+
 def generate_param_level_valid_until_test() -> str:
     """Generate a test function with param-level valid_until markers."""
     return """
@@ -539,3 +565,64 @@ def test_param_level_validity_markers(
         *pytest_args,
     )
     result.assert_outcomes(**outcomes)
+
+
+def test_param_level_deselections_are_reported(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Params dropped by their own validity markers are counted and named.
+
+    `filter_combinations` reports every case it drops; the param-level
+    validity path removed items from the collection without handing them to
+    `pytest_deselected`, so they appeared in no count and no summary.
+    """
+    pytester.makepyfile(generate_param_level_marker_test())
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--from=Berlin",
+        "--until=Paris",
+    )
+
+    # from_tangerine is valid at Berlin, London and Paris; from_paris only at
+    # Paris. Four of the six parametrizations survive.
+    result.assert_outcomes(passed=4, deselected=2)
+    result.stdout.fnmatch_lines(
+        [
+            "*2 deselected by validity markers*",
+            "*test_param_level_valid_from: 2 deselected",
+        ]
+    )
+
+
+def test_param_level_deselection_of_every_case_is_named(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    A test left with no case at all says so, rather than just vanishing.
+
+    Unlike `filter_combinations`, this is not an error: a narrow fork range
+    legitimately excludes every param of a test written for later forks. It
+    is reported because it is otherwise indistinguishable from a typo in a
+    marker.
+    """
+    pytester.makepyfile(generate_param_level_all_excluded_test())
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--from=Berlin",
+        "--until=London",
+    )
+
+    # Berlin and London precede both markers, so all four cases go.
+    result.assert_outcomes(passed=0, deselected=4)
+    result.stdout.fnmatch_lines(
+        ["*test_all_params_excluded: 4 deselected (no cases left)"]
+    )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -570,13 +570,7 @@ def test_param_level_validity_markers(
 def test_param_level_deselections_are_reported(
     pytester: pytest.Pytester,
 ) -> None:
-    """
-    Params dropped by their own validity markers are counted and named.
-
-    `filter_combinations` reports every case it drops; the param-level
-    validity path removed items from the collection without handing them to
-    `pytest_deselected`, so they appeared in no count and no summary.
-    """
+    """Params dropped by their validity markers are counted and named."""
     pytester.makepyfile(generate_param_level_marker_test())
     pytester.copy_example(
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
@@ -588,8 +582,7 @@ def test_param_level_deselections_are_reported(
         "--until=Paris",
     )
 
-    # from_tangerine is valid at Berlin, London and Paris; from_paris only at
-    # Paris. Four of the six parametrizations survive.
+    # from_tangerine covers Berlin, London and Paris; from_paris only Paris.
     result.assert_outcomes(passed=4, deselected=2)
     result.stdout.fnmatch_lines(
         [
@@ -602,14 +595,7 @@ def test_param_level_deselections_are_reported(
 def test_param_level_deselection_of_every_case_is_named(
     pytester: pytest.Pytester,
 ) -> None:
-    """
-    A test left with no case at all says so, rather than just vanishing.
-
-    Unlike `filter_combinations`, this is not an error: a narrow fork range
-    legitimately excludes every param of a test written for later forks. It
-    is reported because it is otherwise indistinguishable from a typo in a
-    marker.
-    """
+    """A test left with no case at all is marked, not silently absent."""
     pytester.makepyfile(generate_param_level_all_excluded_test())
     pytester.copy_example(
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
@@ -625,4 +611,26 @@ def test_param_level_deselection_of_every_case_is_named(
     result.assert_outcomes(passed=0, deselected=4)
     result.stdout.fnmatch_lines(
         ["*test_all_params_excluded: 4 deselected (no cases left)"]
+    )
+
+
+def test_unparametrized_tests_are_counted(
+    pytester: pytest.Pytester,
+) -> None:
+    """A test generation never parametrizes is counted, and named at -vv."""
+    pytester.makepyfile(generate_test(valid_from='"Prague"'))
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    args = ["-c", "pytest-fill.ini", "--from=Berlin", "--until=London"]
+
+    result = pytester.runpytest(*args)
+    result.assert_outcomes(passed=0)
+    result.stdout.fnmatch_lines(["*1 not parametrized for any fork*"])
+    result.stdout.no_fnmatch_line("*validity range*")
+
+    # --clean because the first run already wrote the output directory.
+    verbose = pytester.runpytest(*args, "-vv", "--clean")
+    verbose.stdout.fnmatch_lines(
+        ["*test_case: no selected fork is in its validity range"]
     )


### PR DESCRIPTION
### Description

A filter reports what it deselects and a validity marker does not, so two ways of dropping a test look different in the same run. `pytest_collection_modifyitems` builds `filter_stats` and prints a line per function for `--fill-until` and friends, while a param dropped because its fork is outside the marker's validity range leaves nothing behind.

Generation has the same gap one step earlier. When `test_fork_set` or the intersection with the selected forks comes out empty, `pytest_generate_tests` drops the test without parametrizing it at all, so it never reaches collection and no count anywhere accounts for it. Only `-vv` shows it, as a skip.

Two commits, one for each gap. One records validity-marker deselections beside the existing filter stats. Its pair stashes the node id and the reason whenever generation is about to drop a test unparametrized, then reports the total, so a run says how many tests it never generated rather than silently omitting them.

Three tests cover it: a param-level deselection where every case of a function goes, an unparametrized count, and that reporting line itself. Reverting `forks.py` alone fails all three.

### Related Issues or PRs

Follows #3461, which fixed the config that could not collect these directories at all.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

```
   ,__,
   (oo)
   (__)
```
