### PR TITLE
feat(spec-specs): expose state-independent transaction validation

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -36,6 +36,9 @@ from .exceptions import (
 )
 from .fork_types import Authorization, ExecutionGas, VersionedHash
 
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
+
 
 @final
 @dataclass
@@ -58,11 +61,6 @@ TX_MAX_GAS_LIMIT = Uint(16_777_216)
 BLOB_COUNT_LIMIT = 6
 """
 Maximum number of blobs a single transaction may carry.
-"""
-
-VERSIONED_HASH_VERSION_KZG = b"\x01"
-"""
-Version byte that every blob versioned hash must start with.
 """
 
 ACCESS_LIST_ADDRESS_FLOOR_TOKENS = Uint(80)
@@ -583,9 +581,11 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
+def validate_transaction(
+    tx: Transaction, sender: Address | None = None
+) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate the state-independent properties of a transaction.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -601,8 +601,9 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     Also, the code size of a contract creation transaction must be within
     limits of the protocol.
 
-    This function takes a transaction and gas_limit as parameters and
-    returns the intrinsic gas costs for the transaction after validation.
+    If `sender` has already been recovered, it may be supplied to avoid
+    recovering it again when calculating sender-dependent intrinsic gas.
+    The function returns the intrinsic gas costs after validation.
     It throws an `InsufficientTransactionGasError` exception if the
     transaction does not provide enough gas to cover the intrinsic cost,
     and a `NonceOverflowError` exception if the nonce overflows.
