### PR TITLE
EIP-8198: make slot-duration changes schedule-driven

### DIFF
--- a/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/__init__.py
+++ b/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EIP-8198 slot-duration independence."""

--- a/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_additional_duration_era.py
+++ b/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_additional_duration_era.py
@@ -1,0 +1,103 @@
+"""Extra synthetic era proving EIP-8198 logic is duration-agnostic."""
+
+from ethereum.forks.amsterdam.slot_timing import (
+    BlobScheduleParameters,
+    SlotDurationEntry,
+    get_blob_schedule,
+    get_slot_duration_ms,
+    get_transition_durations,
+    scale_transition_limit,
+)
+from ethereum_types.numeric import U64, Uint
+
+HEGOTA_EPOCH = U64(10)
+MID_TEST_EPOCH = U64(15)
+FUTURE_TEST_EPOCH = U64(20)
+SLOTS_PER_EPOCH = U64(32)
+
+SCHEDULE_12_10_8_6 = (
+    SlotDurationEntry(HEGOTA_EPOCH, Uint(10000)),
+    SlotDurationEntry(MID_TEST_EPOCH, Uint(8000)),
+    SlotDurationEntry(FUTURE_TEST_EPOCH, Uint(6000)),
+)
+
+
+def test_additional_8s_era_is_schedule_data_only() -> None:
+    """A 10 -> 8 -> 6 sequence uses the same duration lookup path."""
+    first_10s_slot = U64(HEGOTA_EPOCH * SLOTS_PER_EPOCH)
+    first_8s_slot = U64(MID_TEST_EPOCH * SLOTS_PER_EPOCH)
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * SLOTS_PER_EPOCH)
+
+    assert get_slot_duration_ms(
+        U64(first_10s_slot - U64(1)), SCHEDULE_12_10_8_6
+    ) == Uint(12000)
+    assert get_slot_duration_ms(first_10s_slot, SCHEDULE_12_10_8_6) == Uint(
+        10000
+    )
+    assert get_slot_duration_ms(first_8s_slot, SCHEDULE_12_10_8_6) == Uint(
+        8000
+    )
+    assert get_slot_duration_ms(first_6s_slot, SCHEDULE_12_10_8_6) == Uint(
+        6000
+    )
+
+
+def test_capacity_scaling_composes_through_8s_era() -> None:
+    """Gas/sec remains constant through 12 -> 10 -> 8 -> 6."""
+    first_10s_slot = U64(HEGOTA_EPOCH * SLOTS_PER_EPOCH)
+    first_8s_slot = U64(MID_TEST_EPOCH * SLOTS_PER_EPOCH)
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * SLOTS_PER_EPOCH)
+
+    old_ms, new_ms = get_transition_durations(
+        None, first_10s_slot, SCHEDULE_12_10_8_6
+    )
+    gas_10s = scale_transition_limit(Uint(72_000_000), old_ms, new_ms)
+    assert (old_ms, new_ms, gas_10s) == (
+        Uint(12000),
+        Uint(10000),
+        Uint(60_000_000),
+    )
+
+    old_ms, new_ms = get_transition_durations(
+        U64(first_8s_slot - U64(7)),
+        U64(first_8s_slot + U64(7)),
+        SCHEDULE_12_10_8_6,
+    )
+    gas_8s = scale_transition_limit(gas_10s, old_ms, new_ms)
+    assert (old_ms, new_ms, gas_8s) == (
+        Uint(10000),
+        Uint(8000),
+        Uint(48_000_000),
+    )
+
+    old_ms, new_ms = get_transition_durations(
+        U64(first_6s_slot - U64(7)),
+        U64(first_6s_slot + U64(7)),
+        SCHEDULE_12_10_8_6,
+    )
+    gas_6s = scale_transition_limit(gas_8s, old_ms, new_ms)
+    assert (old_ms, new_ms, gas_6s) == (
+        Uint(8000),
+        Uint(6000),
+        Uint(36_000_000),
+    )
+
+
+def test_blob_schedule_composes_through_8s_era() -> None:
+    """Derive blob parameters through the added era without a new branch."""
+    first_8s_slot = U64(MID_TEST_EPOCH * SLOTS_PER_EPOCH)
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * SLOTS_PER_EPOCH)
+
+    blob_8s = get_blob_schedule(first_8s_slot, SCHEDULE_12_10_8_6)
+    blob_6s = get_blob_schedule(first_6s_slot, SCHEDULE_12_10_8_6)
+
+    assert blob_8s == BlobScheduleParameters(
+        maximum=U64(13),
+        target=U64(10),
+        update_fraction=Uint(7_511_574),
+    )
+    assert blob_6s == BlobScheduleParameters(
+        maximum=U64(9),
+        target=U64(8),
+        update_fraction=Uint(3_338_477),
+    )

--- a/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_slot_timing.py
+++ b/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_slot_timing.py
@@ -1,0 +1,263 @@
+"""Tests that EIP-8198 duration changes are schedule-driven."""
+
+import inspect
+from dataclasses import replace
+
+import pytest
+from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.exceptions import InvalidBlock
+from ethereum.forks.amsterdam import fork as amsterdam_fork
+from ethereum.forks.amsterdam.blocks import Header
+from ethereum.forks.amsterdam.fork import (
+    EMPTY_OMMER_HASH,
+    calculate_base_fee_per_gas,
+    validate_header,
+)
+from ethereum.forks.amsterdam.fork_types import Bloom
+from ethereum.forks.amsterdam.slot_timing import (
+    BLOB_GAS_PER_BLOB,
+    BlobScheduleParameters,
+    SlotDurationEntry,
+    calculate_blob_gas_price_for_slot,
+    get_blob_schedule,
+    get_max_blob_gas_per_block,
+    get_slot_duration_ms,
+    get_transition_durations,
+    scale_blob_schedule,
+    scale_transition_limit,
+)
+from ethereum.state import Address, Root
+from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes, Bytes8, Bytes32
+from ethereum_types.numeric import U64, U256, Uint
+
+HEGOTA_EPOCH = U64(10)
+FUTURE_TEST_EPOCH = U64(20)
+SCHEDULE_12_10_6 = (
+    SlotDurationEntry(HEGOTA_EPOCH, Uint(10000)),
+    SlotDurationEntry(FUTURE_TEST_EPOCH, Uint(6000)),
+)
+ZERO_ROOT = Root(b"\x00" * 32)
+ZERO_HASH = Hash32(b"\x00" * 32)
+
+
+def _header(
+    *,
+    slot_number: U64,
+    number: Uint,
+    gas_limit: Uint,
+    gas_used: Uint,
+    base_fee_per_gas: Uint,
+    timestamp: U256,
+) -> Header:
+    """Build a minimal Amsterdam header for duration-transition tests."""
+    return Header(
+        parent_hash=ZERO_HASH,
+        ommers_hash=EMPTY_OMMER_HASH,
+        coinbase=Address(b"\x00" * 20),
+        state_root=ZERO_ROOT,
+        transactions_root=ZERO_ROOT,
+        receipt_root=ZERO_ROOT,
+        bloom=Bloom(b"\x00" * 256),
+        difficulty=Uint(0),
+        number=number,
+        gas_limit=gas_limit,
+        gas_used=gas_used,
+        timestamp=timestamp,
+        extra_data=Bytes(b""),
+        prev_randao=Bytes32(b"\x00" * 32),
+        nonce=Bytes8(b"\x00" * 8),
+        base_fee_per_gas=base_fee_per_gas,
+        withdrawals_root=ZERO_ROOT,
+        blob_gas_used=U64(0),
+        excess_blob_gas=U64(0),
+        parent_beacon_block_root=ZERO_ROOT,
+        requests_hash=ZERO_HASH,
+        block_access_list_hash=ZERO_HASH,
+        slot_number=slot_number,
+    )
+
+
+def test_repeated_duration_changes_are_schedule_only() -> None:
+    """A synthetic 10 -> 6 era uses the same lookup as 12 -> 10."""
+    last_12s_slot = U64(HEGOTA_EPOCH * U64(32) - U64(1))
+    first_10s_slot = U64(HEGOTA_EPOCH * U64(32))
+    last_10s_slot = U64(FUTURE_TEST_EPOCH * U64(32) - U64(1))
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * U64(32))
+
+    assert get_slot_duration_ms(last_12s_slot, SCHEDULE_12_10_6) == Uint(12000)
+    assert get_slot_duration_ms(first_10s_slot, SCHEDULE_12_10_6) == Uint(
+        10000
+    )
+    assert get_slot_duration_ms(last_10s_slot, SCHEDULE_12_10_6) == Uint(10000)
+    assert get_slot_duration_ms(first_6s_slot, SCHEDULE_12_10_6) == Uint(6000)
+
+
+def test_gas_limit_scales_once_at_each_duration_boundary() -> None:
+    """Gas/sec is preserved at both 12 -> 10 and 10 -> 6 transitions."""
+    first_10s_slot = U64(HEGOTA_EPOCH * U64(32))
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * U64(32))
+    last_10s_payload_slot = U64(first_6s_slot - U64(7))
+
+    old_ms, new_ms = get_transition_durations(
+        None, first_10s_slot, SCHEDULE_12_10_6
+    )
+    gas_limit_10s = scale_transition_limit(Uint(72_000_000), old_ms, new_ms)
+    assert (old_ms, new_ms) == (Uint(12000), Uint(10000))
+    assert gas_limit_10s == Uint(60_000_000)
+
+    old_ms, new_ms = get_transition_durations(
+        last_10s_payload_slot,
+        U64(first_6s_slot + U64(7)),
+        SCHEDULE_12_10_6,
+    )
+    gas_limit_6s = scale_transition_limit(gas_limit_10s, old_ms, new_ms)
+    assert (old_ms, new_ms) == (Uint(10000), Uint(6000))
+    assert gas_limit_6s == Uint(36_000_000)
+
+    old_ms, new_ms = get_transition_durations(
+        U64(first_6s_slot + U64(7)),
+        U64(first_6s_slot + U64(19)),
+        SCHEDULE_12_10_6,
+    )
+    assert scale_transition_limit(gas_limit_6s, old_ms, new_ms) == gas_limit_6s
+
+
+def test_validate_header_handles_missed_payloads_at_second_boundary() -> None:
+    """
+    Validate the production header path across a synthetic 10 -> 6 change.
+
+    The parent execution payload is seven slots before the boundary and the
+    child payload is seven slots after it. The duration transition must still
+    scale the gas limit exactly once, even though no payload exists at the
+    scheduled boundary slot.
+    """
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * U64(32))
+    parent = _header(
+        slot_number=U64(first_6s_slot - U64(7)),
+        number=Uint(100),
+        gas_limit=Uint(60_000_000),
+        gas_used=Uint(30_000_000),
+        base_fee_per_gas=Uint(960),
+        timestamp=U256(1_000_000),
+    )
+    transition = _header(
+        slot_number=U64(first_6s_slot + U64(7)),
+        number=Uint(101),
+        gas_limit=Uint(36_000_000),
+        gas_used=Uint(18_000_000),
+        base_fee_per_gas=Uint(960),
+        timestamp=U256(1_000_006),
+    )
+    transition = replace(
+        transition,
+        parent_hash=keccak256(rlp.encode(parent)),
+    )
+
+    validate_header(parent, transition, SCHEDULE_12_10_6)
+
+    unscaled = replace(transition, gas_limit=Uint(60_000_000))
+    with pytest.raises(InvalidBlock):
+        validate_header(parent, unscaled, SCHEDULE_12_10_6)
+
+    ordinary_6s = _header(
+        slot_number=U64(first_6s_slot + U64(19)),
+        number=Uint(102),
+        gas_limit=Uint(36_000_000),
+        gas_used=Uint(18_000_000),
+        base_fee_per_gas=Uint(960),
+        timestamp=U256(1_000_012),
+    )
+    ordinary_6s = replace(
+        ordinary_6s,
+        parent_hash=keccak256(rlp.encode(transition)),
+    )
+    validate_header(transition, ordinary_6s, SCHEDULE_12_10_6)
+
+
+def test_production_base_fee_path_supports_second_era() -> None:
+    """Amsterdam's real base-fee calculator remains wall-clock invariant."""
+    common = dict(
+        block_gas_limit=Uint(60_000_000),
+        parent_gas_limit=Uint(60_000_000),
+        parent_gas_used=Uint(60_000_000),
+        parent_base_fee_per_gas=Uint(960),
+        gas_limit_reference=Uint(60_000_000),
+    )
+
+    fee_10s = calculate_base_fee_per_gas(
+        **common,
+        slot_duration_ms=Uint(10000),
+    )
+    fee_6s = calculate_base_fee_per_gas(
+        **common,
+        slot_duration_ms=Uint(6000),
+    )
+
+    assert fee_10s == Uint(1060)
+    assert fee_6s == Uint(1020)
+
+
+def test_blob_schedule_derives_repeated_eras_from_same_transition() -> None:
+    """Blob throughput and fee response derive through 12 -> 10 -> 6."""
+    blob_12s = BlobScheduleParameters(
+        maximum=U64(21),
+        target=U64(14),
+        update_fraction=Uint(11_684_671),
+    )
+
+    blob_10s = scale_blob_schedule(blob_12s, Uint(12000), Uint(10000))
+    assert blob_10s == BlobScheduleParameters(
+        maximum=U64(17),
+        target=U64(12),
+        update_fraction=Uint(10_015_432),
+    )
+
+    blob_6s = scale_blob_schedule(blob_10s, Uint(10000), Uint(6000))
+    assert blob_6s == BlobScheduleParameters(
+        maximum=U64(10),
+        target=U64(7),
+        update_fraction=Uint(10_015_432),
+    )
+
+
+def test_production_blob_paths_follow_same_schedule() -> None:
+    """Capacity and blob-fee inputs both follow the synthetic 6s era."""
+    first_10s_slot = U64(HEGOTA_EPOCH * U64(32))
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * U64(32))
+
+    blob_10s = get_blob_schedule(first_10s_slot, SCHEDULE_12_10_6)
+    blob_6s = get_blob_schedule(first_6s_slot, SCHEDULE_12_10_6)
+    assert blob_10s.maximum == U64(17)
+    assert blob_6s.maximum == U64(10)
+    assert blob_10s.target == U64(12)
+    assert blob_6s.target == U64(7)
+    # For this exact 10s -> 6s ratio the derived update fraction is unchanged.
+    # That is valid: the reduced per-block headroom and shorter cadence cancel.
+    assert blob_6s.update_fraction == blob_10s.update_fraction
+
+    assert get_max_blob_gas_per_block(
+        first_10s_slot, SCHEDULE_12_10_6
+    ) == BLOB_GAS_PER_BLOB * U64(17)
+    assert get_max_blob_gas_per_block(
+        first_6s_slot, SCHEDULE_12_10_6
+    ) == BLOB_GAS_PER_BLOB * U64(10)
+
+    excess = U64(20_000_000)
+    fee_10s = calculate_blob_gas_price_for_slot(
+        excess, first_10s_slot, SCHEDULE_12_10_6
+    )
+    fee_6s = calculate_blob_gas_price_for_slot(
+        excess, first_6s_slot, SCHEDULE_12_10_6
+    )
+    assert fee_10s == Uint(7)
+    assert fee_6s == Uint(7)
+
+
+def test_amsterdam_has_no_12_to_10_transition_special_case() -> None:
+    """The production header path contains no previous-duration constant."""
+    source = inspect.getsource(amsterdam_fork)
+    assert "PREVIOUS_SLOT_DURATION_MS" not in source
+    assert "SLOT_DURATION_MS = Uint(10000)" not in source
+    assert "get_transition_durations" in source
+    assert "scale_transition_limit" in source

