### PR TITLE
fix(test-specs): fail loudly if a test sets env fields not supported by the target fork

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -813,12 +813,13 @@ class BlockchainTest(BaseTest):
 
     def get_genesis_environment(self) -> Environment:
         """Get the genesis environment for pre-allocation groups."""
-        genesis_fork = self.fork.transitions_from()
         # Checked before the defaults below add the mix hash under
         # `prev_randao`, which every genesis header carries.
-        self.genesis_environment.check_fork_fields(genesis_fork)
+        self.genesis_environment.check_fork_fields(
+            self.fork.transitions_from()
+        )
         modified_values = self.genesis_environment.set_fork_requirements(
-            genesis_fork
+            self.fork.transitions_from()
         ).model_dump(exclude_unset=True)
         return Environment(**(GENESIS_ENVIRONMENT_DEFAULTS | modified_values))
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -813,8 +813,12 @@ class BlockchainTest(BaseTest):
 
     def get_genesis_environment(self) -> Environment:
         """Get the genesis environment for pre-allocation groups."""
+        genesis_fork = self.fork.transitions_from()
+        # Checked before the defaults below add the mix hash under
+        # `prev_randao`, which every genesis header carries.
+        self.genesis_environment.check_fork_fields(genesis_fork)
         modified_values = self.genesis_environment.set_fork_requirements(
-            self.fork.transitions_from()
+            genesis_fork
         ).model_dump(exclude_unset=True)
         return Environment(**(GENESIS_ENVIRONMENT_DEFAULTS | modified_values))
 
@@ -878,6 +882,7 @@ class BlockchainTest(BaseTest):
             block_number=env.number, timestamp=env.timestamp
         )
         env = env.set_fork_requirements(fork)
+        env.check_fork_fields(fork)
         txs = block.txs[:]
         if any("gas_limit" not in tx.model_fields_set for tx in block.txs):
             max_tx_gas_limit = Transaction.calculate_max_gas_limit(

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -343,7 +343,7 @@ class StateTest(BaseTest):
         )
 
         env = self.env.set_fork_requirements(fork)
-        env = env.without_fork_ignored_fields(fork)
+        env.check_fork_fields(fork)
         tx = self.tx.with_gas_limit(
             max_gas_limit=env.gas_limit,
             transaction_gas_limit_cap=fork.transaction_gas_limit_cap(),

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -343,6 +343,7 @@ class StateTest(BaseTest):
         )
 
         env = self.env.set_fork_requirements(fork)