@@ -616,6 +617,9 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
+
+    if sender is None:
+        sender = recover_sender(tx)
 
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/bpo1/fork.py
+++ b/src/ethereum/forks/bpo1/fork.py
@@ -35,14 +35,9 @@ from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
-    BlobCountExceededError,
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -77,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -103,7 +100,6 @@ SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
     GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
 )
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -117,7 +113,6 @@ HISTORY_STORAGE_ADDRESS = hex_to_address(
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
-BLOB_COUNT_LIMIT = 6
 
 
 @final
@@ -451,18 +446,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    BlobCountExceededError :
-        If the transaction is a type 3 and has more blobs than the limit.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -504,19 +487,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        blob_count = len(tx.blob_versioned_hashes)
-        if blob_count == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        if blob_count > BLOB_COUNT_LIMIT:
-            raise BlobCountExceededError(
-                f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
-            )
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -530,13 +501,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -865,7 +830,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -22,12 +22,20 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    BlobCountExceededError,
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -43,6 +51,9 @@ class IntrinsicGasCost:
 
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+
+BLOB_COUNT_LIMIT = 6
+"""Maximum number of blobs a single transaction may carry."""
 
 
 @final
@@ -540,8 +551,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -588,6 +608,31 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    blob_count = len(tx.blob_versioned_hashes)
+    if blob_count == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    if blob_count > BLOB_COUNT_LIMIT:
+        raise BlobCountExceededError(
+            f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
+        )
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/src/ethereum/forks/bpo2/fork.py
+++ b/src/ethereum/forks/bpo2/fork.py
@@ -35,14 +35,9 @@ from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
-    BlobCountExceededError,
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -77,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -103,7 +100,6 @@ SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
     GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
 )
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -117,7 +113,6 @@ HISTORY_STORAGE_ADDRESS = hex_to_address(
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
-BLOB_COUNT_LIMIT = 6
 
 
 @final
@@ -451,18 +446,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    BlobCountExceededError :
-        If the transaction is a type 3 and has more blobs than the limit.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -504,19 +487,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        blob_count = len(tx.blob_versioned_hashes)
-        if blob_count == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        if blob_count > BLOB_COUNT_LIMIT:
-            raise BlobCountExceededError(
-                f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
-            )
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -530,13 +501,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -865,7 +830,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -22,12 +22,20 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    BlobCountExceededError,
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -43,6 +51,9 @@ class IntrinsicGasCost:
 
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+
+BLOB_COUNT_LIMIT = 6
+"""Maximum number of blobs a single transaction may carry."""
 
 
 @final
@@ -540,8 +551,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -588,6 +608,31 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    blob_count = len(tx.blob_versioned_hashes)
+    if blob_count == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    if blob_count > BLOB_COUNT_LIMIT:
+        raise BlobCountExceededError(
+            f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
+        )
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/src/ethereum/forks/bpo3/fork.py
+++ b/src/ethereum/forks/bpo3/fork.py
@@ -35,14 +35,9 @@ from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
-    BlobCountExceededError,
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -77,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -103,7 +100,6 @@ SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
     GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
 )
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -117,7 +113,6 @@ HISTORY_STORAGE_ADDRESS = hex_to_address(
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
-BLOB_COUNT_LIMIT = 6
 
 
 @final
@@ -451,18 +446,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    BlobCountExceededError :
-        If the transaction is a type 3 and has more blobs than the limit.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -504,19 +487,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        blob_count = len(tx.blob_versioned_hashes)
-        if blob_count == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        if blob_count > BLOB_COUNT_LIMIT:
-            raise BlobCountExceededError(
-                f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
-            )
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -530,13 +501,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -865,7 +830,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -22,12 +22,20 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    BlobCountExceededError,
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -43,6 +51,9 @@ class IntrinsicGasCost:
 
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+
+BLOB_COUNT_LIMIT = 6
+"""Maximum number of blobs a single transaction may carry."""
 
 
 @final
@@ -540,8 +551,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -588,6 +608,31 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    blob_count = len(tx.blob_versioned_hashes)
+    if blob_count == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    if blob_count > BLOB_COUNT_LIMIT:
+        raise BlobCountExceededError(
+            f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
+        )
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/src/ethereum/forks/bpo4/fork.py
+++ b/src/ethereum/forks/bpo4/fork.py
@@ -35,14 +35,9 @@ from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
-    BlobCountExceededError,
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -77,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -103,7 +100,6 @@ SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
     GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
 )
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -117,7 +113,6 @@ HISTORY_STORAGE_ADDRESS = hex_to_address(
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
-BLOB_COUNT_LIMIT = 6
 
 
 @final
@@ -451,18 +446,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    BlobCountExceededError :
-        If the transaction is a type 3 and has more blobs than the limit.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -504,19 +487,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        blob_count = len(tx.blob_versioned_hashes)
-        if blob_count == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        if blob_count > BLOB_COUNT_LIMIT:
-            raise BlobCountExceededError(
-                f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
-            )
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -530,13 +501,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -865,7 +830,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -22,12 +22,20 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    BlobCountExceededError,
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -43,6 +51,9 @@ class IntrinsicGasCost:
 
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+
+BLOB_COUNT_LIMIT = 6
+"""Maximum number of blobs a single transaction may carry."""
 
 
 @final
@@ -540,8 +551,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -588,6 +608,31 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    blob_count = len(tx.blob_versioned_hashes)
+    if blob_count == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    if blob_count > BLOB_COUNT_LIMIT:
+        raise BlobCountExceededError(
+            f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
+        )
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/src/ethereum/forks/bpo5/fork.py
+++ b/src/ethereum/forks/bpo5/fork.py
@@ -35,14 +35,9 @@ from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
-    BlobCountExceededError,
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -77,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -103,7 +100,6 @@ SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
     GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
 )
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -117,7 +113,6 @@ HISTORY_STORAGE_ADDRESS = hex_to_address(
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
-BLOB_COUNT_LIMIT = 6
 
 
 @final
@@ -451,18 +446,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    BlobCountExceededError :
-        If the transaction is a type 3 and has more blobs than the limit.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -504,19 +487,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        blob_count = len(tx.blob_versioned_hashes)
-        if blob_count == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        if blob_count > BLOB_COUNT_LIMIT:
-            raise BlobCountExceededError(
-                f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
-            )
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -530,13 +501,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -865,7 +830,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -22,12 +22,20 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    BlobCountExceededError,
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -43,6 +51,9 @@ class IntrinsicGasCost:
 
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+
+BLOB_COUNT_LIMIT = 6
+"""Maximum number of blobs a single transaction may carry."""
 
 
 @final
@@ -540,8 +551,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -588,6 +608,31 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    blob_count = len(tx.blob_versioned_hashes)
+    if blob_count == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    if blob_count > BLOB_COUNT_LIMIT:
+        raise BlobCountExceededError(
+            f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
+        )
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/src/ethereum/forks/cancun/fork.py
+++ b/src/ethereum/forks/cancun/fork.py
@@ -38,9 +38,6 @@ from .exceptions import (
     BlobGasLimitExceededError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import VersionedHash
@@ -68,7 +65,8 @@ from .transactions import (
     encode_transaction,
     get_transaction_hash,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -91,7 +89,6 @@ BEACON_ROOTS_ADDRESS = hex_to_address(
 )
 SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = U64(786432)
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 
 @final
@@ -419,13 +416,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -467,16 +457,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-        if len(tx.blob_versioned_hashes) == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -695,7 +676,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas = validate_transaction(tx)
+    intrinsic_gas = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/cancun/transactions.py
+++ b/src/ethereum/forks/cancun/transactions.py
@@ -23,10 +23,16 @@ from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -415,8 +421,16 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> Uint:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic_gas = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    return intrinsic_gas
+
+
+def validate_transaction_common(tx: Transaction) -> Uint:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -460,6 +474,17 @@ def validate_transaction(tx: Transaction) -> Uint:
             )
 
     return intrinsic_gas
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    if not isinstance(tx.to, Address):
+        raise TransactionTypeContractCreationError(tx)
+    if len(tx.blob_versioned_hashes) == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Uint:

--- a/src/ethereum/forks/osaka/fork.py
+++ b/src/ethereum/forks/osaka/fork.py
@@ -35,14 +35,9 @@ from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
-    BlobCountExceededError,
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -77,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -103,7 +100,6 @@ SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = (
     GasCosts.BLOB_SCHEDULE_MAX * GasCosts.PER_BLOB
 )
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -117,7 +113,6 @@ HISTORY_STORAGE_ADDRESS = hex_to_address(
 MAX_BLOCK_SIZE = 10_485_760
 SAFETY_MARGIN = 2_097_152
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
-BLOB_COUNT_LIMIT = 6
 
 
 @final
@@ -451,18 +446,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    BlobCountExceededError :
-        If the transaction is a type 3 and has more blobs than the limit.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -504,19 +487,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        blob_count = len(tx.blob_versioned_hashes)
-        if blob_count == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        if blob_count > BLOB_COUNT_LIMIT:
-            raise BlobCountExceededError(
-                f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
-            )
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -530,13 +501,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -865,7 +830,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -22,12 +22,20 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    BlobCountExceededError,
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
     TransactionGasLimitExceededError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -47,6 +55,9 @@ class IntrinsicGasCost:
 
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
+
+BLOB_COUNT_LIMIT = 6
+"""Maximum number of blobs a single transaction may carry."""
 
 
 @final
@@ -544,8 +555,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -592,6 +612,31 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    blob_count = len(tx.blob_versioned_hashes)
+    if blob_count == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    if blob_count > BLOB_COUNT_LIMIT:
+        raise BlobCountExceededError(
+            f"Tx has {blob_count} blobs. Max allowed: {BLOB_COUNT_LIMIT}"
+        )
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/src/ethereum/forks/prague/fork.py
+++ b/src/ethereum/forks/prague/fork.py
@@ -36,12 +36,8 @@ from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
 from .exceptions import (
     BlobGasLimitExceededError,
-    EmptyAuthorizationListError,
     InsufficientMaxFeePerBlobGasError,
     InsufficientMaxFeePerGasError,
-    InvalidBlobVersionedHashError,
-    NoBlobDataError,
-    TransactionTypeContractCreationError,
     WrongChainIdError,
 )
 from .fork_types import Authorization, VersionedHash
@@ -76,7 +72,9 @@ from .transactions import (
     get_transaction_hash,
     has_access_list,
     recover_sender,
-    validate_transaction,
+    validate_blob_transaction,
+    validate_transaction_common,
+    validate_transaction_type,
 )
 from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
@@ -100,7 +98,6 @@ BEACON_ROOTS_ADDRESS = hex_to_address(
 )
 SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK: Final[U64] = U64(1179648)
-VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -441,16 +438,6 @@ def check_transaction(
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    InvalidBlobVersionedHashError :
-        If the transaction contains a blob versioned hash with an invalid
-        version.
-    NoBlobDataError :
-        If the transaction is a type 3 but has no blobs.
-    TransactionTypeContractCreationError:
-        If the transaction type is not allowed to create contracts.
-    EmptyAuthorizationListError :
-        If the transaction is a SetCodeTransaction and the authorization list
-        is empty.
 
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
@@ -492,14 +479,7 @@ def check_transaction(
         max_gas_fee = tx.gas * tx.gas_price
 
     if isinstance(tx, BlobTransaction):
-        if len(tx.blob_versioned_hashes) == 0:
-            raise NoBlobDataError("no blob data in transaction")
-        for blob_versioned_hash in tx.blob_versioned_hashes:
-            if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
-                raise InvalidBlobVersionedHashError(
-                    "invalid blob versioned hash"
-                )
-
+        validate_blob_transaction(tx)
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InsufficientMaxFeePerBlobGasError(
@@ -513,13 +493,7 @@ def check_transaction(
     else:
         blob_versioned_hashes = ()
 
-    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
-        if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx)
-
-    if isinstance(tx, SetCodeTransaction):
-        if not any(tx.authorizations):
-            raise EmptyAuthorizationListError("empty authorization list")
+    validate_transaction_type(tx)
 
     if sender_account.nonce > Uint(tx.nonce):
         raise NonceMismatchError("nonce too low")
@@ -848,7 +822,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic = validate_transaction(tx)
+    intrinsic = validate_transaction_common(tx)
 
     (
         sender,

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -22,11 +22,18 @@ from ethereum.exceptions import (
 from ethereum.state import Address
 
 from .exceptions import (
+    EmptyAuthorizationListError,
     InitCodeTooLargeError,
+    InvalidBlobVersionedHashError,
+    NoBlobDataError,
     PriorityFeeGreaterThanMaxFeeError,
+    TransactionTypeContractCreationError,
     TransactionTypeError,
 )
 from .fork_types import Authorization, VersionedHash
+
+VERSIONED_HASH_VERSION_KZG = b"\x01"
+"""Version byte that every blob versioned hash must start with."""
 
 
 @final
@@ -540,8 +547,17 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
 
 
 def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
+    """Validate all state-independent properties of a transaction."""
+    intrinsic = validate_transaction_common(tx)
+    if isinstance(tx, BlobTransaction):
+        validate_blob_transaction(tx)
+    validate_transaction_type(tx)
+    return intrinsic
+
+
+def validate_transaction_common(tx: Transaction) -> IntrinsicGasCost:
     """
-    Verifies a transaction.
+    Validate properties common to all transactions.
 
     The gas in a transaction gets used to pay for the intrinsic cost of
     operations, therefore if there is insufficient gas then it would not
@@ -586,6 +602,26 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
             )
 
     return intrinsic
+
+
+def validate_blob_transaction(tx: BlobTransaction) -> None:
+    """Validate properties specific to blob transactions."""
+    if len(tx.blob_versioned_hashes) == 0:
+        raise NoBlobDataError("no blob data in transaction")
+    for blob_versioned_hash in tx.blob_versioned_hashes:
+        if blob_versioned_hash[0:1] != VERSIONED_HASH_VERSION_KZG:
+            raise InvalidBlobVersionedHashError("invalid blob versioned hash")
+
+
+def validate_transaction_type(tx: Transaction) -> None:
+    """Validate restrictions imposed by the transaction type."""
+    if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
+        if not isinstance(tx.to, Address):
+            raise TransactionTypeContractCreationError(tx)
+
+    if isinstance(tx, SetCodeTransaction):
+        if not any(tx.authorizations):
+            raise EmptyAuthorizationListError("empty authorization list")
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:

--- a/tests/json_loader/test_transaction_validation.py
+++ b/tests/json_loader/test_transaction_validation.py
@@ -1,0 +1,188 @@
+"""Test state-independent transaction validation across EELS forks."""
+
+from importlib import import_module
+from typing import Any
+
+import pytest
+from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes, Bytes0
+from ethereum_types.numeric import U64, U256, Uint
+from execution_testing import Transaction as FixtureTransaction
+
+from ethereum.crypto.hash import Hash32
+from ethereum.state import Address
+
+BLOB_FORKS = (
+    "cancun",
+    "prague",
+    "osaka",
+    "bpo1",
+    "bpo2",
+    "bpo3",
+    "bpo4",
+    "bpo5",
+    "amsterdam",
+)
+SET_CODE_FORKS = BLOB_FORKS[1:]
+BLOB_COUNT_FORKS = BLOB_FORKS[2:]
+
+SENDER = Address(b"\x11" * 20)
+RECIPIENT = Address(b"\x22" * 20)
+VALID_BLOB_HASH = Hash32(b"\x01" + b"\x00" * 31)
+INVALID_BLOB_HASH = Hash32(b"\x02" + b"\x00" * 31)
+
+
+def _modules(fork_name: str) -> tuple[Any, Any]:
+    """Load a fork's transaction and exception modules."""
+    prefix = f"ethereum.forks.{fork_name}"
+    return (
+        import_module(f"{prefix}.transactions"),
+        import_module(f"{prefix}.exceptions"),
+    )
+
+
+def _blob_transaction(
+    transactions: Any,
+    *,
+    to: Address | Bytes0 = RECIPIENT,
+    blob_hashes: tuple[Hash32, ...] = (VALID_BLOB_HASH,),
+) -> Any:
+    """Build a blob transaction for direct validation."""
+    return transactions.BlobTransaction(
+        chain_id=U64(1),
+        nonce=U256(0),
+        max_priority_fee_per_gas=Uint(1),
+        max_fee_per_gas=Uint(1),
+        gas=Uint(100_000),
+        to=to,
+        value=U256(0),
+        data=Bytes(b""),
+        access_list=(),
+        max_fee_per_blob_gas=U256(1),
+        blob_versioned_hashes=blob_hashes,
+        y_parity=U256(0),
+        r=U256(1),
+        s=U256(1),
+    )
+
+
+def _set_code_transaction(
+    transactions: Any,
+    *,
+    to: Address | Bytes0 = RECIPIENT,
+) -> Any:
+    """Build a set-code transaction for direct validation."""
+    return transactions.SetCodeTransaction(
+        chain_id=U64(1),
+        nonce=U64(0),
+        max_priority_fee_per_gas=Uint(1),
+        max_fee_per_gas=Uint(1),
+        gas=Uint(100_000),
+        to=to,
+        value=U256(0),
+        data=Bytes(b""),
+        access_list=(),
+        authorizations=(),
+        y_parity=U256(0),
+        r=U256(1),
+        s=U256(1),
+    )
+
+
+def _validate(fork_name: str, transactions: Any, tx: Any) -> None:
+    """Validate a transaction while avoiding signature recovery in fixtures."""
+    if fork_name == "amsterdam":
+        transactions.validate_transaction(tx, SENDER)
+    else:
+        transactions.validate_transaction(tx)
+
+
+@pytest.mark.parametrize("fork_name", BLOB_FORKS)
+def test_blob_transaction_requires_data(fork_name: str) -> None:
+    """Reject a blob transaction without versioned hashes."""
+    transactions, exceptions = _modules(fork_name)
+    tx = _blob_transaction(transactions, blob_hashes=())
+
+    with pytest.raises(exceptions.NoBlobDataError):
+        _validate(fork_name, transactions, tx)
+
+
+@pytest.mark.parametrize("fork_name", BLOB_FORKS)
+def test_blob_transaction_requires_supported_hash_version(
+    fork_name: str,
+) -> None:
+    """Reject a blob transaction with an unsupported hash version."""
+    transactions, exceptions = _modules(fork_name)
+    tx = _blob_transaction(transactions, blob_hashes=(INVALID_BLOB_HASH,))
+
+    with pytest.raises(exceptions.InvalidBlobVersionedHashError):
+        _validate(fork_name, transactions, tx)
+
+
+@pytest.mark.parametrize("fork_name", BLOB_FORKS)
+def test_blob_transaction_cannot_create_contract(fork_name: str) -> None:
+    """Reject contract creation by a blob transaction."""
+    transactions, exceptions = _modules(fork_name)
+    tx = _blob_transaction(transactions, to=Bytes0(b""))
+
+    with pytest.raises(exceptions.TransactionTypeContractCreationError):
+        _validate(fork_name, transactions, tx)
+
+
+@pytest.mark.parametrize("fork_name", BLOB_COUNT_FORKS)
+def test_blob_transaction_count_is_limited(fork_name: str) -> None:
+    """Reject a blob transaction that exceeds the per-transaction limit."""
+    transactions, exceptions = _modules(fork_name)
+    tx = _blob_transaction(
+        transactions,
+        blob_hashes=(VALID_BLOB_HASH,) * 7,
+    )
+
+    with pytest.raises(exceptions.BlobCountExceededError):
+        _validate(fork_name, transactions, tx)
+
+
+@pytest.mark.parametrize("fork_name", SET_CODE_FORKS)
+def test_set_code_transaction_requires_authorization(fork_name: str) -> None:
+    """Reject a set-code transaction without authorizations."""
+    transactions, exceptions = _modules(fork_name)
+    tx = _set_code_transaction(transactions)
+
+    with pytest.raises(exceptions.EmptyAuthorizationListError):
+        _validate(fork_name, transactions, tx)
+
+
+@pytest.mark.parametrize("fork_name", SET_CODE_FORKS)
+def test_set_code_transaction_cannot_create_contract(fork_name: str) -> None:
+    """Reject contract creation by a set-code transaction."""
+    transactions, exceptions = _modules(fork_name)
+    tx = _set_code_transaction(transactions, to=Bytes0(b""))
+
+    with pytest.raises(exceptions.TransactionTypeContractCreationError):
+        _validate(fork_name, transactions, tx)
+
+
+@pytest.mark.parametrize("fork_name", BLOB_FORKS[:-1])
+def test_validation_accepts_legacy_transaction(fork_name: str) -> None:
+    """Accept a valid legacy transaction through the public validator."""
+    transactions, _ = _modules(fork_name)
+    raw = Bytes(
+        FixtureTransaction(gas_limit=100_000).with_signature_and_sender().rlp()
+    )
+    tx = rlp.decode_to(transactions.LegacyTransaction, raw)
+
+    transactions.validate_transaction(tx)
+
+
+def test_amsterdam_validation_can_recover_sender() -> None:
+    """Validate an Amsterdam transaction without precomputing its sender."""
+    transactions, _ = _modules("amsterdam")
+    raw = Bytes(
+        FixtureTransaction(gas_limit=100_000).with_signature_and_sender().rlp()
+    )
+    tx = transactions.decode_transaction(raw)
+    sender = transactions.recover_sender(tx)
+
+    assert transactions.validate_transaction(tx) == (
+        transactions.validate_transaction(tx, sender)
+    )


### PR DESCRIPTION
### Description

Transaction test consumers need to validate a raw transaction without constructing account or block state. Some checks that depend only on the transaction were still performed by the stateful `check_transaction` path, so callers could not use `validate_transaction` as a complete state-independent boundary.

This PR moves those checks into `validate_transaction` from Cancun through Amsterdam. It covers blob hashes, blob and set-code contract creation, empty authorization lists, and per-transaction blob limits. Amsterdam can now recover the sender when one is not supplied, giving callers the same one-argument validation entry point across forks.

State and blockchain validation continue through the same checks. Their existing exception order is preserved by invoking the common and type-specific validation stages at their original points, while stateless callers use the complete `validate_transaction` entry point.

### Stack

This is the first PR in a three-PR stack:

1. #3492 — Expose state-independent transaction validation (this PR).
2. #3493 — Resolve implicit transaction test gas limits.
3. #3494 — Validate transaction test fixtures with EELS.

### Related Issues or PRs

N/A.

### Testing

- Added 51 focused validation cases across Cancun, Prague, Osaka, BPO1–BPO5, and Amsterdam.
- Full Prague fill: 14,287 passed and 12 skipped.
- Full Osaka fill: 15,088 passed and 12 skipped.
- `just static`
- `just test-tests`

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` match the applied labels.

### Cute Animal Picture

![A cat](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)
