### PR TITLE
chore(deps): bump ethereum-hive to v0.1.0

### DIFF
--- a/packages/testing/pyproject.toml
+++ b/packages/testing/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.0,<9",
-    "ethereum-hive>=0.1.0a5,<1.0.0",
+    "ethereum-hive>=0.1.0,<1.0.0",
     "ethereum-execution",
     "gitpython>=3.1.31,<4",
     "PyJWT>=2.3.0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -1122,7 +1122,7 @@ requires-dist = [
     { name = "eth-abi", specifier = ">=5.2.0" },
     { name = "eth-remerkleable", specifier = "==0.1.31" },
     { name = "ethereum-execution", editable = "." },
-    { name = "ethereum-hive", specifier = ">=0.1.0a5,<1.0.0" },
+    { name = "ethereum-hive", specifier = ">=0.1.0,<1.0.0" },
     { name = "ethereum-rlp", specifier = ">=0.1.6,<0.2" },
     { name = "ethereum-types", specifier = ">=0.4.1,<0.5" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
@@ -1168,14 +1168,15 @@ test = [{ name = "pytest-cov", specifier = ">=4.1.0,<5" }]
 
 [[package]]
 name = "ethereum-hive"
-version = "0.1.0a5"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/a8/95676acd86095a5dcf5dacfa5a991175b3a547dcd5729735fea777b8feec/ethereum_hive-0.1.0a5.tar.gz", hash = "sha256:bf91d3144c263a1a6407c931b3864ab3edd40bc5c34b812e571e7c49cc70f9eb", size = 75064, upload-time = "2026-03-11T07:36:24.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/06/583cb86c2fef9e0da8bb8d4165c9dde076a8c9e1f940327dbbb64bf68dfc/ethereum_hive-0.1.0.tar.gz", hash = "sha256:7f047fc03f15fc43081432c4adca362e9dffd6bf2faad163f707c7221148d61b", size = 79244, upload-time = "2026-08-31T07:44:36.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/95/986727018ac0401562d91961e2f46462ed65a08e2d5162a255d9f871a7ad/ethereum_hive-0.1.0a5-py3-none-any.whl", hash = "sha256:3225747ed83a9124a697db0ab8d736c4820117462e64aa3395bbc1588c4d40d0", size = 37589, upload-time = "2026-03-11T07:36:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/93/2f/461e38bd697e90f6e7a2199193eedd3653e69ca331cc98431653b46ad156/ethereum_hive-0.1.0-py3-none-any.whl", hash = "sha256:5a511ef89bab8b4740ed501ce7c3d244085f687c5001d9fa1ecc2ab01ad14b51", size = 41184, upload-time = "2026-08-31T07:44:35.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Bump `ethereum-hive` to its first stable release, v0.1.0, which pools Hive API connections in a shared keep-alive session — fixing sporadic `EADDRNOTAVAIL` errors and silently lost test results at high simulator throughput (`consume enginex`), see ethereum/hive-python-api#18.

### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A honey bee, in honor of the hive](https://commons.wikimedia.org/wiki/Special:FilePath/Apis_mellifera_Western_honey_bee.jpg?width=640)