### PR TITLE
fix(tests): assert zero-amount withdrawal post-state

### DIFF
--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -673,16 +673,13 @@ def test_zero_amount(
         withdrawals = all_withdrawals[0:2]
         post = {
             account: all_post[account]
-            for account in post
-            if account in [empty_accounts[0], zero_balance_contract]
+            for account in [empty_accounts[0], zero_balance_contract]
         }
     elif test_case == ZeroAmountTestCases.THREE_ONE_WITH_VALUE:
         withdrawals = all_withdrawals[0:3]
         post = {
             account: all_post[account]
-            for account in post
-            if account
-            in [
+            for account in [
                 empty_accounts[0],
                 zero_balance_contract,
                 empty_accounts[1],


### PR DESCRIPTION
## Summary

- build the expected post-state for the two shorter zero-amount withdrawal scenarios from `all_post`
- restore assertions for the untouched account, the zero-balance contract, and the positive-value recipient
- keep the existing withdrawal vectors and production behavior unchanged

## Problem

`post` is initialized as an empty mapping immediately before the test-case branches. The `TWO_ZERO` and `THREE_ONE_WITH_VALUE` branches then used that empty mapping as the iterable for their comprehensions. Both comprehensions therefore always produced an empty expected post-state.

As a result, those generated fixtures exercised the withdrawals but did not enforce the account-state outcomes described by the test: that a zero-value withdrawal does not create an untouched account, that an existing zero-balance contract remains unchanged, and (in the three-withdrawal case) that the positive-value recipient receives one gwei.

This change selects the intended accounts directly and looks up their expectations in `all_post`.

## Validation

- `uv run fill -n 1 --skip-index --output=.just\focused-fixtures --until Shanghai -k test_zero_amount tests\shanghai\eip4895_withdrawals\test_withdrawals.py` — 8 passed
- `uv run ruff check` — passed
- `uv run ruff format --check` — 4,284 files already formatted
- `uv run mypy tests\shanghai\eip4895_withdrawals\test_withdrawals.py` — passed
- `uv run ethereum-spec-lint` — passed
- `uv run vulture src/ packages/testing/src/execution_testing/evm_tools/ vulture_whitelist.py` — passed
- `uv run codespell` and `uv lock --check` — passed
