### PR TITLE
chore(doc): remove broken GitPOAP badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Ethereum Execution Layer Specifications
 
-[![latest version](https://img.shields.io/github/v/release/ethereum/execution-specs)](https://github.com/ethereum/execution-specs/releases/latest)
-[![PyPI version](https://img.shields.io/pypi/v/ethereum-execution)](https://pypi.org/project/ethereum-execution/)
-[![License](https://img.shields.io/github/license/ethereum/execution-specs)](https://github.com/ethereum/execution-specs/blob/main/LICENSE)
+[![PyPI release](https://img.shields.io/pypi/v/ethereum-execution)](https://pypi.org/project/ethereum-execution/)
+[![Tests release](https://img.shields.io/github/v/release/ethereum/execution-specs?filter=tests%40v%2A&label=tests)](https://github.com/ethereum/execution-specs/releases)
+[![License](https://img.shields.io/github/license/ethereum/execution-specs)](LICENSE.md)
 [![Python Specification](https://github.com/ethereum/execution-specs/actions/workflows/test.yaml/badge.svg)](https://github.com/ethereum/execution-specs/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/gh/ethereum/execution-specs/graph/badge.svg?token=0LQZO56RTM)](https://codecov.io/gh/ethereum/execution-specs)
 ![Python Versions](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/ethereum/execution-specs/badge)](https://www.gitpoap.io/gh/ethereum/execution-specs)
 
 The Ethereum Execution Layer Specifications (EELS) are an executable Python reference implementation of Ethereum's execution layer, along with the test cases that verify it. It provides a shared, runnable description of consensus-critical behaviour, and the accompanying tests generate fixtures that can be used to validate execution client implementations.
 


### PR DESCRIPTION
### Description

I saw that the GitPOAP badge link was now broken :sob: :sob:, so I removed it and asked Codex to improve the other badges. It:

- Fixed the license link.
- Clarified the two release streams: one link for `tests@` fixture releases and one for the PyPI spec release.
  <img width="1279" height="257" alt="image" src="https://github.com/user-attachments/assets/1cfda7c3-def1-49ce-84c7-7f8afd74a989" />


### Related Issues or PRs

N/A.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![A cute but sad puppy](https://www.publicdomainpictures.net/pictures/50000/nahled/cute-puppy-13685720501CR.jpg)