### PR TITLE
feat(tests): pin cross-frame state gas refund placement and settlement

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -78,7 +78,7 @@ def test_cross_frame_refund_parks_in_reservoir(
     """
     clearer = pre.deploy_contract(code=Op.SSTORE(SLOT_X, 0))
 
-    call_window = Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=clearer))
+    call_window = Op.POP(Op.DELEGATECALL(address=clearer))
     code = (
         # Warm the clearer and the slot while it is still zero, and
         # pre-expand the measurement memory, so the two measured
@@ -101,7 +101,7 @@ def test_cross_frame_refund_parks_in_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=1_000_000,
+        state_gas_reservoir=0,
         sender=pre.fund_eoa(),
     )
 
@@ -183,7 +183,7 @@ def test_parked_credit_returns_at_settlement(
 
     tx = Transaction(
         to=contract,
-        gas_limit=1_000_000,
+        state_gas_reservoir=0,
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(
             cumulative_gas_used=expected_gas_used
@@ -278,7 +278,7 @@ def test_parked_credit_funds_state_at_full_price(
 
     tx = Transaction(
         to=contract,
-        gas_limit=1_000_000,
+        state_gas_reservoir=0,
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(
             cumulative_gas_used=expected_gas_used
@@ -337,9 +337,13 @@ def test_parked_credit_cannot_fund_execution(
             Op.DELEGATECALL(gas=Op.GAS, address=clearer, address_warm=False)
         )
     )
-    tail = Op.MSTORE.with_metadata(new_memory_size=192_032, old_memory_size=0)(
-        192_000, 1
+    # TODO: The tail spends a set amount of execution gas; a JUMPDEST
+    # run is the most future-proof inline way until a fork util exists.
+    tail_ops = min(
+        sstore_state_gas // Op.JUMPDEST.gas_cost(fork),
+        fork.max_code_size() - len(head),
     )
+    tail = Op.JUMPDEST * tail_ops
     code = head + tail
     contract = pre.deploy_contract(code=code)
 
@@ -482,21 +486,9 @@ def test_child_clear_repays_own_spill_first(
     else:
         raise ValueError(f"unhandled child ending: {child_ending}")
 
-    gas_limit = (
-        intrinsic_cost
-        + code.gas_cost(fork)
-        + child_budget
-        + child_budget // 63
-        + 1
-    )
-    # The spill premise needs the reservoir empty at transaction start.
-    gas_limit_cap = fork.transaction_gas_limit_cap()
-    assert gas_limit_cap is not None
-    assert gas_limit <= gas_limit_cap
-
     tx = Transaction(
         to=contract,
-        gas_limit=gas_limit,
+        state_gas_reservoir=0,
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(
             cumulative_gas_used=expected_gas_used

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -32,7 +32,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .spec import ref_spec_8037
+from .spec import Spec, ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -369,4 +369,154 @@ def test_parked_credit_cannot_fund_execution(
     )
 
     post = {contract: Account(storage={SLOT_MARKER: 0, SLOT_X: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize("child_ending", ["stop", "revert", "invalid"])
+@pytest.mark.valid_from("EIP8037")
+def test_child_clear_repays_own_spill_first(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    child_ending: str,
+) -> None:
+    """
+    Test the cross-slot LIFO split of a cross-frame refund in a child.
+
+    The parent spills two fresh sets; a delegated child spills a set
+    of its own, then clears both parent slots. The first credit repays
+    the child's borrow, the second parks in the reservoir, and a
+    failing child discards the parked credit with its rollback.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+
+    fresh_set = Op.SSTORE.with_metadata(
+        key_warm=False,
+        original_value=0,
+        current_value=0,
+        new_value=1,
+    )
+    warm_clear = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )
+
+    child_body = (
+        fresh_set(SLOT_MARKER, 1)
+        + warm_clear(SLOT_X, 0)
+        + warm_clear(SLOT_Y, 0)
+    )
+    if child_ending == "stop":
+        child_code = child_body + Op.STOP
+    elif child_ending == "revert":
+        child_code = child_body + Op.REVERT(0, 0)
+    elif child_ending == "invalid":
+        child_code = child_body + Op.INVALID
+    else:
+        raise ValueError(f"unhandled child ending: {child_ending}")
+    child = pre.deploy_contract(code=child_code)
+
+    # A budget covering the child's SSTORE stipend sentry through its
+    # own spilled set and both clears.
+    child_budget = fork.call_value_stipend() + 1 + child_code.gas_cost(fork)
+
+    call_window = Op.POP(
+        Op.DELEGATECALL(gas=child_budget, address=child, address_warm=False)
+    )
+    code = (
+        fresh_set(SLOT_X, 1)
+        + fresh_set(SLOT_Y, 1)
+        + Op.MSTORE(32, 0, new_memory_size=64, old_memory_size=0)
+        + Op.MSTORE(0, Op.GAS)
+        + call_window
+        + Op.MSTORE(32, Op.GAS)
+        + fresh_set(SLOT_RESULT, Op.SUB(Op.MLOAD(0), Op.MLOAD(32)))
+    )
+    contract = pre.deploy_contract(code=code)
+
+    if child_ending == "stop":
+        child_consumed = child_code.execution_cost(fork)
+    elif child_ending == "revert":
+        child_consumed = child_code.execution_cost(fork)
+    elif child_ending == "invalid":
+        child_consumed = child_budget
+    else:
+        raise ValueError(f"unhandled child ending: {child_ending}")
+    # Gas measured between the two reads: the first stamp's store, the
+    # call window, the child's consumption, and the second read itself.
+    window_cost = (
+        Op.MSTORE(0, Op.GAS).gas_cost(fork)
+        + call_window.execution_cost(fork)
+        + child_consumed
+    )
+
+    parent_exec = code.execution_cost(fork)
+    if child_ending == "stop":
+        # The child's slot and the result slot survive; the child's
+        # borrow was repaid by the first clear's credit, so only the
+        # parked second credit cancels a parent spill at settlement.
+        before_refund = (
+            intrinsic_cost
+            + parent_exec
+            + child_code.execution_cost(fork)
+            + 2 * sstore_state_gas
+        )
+        restore_refund = 2 * (warm_clear.refund(fork) - sstore_state_gas)
+        expected_gas_used = before_refund - min(
+            before_refund // fork.max_refund_quotient(), restore_refund
+        )
+    elif child_ending == "revert":
+        expected_gas_used = (
+            intrinsic_cost
+            + parent_exec
+            + child_code.execution_cost(fork)
+            + 3 * sstore_state_gas
+        )
+    elif child_ending == "invalid":
+        expected_gas_used = (
+            intrinsic_cost + parent_exec + child_budget + 3 * sstore_state_gas
+        )
+    else:
+        raise ValueError(f"unhandled child ending: {child_ending}")
+
+    gas_limit = (
+        intrinsic_cost
+        + code.gas_cost(fork)
+        + child_budget
+        + child_budget // 63
+        + 1
+    )
+    # The spill premise needs the reservoir empty at transaction start.
+    assert gas_limit <= Spec.TX_MAX_GAS_LIMIT
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used
+        ),
+    )
+
+    if child_ending == "stop":
+        storage = {
+            SLOT_X: 0,
+            SLOT_Y: 0,
+            SLOT_MARKER: 1,
+            SLOT_RESULT: window_cost,
+        }
+    elif child_ending in ("revert", "invalid"):
+        storage = {
+            SLOT_X: 1,
+            SLOT_Y: 1,
+            SLOT_MARKER: 0,
+            SLOT_RESULT: window_cost,
+        }
+    else:
+        raise ValueError(f"unhandled child ending: {child_ending}")
+
+    post = {contract: Account(storage=storage)}
     state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -32,7 +32,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -490,7 +490,9 @@ def test_child_clear_repays_own_spill_first(
         + 1
     )
     # The spill premise needs the reservoir empty at transaction start.