--- a/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_vm_blob_schedule.py
+++ b/packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_vm_blob_schedule.py
@@ -1,0 +1,61 @@
+"""Prove VM blob helpers remain slot-duration agnostic."""
+
+import inspect
+
+from ethereum.forks.amsterdam.slot_timing import (
+    SlotDurationEntry,
+    calculate_blob_gas_price_for_slot,
+)
+from ethereum.forks.amsterdam.vm import gas as vm_gas
+from ethereum_types.numeric import U64, Uint
+
+FUTURE_TEST_EPOCH = U64(20)
+SCHEDULE_10_6 = (
+    SlotDurationEntry(U64(0), Uint(10000)),
+    SlotDurationEntry(FUTURE_TEST_EPOCH, Uint(6000)),
+)
+
+
+def test_vm_blob_price_uses_slot_schedule_for_future_era() -> None:
+    """The VM compatibility helper follows the same 10 -> 6 schedule."""
+    last_10s_slot = U64(FUTURE_TEST_EPOCH * U64(32) - U64(1))
+    first_6s_slot = U64(FUTURE_TEST_EPOCH * U64(32))
+    excess_blob_gas = U64(20_000_000)
+
+    vm_10s = vm_gas.calculate_blob_gas_price(
+        excess_blob_gas,
+        last_10s_slot,
+        SCHEDULE_10_6,
+    )
+    vm_6s = vm_gas.calculate_blob_gas_price(
+        excess_blob_gas,
+        first_6s_slot,
+        SCHEDULE_10_6,
+    )
+
+    assert vm_10s == calculate_blob_gas_price_for_slot(
+        excess_blob_gas,
+        last_10s_slot,
+        SCHEDULE_10_6,
+    )
+    assert vm_6s == calculate_blob_gas_price_for_slot(
+        excess_blob_gas,
+        first_6s_slot,
+        SCHEDULE_10_6,
+    )
+    # The derived update fraction happens to be identical for this ratio,
+    # so equal prices at equal excess are expected rather than a failure.
+    assert vm_10s == Uint(7)
+    assert vm_6s == Uint(7)
+
+
+def test_vm_blob_protocol_calculators_do_not_use_initial_snapshot() -> None:
+    """Initial-era compatibility constants cannot govern later eras."""
+    excess_source = inspect.getsource(vm_gas.calculate_excess_blob_gas)
+    price_source = inspect.getsource(vm_gas.calculate_blob_gas_price)
+
+    assert "get_blob_schedule" in excess_source
+    assert "BLOB_SCHEDULE_TARGET" not in excess_source
+    assert "BLOB_SCHEDULE_MAX" not in excess_source
+    assert "calculate_blob_gas_price_for_slot" in price_source
+    assert "BLOB_BASE_FEE_UPDATE_FRACTION" not in price_source

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -56,6 +56,14 @@ from .requests import (
     compute_requests_hash,
     parse_deposit_requests,
 )
