### PR TITLE
fix(test-specs): calculate transaction fixture gas from context

### DIFF
--- a/packages/testing/src/execution_testing/specs/tests/test_transaction.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_transaction.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from execution_testing import TestAddress
 from execution_testing.fixtures import TransactionFixture
-from execution_testing.forks import Fork, Shanghai
+from execution_testing.forks import Amsterdam, Fork, Shanghai
 from execution_testing.test_types import Transaction
 
 from ..transaction import TransactionTest
@@ -51,3 +52,44 @@ def test_transaction_test_filling(
 
     remove_info_metadata(fixture)
     assert fixture == expected
+
+
+@pytest.mark.parametrize(
+    "tx,expected_intrinsic_gas",
+    [
+        pytest.param(
+            Transaction(gas_limit=100_000),
+            15_000,
+            id="non_value_transfer",
+        ),
+        pytest.param(
+            Transaction(gas_limit=100_000, value=1),
+            21_000,
+            id="value_transfer",
+        ),
+        pytest.param(
+            Transaction(gas_limit=100_000, to=TestAddress),
+            12_000,
+            id="self_transfer",
+        ),
+    ],
+)
+def test_amsterdam_transaction_fixture_intrinsic_gas(
+    tx: Transaction,
+    expected_intrinsic_gas: int,
+) -> None:
+    """Calculate Amsterdam intrinsic gas from transaction context."""
+    fixture = (
+        TransactionTest(
+            tx=tx.with_signature_and_sender(),
+            fork=Amsterdam,
+        )
+        .generate(
+            t8n=None,  # type: ignore
+            fixture_format=TransactionFixture,
+        )
+        .fixture
+    )
+    assert isinstance(fixture, TransactionFixture)
+    result = next(iter(fixture.result.values()))
+    assert result.intrinsic_gas == expected_intrinsic_gas

--- a/packages/testing/src/execution_testing/specs/transaction.py
+++ b/packages/testing/src/execution_testing/specs/transaction.py
@@ -15,6 +15,7 @@ from execution_testing.fixtures import (
     TransactionFixture,
 )
 from execution_testing.fixtures.transaction import FixtureResult
+from execution_testing.recipient_type import RecipientType
 from execution_testing.test_types import Alloc, Transaction
 
 from .base import BaseTest, FillResult, OpMode
@@ -62,6 +63,12 @@ class TransactionTest(BaseTest):
                 contract_creation=self.tx.to is None,
                 access_list=self.tx.access_list,
                 authorization_list_or_count=self.tx.authorization_list,
+                sends_value=self.tx.value > 0,
+                recipient_type=(
+                    RecipientType.SELF
+                    if self.tx.to == self.tx.sender
+                    else RecipientType.CONTRACT
+                ),
             )
             result = FixtureResult(
                 exception=None,


### PR DESCRIPTION
### Description

Passes value-transfer and recipient context to the transaction fixture intrinsic gas calculation.

[The transaction added by #3156](https://github.com/ethereum/execution-specs/pull/3156/changes#diff-736f18aa7e871bc91c153bea4bbbf90465ef97a9b1ca10bd827bdbe07f908e06R83-R92) sends a value of 1 to a different address. In Amsterdam, EIP-2780 makes its intrinsic gas depend on that context. Without it, the fixture records 15,000 gas instead of 21,000. This change lets #3156 generate the correct Amsterdam fixture without modifying its test.

Adds unit coverage for non-value, value, and self transfers.

### Related Issues or PRs

Required by #3156.

### Checklist

- [x] Ran fast static checks to avoid CI failures: just static
- [x] The PR title matches the target squash commit and repository label convention.