### PR TITLE
fix(tests,test-specs): fix invalid inclusion-list engine fixture generation

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -595,7 +595,11 @@ class BuiltBlock(CamelModel):
             if self.block_access_list
             else None,
             inclusion_list_transactions=self.inclusion_list_txs,
-            inclusion_list_satisfied=self.inclusion_list_satisfied,
+            inclusion_list_satisfied=(
+                self.inclusion_list_satisfied
+                if self.expected_exception is None
+                else None
+            ),
             execution_payload_modifier=self.engine_payload_modifier(),
             validation_error=self.expected_exception,
             error_code=self.engine_api_error_code,

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1396,6 +1396,8 @@ class BlockchainTest(BaseTest):
                     block.expected_inclusion_list_satisfied = False
                 if block.header_verify:
                     block.header_verify = None
+                if block.rlp_modifier:
+                    block.rlp_modifier = None
                 if block.expected_gas_used:
                     block.expected_gas_used = None
                 if block.expected_block_access_list:

--- a/packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py
@@ -38,7 +38,11 @@ def test_inclusion_list_result_only_emitted_for_valid_payloads(
         staticmethod(capture),
     )
 
-    block = BuiltBlock.model_construct(
+    # `model_construct` skips validation and
+    # `get_fixture_engine_new_payload` only forwards these fields, so the
+    # sentinels never need to satisfy the model's field types. Splat them
+    # from an untyped dict so the type checker does not require them to.
+    fields: dict[str, Any] = dict(
         fork=object(),
         header=object(),
         txs=[],
@@ -53,6 +57,7 @@ def test_inclusion_list_result_only_emitted_for_valid_payloads(
         engine_new_payload_block_access_list=None,
         engine_new_payload_slot_number=None,
     )
+    block = BuiltBlock.model_construct(**fields)
 
     assert block.get_fixture_engine_new_payload() is sentinel
     assert captured["inclusion_list_satisfied"] is expected

--- a/packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py
@@ -1,0 +1,58 @@
+"""Regression tests for Engine API inclusion-list payload metadata."""
+
+from typing import Any
+
+import pytest
+
+from execution_testing.fixtures.blockchain import FixtureEngineNewPayload
+
+from ..blockchain import BuiltBlock
+
+
+@pytest.mark.parametrize(
+    "validation_error,inclusion_list_satisfied,expected",
+    [
+        pytest.param(None, True, True, id="valid-satisfied"),
+        pytest.param(None, False, False, id="valid-unsatisfied"),
+        pytest.param(object(), True, None, id="invalid-satisfied"),
+        pytest.param(object(), False, None, id="invalid-unsatisfied"),
+    ],
+)
+def test_inclusion_list_result_only_emitted_for_valid_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    validation_error: object | None,
+    inclusion_list_satisfied: bool,
+    expected: bool | None,
+) -> None:
+    """Invalid payload fixtures must carry a null inclusion-list result."""
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    def capture(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        FixtureEngineNewPayload,
+        "from_fixture_header",
+        staticmethod(capture),
+    )
+
+    block = BuiltBlock.model_construct(
+        fork=object(),
+        header=object(),
+        txs=[],
+        withdrawals=None,
+        requests=None,
+        block_access_list=None,
+        inclusion_list_txs=None,
+        inclusion_list_satisfied=inclusion_list_satisfied,
+        expected_exception=validation_error,
+        engine_api_error_code=None,
+        rlp_modifier=None,
+        engine_new_payload_block_access_list=None,
+        engine_new_payload_slot_number=None,
+    )
+
+    assert block.get_fixture_engine_new_payload() is sentinel
+    assert captured["inclusion_list_satisfied"] is expected

--- a/tests/frontier/validation/test_transaction.py
+++ b/tests/frontier/validation/test_transaction.py
@@ -41,8 +41,17 @@ def test_tx_gas_limit(
     sender = pre.fund_eoa()
     to = pre.fund_eoa()
 
+    # One gas above the block gas limit, so the transaction is otherwise
+    # valid (well above intrinsic cost) and only the allowance check fires.
+    # The limit itself is 100k rather than the 21k intrinsic minimum so that
+    # a block in this environment CAN be valid on forks with the EIP-7928
+    # block-access-list item budget (`gas_limit // 2000`): at 21k the budget
+    # is 10 items, less than the protocol-level writes of an empty block, so
+    # the auto-generated inclusion-list variant of this test — which moves
+    # the failing transaction into the inclusion list and expects the
+    # emptied block to be VALID — was invalid-by-environment.
     tx = Transaction(
-        gas_limit=21001,
+        gas_limit=100_001,
         to=to,
         gas_price=0x10,  # Must be >= base fee to isolate gas limit validation
         sender=sender,
@@ -50,8 +59,8 @@ def test_tx_gas_limit(
         error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
     )
 
-    modified_fields = {"gas_limit": ZeroPaddedHexNumber(21000)}
-    env.gas_limit = ZeroPaddedHexNumber(21000)
+    modified_fields = {"gas_limit": ZeroPaddedHexNumber(100_000)}
+    env.gas_limit = ZeroPaddedHexNumber(100_000)
 
     block = Block(
         txs=[tx],


### PR DESCRIPTION
### Description

Three fixture-side fixes covering the 127 `blockchain_tests_engine` fixtures that `tests-focil-devnet@v0.2.0` ships with expectations EELS itself rejects, plus the invalid-payload `inclusionListSatisfied` stamping reported in #3436:

1. Port #3406 (merged on `eips/amsterdam/eip-7805`): clear `Block.rlp_modifier` when building inclusion-list variants. Without it the variant's emptied block keeps the moved transaction's `blobGasUsed` in its header. Accounts for 126 of the 127.
2. Revive #3445 (cherry-picked): `BuiltBlock.get_fixture_engine_new_payload()` emits `None` for `inclusion_list_satisfied` when the block has an expected exception, per `bogota.md`. Refilled fixtures then stop stamping a verdict on expected-INVALID payloads and pass even under the currently deployed simulator check.
3. `test_tx_gas_limit`: raise the pinned block gas limit from 21000 to 100000 (tx gas 21001 to 100001). At 21000 the EIP-7928 item budget (`gas_limit // 2000` = 10) is below the protocol-level writes of an empty block, so no block in that environment can be valid, while the auto-generated inclusion-list variant expects its emptied block to be VALID. At 100000 the budget is 50 and the variant fills to a valid block. Accounts for the 127th.

A refill and release after this merges clears the remaining 127 failures on the Hive focil board.

### Related Issues or PRs

Fixes #3436 (fixture side). Ports #3406. Revives #3445.

### Verification

- `uv run fill tests/frontier/validation/test_transaction.py::test_tx_gas_limit --fork Bogota`: the inclusion-list variant fills with `gasLimit=100000`, 0 txs, no `validationError`, and passes ethrex's engine fixture runner (previously rejected for exceeding the BAL item budget).
- `uv run fill tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx --fork Bogota`: 144 inclusion-list variants refilled, none with the pinned `blobGasUsed`; all 504 fixtures in the file pass ethrex's runner.
- `uv run pytest packages/testing/src/execution_testing/specs/tests/test_focil_payload_metadata.py`: 4 passed.
