### PR TITLE
fix(test-forks): model the pre-Berlin gas and refund schedules

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/berlin/eip_2929.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/berlin/eip_2929.py
@@ -1,0 +1,62 @@
+"""
+EIP-2929: Gas cost increases for state access opcodes.
+
+Replace the flat account and storage access costs with warm and cold
+pricing driven by the `address_warm` and `key_warm` opcode metadata.
+
+https://eips.ethereum.org/EIPS/eip-2929
+"""
+
+from typing import Callable, Dict
+
+from execution_testing.vm import OpcodeBase, Opcodes
+
+from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
+
+
+class EIP2929(BaseFork):
+    """EIP-2929 class."""
+
+    @classmethod
+    def _call_access_cost(cls, opcode: OpcodeBase, gas_costs: GasCosts) -> int:
+        """Price the CALL family target access by warmth."""
+        if opcode.metadata["address_warm"]:
+            return gas_costs.WARM_ACCESS
+        return gas_costs.COLD_ACCOUNT_ACCESS
+
+    @classmethod
+    def _selfdestruct_access_cost(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """Charge cold beneficiary access."""
+        if opcode.metadata["address_warm"]:
+            return 0
+        return gas_costs.COLD_ACCOUNT_ACCESS
+
+    @classmethod
+    def opcode_gas_map(
+        cls,
+    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
+        """Price the account and storage access opcodes by warmth."""
+        gas_costs = cls.gas_costs()
+        memory_expansion_calculator = cls.memory_expansion_gas_calculator()
+        base_map = super(EIP2929, cls).opcode_gas_map()
+        return {
+            **base_map,
+            Opcodes.BALANCE: cls._with_account_access(0, gas_costs),
+            Opcodes.EXTCODESIZE: cls._with_account_access(0, gas_costs),
+            Opcodes.EXTCODECOPY: cls._with_memory_expansion(
+                cls._with_data_copy(
+                    cls._with_account_access(0, gas_costs),
+                    gas_costs,
+                ),
+                memory_expansion_calculator,
+            ),
+            Opcodes.EXTCODEHASH: cls._with_account_access(0, gas_costs),
+            Opcodes.SLOAD: lambda op: (
+                gas_costs.WARM_SLOAD
+                if op.metadata["key_warm"]
+                else gas_costs.COLD_STORAGE_ACCESS
+            ),
+        }

--- a/packages/testing/src/execution_testing/forks/forks/eips/berlin/eip_2929.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/berlin/eip_2929.py
@@ -26,6 +26,72 @@ class EIP2929(BaseFork):
         return gas_costs.COLD_ACCOUNT_ACCESS
 
     @classmethod
+    def _calculate_sstore_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """Charge SSTORE by net gas metering with warm and cold keys."""
+        metadata = opcode.metadata
+
+        original_value = metadata["original_value"]
+        current_value = metadata["current_value"]
+        if current_value is None:
+            current_value = original_value
+        new_value = metadata["new_value"]
+
+        gas_cost = 0 if metadata["key_warm"] else gas_costs.COLD_STORAGE_ACCESS
+
+        if original_value == current_value and current_value != new_value:
+            if original_value == 0:
+                gas_cost += gas_costs.STORAGE_SET
+            else:
+                gas_cost += (
+                    gas_costs.COLD_STORAGE_WRITE
+                    - gas_costs.COLD_STORAGE_ACCESS
+                )
+        else:
+            gas_cost += gas_costs.WARM_SLOAD
+
+        return gas_cost
+
+    @classmethod
+    def _calculate_sstore_refund(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """Refund SSTORE by net gas metering with warm and cold keys."""
+        metadata = opcode.metadata
+
+        original_value = metadata["original_value"]
+        current_value = metadata["current_value"]
+        if current_value is None:
+            current_value = original_value
+        new_value = metadata["new_value"]
+
+        refund = 0
+        if current_value != new_value:
+            if original_value != 0 and current_value != 0 and new_value == 0:
+                # Storage is cleared for the first time in the transaction
+                refund += gas_costs.REFUND_STORAGE_CLEAR
+
+            if original_value != 0 and current_value == 0:
+                # Gas refund issued earlier to be reversed
+                refund -= gas_costs.REFUND_STORAGE_CLEAR
+
+            if original_value == new_value:
+                # Storage slot being restored to its original value
+                if original_value == 0:
+                    # Slot was originally empty and was SET earlier
+                    refund += gas_costs.STORAGE_SET - gas_costs.WARM_SLOAD
+                else:
+                    # Slot was originally non-empty and was UPDATED earlier
+                    refund += (
+                        gas_costs.COLD_STORAGE_WRITE
+                        - gas_costs.COLD_STORAGE_ACCESS
+                        - gas_costs.WARM_SLOAD
+                    )
+
+        return refund
+
+    @classmethod
     def _selfdestruct_access_cost(
         cls, opcode: OpcodeBase, gas_costs: GasCosts
     ) -> int:

--- a/packages/testing/src/execution_testing/forks/forks/eips/constantinople/eip_1052.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/constantinople/eip_1052.py
@@ -7,15 +7,25 @@ code.
 https://eips.ethereum.org/EIPS/eip-1052
 """
 
+from dataclasses import replace
 from typing import Callable, Dict, List
 
 from execution_testing.vm import OpcodeBase, Opcodes
 
 from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
 
 
 class EIP1052(BaseFork):
     """EIP-1052 class."""
+
+    @classmethod
+    def gas_costs(cls) -> GasCosts:
+        """Introduce the EXTCODEHASH gas cost."""
+        return replace(
+            super(EIP1052, cls).gas_costs(),
+            OPCODE_EXTCODEHASH=400,
+        )
 
     @classmethod
     def opcode_gas_map(
@@ -26,7 +36,7 @@ class EIP1052(BaseFork):
         base_map = super(EIP1052, cls).opcode_gas_map()
         return {
             **base_map,
-            Opcodes.EXTCODEHASH: cls._with_account_access(0, gas_costs),
+            Opcodes.EXTCODEHASH: gas_costs.OPCODE_EXTCODEHASH,
         }
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/forks/eips/istanbul/eip_1884.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/istanbul/eip_1884.py
@@ -6,15 +6,27 @@ Introduces SELFBALANCE opcode.
 https://eips.ethereum.org/EIPS/eip-1884
 """
 
+from dataclasses import replace
 from typing import Callable, Dict, List
 
 from execution_testing.vm import OpcodeBase, Opcodes
 
 from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
 
 
 class EIP1884(BaseFork):
     """EIP-1884 class."""
+
+    @classmethod
+    def gas_costs(cls) -> GasCosts:
+        """Reprice the trie-size-dependent opcodes."""
+        return replace(
+            super(EIP1884, cls).gas_costs(),
+            OPCODE_BALANCE=700,
+            OPCODE_SLOAD=800,
+            OPCODE_EXTCODEHASH=700,
+        )
 
     @classmethod
     def opcode_gas_map(

--- a/packages/testing/src/execution_testing/forks/forks/eips/istanbul/eip_2200.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/istanbul/eip_2200.py
@@ -1,0 +1,76 @@
+"""
+EIP-2200: Structured definitions for net gas metering.
+
+Charge and refund SSTORE by the original, current and new value of the
+slot. The dirty and no-op write cost is the SLOAD cost. EIP-1283
+introduced the same scheme at Constantinople and was reverted before
+activation, so it is not modeled.
+
+https://eips.ethereum.org/EIPS/eip-2200
+"""
+
+from execution_testing.vm import OpcodeBase
+
+from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
+
+
+class EIP2200(BaseFork):
+    """EIP-2200 class."""
+
+    @classmethod
+    def _calculate_sstore_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """Charge SSTORE by net gas metering."""
+        metadata = opcode.metadata
+
+        original_value = metadata["original_value"]
+        current_value = metadata["current_value"]
+        if current_value is None:
+            current_value = original_value
+        new_value = metadata["new_value"]
+
+        if original_value == current_value and current_value != new_value:
+            if original_value == 0:
+                return gas_costs.STORAGE_SET
+            return gas_costs.COLD_STORAGE_WRITE
+
+        # No-op and dirty writes charge the SLOAD cost.
+        return gas_costs.OPCODE_SLOAD
+
+    @classmethod
+    def _calculate_sstore_refund(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """Refund SSTORE by net gas metering."""
+        metadata = opcode.metadata
+
+        original_value = metadata["original_value"]
+        current_value = metadata["current_value"]
+        if current_value is None:
+            current_value = original_value
+        new_value = metadata["new_value"]
+
+        refund = 0
+        if current_value != new_value:
+            if original_value != 0 and current_value != 0 and new_value == 0:
+                # Storage is cleared for the first time in the transaction
+                refund += gas_costs.REFUND_STORAGE_CLEAR
+
+            if original_value != 0 and current_value == 0:
+                # Gas refund issued earlier to be reversed
+                refund -= gas_costs.REFUND_STORAGE_CLEAR
+
+            if original_value == new_value:
+                # Storage slot being restored to its original value
+                if original_value == 0:
+                    # Slot was originally empty and was SET earlier
+                    refund += gas_costs.STORAGE_SET - gas_costs.OPCODE_SLOAD
+                else:
+                    # Slot was originally non-empty and was UPDATED earlier
+                    refund += (
+                        gas_costs.COLD_STORAGE_WRITE - gas_costs.OPCODE_SLOAD
+                    )
+
+        return refund

--- a/packages/testing/src/execution_testing/forks/forks/eips/london/eip_3529.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/london/eip_3529.py
@@ -17,10 +17,14 @@ class EIP3529(BaseFork):
 
     @classmethod
     def gas_costs(cls) -> GasCosts:
-        """Storage clearing refund is reduced from 15000 to 4800."""
+        """
+        Reduce the storage clearing refund, remove the SELFDESTRUCT
+        refund.
+        """
         return replace(
             super(EIP3529, cls).gas_costs(),
             REFUND_STORAGE_CLEAR=4_800,
+            REFUND_SELF_DESTRUCT=0,
         )
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/forks/eips/spurious_dragon/eip_161.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/spurious_dragon/eip_161.py
@@ -17,19 +17,12 @@ class EIP161(BaseFork):
         cls, opcode: OpcodeBase, gas_costs: GasCosts
     ) -> int:
         """
-        The call gas cost needs to take the value transfer
-        and account new into account.
+        Couple the new account charge to a value transfer, per the dead
+        account rules. The charge itself applies from Frontier.
         """
-        base_cost = super(EIP161, cls)._calculate_call_gas(opcode, gas_costs)
-
-        # Additional costs for value transfer, does not apply to STATICCALL
         metadata = opcode.metadata
         if "value_transfer" in metadata:
-            if metadata["value_transfer"]:
-                base_cost += gas_costs.CALL_VALUE
-                if metadata["account_new"]:
-                    base_cost += gas_costs.NEW_ACCOUNT
-            elif metadata["account_new"]:
+            if metadata["account_new"] and not metadata["value_transfer"]:
                 raise ValueError("Account new requires value transfer")
 
-        return base_cost
+        return super(EIP161, cls)._calculate_call_gas(opcode, gas_costs)

--- a/packages/testing/src/execution_testing/forks/forks/eips/tangerine_whistle/__init__.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/tangerine_whistle/__init__.py
@@ -1,0 +1,1 @@
+"""Listings of all EIPs for Tangerine Whistle fork."""

--- a/packages/testing/src/execution_testing/forks/forks/eips/tangerine_whistle/eip_150.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/tangerine_whistle/eip_150.py
@@ -9,6 +9,8 @@ https://eips.ethereum.org/EIPS/eip-150
 
 from dataclasses import replace
 
+from execution_testing.vm import OpcodeBase
+
 from ....base_fork import BaseFork
 from ....gas_costs import GasCosts
 
@@ -27,3 +29,15 @@ class EIP150(BaseFork):
             OPCODE_SLOAD=200,
             OPCODE_SELFDESTRUCT_BASE=5_000,
         )
+
+    @classmethod
+    def _calculate_selfdestruct_gas(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """Charge for beneficiary creation, introduced by EIP-150."""
+        base_cost = super(EIP150, cls)._calculate_selfdestruct_gas(
+            opcode, gas_costs
+        )
+        if opcode.metadata["account_new"]:
+            base_cost += gas_costs.NEW_ACCOUNT
+        return base_cost

--- a/packages/testing/src/execution_testing/forks/forks/eips/tangerine_whistle/eip_150.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/tangerine_whistle/eip_150.py
@@ -1,0 +1,29 @@
+"""
+EIP-150: Gas cost changes for IO-heavy operations.
+
+Reprice the flat account and storage access costs. Only the costs
+consumed by the opcode gas model are modeled here.
+
+https://eips.ethereum.org/EIPS/eip-150
+"""
+
+from dataclasses import replace
+
+from ....base_fork import BaseFork
+from ....gas_costs import GasCosts
+
+
+class EIP150(BaseFork):
+    """EIP-150 class."""
+
+    @classmethod
+    def gas_costs(cls) -> GasCosts:
+        """Reprice the IO-heavy opcodes."""
+        return replace(
+            super(EIP150, cls).gas_costs(),
+            OPCODE_BALANCE=400,
+            OPCODE_EXTERNAL_BASE=700,
+            OPCODE_CALL_BASE=700,
+            OPCODE_SLOAD=200,
+            OPCODE_SELFDESTRUCT_BASE=5_000,
+        )

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -101,6 +101,10 @@ class Frontier(BaseFork):
             COLD_ACCOUNT_ACCESS=2_600,
             WARM_SLOAD=100,
             COLD_STORAGE_ACCESS=2_100,
+            OPCODE_BALANCE=20,
+            OPCODE_EXTERNAL_BASE=20,
+            OPCODE_CALL_BASE=40,
+            OPCODE_SLOAD=50,
             # Storage
             STORAGE_SET=20_000,
             COLD_STORAGE_WRITE=5_000,
@@ -170,7 +174,7 @@ class Frontier(BaseFork):
             OPCODE_MLOAD_BASE=VERY_LOW,
             OPCODE_MSTORE_BASE=VERY_LOW,
             OPCODE_MSTORE8_BASE=VERY_LOW,
-            OPCODE_SELFDESTRUCT_BASE=5_000,
+            OPCODE_SELFDESTRUCT_BASE=0,
             OPCODE_COPY_PER_WORD=3,
             OPCODE_CREATE_BASE=32_000,
             OPCODE_EXP_BASE=10,
@@ -377,7 +381,7 @@ class Frontier(BaseFork):
                 memory_expansion_calculator,
             ),
             Opcodes.ADDRESS: gas_costs.BASE,
-            Opcodes.BALANCE: cls._with_account_access(0, gas_costs),
+            Opcodes.BALANCE: gas_costs.OPCODE_BALANCE,
             Opcodes.ORIGIN: gas_costs.BASE,
             Opcodes.CALLER: gas_costs.BASE,
             Opcodes.CALLVALUE: gas_costs.BASE,
@@ -395,10 +399,10 @@ class Frontier(BaseFork):
                 memory_expansion_calculator,
             ),
             Opcodes.GASPRICE: gas_costs.BASE,
-            Opcodes.EXTCODESIZE: cls._with_account_access(0, gas_costs),
+            Opcodes.EXTCODESIZE: gas_costs.OPCODE_EXTERNAL_BASE,
             Opcodes.EXTCODECOPY: cls._with_memory_expansion(
                 cls._with_data_copy(
-                    cls._with_account_access(0, gas_costs),
+                    gas_costs.OPCODE_EXTERNAL_BASE,
                     gas_costs,
                 ),
                 memory_expansion_calculator,
@@ -422,11 +426,7 @@ class Frontier(BaseFork):
                 gas_costs.OPCODE_MSTORE8_BASE,
                 memory_expansion_calculator,
             ),
-            Opcodes.SLOAD: lambda op: (
-                gas_costs.WARM_SLOAD
-                if op.metadata["key_warm"]
-                else gas_costs.COLD_STORAGE_ACCESS
-            ),
+            Opcodes.SLOAD: gas_costs.OPCODE_SLOAD,
             Opcodes.SSTORE: lambda op: cls._calculate_sstore_gas(
                 op, gas_costs
             ),
@@ -679,6 +679,28 @@ class Frontier(BaseFork):
         return gas_cost
 
     @classmethod
+    def _call_access_cost(cls, opcode: OpcodeBase, gas_costs: GasCosts) -> int:
+        """
+        Return the CALL family account access cost.
+
+        Flat before EIP-2929 introduces warm and cold pricing.
+        """
+        del opcode
+        return gas_costs.OPCODE_CALL_BASE
+
+    @classmethod
+    def _selfdestruct_access_cost(
+        cls, opcode: OpcodeBase, gas_costs: GasCosts
+    ) -> int:
+        """
+        Return the SELFDESTRUCT beneficiary access cost.
+
+        Zero before EIP-2929 introduces warm and cold pricing.
+        """
+        del opcode, gas_costs
+        return 0
+
+    @classmethod
     def _calculate_call_gas(
         cls, opcode: OpcodeBase, gas_costs: GasCosts
     ) -> int:
@@ -687,11 +709,7 @@ class Frontier(BaseFork):
         """
         metadata = opcode.metadata
 
-        # Base cost depends on address warmth
-        if metadata["address_warm"]:
-            base_cost = gas_costs.WARM_ACCESS
-        else:
-            base_cost = gas_costs.COLD_ACCOUNT_ACCESS
+        base_cost = cls._call_access_cost(opcode, gas_costs)
 
         if metadata["inner_call_cost"]:
             return base_cost + metadata["inner_call_cost"]
@@ -737,9 +755,7 @@ class Frontier(BaseFork):
 
         base_cost = gas_costs.OPCODE_SELFDESTRUCT_BASE
 
-        # Check if the beneficiary is cold
-        if not metadata["address_warm"]:
-            base_cost += gas_costs.COLD_ACCOUNT_ACCESS
+        base_cost += cls._selfdestruct_access_cost(opcode, gas_costs)
 
         # Check if creating a new account
         if metadata["account_new"]:
@@ -1362,6 +1378,7 @@ class DAOFork(
 
 
 class TangerineWhistle(
+    eips.EIP150,
     DAOFork,
     ruleset_name="TANGERINE",
 ):
@@ -1444,6 +1461,7 @@ class MuirGlacier(
 
 class Berlin(
     eips.EIP2930,
+    eips.EIP2929,
     Istanbul,
 ):
     """Berlin fork."""

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -128,6 +128,7 @@ class Frontier(BaseFork):
             TX_CREATE=32_000,
             # Refunds
             REFUND_STORAGE_CLEAR=15_000,
+            REFUND_SELF_DESTRUCT=24_000,
             REFUND_AUTH_PER_EXISTING_ACCOUNT=0,
             # Precompiles
             PRECOMPILE_ECRECOVER=3_000,
@@ -569,6 +570,11 @@ class Frontier(BaseFork):
             Opcodes.SSTORE: lambda op: cls._calculate_sstore_refund(
                 op, gas_costs
             ),
+            Opcodes.SELFDESTRUCT: lambda op: (
+                gas_costs.REFUND_SELF_DESTRUCT
+                if op.metadata["self_destructed_account"]
+                else 0
+            ),
         }
 
     @classmethod
@@ -618,37 +624,17 @@ class Frontier(BaseFork):
         """Calculate SSTORE gas refund based on metadata."""
         metadata = opcode.metadata
 
-        original_value = metadata["original_value"]
         current_value = metadata["current_value"]
         if current_value is None:
-            current_value = original_value
+            current_value = metadata["original_value"]
         new_value = metadata["new_value"]
 
-        # Refund is provided when setting from non-zero to zero
-        refund = 0
-        if current_value != new_value:
-            if original_value != 0 and current_value != 0 and new_value == 0:
-                # Storage is cleared for the first time in the transaction
-                refund += gas_costs.REFUND_STORAGE_CLEAR
+        # Every clearing write is refunded, no net metering before
+        # EIP-2200.
+        if current_value != 0 and new_value == 0:
+            return gas_costs.REFUND_STORAGE_CLEAR
 
-            if original_value != 0 and current_value == 0:
-                # Gas refund issued earlier to be reversed
-                refund -= gas_costs.REFUND_STORAGE_CLEAR
-
-            if original_value == new_value:
-                # Storage slot being restored to its original value
-                if original_value == 0:
-                    # Slot was originally empty and was SET earlier
-                    refund += gas_costs.STORAGE_SET - gas_costs.WARM_SLOAD
-                else:
-                    # Slot was originally non-empty and was UPDATED earlier
-                    refund += (
-                        gas_costs.COLD_STORAGE_WRITE
-                        - gas_costs.COLD_STORAGE_ACCESS
-                        - gas_costs.WARM_SLOAD
-                    )
-
-        return refund
+        return 0
 
     @classmethod
     def _calculate_sstore_gas(
@@ -657,26 +643,17 @@ class Frontier(BaseFork):
         """Calculate SSTORE gas cost based on metadata."""
         metadata = opcode.metadata
 
-        original_value = metadata["original_value"]
         current_value = metadata["current_value"]
         if current_value is None:
-            current_value = original_value
+            current_value = metadata["original_value"]
         new_value = metadata["new_value"]
 
-        gas_cost = 0 if metadata["key_warm"] else gas_costs.COLD_STORAGE_ACCESS
+        # The charge depends on the current value only, no net metering
+        # before EIP-2200.
+        if current_value == 0 and new_value != 0:
+            return gas_costs.STORAGE_SET
 
-        if original_value == current_value and current_value != new_value:
-            if original_value == 0:
-                gas_cost += gas_costs.STORAGE_SET
-            else:
-                gas_cost += (
-                    gas_costs.COLD_STORAGE_WRITE
-                    - gas_costs.COLD_STORAGE_ACCESS
-                )
-        else:
-            gas_cost += gas_costs.WARM_SLOAD
-
-        return gas_cost
+        return gas_costs.COLD_STORAGE_WRITE
 
     @classmethod
     def _call_access_cost(cls, opcode: OpcodeBase, gas_costs: GasCosts) -> int:
@@ -712,7 +689,15 @@ class Frontier(BaseFork):
         base_cost = cls._call_access_cost(opcode, gas_costs)
 
         if metadata["inner_call_cost"]:
-            return base_cost + metadata["inner_call_cost"]
+            base_cost += metadata["inner_call_cost"]
+
+        # Value transfer and new account charges apply from Frontier.
+        # They are independent until EIP-161 couples the new account
+        # charge to a value transfer.
+        if "value_transfer" in metadata and metadata["value_transfer"]:
+            base_cost += gas_costs.CALL_VALUE
+        if "account_new" in metadata and metadata["account_new"]:
+            base_cost += gas_costs.NEW_ACCOUNT
 
         return base_cost
 
@@ -751,15 +736,9 @@ class Frontier(BaseFork):
         cls, opcode: OpcodeBase, gas_costs: GasCosts
     ) -> int:
         """Calculate SELFDESTRUCT gas cost based on metadata."""
-        metadata = opcode.metadata
-
         base_cost = gas_costs.OPCODE_SELFDESTRUCT_BASE
 
         base_cost += cls._selfdestruct_access_cost(opcode, gas_costs)
-
-        # Check if creating a new account
-        if metadata["account_new"]:
-            base_cost += gas_costs.NEW_ACCOUNT
 
         return base_cost
 
@@ -1437,6 +1416,7 @@ class ConstantinopleFix(
 
 
 class Istanbul(
+    eips.EIP2200,
     eips.EIP2028,
     eips.EIP1884,
     eips.EIP1344,

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -76,6 +76,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: int
+    REFUND_SELF_DESTRUCT: int
     REFUND_AUTH_PER_EXISTING_ACCOUNT: int
 
     # Precompiles

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -26,6 +26,14 @@ class GasCosts:
     COLD_ACCOUNT_ACCESS: int
     WARM_SLOAD: int
     COLD_STORAGE_ACCESS: int
+    # Flat access costs used before EIP-2929 introduces warm and cold
+    # pricing. Field names follow the EELS gas constants.
+    OPCODE_BALANCE: int
+    OPCODE_EXTERNAL_BASE: int
+    OPCODE_CALL_BASE: int
+    OPCODE_SLOAD: int
+    # Introduced by EIP-1052, zero before Constantinople.
+    OPCODE_EXTCODEHASH: int = 0
 
     # Storage
     STORAGE_SET: int

--- a/packages/testing/src/execution_testing/forks/tests/test_opcode_gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_opcode_gas_costs.py
@@ -4,7 +4,13 @@ import pytest
 
 from execution_testing.vm import Bytecode, Op
 
-from ..forks.forks import Homestead, Osaka
+from ..forks.forks import (
+    ConstantinopleFix,
+    Homestead,
+    Istanbul,
+    Osaka,
+    SpuriousDragon,
+)
 from ..helpers import Fork
 
 
@@ -322,7 +328,7 @@ from ..helpers import Fork
         pytest.param(
             Homestead,
             Op.CALL(address_warm=False, value_transfer=True, account_new=True),
-            Homestead.gas_costs().COLD_ACCOUNT_ACCESS,
+            Homestead.gas_costs().OPCODE_CALL_BASE,
             id="call_cold_account_new_homestead",
         ),
         pytest.param(
@@ -418,6 +424,64 @@ from ..helpers import Fork
             Op.CLZ,
             Osaka.gas_costs().LOW,
             id="clz_osaka",
+        ),
+        # Pre-Berlin flat access costs. Literal values are the point:
+        # they pin the historical schedule from the EELS vm/gas.py
+        # constants of each fork.
+        pytest.param(Homestead, Op.CALL, 40, id="call_homestead"),
+        pytest.param(SpuriousDragon, Op.CALL, 700, id="call_spurious_dragon"),
+        pytest.param(
+            SpuriousDragon,
+            Op.CALL(address_warm=True),
+            700,
+            id="call_warmth_inert_spurious_dragon",
+        ),
+        pytest.param(
+            SpuriousDragon,
+            Op.CALL(address_warm=True, value_transfer=True, account_new=True),
+            700 + 9_000 + 25_000,
+            id="call_value_new_account_spurious_dragon",
+        ),
+        pytest.param(Homestead, Op.BALANCE, 20, id="balance_homestead"),
+        pytest.param(
+            SpuriousDragon, Op.BALANCE, 400, id="balance_spurious_dragon"
+        ),
+        pytest.param(Istanbul, Op.BALANCE, 700, id="balance_istanbul"),
+        pytest.param(Homestead, Op.SLOAD, 50, id="sload_homestead"),
+        pytest.param(
+            SpuriousDragon, Op.SLOAD, 200, id="sload_spurious_dragon"
+        ),
+        pytest.param(Istanbul, Op.SLOAD, 800, id="sload_istanbul"),
+        pytest.param(
+            Homestead, Op.EXTCODESIZE, 20, id="extcodesize_homestead"
+        ),
+        pytest.param(
+            SpuriousDragon,
+            Op.EXTCODESIZE,
+            700,
+            id="extcodesize_spurious_dragon",
+        ),
+        pytest.param(
+            ConstantinopleFix,
+            Op.EXTCODEHASH,
+            400,
+            id="extcodehash_constantinople_fix",
+        ),
+        pytest.param(Istanbul, Op.EXTCODEHASH, 700, id="extcodehash_istanbul"),
+        pytest.param(
+            Homestead, Op.SELFDESTRUCT, 0, id="selfdestruct_homestead"
+        ),
+        pytest.param(
+            SpuriousDragon,
+            Op.SELFDESTRUCT,
+            5_000,
+            id="selfdestruct_spurious_dragon",
+        ),
+        pytest.param(
+            SpuriousDragon,
+            Op.SELFDESTRUCT(account_new=True),
+            5_000 + 25_000,
+            id="selfdestruct_new_account_spurious_dragon",
         ),
     ],
 )

--- a/packages/testing/src/execution_testing/forks/tests/test_opcode_gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_opcode_gas_costs.py
@@ -5,6 +5,7 @@ import pytest
 from execution_testing.vm import Bytecode, Op
 
 from ..forks.forks import (
+    Berlin,
     ConstantinopleFix,
     Homestead,
     Istanbul,
@@ -328,7 +329,7 @@ from ..helpers import Fork
         pytest.param(
             Homestead,
             Op.CALL(address_warm=False, value_transfer=True, account_new=True),
-            Homestead.gas_costs().OPCODE_CALL_BASE,
+            40 + 9_000 + 25_000,
             id="call_cold_account_new_homestead",
         ),
         pytest.param(
@@ -483,6 +484,21 @@ from ..helpers import Fork
             5_000 + 25_000,
             id="selfdestruct_new_account_spurious_dragon",
         ),
+        # The new account charge is independent of a value transfer
+        # until EIP-161, and SELFDESTRUCT charges nothing before
+        # EIP-150.
+        pytest.param(
+            Homestead,
+            Op.CALL(account_new=True),
+            40 + 25_000,
+            id="call_new_account_without_value_homestead",
+        ),
+        pytest.param(
+            Homestead,
+            Op.SELFDESTRUCT(account_new=True),
+            0,
+            id="selfdestruct_new_account_homestead",
+        ),
     ],
 )
 def test_opcode_gas_costs(fork: Fork, opcode: Op, expected_cost: int) -> None:  # noqa: D103
@@ -551,6 +567,67 @@ def test_bytecode_gas_costs(  # noqa: D103
             Op.MSTORE,
             0,
             id="mstore_no_refund",
+        ),
+        # Legacy storage refunds, every clearing write refunds.
+        pytest.param(
+            Homestead,
+            Op.SSTORE(original_value=5, new_value=0),
+            15_000,
+            id="sstore_clear_homestead",
+        ),
+        pytest.param(
+            Homestead,
+            Op.SSTORE(original_value=0, current_value=5, new_value=0),
+            15_000,
+            id="sstore_re_clear_homestead",
+        ),
+        # EIP-2200 net metering refunds at Istanbul.
+        pytest.param(
+            Istanbul,
+            Op.SSTORE(original_value=5, current_value=6, new_value=5),
+            5_000 - 800,
+            id="sstore_restore_reset_istanbul",
+        ),
+        pytest.param(
+            Istanbul,
+            Op.SSTORE(original_value=0, current_value=5, new_value=0),
+            20_000 - 800,
+            id="sstore_restore_set_istanbul",
+        ),
+        # EIP-2929 warm and cold refund terms.
+        pytest.param(
+            Osaka,
+            Op.SSTORE(original_value=5, current_value=6, new_value=5),
+            Osaka.gas_costs().COLD_STORAGE_WRITE
+            - Osaka.gas_costs().COLD_STORAGE_ACCESS
+            - Osaka.gas_costs().WARM_SLOAD,
+            id="sstore_restore_reset_osaka",
+        ),
+        # EIP-3529 boundary for the storage clear refund.
+        pytest.param(
+            Berlin,
+            Op.SSTORE(original_value=5, new_value=0),
+            15_000,
+            id="sstore_clear_berlin",
+        ),
+        # SELFDESTRUCT refund until EIP-3529 removes it.
+        pytest.param(
+            Homestead,
+            Op.SELFDESTRUCT(self_destructed_account=True),
+            24_000,
+            id="selfdestruct_refund_homestead",
+        ),
+        pytest.param(
+            Berlin,
+            Op.SELFDESTRUCT(self_destructed_account=True),
+            24_000,
+            id="selfdestruct_refund_berlin",
+        ),
+        pytest.param(
+            Osaka,
+            Op.SELFDESTRUCT(self_destructed_account=True),
+            0,
+            id="selfdestruct_refund_osaka",
         ),
     ],
 )
@@ -667,6 +744,58 @@ def test_bytecode_refunds(  # noqa: D103
             Osaka.gas_costs().COLD_STORAGE_ACCESS
             + Osaka.gas_costs().STORAGE_RESET,
             id="sstore_clear_cold",  # 5 → 0
+        ),
+        # Legacy SSTORE, charged by the current value only. Literal
+        # values pin the historical schedule from the EELS vm/gas.py
+        # constants of each fork.
+        pytest.param(
+            Homestead,
+            Op.SSTORE(new_value=5),
+            20_000,
+            id="sstore_set_homestead",  # 0 → 5
+        ),
+        pytest.param(
+            Homestead,
+            Op.SSTORE(original_value=5, new_value=0),
+            5_000,
+            id="sstore_clear_homestead",  # 5 → 0
+        ),
+        pytest.param(
+            Homestead,
+            Op.SSTORE(original_value=5, current_value=0, new_value=7),
+            20_000,
+            id="sstore_dirty_set_homestead",  # 5 → 0 → 7
+        ),
+        pytest.param(
+            Homestead,
+            Op.SSTORE(key_warm=True, new_value=5),
+            20_000,
+            id="sstore_warmth_inert_homestead",  # 0 → 5
+        ),
+        # EIP-2200 net metering at Istanbul.
+        pytest.param(
+            Istanbul,
+            Op.SSTORE(original_value=5, new_value=5),
+            800,
+            id="sstore_noop_istanbul",  # 5 → 5
+        ),
+        pytest.param(
+            Istanbul,
+            Op.SSTORE(original_value=5, current_value=6, new_value=7),
+            800,
+            id="sstore_dirty_istanbul",  # 5 → 6 → 7
+        ),
+        pytest.param(
+            Istanbul,
+            Op.SSTORE(new_value=5),
+            20_000,
+            id="sstore_set_istanbul",  # 0 → 5
+        ),
+        pytest.param(
+            Istanbul,
+            Op.SSTORE(original_value=5, new_value=0),
+            5_000,
+            id="sstore_clear_istanbul",  # 5 → 0
         ),
     ],
 )

--- a/tests/byzantium/eip196_ec_add_mul/test_gas.py
+++ b/tests/byzantium/eip196_ec_add_mul/test_gas.py
@@ -14,7 +14,6 @@ from execution_testing import (
 from execution_testing import (
     Macros as Om,
 )
-from execution_testing.forks.forks.forks import Berlin
 from execution_testing.vm import Opcodes as Op
 
 from .spec import PointG1, Scalar, Spec, ref_spec_196
@@ -116,12 +115,8 @@ def test_invalid_gas_consumption(
         address_warm=False
     ).gas_cost(fork)
 
-    # Pre-EIP-2929: fixed call = 700; Berlin+: warm access cost.
-    gas_costs = fork.gas_costs()
-    if fork >= Berlin:
-        staticcall_base = gas_costs.WARM_ACCESS
-    else:
-        staticcall_base = 700
+    # Precompiles are warm from Berlin, flat call cost before.
+    staticcall_base = Op.STATICCALL(address_warm=True).gas_cost(fork)
 
     account = pre.deploy_contract(
         code=(

--- a/tests/byzantium/eip197_ec_pairing/test_gas.py
+++ b/tests/byzantium/eip197_ec_pairing/test_gas.py
@@ -13,7 +13,6 @@ from execution_testing import (
 from execution_testing import (
     Macros as Om,
 )
-from execution_testing.forks.forks.forks import Berlin
 from execution_testing.vm import Opcodes as Op
 
 from .spec import PointG1, Spec, ref_spec_197
@@ -106,12 +105,8 @@ def test_invalid_gas_consumption(
         address_warm=False
     ).gas_cost(fork)
 
-    # Pre-EIP-2929: fixed call = 700; Berlin+: warm access cost.
-    gas_costs = fork.gas_costs()
-    if fork >= Berlin:
-        staticcall_base = gas_costs.WARM_ACCESS
-    else:
-        staticcall_base = 700
+    # Precompiles are warm from Berlin, flat call cost before.
+    staticcall_base = Op.STATICCALL(address_warm=True).gas_cost(fork)
 
     account = pre.deploy_contract(
         code=(


### PR DESCRIPTION
### Description

Split out of #3477. The opcode metadata gas model priced account and storage access with EIP-2929 warm and cold constants on every fork, so pre-Berlin costs could not be expressed and pre-Berlin exact-gas tests could not be written.

First commit, flat access pricing:

- Flat `OPCODE_BALANCE`, `OPCODE_EXTERNAL_BASE`, `OPCODE_CALL_BASE`, `OPCODE_SLOAD` and `OPCODE_EXTCODEHASH` fields (names follow the EELS gas constants), with a new `EIP150` module and `EIP1052`/`EIP1884` repricings carrying the historical schedule.
- A new `EIP2929` module now owns the warm and cold pricing, wired into `Berlin`. Berlin and later costs are unchanged, pinned by the existing unit tests.

Second commit, the remaining pre-Berlin schedules:

- SSTORE: legacy current-value charging and clear refunds in the Frontier base, net gas metering in a new `EIP2200` module at Istanbul (EIP-1283 is not modeled, it never activated), and the warm/cold bodies move into `EIP2929`.
- CALL: the value transfer and new account charges apply from Frontier (they are independent there, per the EELS frontier gas rules); the `EIP161` module keeps only the dead-account coupling validation.
- SELFDESTRUCT: the beneficiary creation charge moves to `EIP150` where it was introduced, and the 24000 refund is modeled from Frontier until `EIP3529` removes it.

Third commit: the `tests/byzantium/eip19{6,7}` gas tests drop their `if fork >= Berlin` workaround for the old model.

#3477 is stacked on this branch and adds fill-level coverage: exact-gas EIP-161 emptiness probes filled from SpuriousDragon against the EELS reference.

### Related Issues or PRs

#3477

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