-    assert gas_limit <= Spec.TX_MAX_GAS_LIMIT
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    assert gas_limit <= gas_limit_cap
 
     tx = Transaction(
         to=contract,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -1,0 +1,372 @@
+"""
+Test where a state gas refund lands when it is credited in a
+different frame than the spilled charge it undoes.
+
+A state charge spilled from `gas_left` can be refunded in a child
+frame. The credit lands in the child's reservoir and merges upward as
+reservoir, so `gas_left` is never repaid mid-transaction. The parked
+credit still funds later state creation at full price and returns to
+the sender at settlement, so cross-frame placement opens no discount
+on state and costs the sender nothing at the transaction boundary.
+
+The merge-time repayment proposed in [ethereum/EIPs#12265]
+(https://github.com/ethereum/EIPs/pull/12265) moves the credit back
+to `gas_left` when a successful child merges. The placement pins here
+flip under it, while the settlement pins are placement-independent
+and must hold unchanged.
+
+Tests for [EIP-8037: State Creation Gas Cost Increase]
+(https://eips.ethereum.org/EIPS/eip-8037).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Fork,
+    Op,
+    Opcode,
+    StateTestFiller,
+    Transaction,
+    TransactionReceipt,
+)
+
+from .spec import ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+SLOT_X = 1
+SLOT_Y = 2
+SLOT_MARKER = 3
+SLOT_RESULT = 4
+SLOT_INCREASED = 5
+
+
+def window_cost_excess(result_sstore: Opcode = Op.SSTORE) -> Bytecode:
+    """
+    Return code storing the first window's cost over the second's.
+
+    Memory holds `g0`, `g1` and `g2` at 0, 32 and 64. The stored
+    value is `(g0 - g1) - (g1 - g2)`, the first window's cost minus
+    the second's, computed modulo 2**256. `result_sstore` lets
+    gas-settlement tests carry metadata on the storing opcode.
+    """
+    return result_sstore(
+        SLOT_RESULT,
+        Op.SUB(
+            Op.ADD(Op.MLOAD(0), Op.MLOAD(64)),
+            Op.ADD(Op.MLOAD(32), Op.MLOAD(32)),
+        ),
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_cross_frame_refund_parks_in_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test a cross-frame refund credits the reservoir, not `gas_left`.
+
+    The frame sets a slot with the reservoir empty, spilling the state
+    charge from `gas_left`. A delegated child clears the slot and the
+    credit lands in the reservoir, where it stays through the merge:
+    `gas_left` is lower after the clearing call than before it, and
+    the clearing window costs the same as a no-op window.
+    """
+    clearer = pre.deploy_contract(code=Op.SSTORE(SLOT_X, 0))
+
+    call_window = Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=clearer))
+    code = (
+        # Warm the clearer and the slot while it is still zero, and
+        # pre-expand the measurement memory, so the two measured
+        # windows below are byte-identical and cost-identical.
+        call_window
+        + Op.MSTORE(64, 0)
+        + Op.SSTORE(SLOT_X, 1)
+        + Op.MSTORE(0, Op.GAS)
+        + call_window
+        + Op.MSTORE(32, Op.GAS)
+        + call_window
+        + Op.MSTORE(64, Op.GAS)
+        + Op.SSTORE(SLOT_INCREASED, Op.GT(Op.MLOAD(32), Op.MLOAD(0)))
+        + window_cost_excess()
+        # Every other expected slot is zero, so the marker is what
+        # distinguishes the pinned run from a reverted one.
+        + Op.SSTORE(SLOT_MARKER, 1)
+    )
+    contract = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=1_000_000,
+        sender=pre.fund_eoa(),
+    )
+
+    # Under the merge-time repayment of ethereum/EIPs#12265 the
+    # clearing window repays the spill: the increase flag becomes 1
+    # and the window excess wraps to minus the slot's state cost.
+    post = {
+        contract: Account(
+            storage={
+                SLOT_X: 0,
+                SLOT_MARKER: 1,
+                SLOT_INCREASED: 0,
+                SLOT_RESULT: 0,
+            }
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_parked_credit_returns_at_settlement(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test the parked credit refunds the sender at settlement.
+
+    The frame's spilled set is cleared by a child, parking the credit
+    in the reservoir. Settlement sums `gas_left` and the reservoir, so
+    the spilled charge and the parked credit cancel and the receipt
+    carries no state term at all. The receipt is placement-independent
+    and holds unchanged under ethereum/EIPs#12265.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+
+    clearer_code = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )(SLOT_X, 0)
+    clearer = pre.deploy_contract(code=clearer_code)
+
+    # A budget covering the child's SSTORE stipend sentry through the
+    # clear, so the child succeeds and returns the sentry unspent.
+    child_budget = (
+        fork.call_value_stipend() + 1 + clearer_code.execution_cost(fork)
+    )
+    code = Op.SSTORE(
+        SLOT_X,
+        1,
+        key_warm=False,
+        original_value=0,
+        current_value=0,
+        new_value=1,
+    ) + Op.POP(
+        Op.DELEGATECALL(gas=child_budget, address=clearer, address_warm=False)
+    )
+    contract = pre.deploy_contract(code=code)
+
+    before_refund = (
+        intrinsic_cost
+        + code.execution_cost(fork)
+        + clearer_code.execution_cost(fork)
+    )
+    # Clearing the slot back to its original value also refunds the
+    # write cost through the classic refund counter at settlement.
+    restore_refund = clearer_code.refund(fork) - sstore_state_gas
+    expected_gas_used = before_refund - min(
+        before_refund // fork.max_refund_quotient(), restore_refund
+    )
+    # The post-refund usage must clear the calldata floor, or the
+    # floor masks a lost or doubled credit.
+    assert expected_gas_used > fork.transaction_data_floor_cost_calculator()(
+        data=b""
+    )
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=1_000_000,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used
+        ),
+    )
+
+    post = {contract: Account(storage={SLOT_X: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_parked_credit_funds_state_at_full_price(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test the parked credit funds a later creation at full price.
+
+    After the cross-frame clear parks the credit, a fresh set draws
+    its state charge from the reservoir: `gas_left` drops by only the
+    execution premium across the set window. The receipt still bills
+    both surviving slots at the full state price, so routing a refund
+    through another frame buys no discount on state that persists.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+
+    clearer_code = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )(SLOT_X, 0)
+    clearer = pre.deploy_contract(code=clearer_code)
+    child_budget = (
+        fork.call_value_stipend() + 1 + clearer_code.execution_cost(fork)
+    )
+
+    fresh_set = Op.SSTORE.with_metadata(
+        key_warm=False,
+        original_value=0,
+        current_value=0,
+        new_value=1,
+    )
+    window_1 = fresh_set(SLOT_Y, 1)
+    window_2 = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=1,
+    )(SLOT_Y, 1)
+    # The windows are byte-identical, so the excess is the fresh set's
+    # execution premium plus whatever its state charge takes from
+    # `gas_left`. The parked credit covers the state charge, leaving
+    # the execution premium alone. Under ethereum/EIPs#12265 the merge
+    # drains the credit into `gas_left` first, so the set spills and
+    # the excess grows by the slot's state cost.
+    execution_premium = window_1.execution_cost(
+        fork
+    ) - window_2.execution_cost(fork)
+
+    code = (
+        Op.MSTORE(64, 0, new_memory_size=96, old_memory_size=0)
+        + fresh_set(SLOT_X, 1)
+        + Op.POP(
+            Op.DELEGATECALL(
+                gas=child_budget, address=clearer, address_warm=False
+            )
+        )
+        + Op.MSTORE(0, Op.GAS)
+        + window_1
+        + Op.MSTORE(32, Op.GAS)
+        + window_2
+        + Op.MSTORE(64, Op.GAS)
+        + window_cost_excess(result_sstore=fresh_set)
+    )
+    contract = pre.deploy_contract(code=code)
+
+    # Slot Y and the result slot survive, each fully priced. The
+    # cleared slot cancels out of the settlement sum.
+    before_refund = (
+        intrinsic_cost
+        + code.execution_cost(fork)
+        + clearer_code.execution_cost(fork)
+        + 2 * sstore_state_gas
+    )
+    restore_refund = clearer_code.refund(fork) - sstore_state_gas
+    expected_gas_used = before_refund - min(
+        before_refund // fork.max_refund_quotient(), restore_refund
+    )
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=1_000_000,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used
+        ),
+    )
+
+    post = {
+        contract: Account(
+            storage={
+                SLOT_X: 0,
+                SLOT_Y: 1,
+                SLOT_RESULT: execution_premium,
+            }
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_parked_credit_cannot_fund_execution(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test the parked credit cannot fund execution work.
+
+    The gas limit covers the transaction only up to the clearing
+    child's merge plus a sliver. An execution tail worth less than the
+    parked credit follows, and the transaction halts anyway: the
+    credit sits in the reservoir, spendable on state creation alone.
+    Under ethereum/EIPs#12265 the merge repays the spill and the same
+    budget completes.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+
+    clearer_code = Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )(SLOT_X, 0)
+    clearer = pre.deploy_contract(code=clearer_code)
+
+    fresh_set = Op.SSTORE.with_metadata(
+        key_warm=False,
+        original_value=0,
+        current_value=0,
+        new_value=1,
+    )
+    head = (
+        fresh_set(SLOT_MARKER, 1)
+        + fresh_set(SLOT_X, 1)
+        + Op.POP(
+            Op.DELEGATECALL(gas=Op.GAS, address=clearer, address_warm=False)
+        )
+    )
+    tail = Op.MSTORE.with_metadata(new_memory_size=192_032, old_memory_size=0)(
+        192_000, 1
+    )
+    code = head + tail
+    contract = pre.deploy_contract(code=code)
+
+    # A sliver covering the child's SSTORE stipend sentry through the
+    # one-in-64 withholding. It survives the merge unspent.
+    sliver = (
+        fork.call_value_stipend() + 1 + clearer_code.execution_cost(fork)
+    ) * 64 // 63 + 1
+    tail_cost = tail.gas_cost(fork)
+    # The tail must overrun the sliver yet fit inside the parked
+    # credit, or the halt stops demonstrating the credit cannot buy
+    # execution.
+    assert sliver < tail_cost <= sstore_state_gas
+
+    gas_limit = (
+        intrinsic_cost
+        + head.gas_cost(fork)
+        + clearer_code.gas_cost(fork)
+        + sliver
+    )
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_limit),
+    )
+
+    post = {contract: Account(storage={SLOT_MARKER: 0, SLOT_X: 0})}
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Add coverage for a state charge spilled from `gas_left` whose refund is credited in a different frame. Four tests pin the current placement and its settlement consequences:

- the credit lands in the reservoir and `gas_left` is not repaid at the merge
- settlement sums both pools, so the parked credit returns to the sender and the receipt carries no state term
- the parked credit funds a later creation that still bills the full state price, so the cross-frame route opens no discount
- the parked credit cannot fund execution work

The settlement pins are placement independent and hold unchanged under the merge-time repayment of ethereum/EIPs#12265. The placement pins flip with it: three of the four tests fail when filled against #3478.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Coverage baseline for ethereum/EIPs#12265. #3478 revises the flipped pins if the repayment lands.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