+        env = env.without_fork_ignored_fields(fork)
         tx = self.tx.with_gas_limit(
             max_gas_limit=env.gas_limit,
             transaction_gas_limit_cap=fork.transaction_gas_limit_cap(),

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -322,6 +322,13 @@ class StateTest(BaseTest):
 
     def generate_blockchain_test(self) -> BlockchainTest:
         """Generate a BlockchainTest fixture from this StateTest fixture."""
+        # Checked before the genesis derivation below, which asks the
+        # fork for blob constants a fork without blobs does not have.
+        self.env.check_fork_fields(
+            self.fork.fork_at(
+                block_number=self.env.number, timestamp=self.env.timestamp
+            )
+        )
         return BlockchainTest.from_test(
             base_test=self,
             genesis_environment=self._generate_blockchain_genesis_environment(),

--- a/packages/testing/src/execution_testing/specs/tests/test_specs.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_specs.py
@@ -11,6 +11,8 @@ from execution_testing.fixtures import (
     LabeledFixtureFormat,
     StateFixture,
 )
+from execution_testing.forks import Istanbul
+from execution_testing.test_types import Alloc, Environment, Transaction
 
 from ..base import BaseTest
 from ..blockchain import BlockchainTest
@@ -177,3 +179,23 @@ def test_state_test_labels_every_blockchain_test_format() -> None:
             derived[label].transition_tool_cache_key
             == fixture_format.transition_tool_cache_key
         )
+
+
+def test_state_test_conversion_checks_the_env_first() -> None:
+    """
+    Verify converting a state test to a blockchain test reports an env
+    field the fork lacks with the field check's message.
+
+    The genesis derivation runs before `BlockchainTest` checks the env,
+    and for a blob field on a fork without blobs it fails on the fork's
+    missing blob constants instead, which does not name the field.
+    """
+    state_test = StateTest(
+        env=Environment(excess_blob_gas=1),
+        pre=Alloc(),
+        post=Alloc(),
+        tx=Transaction(),
+        fork=Istanbul,
+    )
+    with pytest.raises(ValueError, match="excess_blob_gas"):
+        state_test.generate_blockchain_test()

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -214,6 +214,33 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
 
         return self.copy(**updated_values)
 
+    def without_fork_ignored_fields(self, fork: Fork) -> "Environment":
+        """
+        Return a copy with the fields the fork's header lacks unset.
+
+        A test may pin fields for the newest forks it runs on. Older
+        forks ignore the pins, and serializing them into those forks'
+        fixtures would misstate the environment.
+        """
+        cleared: Dict[str, Any] = {}
+
+        if not fork.header_prev_randao_required():
+            cleared["prev_randao"] = None
+
+        if not fork.header_base_fee_required():
+            cleared["base_fee_per_gas"] = None
+
+        if not fork.header_excess_blob_gas_required():
+            cleared["excess_blob_gas"] = None
+
+        if not fork.header_blob_gas_used_required():
+            cleared["blob_gas_used"] = None
+
+        if not fork.header_slot_number_required():
+            cleared["slot_number"] = None
+
+        return self.copy(**cleared)
+
     def canonical_json(self) -> str:
         """
         Return the canonical JSON encoding of this model.

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -33,15 +33,20 @@ FORK_GATED_FIELDS: Dict[str, Callable[[Fork], bool]] = {
     "parent_base_fee_per_gas": lambda fork: fork.header_base_fee_required(),
     "withdrawals": lambda fork: fork.header_withdrawals_required(),
     "excess_blob_gas": lambda fork: fork.header_excess_blob_gas_required(),
+    "parent_excess_blob_gas": (
+        lambda fork: fork.header_excess_blob_gas_required()
+    ),
     "blob_gas_used": lambda fork: fork.header_blob_gas_used_required(),
+    "parent_blob_gas_used": lambda fork: fork.header_blob_gas_used_required(),
     "parent_beacon_block_root": (
         lambda fork: fork.header_beacon_root_required()
     ),
     "slot_number": lambda fork: fork.header_slot_number_required(),
+    "parent_slot_number": lambda fork: fork.header_slot_number_required(),
 }
 """
-Environment fields that only some block headers carry, keyed by the
-fork predicate that admits each one.
+Environment fields, current and parent, that only some block headers
+carry, keyed by the fork predicate that admits each one.
 """
 
 

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -3,7 +3,7 @@
 import json
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Dict, Generic, List, Sequence
+from typing import Any, Callable, Dict, Generic, List, Sequence
 
 import ethereum_rlp as eth_rlp
 from ethereum_types.numeric import Uint
@@ -26,6 +26,23 @@ from execution_testing.forks import Fork
 DEFAULT_BASE_FEE = 7
 CURRENT_MAINNET_BLOCK_GAS_LIMIT = 60_000_000
 DEFAULT_BLOCK_GAS_LIMIT = CURRENT_MAINNET_BLOCK_GAS_LIMIT * 2
+
+FORK_GATED_FIELDS: Dict[str, Callable[[Fork], bool]] = {
+    "prev_randao": lambda fork: fork.header_prev_randao_required(),
+    "base_fee_per_gas": lambda fork: fork.header_base_fee_required(),
+    "parent_base_fee_per_gas": lambda fork: fork.header_base_fee_required(),
+    "withdrawals": lambda fork: fork.header_withdrawals_required(),
+    "excess_blob_gas": lambda fork: fork.header_excess_blob_gas_required(),
+    "blob_gas_used": lambda fork: fork.header_blob_gas_used_required(),
+    "parent_beacon_block_root": (
+        lambda fork: fork.header_beacon_root_required()
+    ),
+    "slot_number": lambda fork: fork.header_slot_number_required(),
+}
+"""
+Environment fields that only some block headers carry, keyed by the
+fork predicate that admits each one.
+"""
 
 
 @dataclass
@@ -214,32 +231,46 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
 
         return self.copy(**updated_values)
 
-    def without_fork_ignored_fields(self, fork: Fork) -> "Environment":
+    @classmethod
+    def for_fork(cls, fork: Fork, **kwargs: Any) -> "Environment":
         """
-        Return a copy with the fields the fork's header lacks unset.
+        Build an environment from only the fields the fork's header has.
 
-        A test may pin fields for the newest forks it runs on. Older
-        forks ignore the pins, and serializing them into those forks'
-        fixtures would misstate the environment.
+        Use it when one pinned context spans forks whose headers differ:
+        the pins the fork lacks are dropped instead of raising in
+        `check_fork_fields`.
         """
-        cleared: Dict[str, Any] = {}
+        return cls(
+            **{
+                name: value
+                for name, value in kwargs.items()
+                if name not in FORK_GATED_FIELDS
+                or FORK_GATED_FIELDS[name](fork)
+            }
+        )
 
-        if not fork.header_prev_randao_required():
-            cleared["prev_randao"] = None
+    def check_fork_fields(self, fork: Fork) -> None:
+        """
+        Raise if a set field is one the fork's block header lacks.
 
-        if not fork.header_base_fee_required():
-            cleared["base_fee_per_gas"] = None
-
-        if not fork.header_excess_blob_gas_required():
-            cleared["excess_blob_gas"] = None
-
-        if not fork.header_blob_gas_used_required():
-            cleared["blob_gas_used"] = None
-
-        if not fork.header_slot_number_required():
-            cleared["slot_number"] = None
-
-        return self.copy(**cleared)
+        Serializing such a field into a fixture would misstate the block
+        context, so the test has to state its intent instead.
+        """
+        unsupported = [
+            name
+            for name, required in FORK_GATED_FIELDS.items()
+            if getattr(self, name) is not None and not required(fork)
+        ]
+        if not unsupported:
+            return
+        raise ValueError(
+            f"{', '.join(unsupported)} set for {fork.name()}, whose block "
+            "header has no such field. Remove the field from the test, "
+            "build the environment with Environment.for_fork(fork, ...) "
+            "to keep only the fields the fork has, or, to check that "
+            "clients reject the field, set it on the block through "
+            "Block(rlp_modifier=Header(...))."
+        )
 
     def canonical_json(self) -> str:
         """

--- a/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
@@ -53,11 +53,16 @@ def test_for_fork_keeps_only_the_fork_fields(fork: Fork) -> None:
 @fork_cases
 @pytest.mark.parametrize("name", list(PINS))
 def test_check_fork_fields(fork: Fork, name: str) -> None:
-    """A pin the fork's header lacks raises and names the field."""
+    """
+    A pin the fork's header lacks raises, naming the field and both
+    ways out.
+    """
     env = Environment(**{name: PINS[name]})
     if name in DROPPED[fork]:
-        with pytest.raises(ValueError, match=name):
+        with pytest.raises(ValueError, match=name) as excinfo:
             env.check_fork_fields(fork)
+        assert "Environment.for_fork" in str(excinfo.value)
+        assert "rlp_modifier" in str(excinfo.value)
     else:
         env.check_fork_fields(fork)
 

--- a/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
@@ -1,51 +1,68 @@
 """
-Test that an environment sheds the fields a fork's header lacks.
+Test the fork gating of the environment fields some headers lack.
 """
+
+from typing import Any, Dict, Set
 
 import pytest
 
-from execution_testing.forks import Amsterdam, Fork, Istanbul, Paris
+from execution_testing.forks import Amsterdam, Cancun, Fork, Istanbul, Paris
 
 from ..block_types import Environment
 
-PINNED = Environment(
-    prev_randao=0x20000,
-    base_fee_per_gas=10,
-    excess_blob_gas=0,
-    slot_number=7,
+PINS: Dict[str, Any] = {
+    "prev_randao": 0x20000,
+    "base_fee_per_gas": 10,
+    "parent_base_fee_per_gas": 9,
+    "withdrawals": [],
+    "excess_blob_gas": 3,
+    "blob_gas_used": 4,
+    "parent_beacon_block_root": 5,
+    "slot_number": 7,
+}
+
+DROPPED: Dict[Fork, Set[str]] = {
+    Istanbul: set(PINS),
+    Paris: {
+        "withdrawals",
+        "excess_blob_gas",
+        "blob_gas_used",
+        "parent_beacon_block_root",
+        "slot_number",
+    },
+    Cancun: {"slot_number"},
+    Amsterdam: set(),
+}
+
+fork_cases = pytest.mark.parametrize(
+    "fork", list(DROPPED), ids=lambda fork: fork.name()
 )
 
 
-@pytest.mark.parametrize(
-    "fork,dropped",
-    [
-        pytest.param(
-            Istanbul,
-            {
-                "currentRandom",
-                "currentBaseFee",
-                "currentExcessBlobGas",
-                "slotNumber",
-            },
-            id="istanbul",
-        ),
-        pytest.param(
-            Paris,
-            {"currentExcessBlobGas", "slotNumber"},
-            id="paris",
-        ),
-        pytest.param(Amsterdam, set(), id="amsterdam"),
-    ],
-)
-def test_without_fork_ignored_fields(fork: Fork, dropped: set) -> None:
-    """Pinned fields the fork's header lacks must not serialize."""
-    env = PINNED.set_fork_requirements(fork).without_fork_ignored_fields(fork)
-    keys = env.model_dump(mode="json", by_alias=True, exclude_none=True).keys()
-    assert dropped.isdisjoint(keys)
-    kept = {
-        "currentRandom",
-        "currentBaseFee",
-        "currentExcessBlobGas",
-        "slotNumber",
-    } - dropped
-    assert kept <= keys
+@fork_cases
+def test_for_fork_keeps_only_the_fork_fields(fork: Fork) -> None:
+    """Pins the fork's header lacks are dropped, the rest kept verbatim."""
+    env = Environment.for_fork(fork, **PINS)
+    for name, value in PINS.items():
+        if name in DROPPED[fork]:
+            assert getattr(env, name) is None, name
+        else:
+            assert getattr(env, name) == value, name
+
+
+@fork_cases
+@pytest.mark.parametrize("name", list(PINS))
+def test_check_fork_fields(fork: Fork, name: str) -> None:
+    """A pin the fork's header lacks raises and names the field."""
+    env = Environment(**{name: PINS[name]})
+    if name in DROPPED[fork]:
+        with pytest.raises(ValueError, match=name):
+            env.check_fork_fields(fork)
+    else:
+        env.check_fork_fields(fork)
+
+
+@fork_cases
+def test_fork_requirements_pass_the_check(fork: Fork) -> None:
+    """The fields a fork requires never trip its own check."""
+    Environment().set_fork_requirements(fork).check_fork_fields(fork)

--- a/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
@@ -1,0 +1,51 @@
+"""
+Test that an environment sheds the fields a fork's header lacks.
+"""
+
+import pytest
+
+from execution_testing.forks import Amsterdam, Fork, Istanbul, Paris
+
+from ..block_types import Environment
+
+PINNED = Environment(
+    prev_randao=0x20000,
+    base_fee_per_gas=10,
+    excess_blob_gas=0,
+    slot_number=7,
+)
+
+
+@pytest.mark.parametrize(
+    "fork,dropped",
+    [
+        pytest.param(
+            Istanbul,
+            {
+                "currentRandom",
+                "currentBaseFee",
+                "currentExcessBlobGas",
+                "slotNumber",
+            },
+            id="istanbul",
+        ),
+        pytest.param(
+            Paris,
+            {"currentExcessBlobGas", "slotNumber"},
+            id="paris",
+        ),
+        pytest.param(Amsterdam, set(), id="amsterdam"),
+    ],
+)
+def test_without_fork_ignored_fields(fork: Fork, dropped: set) -> None:
+    """Pinned fields the fork's header lacks must not serialize."""
+    env = PINNED.set_fork_requirements(fork).without_fork_ignored_fields(fork)
+    keys = env.model_dump(mode="json", by_alias=True, exclude_none=True).keys()
+    assert dropped.isdisjoint(keys)
+    kept = {
+        "currentRandom",
+        "currentBaseFee",
+        "currentExcessBlobGas",
+        "slotNumber",
+    } - dropped
+    assert kept <= keys

--- a/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_environment_fork_fields.py
@@ -16,9 +16,12 @@ PINS: Dict[str, Any] = {
     "parent_base_fee_per_gas": 9,
     "withdrawals": [],
     "excess_blob_gas": 3,
+    "parent_excess_blob_gas": 2,
     "blob_gas_used": 4,
+    "parent_blob_gas_used": 1,
     "parent_beacon_block_root": 5,
     "slot_number": 7,
+    "parent_slot_number": 6,
 }
 
 DROPPED: Dict[Fork, Set[str]] = {
@@ -26,11 +29,14 @@ DROPPED: Dict[Fork, Set[str]] = {
     Paris: {
         "withdrawals",
         "excess_blob_gas",
+        "parent_excess_blob_gas",
         "blob_gas_used",
+        "parent_blob_gas_used",
         "parent_beacon_block_root",
         "slot_number",
+        "parent_slot_number",
     },
-    Cancun: {"slot_number"},
+    Cancun: {"slot_number", "parent_slot_number"},
     Amsterdam: set(),
 }
 

--- a/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
+++ b/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
@@ -123,15 +123,31 @@ def _jump_over_revert(conditional: bool) -> Bytecode:
     return code
 
 
-ENV = Environment(
-    fee_recipient=COINBASE,
-    number=BLOCK_NUMBER,
-    timestamp=BLOCK_TIMESTAMP,
-    prev_randao=PREV_RANDAO,
-    base_fee_per_gas=BASE_FEE_PER_GAS,
-    excess_blob_gas=EXCESS_BLOB_GAS,
-    slot_number=SLOT_NUMBER,
-)
+def _env(fork: Fork) -> Environment:
+    """
+    Build the pinned block context, limited to the fork's own fields.
+
+    A pin the fork ignores would otherwise be serialized into its
+    fixtures verbatim.
+    """
+    pins: dict[str, int] = {}
+    if fork.header_prev_randao_required():
+        pins["prev_randao"] = PREV_RANDAO
+    else:
+        # Pre-merge, the 0x44 opcode reads the difficulty instead.
+        pins["difficulty"] = PREV_RANDAO
+    if fork.header_base_fee_required():
+        pins["base_fee_per_gas"] = BASE_FEE_PER_GAS
+    if fork.header_excess_blob_gas_required():
+        pins["excess_blob_gas"] = EXCESS_BLOB_GAS
+    if fork.header_slot_number_required():
+        pins["slot_number"] = SLOT_NUMBER
+    return Environment(
+        fee_recipient=COINBASE,
+        number=BLOCK_NUMBER,
+        timestamp=BLOCK_TIMESTAMP,
+        **pins,
+    )
 
 
 @dataclass(frozen=True)
@@ -154,6 +170,7 @@ class Context:
     sender: Address
     init_code: Bytecode
     fork: Fork
+    env: Environment
 
 
 @dataclass(frozen=True)
@@ -405,7 +422,7 @@ CASES: dict[Opcodes, Case] = {
     Op.TIMESTAMP: Case(Op.TIMESTAMP, BLOCK_TIMESTAMP),
     Op.PREVRANDAO: Case(Op.PREVRANDAO, PREV_RANDAO),
     Op.BASEFEE: Case(Op.BASEFEE, BASE_FEE_PER_GAS),
-    Op.GASLIMIT: Case(Op.GASLIMIT, int(ENV.gas_limit)),
+    Op.GASLIMIT: Case(Op.GASLIMIT, lambda c: int(c.env.gas_limit)),
     Op.SLOTNUM: Case(Op.SLOTNUM, SLOT_NUMBER),
     Op.BLOBBASEFEE: Case(
         Op.BLOBBASEFEE,
@@ -547,8 +564,13 @@ def test_opcodes_transaction_init(
             + Op.RETURN(offset=0x0, size=WORD)
         )
 
+    env = _env(fork)
     context = Context(
-        created=created, sender=sender, init_code=init_code, fork=fork
+        created=created,
+        sender=sender,
+        init_code=init_code,
+        fork=fork,
+        env=env,
     )
     deployed_code = b""
     if case.expected is not None:
@@ -581,4 +603,4 @@ def test_opcodes_transaction_init(
     if case.extra is not None:
         post.update(case.extra(context))
 
-    state_test(env=ENV, pre=pre, post=post, tx=tx)
+    state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
+++ b/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
@@ -124,30 +124,21 @@ def _jump_over_revert(conditional: bool) -> Bytecode:
 
 
 def _env(fork: Fork) -> Environment:
-    """
-    Build the pinned block context, limited to the fork's own fields.
-
-    A pin the fork ignores would otherwise be serialized into its
-    fixtures verbatim.
-    """
-    pins: dict[str, int] = {}
-    if fork.header_prev_randao_required():
-        pins["prev_randao"] = PREV_RANDAO
-    else:
-        # Pre-merge, the 0x44 opcode reads the difficulty instead.
-        pins["difficulty"] = PREV_RANDAO
-    if fork.header_base_fee_required():
-        pins["base_fee_per_gas"] = BASE_FEE_PER_GAS
-    if fork.header_excess_blob_gas_required():
-        pins["excess_blob_gas"] = EXCESS_BLOB_GAS
-    if fork.header_slot_number_required():
-        pins["slot_number"] = SLOT_NUMBER
-    return Environment(
+    """Build the pinned block context out of the fields the fork has."""
+    env = Environment.for_fork(
+        fork,
         fee_recipient=COINBASE,
         number=BLOCK_NUMBER,
         timestamp=BLOCK_TIMESTAMP,
-        **pins,
+        prev_randao=PREV_RANDAO,
+        base_fee_per_gas=BASE_FEE_PER_GAS,
+        excess_blob_gas=EXCESS_BLOB_GAS,
+        slot_number=SLOT_NUMBER,
     )
+    if not fork.header_prev_randao_required():
+        # Pre-merge, the 0x44 opcode reads the difficulty instead.
+        env = env.copy(difficulty=PREV_RANDAO)
+    return env
 
 
 @dataclass(frozen=True)

--- a/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
+++ b/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
@@ -63,13 +63,6 @@ BASE_FEE_PER_GAS = 10
 EXCESS_BLOB_GAS = 0
 SLOT_NUMBER = 7
 
-FORK_DEPENDENT_ENVIRONMENT_FIELDS: dict[Opcodes, dict[str, int]] = {
-    Op.BASEFEE: {"base_fee_per_gas": BASE_FEE_PER_GAS},
-    Op.BLOBBASEFEE: {"excess_blob_gas": EXCESS_BLOB_GAS},
-    Op.SLOTNUM: {"slot_number": SLOT_NUMBER},
-}
-"""Environment pins needed only by the opcode case that reads them."""
-
 # Markers written then read back, so a store or copy that silently did
 # nothing is distinguishable from one that worked.
 STORE_MARKER = 0xD1CE
@@ -544,21 +537,21 @@ def test_opcodes_transaction_init(
             + Op.RETURN(offset=0x0, size=WORD)
         )
 
-    environment_fields = FORK_DEPENDENT_ENVIRONMENT_FIELDS.get(opcode, {})
-    if opcode == Op.PREVRANDAO:
-        # Opcode 0x44 reads difficulty pre-merge and prev_randao post-merge.
-        environment_fields = {
-            (
-                "prev_randao"
-                if fork.header_prev_randao_required()
-                else "difficulty"
-            ): PREV_RANDAO
-        }
-    env = Environment(
+    env = Environment.for_fork(
+        fork,
         fee_recipient=COINBASE,
         number=BLOCK_NUMBER,
         timestamp=BLOCK_TIMESTAMP,
-        **environment_fields,
+        prev_randao=PREV_RANDAO,
+        base_fee_per_gas=BASE_FEE_PER_GAS,
+        excess_blob_gas=EXCESS_BLOB_GAS,
+        slot_number=SLOT_NUMBER,
+        # Pre-merge, opcode 0x44 reads the difficulty instead.
+        **(
+            {}
+            if fork.header_prev_randao_required()
+            else {"difficulty": PREV_RANDAO}
+        ),
     )
     context = Context(
         created=created,

--- a/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
+++ b/tests/ported_static/stTransactionTest/test_opcodes_transaction_init.py
@@ -63,6 +63,13 @@ BASE_FEE_PER_GAS = 10
 EXCESS_BLOB_GAS = 0
 SLOT_NUMBER = 7
 
+FORK_DEPENDENT_ENVIRONMENT_FIELDS: dict[Opcodes, dict[str, int]] = {
+    Op.BASEFEE: {"base_fee_per_gas": BASE_FEE_PER_GAS},
+    Op.BLOBBASEFEE: {"excess_blob_gas": EXCESS_BLOB_GAS},
+    Op.SLOTNUM: {"slot_number": SLOT_NUMBER},
+}
+"""Environment pins needed only by the opcode case that reads them."""
+
 # Markers written then read back, so a store or copy that silently did
 # nothing is distinguishable from one that worked.
 STORE_MARKER = 0xD1CE
@@ -121,24 +128,6 @@ def _jump_over_revert(conditional: bool) -> Bytecode:
     code = jump + revert + Op.JUMPDEST + Op.PUSH1[JUMP_MARKER]
     code.substitute(target=len(jump) + len(revert))
     return code
-
-
-def _env(fork: Fork) -> Environment:
-    """Build the pinned block context out of the fields the fork has."""
-    env = Environment.for_fork(
-        fork,
-        fee_recipient=COINBASE,
-        number=BLOCK_NUMBER,
-        timestamp=BLOCK_TIMESTAMP,
-        prev_randao=PREV_RANDAO,
-        base_fee_per_gas=BASE_FEE_PER_GAS,
-        excess_blob_gas=EXCESS_BLOB_GAS,
-        slot_number=SLOT_NUMBER,
-    )
-    if not fork.header_prev_randao_required():
-        # Pre-merge, the 0x44 opcode reads the difficulty instead.
-        env = env.copy(difficulty=PREV_RANDAO)
-    return env
 
 
 @dataclass(frozen=True)
@@ -555,7 +544,22 @@ def test_opcodes_transaction_init(
             + Op.RETURN(offset=0x0, size=WORD)
         )
 
-    env = _env(fork)
+    environment_fields = FORK_DEPENDENT_ENVIRONMENT_FIELDS.get(opcode, {})
+    if opcode == Op.PREVRANDAO:
+        # Opcode 0x44 reads difficulty pre-merge and prev_randao post-merge.
+        environment_fields = {
+            (
+                "prev_randao"
+                if fork.header_prev_randao_required()
+                else "difficulty"
+            ): PREV_RANDAO
+        }
+    env = Environment(
+        fee_recipient=COINBASE,
+        number=BLOCK_NUMBER,
+        timestamp=BLOCK_TIMESTAMP,
+        **environment_fields,
+    )
     context = Context(
         created=created,
         sender=sender,


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Reported by jangko on #3479: the v8.1.3 `test_opcodes_transaction_init` fixtures for pre-London forks carry `currentBaseFee`, `currentExcessBlobGas` and `slotNumber` (and `currentRandom`, unflagged). The enhanced test pins one module-level `Environment` across every fork so the `BASEFEE`, `BLOBBASEFEE`, `SLOTNUM` and `PREVRANDAO` arms can assert exact values, and nothing in the fill pipeline strips fields the target fork ignores. It is the only ported test that both reaches back before London and pins post-fork fields.

- `Environment.check_fork_fields` fails the fill when an env sets a field the fork's header lacks, gated on the fork's `header_*_required` predicates, and runs after `set_fork_requirements` on the state test env, the genesis env and each block env, so no other test can reintroduce the leak. `Environment.for_fork` keeps only the fields the fork has, for a test that spans forks with one pinned context.
- The test now pins only the field each opcode case reads. Pre-merge the `0x44` arm pins the difficulty explicitly, where it previously matched only because the framework's difficulty default equals the randao pin.

Istanbul now fills with the classic five env fields only. Amsterdam keeps every pin and all arms stay green.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#3479

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

