### PR TITLE
fix(consume): require null inclusionListSatisfied on non-VALID payloads

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -160,23 +160,34 @@ def test_blockchain_via_engine(
                                 f"unexpected status: want {expected_validity},"
                                 f" got {payload_response.status}"
                             )
-                        if payload.inclusion_list_satisfied is not None:
-                            if (
-                                payload_response.inclusion_list_satisfied
-                                is None
-                            ):
+                        response_ils = (
+                            payload_response.inclusion_list_satisfied
+                        )
+                        if not payload.valid():
+                            # `PayloadStatusV2` requires a null
+                            # `inclusionListSatisfied` unless the payload
+                            # is deemed VALID, and no earlier payload
+                            # status carries the field at all.
+                            if response_ils is not None:
+                                raise LoggedError(
+                                    "expected null "
+                                    "`inclusionListSatisfied` on a payload "
+                                    f"not deemed VALID, got {response_ils}"
+                                )
+                        elif payload.inclusion_list_satisfied is not None:
+                            if response_ils is None:
                                 raise LoggedError(
                                     "expected `inclusion_list_satisfied` in "
                                     "response."
                                 )
                             if (
                                 payload.inclusion_list_satisfied
-                                != payload_response.inclusion_list_satisfied
+                                != response_ils
                             ):
                                 raise LoggedError(
                                     f"unexpected inclusion list satisfied: "
                                     f"want {payload.inclusion_list_satisfied},"
-                                    f" got {payload_response.inclusion_list_satisfied}"  # noqa: E501
+                                    f" got {response_ils}"
                                 )
                         if payload.error_code is not None:
                             raise LoggedError(


### PR DESCRIPTION
### Description

The engine simulator on `devnets/focil/0` requires a non-null `inclusionListSatisfied` in the `engine_newPayloadV6` response whenever the fixture stamps the field, regardless of the expected payload status. `bogota.md` requires the field to be `null` for any payload not deemed `VALID`. JSON `null` and an absent key both deserialize to `None`, so no spec-compliant client can pass the check.

`tests-focil-devnet@v0.2.0` stamps the field on 5,489 of its 26,689 expected-INVALID engine fixtures (4,588 `blockchain_test_engine`, 901 `blockchain_test_engine_from_state_test`). All four clients on the Hive focil board fail these with `expected inclusion_list_satisfied in response`.

This ports the guard from #3410 verbatim: a payload not deemed `VALID` must report `null`; only `VALID` payloads have the fixture's verdict enforced. The simulator builds from this branch, so merging fixes these failures on the next run without a refill or release.

### Related Issues or PRs

Fixes #3436 for the consume path. Guard taken verbatim from #3410.

### Verification

- Hive `ethereum/eels/consume-engine` built from this branch with the v0.2.0 fixtures, `--sim.limit ".*test_invalid_static_excess_blob_gas.*fork_Bogota.*"` (49 previously failing fixtures): 49/49 pass, from 0/49.
- `uv run ruff check` on the touched file: clean.