+from .slot_timing import (
+    BASE_SLOT_DURATION_MS,
+    SLOT_DURATION_SCHEDULE,
+    SlotDurationSchedule,
+    get_slot_duration_ms,
+    get_transition_durations,
+    scale_transition_limit,
+)
 from .state_tracker import (
     BlockState,
     TransactionState,
@@ -111,6 +119,12 @@ SYSTEM_ADDRESS = hex_to_address("0xfffffffffffffffffffffffffffffffffffffffe")
 BEACON_ROOTS_ADDRESS = hex_to_address(
     "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02"
 )
+"""
+Address of the beacon roots ring buffer contract. Its 8191-entry buffer
+holds one root per slot, so its wall-clock coverage shrinks from ~27.3
+hours to ~22.8 hours under 10-second slots. The buffer length is part of
+the deployed contract and is deliberately not changed by this fork.
+"""
 SYSTEM_TRANSACTION_GAS = ExecutionGas(Uint(30000000))
 SYSTEM_MAX_SSTORES_PER_CALL = Uint(16)
 """
@@ -134,6 +148,12 @@ BUILDER_EXIT_CONTRACT_ADDRESS = hex_to_address(
 HISTORY_STORAGE_ADDRESS = hex_to_address(
     "0x0000F90827F1C53a10cb7A02335B175320002935"
 )
+"""
+Address of the block hash history contract. Its 8191-entry window is
+denominated in blocks, so its wall-clock coverage shrinks from ~27.3
+hours to ~22.8 hours under 10-second slots. The window length is part of
+the deployed contract and is deliberately not changed by this fork.
+"""
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
@@ -370,57 +390,42 @@ def calculate_base_fee_per_gas(
     parent_gas_limit: Uint,
     parent_gas_used: Uint,
     parent_base_fee_per_gas: Uint,
+    gas_limit_reference: Optional[Uint] = None,
+    slot_duration_ms: Optional[Uint] = None,
 ) -> Uint:
-    """
-    Calculates the base fee per gas for the block.
-
-    Parameters
-    ----------
-    block_gas_limit :
-        Gas limit of the block for which the base fee is being calculated.
-    parent_gas_limit :
-        Gas limit of the parent block.
-    parent_gas_used :
-        Gas used in the parent block.
-    parent_base_fee_per_gas :
-        Base fee per gas of the parent block.
-
-    Returns
-    -------
-    base_fee_per_gas : `Uint`
-        Base fee per gas for the block.
-
-    """
+    """Calculate the base fee while preserving wall-clock response."""
+    if gas_limit_reference is None:
+        gas_limit_reference = parent_gas_limit
+    if slot_duration_ms is None:
+        slot_duration_ms = get_slot_duration_ms(U64(0))
     parent_gas_target = parent_gas_limit // ELASTICITY_MULTIPLIER
-    if not check_gas_limit(block_gas_limit, parent_gas_limit):
+    if not check_gas_limit(block_gas_limit, gas_limit_reference):
         raise InvalidBlock
 
     if parent_gas_used == parent_gas_target:
         expected_base_fee_per_gas = parent_base_fee_per_gas
     elif parent_gas_used > parent_gas_target:
         gas_used_delta = parent_gas_used - parent_gas_target
-
         parent_fee_gas_delta = parent_base_fee_per_gas * gas_used_delta
         target_fee_gas_delta = parent_fee_gas_delta // parent_gas_target
-
         base_fee_per_gas_delta = max(
-            target_fee_gas_delta // BASE_FEE_MAX_CHANGE_DENOMINATOR,
+            target_fee_gas_delta
+            * slot_duration_ms
+            // (BASE_SLOT_DURATION_MS * BASE_FEE_MAX_CHANGE_DENOMINATOR),
             Uint(1),
         )
-
         expected_base_fee_per_gas = (
             parent_base_fee_per_gas + base_fee_per_gas_delta
         )
     else:
         gas_used_delta = parent_gas_target - parent_gas_used
-
         parent_fee_gas_delta = parent_base_fee_per_gas * gas_used_delta
         target_fee_gas_delta = parent_fee_gas_delta // parent_gas_target
-
         base_fee_per_gas_delta = (
-            target_fee_gas_delta // BASE_FEE_MAX_CHANGE_DENOMINATOR
+            target_fee_gas_delta
+            * slot_duration_ms
+            // (BASE_SLOT_DURATION_MS * BASE_FEE_MAX_CHANGE_DENOMINATOR)
         )
-
         expected_base_fee_per_gas = (
             parent_base_fee_per_gas - base_fee_per_gas_delta
         )
@@ -429,41 +434,48 @@ def calculate_base_fee_per_gas(
 
 
 def validate_header(
-    parent_header: Header | PreviousHeader, header: Header
+    parent_header: Header | PreviousHeader,
+    header: Header,
+    slot_duration_schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
 ) -> None:
-    """
-    Verify a block header against its parent.
-
-    In order to consider a block's header valid, the logic for the
-    quantities in the header should match the logic for the block itself.
-    For example the header timestamp should be greater than the block's parent
-    timestamp because the block was created *after* the parent block.
-    Additionally, the block's number should be directly following the parent
-    block's number since it is the next block in the sequence.
-
-    Parameters
-    ----------
-    parent_header :
-        Header of the parent block.
-    header :
-        Header to check for correctness.
-
-    """
+    """Verify a block header against its parent."""
     if header.number < Uint(1):
         raise InvalidBlock
 
-    excess_blob_gas = calculate_excess_blob_gas(parent_header)
+    excess_blob_gas = calculate_excess_blob_gas(
+        parent_header,
+        header.slot_number,
+        slot_duration_schedule,
+    )
     if header.excess_blob_gas != excess_blob_gas:
         raise InvalidBlock
 
     if header.gas_used > header.gas_limit:
         raise InvalidBlock
 
+    parent_slot_number: Optional[U64]
+    if isinstance(parent_header, Header):
+        parent_slot_number = parent_header.slot_number
+    else:
+        parent_slot_number = None
+
+    old_duration_ms, new_duration_ms = get_transition_durations(
+        parent_slot_number,
+        header.slot_number,
+        slot_duration_schedule,
+    )
+    gas_limit_reference = scale_transition_limit(
+        parent_header.gas_limit,
+        old_duration_ms,
+        new_duration_ms,
+    )
     expected_base_fee_per_gas = calculate_base_fee_per_gas(
         header.gas_limit,
         parent_header.gas_limit,
         parent_header.gas_used,
         parent_header.base_fee_per_gas,
+        gas_limit_reference=gas_limit_reference,
+        slot_duration_ms=new_duration_ms,
     )
     if expected_base_fee_per_gas != header.base_fee_per_gas:
         raise InvalidBlock
@@ -560,6 +572,7 @@ def check_transaction(
             tx.blob_versioned_hashes,
             tx.max_fee_per_blob_gas,
             block_env.excess_blob_gas,
+            block_env.slot_number,
         )
 
         max_gas_fee += Uint(calculate_total_blob_gas(tx)) * Uint(
@@ -955,7 +968,11 @@ def update_sender_state(
 
     effective_gas_fee = tx_env.gas_limit * tx_env.effective_gas_price
     if isinstance(tx, BlobTransaction):
-        blob_gas_fee = calculate_data_fee(block_env.excess_blob_gas, tx)
+        blob_gas_fee = calculate_data_fee(
+            block_env.excess_blob_gas,
+            tx,
+            block_env.slot_number,
+        )
     else:
         blob_gas_fee = Uint(0)
 

--- a/src/ethereum/forks/amsterdam/slot_timing.py
+++ b/src/ethereum/forks/amsterdam/slot_timing.py
@@ -1,0 +1,220 @@
+"""
+Slot-duration schedule helpers for EIP-8198.
+
+The execution layer needs two distinct duration ratios:
+
+* transition ratios compare the current execution payload's duration with
+  its parent execution payload's duration and apply once at an era boundary;
+* wall-clock response ratios compare the current duration with the
+  pre-schedule base duration and apply to every block in the era.
+
+Keeping these operations separate prevents a second slot-duration change
+from accidentally reusing the one-off transition ratio as an ongoing rate.
+"""
+
+from dataclasses import dataclass
+from typing import Final, Optional, Tuple, final
+
+from ethereum_types.numeric import U64, Uint
+
+from ethereum.utils.numeric import taylor_exponential
+
+BASE_SLOT_DURATION_MS: Final[Uint] = Uint(12000)
+"""Pre-schedule slot duration, in milliseconds."""
+
+SLOTS_PER_EPOCH: Final[U64] = U64(32)
+"""Number of slots per epoch; EIP-8198 does not change this value."""
+
+BLOB_GAS_PER_BLOB: Final[U64] = U64(2**17)
+BLOB_BASE_COST: Final[Uint] = Uint(2**13)
+BLOB_MIN_GASPRICE: Final[Uint] = Uint(1)
+
+
+@final
+@dataclass(frozen=True)
+class SlotDurationEntry:
+    """One slot-duration schedule entry."""
+
+    epoch: U64
+    duration_ms: Uint
+
+
+SlotDurationSchedule = Tuple[SlotDurationEntry, ...]
+
+
+# The epoch-zero entry is an always-active initial Amsterdam duration when this
+# fork package executes. Additional entries use consensus epoch numbers derived
+# from Header.slot_number. A future duration change is therefore schedule data;
+# protocol logic does not change.
+SLOT_DURATION_SCHEDULE: Final[SlotDurationSchedule] = (
+    SlotDurationEntry(U64(0), Uint(10000)),
+)
+
+
+@final
+@dataclass(frozen=True)
+class BlobScheduleParameters:
+    """Blob parameters coupled to one slot-duration era."""
+
+    maximum: U64
+    target: U64
+    update_fraction: Uint
+
+
+BASE_BLOB_SCHEDULE: Final[BlobScheduleParameters] = BlobScheduleParameters(
+    maximum=U64(21),
+    target=U64(14),
+    update_fraction=Uint(11_684_671),
+)
+"""Blob schedule in force before EIP-8198 activates."""
+
+
+def validate_slot_duration_schedule(schedule: SlotDurationSchedule) -> None:
+    """Validate ordering and duration constraints of a duration schedule."""
+    previous_epoch: Optional[U64] = None
+    for entry in schedule:
+        if entry.duration_ms == 0 or entry.duration_ms % Uint(1000) != 0:
+            raise ValueError("slot duration must be a positive whole second")
+        if previous_epoch is not None and entry.epoch <= previous_epoch:
+            raise ValueError(
+                "slot duration epochs must be strictly increasing"
+            )
+        previous_epoch = entry.epoch
+
+
+def get_slot_duration_ms(
+    slot_number: U64,
+    schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+    base_duration_ms: Uint = BASE_SLOT_DURATION_MS,
+    slots_per_epoch: U64 = SLOTS_PER_EPOCH,
+) -> Uint:
+    """Return the scheduled duration in effect for ``slot_number``."""
+    validate_slot_duration_schedule(schedule)
+    if base_duration_ms == 0 or slots_per_epoch == 0:
+        raise ValueError("base duration and slots per epoch must be positive")
+
+    epoch = slot_number // slots_per_epoch
+    duration_ms = base_duration_ms
+    for entry in schedule:
+        if epoch < entry.epoch:
+            break
+        duration_ms = entry.duration_ms
+    return duration_ms
+
+
+def get_transition_durations(
+    parent_slot_number: Optional[U64],
+    current_slot_number: U64,
+    schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+    base_duration_ms: Uint = BASE_SLOT_DURATION_MS,
+) -> Tuple[Uint, Uint]:
+    """
+    Return parent/current execution-payload durations.
+
+    ``None`` represents the legacy parent at the first EIP-8198 execution
+    payload. Future transitions use the parent execution payload's actual
+    slot, so missed slots and withheld payloads cannot suppress the change.
+    """
+    new_duration_ms = get_slot_duration_ms(
+        current_slot_number, schedule, base_duration_ms
+    )
+    if parent_slot_number is None:
+        old_duration_ms = base_duration_ms
+    else:
+        old_duration_ms = get_slot_duration_ms(
+            parent_slot_number, schedule, base_duration_ms
+        )
+    return old_duration_ms, new_duration_ms
+
+
+def scale_transition_limit(
+    value: Uint, old_duration_ms: Uint, new_duration_ms: Uint
+) -> Uint:
+    """Scale a per-block capacity once when the duration era changes."""
+    if old_duration_ms == 0 or new_duration_ms == 0:
+        raise ValueError("slot durations must be positive")
+    if old_duration_ms == new_duration_ms:
+        return value
+    return Uint(value * new_duration_ms // old_duration_ms)
+
+
+def scale_blob_schedule(
+    previous: BlobScheduleParameters,
+    old_duration_ms: Uint,
+    new_duration_ms: Uint,
+) -> BlobScheduleParameters:
+    """
+    Derive blob parameters for the next duration era.
+
+    Maximum blob count truncates down, target blob count rounds to nearest,
+    and the update fraction preserves maximum sustained blob-fee response
+    per unit of wall-clock time.
+    """
+    if old_duration_ms == 0 or new_duration_ms == 0:
+        raise ValueError("slot durations must be positive")
+    if previous.maximum <= previous.target:
+        raise ValueError("blob maximum must exceed blob target")
+
+    maximum = U64(Uint(previous.maximum) * new_duration_ms // old_duration_ms)
+    target = U64(
+        (Uint(previous.target) * new_duration_ms + old_duration_ms // Uint(2))
+        // old_duration_ms
+    )
+    if maximum <= target:
+        raise ValueError("scaled blob maximum must exceed scaled target")
+
+    old_headroom = Uint(previous.maximum - previous.target)
+    new_headroom = Uint(maximum - target)
+    update_fraction = Uint(
+        previous.update_fraction
+        * new_headroom
+        * old_duration_ms
+        // (old_headroom * new_duration_ms)
+    )
+    return BlobScheduleParameters(maximum, target, update_fraction)
+
+
+def get_blob_schedule(
+    slot_number: U64,
+    schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+    base_duration_ms: Uint = BASE_SLOT_DURATION_MS,
+    base_blob_schedule: BlobScheduleParameters = BASE_BLOB_SCHEDULE,
+) -> BlobScheduleParameters:
+    """Return blob parameters derived through every active duration era."""
+    validate_slot_duration_schedule(schedule)
+    current_epoch = slot_number // SLOTS_PER_EPOCH
+    duration_ms = base_duration_ms
+    blob_schedule = base_blob_schedule
+
+    for entry in schedule:
+        if current_epoch < entry.epoch:
+            break
+        if entry.duration_ms != duration_ms:
+            blob_schedule = scale_blob_schedule(
+                blob_schedule, duration_ms, entry.duration_ms
+            )
+            duration_ms = entry.duration_ms
+
+    return blob_schedule
+
+
+def get_max_blob_gas_per_block(
+    slot_number: U64,
+    schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+) -> U64:
+    """Return blob gas capacity for the active duration era."""
+    return BLOB_GAS_PER_BLOB * get_blob_schedule(slot_number, schedule).maximum
+
+
+def calculate_blob_gas_price_for_slot(
+    excess_blob_gas: U64,
+    slot_number: U64,
+    schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+) -> Uint:
+    """Calculate the blob gas price using the current duration era."""
+    blob_schedule = get_blob_schedule(slot_number, schedule)
+    return taylor_exponential(
+        BLOB_MIN_GASPRICE,
+        Uint(excess_blob_gas),
+        blob_schedule.update_fraction,
+    )

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -19,7 +19,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 from ethereum.exceptions import GasUsedExceedsLimitError
 from ethereum.forks.bpo5.blocks import Header as PreviousHeader
 from ethereum.trace import GasAndRefund, StateGasAndRefund, evm_trace
-from ethereum.utils.numeric import ceil32, taylor_exponential
+from ethereum.utils.numeric import ceil32
 
 from ..blocks import Header
 from ..exceptions import (
@@ -32,6 +32,13 @@ from ..fork_types import (
     StateGasPerByte,
     VersionedHash,
 )
+from ..slot_timing import (
+    SLOT_DURATION_SCHEDULE,
+    SlotDurationSchedule,
+    calculate_blob_gas_price_for_slot,
+    get_blob_schedule,
+    get_max_blob_gas_per_block,
+)
 from ..transactions import (
     TX_MAX_GAS_LIMIT,
     BlobTransaction,
@@ -42,6 +49,9 @@ from .exceptions import OutOfGasError
 
 if TYPE_CHECKING:
     from . import BlockEnvironment, BlockOutput, Evm
+
+
+_INITIAL_SLOT = U64(0)
 
 
 # These may be patched at runtime by a future gas repricing utility to
@@ -140,13 +150,22 @@ class GasCosts:
     )
 
     # Blobs
+    #
+    # The per-block blob schedule is rescaled from the previous fork's
+    # target of 14 and maximum of 21 by the slot-duration ratio
+    # (10s / 12s), keeping blob throughput per unit of wall-clock time
+    # approximately constant under the shorter slot: 21 * 10 // 12 = 17
+    # and 14 * 10 / 12 = 11.67, rounded to 12. The update fraction is
+    # rescaled so that the maximum sustained blob base fee growth rate
+    # per unit of wall-clock time is preserved:
+    # 11684671 * (17 - 12) / (21 - 14) * 12 / 10 = 10015432.
     PER_BLOB: Final[U64] = U64(2**17)
-    BLOB_SCHEDULE_TARGET: Final[U64] = U64(14)
+    BLOB_SCHEDULE_TARGET: Final[U64] = U64(12)
     BLOB_TARGET_GAS_PER_BLOCK: Final[U64] = PER_BLOB * BLOB_SCHEDULE_TARGET
     BLOB_BASE_COST: Final[Uint] = Uint(2**13)
-    BLOB_SCHEDULE_MAX: Final[U64] = U64(21)
+    BLOB_SCHEDULE_MAX: Final[U64] = U64(17)
     BLOB_MIN_GASPRICE: Final[Uint] = Uint(1)
-    BLOB_BASE_FEE_UPDATE_FRACTION: Final[Uint] = Uint(11684671)
+    BLOB_BASE_FEE_UPDATE_FRACTION: Final[Uint] = Uint(10015432)
 
     # Block Access Lists
     BLOCK_ACCESS_LIST_ITEM: Final[ExecutionGas] = ExecutionGas(Uint(2000))
@@ -862,52 +881,43 @@ def init_code_cost(init_code_length: Uint) -> ExecutionGas:
 
 def calculate_excess_blob_gas(
     parent_header: Header | PreviousHeader,
+    current_slot_number: U64 = _INITIAL_SLOT,
+    slot_duration_schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
 ) -> U64:
-    """
-    Calculates the excess blob gas for the current block based
-    on the gas used in the parent block.
-
-    Parameters
-    ----------
-    parent_header :
-        The parent block of the current block.
-
-    Returns
-    -------
-    excess_blob_gas: `ethereum.base_types.U64`
-        The excess blob gas for the current block.
-
-    """
-    # Defaults for a parent without blob gas fields.
+    """Calculate excess blob gas using the current slot-duration era."""
     excess_blob_gas = U64(0)
     blob_gas_used = U64(0)
     base_fee_per_gas = Uint(0)
 
     if isinstance(parent_header, (Header, PreviousHeader)):
-        # Read them from any parent that carries the fields, so
-        # accumulated excess blob gas survives a fork transition.
         excess_blob_gas = parent_header.excess_blob_gas
         blob_gas_used = parent_header.blob_gas_used
         base_fee_per_gas = parent_header.base_fee_per_gas
 
+    blob_schedule = get_blob_schedule(
+        current_slot_number, slot_duration_schedule
+    )
+    target_blob_gas_per_block = GasCosts.PER_BLOB * blob_schedule.target
     parent_blob_gas = excess_blob_gas + blob_gas_used
-    if parent_blob_gas < GasCosts.BLOB_TARGET_GAS_PER_BLOCK:
+    if parent_blob_gas < target_blob_gas_per_block:
         return U64(0)
 
     target_blob_gas_price = Uint(GasCosts.PER_BLOB)
-    target_blob_gas_price *= calculate_blob_gas_price(excess_blob_gas)
+    target_blob_gas_price *= calculate_blob_gas_price(
+        excess_blob_gas,
+        current_slot_number,
+        slot_duration_schedule,
+    )
 
     base_blob_tx_price = GasCosts.BLOB_BASE_COST * base_fee_per_gas
     if base_blob_tx_price > target_blob_gas_price:
-        blob_schedule_delta = (
-            GasCosts.BLOB_SCHEDULE_MAX - GasCosts.BLOB_SCHEDULE_TARGET
-        )
-        return (
+        blob_schedule_delta = blob_schedule.maximum - blob_schedule.target
+        return U64(
             excess_blob_gas
-            + blob_gas_used * blob_schedule_delta // GasCosts.BLOB_SCHEDULE_MAX
+            + blob_gas_used * blob_schedule_delta // blob_schedule.maximum
         )
 
-    return parent_blob_gas - GasCosts.BLOB_TARGET_GAS_PER_BLOCK
+    return U64(parent_blob_gas - target_blob_gas_per_block)
 
 
 def calculate_total_blob_gas(tx: Transaction) -> U64:
@@ -931,47 +941,30 @@ def calculate_total_blob_gas(tx: Transaction) -> U64:
         return U64(0)
 
 
-def calculate_blob_gas_price(excess_blob_gas: U64) -> Uint:
-    """
-    Calculate the blob gasprice for a block.
-
-    Parameters
-    ----------
-    excess_blob_gas :
-        The excess blob gas for the block.
-
-    Returns
-    -------
-    blob_gasprice: `Uint`
-        The blob gasprice.
-
-    """
-    return taylor_exponential(
-        GasCosts.BLOB_MIN_GASPRICE,
-        Uint(excess_blob_gas),
-        GasCosts.BLOB_BASE_FEE_UPDATE_FRACTION,
+def calculate_blob_gas_price(
+    excess_blob_gas: U64,
+    slot_number: U64 = _INITIAL_SLOT,
+    slot_duration_schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+) -> Uint:
+    """Calculate the blob gas price for the supplied duration era."""
+    return calculate_blob_gas_price_for_slot(
+        excess_blob_gas,
+        slot_number,
+        slot_duration_schedule,
     )
 
 
-def calculate_data_fee(excess_blob_gas: U64, tx: Transaction) -> Uint:
-    """
-    Calculate the blob data fee for a transaction.
-
-    Parameters
-    ----------
-    excess_blob_gas :
-        The excess_blob_gas for the execution.
-    tx :
-        The transaction for which the blob data fee is to be calculated.
-
-    Returns
-    -------
-    data_fee: `Uint`
-        The blob data fee.
-
-    """
+def calculate_data_fee(
+    excess_blob_gas: U64,
+    tx: Transaction,
+    slot_number: U64 = _INITIAL_SLOT,
+    slot_duration_schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
+) -> Uint:
+    """Calculate the blob data fee for the supplied duration era."""
     return Uint(calculate_total_blob_gas(tx)) * calculate_blob_gas_price(
-        excess_blob_gas
+        excess_blob_gas,
+        slot_number,
+        slot_duration_schedule,
     )
 
 
@@ -979,33 +972,18 @@ def check_max_fee_per_blob_gas(
     blob_versioned_hashes: Tuple[VersionedHash, ...],
     max_fee_per_blob_gas: U256,
     excess_blob_gas: U64,
+    slot_number: U64 = _INITIAL_SLOT,
+    slot_duration_schedule: SlotDurationSchedule = SLOT_DURATION_SCHEDULE,
 ) -> None:
-    """
-    Check that a transaction carrying blobs pays at least the blob gas
-    price.
-
-    A transaction without blobs pays no blob fee, so its fee cap is not
-    checked.
-
-    Parameters
-    ----------
-    blob_versioned_hashes :
-        The transaction's blob versioned hashes.
-    max_fee_per_blob_gas :
-        The transaction's fee cap per unit of blob gas.
-    excess_blob_gas :
-        The block's excess blob gas.
-
-    Raises
-    ------
-    InsufficientMaxFeePerBlobGasError :
-        If the fee cap does not cover the blob gas price.
-
-    """
+    """Check that a blob transaction covers the active-era blob price."""
     if not blob_versioned_hashes:
         return
 
-    blob_gas_price = calculate_blob_gas_price(excess_blob_gas)
+    blob_gas_price = calculate_blob_gas_price(
+        excess_blob_gas,
+        slot_number,
+        slot_duration_schedule,
+    )
     if Uint(max_fee_per_blob_gas) < blob_gas_price:
         raise InsufficientMaxFeePerBlobGasError(
             "insufficient max fee per blob gas"
@@ -1053,7 +1031,10 @@ def check_block_gas_capacity(
     state_gas_available = (
         block_env.block_gas_limit - block_output.block_state_gas_used
     )
-    blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
+    blob_gas_available = (
+        get_max_blob_gas_per_block(block_env.slot_number)
+        - block_output.blob_gas_used
+    )
 
     if min(TX_MAX_GAS_LIMIT, tx_gas) > execution_gas_available:
         raise GasUsedExceedsLimitError("execution gas used exceeds limit")

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -603,7 +603,10 @@ def blob_base_fee(evm: Evm) -> None:
     charge_gas(evm, GasCosts.OPCODE_BLOBBASEFEE)
 
     # OPERATION
-    blob_base_fee = calculate_blob_gas_price(evm.block_env.excess_blob_gas)
+    blob_base_fee = calculate_blob_gas_price(
+        evm.block_env.excess_blob_gas,
+        evm.block_env.slot_number,
+    )
     push(evm.stack, U256(blob_base_fee))
 
     # PROGRAM COUNTER


### PR DESCRIPTION
This is an executable EL proof for the infrastructure goal of EIP-8198: remove the one-off slot-duration assumption so later reductions can be expressed through schedule data rather than new execution logic.

The Hegotá-facing behavior remains the existing 12s -> 10s reference implementation from `0e8cc7fa0c49f7abfddde9e1f14a40bc54fd407c`. Synthetic 10s -> 8s -> 6s entries are test data only: they exist to prove that the same production paths compose across multiple later duration eras. They are not a proposal to activate 8- or 6-second slots without the consensus-layer performance work EIP-8198 calls for.

What this changes:
- gas-limit scaling is derived from the parent/current execution-payload duration eras, so a duration boundary applies exactly once even when payloads are missed or withheld around it;
- base-fee responsiveness uses current slot duration / the pre-schedule base duration on every block, preserving intended wall-clock response across repeated eras;
- blob capacity, excess accounting, blob pricing, transaction data fees, and BLOBBASEFEE resolve the active duration era from the same schedule;
- no 8-second- or 6-second-specific execution branch is introduced. Future durations are schedule data only.

Proof matrix:
- existing 12s -> 10s behavior is preserved;
- synthetic 10s -> 8s -> 6s capacity scaling composes 60M -> 48M -> 36M without a new execution branch;
- the added 8s era uses the same slot-duration lookup and transition-ratio machinery;
- blob schedule parameters derive through 12s -> 10s -> 8s -> 6s using the same production helper;
- parent payload 7 slots before and child payload 7 slots after the 10s -> 6s boundary still transition correctly;
- an unscaled child is rejected;
- an ordinary later 6s block stays at 36M;
- base-fee response remains tied to the original 12-second wall-clock baseline;
- VM blob helpers read the active schedule rather than an initial-era constant snapshot.

## Validation

Exact upstream-adapted head: `739c87067d4d9b2677d017bdc90ad915e61c099e`

Current upstream Amsterdam base used for validation: `117c9240c86ececb57440cd3342b4b82688fec06`

Green exact validation run: https://github.com/chugarchugarr/execution-specs/actions/runs/33560067598

That run completed successfully through:
- exact pin, direct-parent, one-commit, and merge-base verification against the current upstream Amsterdam head;
- `just static`;
- `just spec-tools`;
- focused `packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots/test_additional_duration_era.py`;
- the full `packages/testing/src/execution_testing/evm_tools/tests/eip8198_quick_slots` suite;
- `git diff --check`;
- exact changed-file-set verification for the eight intended EIP-8198 files;
- immutable candidate-head verification.

The upstream commit since the previous validated base changed only `tests/shanghai/eip4895_withdrawals/test_withdrawals.py` to assert zero withdrawal post-state and did not touch any of the eight EIP-8198 candidate files. This refresh therefore preserves the exact eight candidate blobs while remaining one commit over current `forks/amsterdam`.

The review question is narrow: should EIP-8198's EL implementation be schedule-driven so the one-time Hegotá refactor actually makes later slot reductions configuration changes rather than new duration-specific execution logic?