### PR TITLE
feat(test-fixtures): resolve implicit transaction test gas limits

### DIFF
--- a/packages/testing/src/execution_testing/specs/tests/test_transaction.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_transaction.py
@@ -4,12 +4,13 @@ import json
 from os.path import realpath
 from pathlib import Path
 
+import ethereum_rlp as eth_rlp
 import pytest
 
 from execution_testing import TestAddress
 from execution_testing.fixtures import TransactionFixture
-from execution_testing.forks import Amsterdam, Fork, Shanghai
-from execution_testing.test_types import Transaction
+from execution_testing.forks import Amsterdam, Fork, Osaka, Shanghai
+from execution_testing.test_types import EnvironmentDefaults, Transaction
 
 from ..transaction import TransactionTest
 from .helpers import remove_info_metadata
@@ -30,7 +31,7 @@ def test_transaction_test_filling(
     """Test the transaction test filling."""
     generated_fixture = (
         TransactionTest(
-            tx=tx.with_signature_and_sender(),
+            tx=tx,
             fork=fork,
         )
         .generate(
@@ -58,17 +59,17 @@ def test_transaction_test_filling(
     "tx,expected_intrinsic_gas",
     [
         pytest.param(
-            Transaction(gas_limit=100_000),
+            Transaction(),
             15_000,
             id="non_value_transfer",
         ),
         pytest.param(
-            Transaction(gas_limit=100_000, value=1),
+            Transaction(value=1),
             21_000,
             id="value_transfer",
         ),
         pytest.param(
-            Transaction(gas_limit=100_000, to=TestAddress),
+            Transaction(to=TestAddress),
             12_000,
             id="self_transfer",
         ),
@@ -81,7 +82,7 @@ def test_amsterdam_transaction_fixture_intrinsic_gas(
     """Calculate Amsterdam intrinsic gas from transaction context."""
     fixture = (
         TransactionTest(
-            tx=tx.with_signature_and_sender(),
+            tx=tx,
             fork=Amsterdam,
         )
         .generate(
@@ -93,3 +94,54 @@ def test_amsterdam_transaction_fixture_intrinsic_gas(
     assert isinstance(fixture, TransactionFixture)
     result = next(iter(fixture.result.values()))
     assert result.intrinsic_gas == expected_intrinsic_gas
+
+
+@pytest.mark.parametrize(
+    "tx,fork,expected_gas_limit",
+    [
+        pytest.param(
+            Transaction(),
+            Shanghai,
+            EnvironmentDefaults.gas_limit,
+            id="implicit-before-cap",
+        ),
+        pytest.param(
+            Transaction(gas_limit=50_000),
+            Shanghai,
+            50_000,
+            id="explicit",
+        ),
+        pytest.param(
+            Transaction(),
+            Osaka,
+            Osaka.transaction_gas_limit_cap(),
+            id="implicit-with-cap",
+        ),
+        pytest.param(
+            Transaction(),
+            Amsterdam,
+            EnvironmentDefaults.gas_limit,
+            id="implicit-with-state-gas-reservoir",
+        ),
+    ],
+)
+def test_transaction_fixture_gas_limit(
+    tx: Transaction,
+    fork: Fork,
+    expected_gas_limit: int,
+) -> None:
+    """Resolve omitted gas limits before signing transaction fixtures."""
+    fixture = (
+        TransactionTest(tx=tx, fork=fork)
+        .generate(
+            t8n=None,  # type: ignore
+            fixture_format=TransactionFixture,
+        )
+        .fixture
+    )
+    assert isinstance(fixture, TransactionFixture)
+    decoded_transaction = eth_rlp.decode(fixture.transaction)
+    assert not isinstance(decoded_transaction, bytes)
+    encoded_gas_limit = decoded_transaction[2]
+    assert isinstance(encoded_gas_limit, bytes)
+    assert int.from_bytes(encoded_gas_limit) == expected_gas_limit

--- a/packages/testing/src/execution_testing/specs/transaction.py
+++ b/packages/testing/src/execution_testing/specs/transaction.py
@@ -16,7 +16,11 @@ from execution_testing.fixtures import (
 )
 from execution_testing.fixtures.transaction import FixtureResult
 from execution_testing.recipient_type import RecipientType
-from execution_testing.test_types import Alloc, Transaction
+from execution_testing.test_types import (
+    Alloc,
+    EnvironmentDefaults,
+    Transaction,
+)
 
 from .base import BaseTest, FillResult, OpMode
 
@@ -45,11 +49,21 @@ class TransactionTest(BaseTest):
     def make_transaction_test_fixture(
         self,
     ) -> FillResult:
-        """Create a fixture from the transaction test definition."""
+        """
+        Create a fixture from the transaction test definition.
+
+        Resolve omitted gas limits against the configured default block gas
+        budget before signing the transaction.
+        """
         fork = self.fork.transitions_from()
-        if self.tx.error is not None:
+        tx = self.tx.with_gas_limit(
+            max_gas_limit=EnvironmentDefaults.gas_limit,
+            transaction_gas_limit_cap=fork.transaction_gas_limit_cap(),
+            state_gas_reservoir_enabled=fork.state_gas_reservoir_enabled(),
+        ).with_signature_and_sender()
+        if tx.error is not None:
             result = FixtureResult(
-                exception=self.tx.error,
+                exception=tx.error,
                 hash=None,
                 intrinsic_gas=0,
                 sender=None,
@@ -59,29 +73,29 @@ class TransactionTest(BaseTest):
                 fork.transitions_from().transaction_intrinsic_cost_calculator()
             )
             intrinsic_gas = intrinsic_gas_cost_calculator(
-                calldata=self.tx.data,
-                contract_creation=self.tx.to is None,
-                access_list=self.tx.access_list,
-                authorization_list_or_count=self.tx.authorization_list,
-                sends_value=self.tx.value > 0,
+                calldata=tx.data,
+                contract_creation=tx.to is None,
+                access_list=tx.access_list,
+                authorization_list_or_count=tx.authorization_list,
+                sends_value=tx.value > 0,
                 recipient_type=(
                     RecipientType.SELF
-                    if self.tx.to == self.tx.sender
+                    if tx.to == tx.sender
                     else RecipientType.CONTRACT
                 ),
             )
             result = FixtureResult(
                 exception=None,
-                hash=self.tx.hash,
+                hash=tx.hash,
                 intrinsic_gas=intrinsic_gas,
-                sender=self.tx.sender,
+                sender=tx.sender,
             )
 
         fixture = TransactionFixture(
             result={
                 fork: result,
             },
-            transaction=self.tx.with_signature_and_sender().rlp(),
+            transaction=tx.rlp(),
         )
         return FillResult(
             fixture=fixture,

--- a/tests/frontier/validation/test_transaction.py
+++ b/tests/frontier/validation/test_transaction.py
@@ -137,7 +137,6 @@ def test_tx_max_nonce(state_test: StateTestFiller, pre: Alloc) -> None:
 def test_tx_nonce_overflow(
     transaction_test: TransactionTestFiller,
     pre: Alloc,
-    fork: BaseFork,
 ) -> None:
     """
     Test that a transaction with a nonce that does not fit in 64 bits is
@@ -146,7 +145,6 @@ def test_tx_nonce_overflow(
     tx = Transaction(
         to=pre.nonexistent_account(),
         nonce=2**64,
-        gas_limit=fork.transaction_intrinsic_cost_calculator()(),
         sender=pre.fund_eoa(),
         protected=False,
         error=TransactionException.NONCE_OVERFLOW,

--- a/tests/frontier/validation/test_transaction_rlp.py
+++ b/tests/frontier/validation/test_transaction_rlp.py
@@ -124,7 +124,6 @@ def invalid_tx(
         sender=pre.fund_eoa(amount=0),
         to=0,
         gas_price=10,
-        gas_limit=30_000,
         error=error,
     )
     tx.rlp_override = Bytes(rlp)

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -83,7 +83,6 @@ def test_empty_authorization_list(
 ) -> None:
     """Test sending a transaction with an empty authorization list."""
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[],
@@ -128,7 +127,6 @@ def test_invalid_auth_signature(
     range.
     """
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[
@@ -187,7 +185,6 @@ def test_invalid_tx_invalid_auth_chain_id(
     )
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[authorization],
@@ -241,7 +238,6 @@ def test_invalid_tx_invalid_auth_chain_id_encoding(
     )
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[authorization],
@@ -284,7 +280,6 @@ def test_invalid_tx_invalid_nonce(
     auth_signer = pre.fund_eoa()
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[
@@ -337,7 +332,6 @@ def test_invalid_tx_invalid_nonce_as_list(
         nonce: List[HexNumber]  # type: ignore
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[
@@ -386,7 +380,6 @@ def test_invalid_tx_invalid_nonce_encoding(
     )
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[authorization],
@@ -439,7 +432,6 @@ def test_invalid_tx_invalid_address(
         address: address_type  # type: ignore
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[
@@ -493,7 +485,6 @@ def test_invalid_tx_invalid_authorization_tuple_extra_element(
             return rlp_fields
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[
@@ -558,7 +549,6 @@ def test_invalid_tx_invalid_authorization_tuple_missing_element(
             return rlp_fields
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[
@@ -610,7 +600,6 @@ def test_invalid_tx_invalid_authorization_tuple_encoded_as_bytes(
         signer=auth_signer,
     )
     tx = ModifiedTransaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[authorization_list.rlp()],
@@ -653,7 +642,6 @@ def test_invalid_tx_invalid_rlp_encoding(
     auth_signer = pre.fund_eoa()
 
     tx = Transaction(
-        gas_limit=100_000,
         to=0,
         value=0,
         authorization_list=[


### PR DESCRIPTION
### Description

`StateTest` and `BlockchainTest` resolve an omitted transaction gas limit before signing, but `TransactionTest` previously signed the transaction directly. This forced transaction tests to provide an otherwise arbitrary gas limit or fail with `gas_limit must be set to sign a transaction`.

This PR resolves omitted limits through the shared `Transaction.with_gas_limit(...)` behavior before signing. It uses the configured default block gas budget, preserves explicit limits, applies Osaka's transaction gas cap, and retains Amsterdam's state gas reservoir behavior.

The existing transaction tests now omit gas limits when gas is unrelated to the behavior under test. This keeps them useful as examples of the intended `TransactionTest` API. The explicit limit in the raw RLP source helper remains because that helper signs and serializes its transaction before the filler or execute pipeline can resolve an implicit limit.

The test intentions and expected results remain unchanged. The refactored tests still exercise the same nonce overflow, authorization-format, and RLP-validation cases with the same expected exceptions. Their serialized bytes and signatures intentionally change because the framework now supplies the gas limit.

Execute mode remains supported. `TransactionPost.prepare_transactions()` resolves omitted limits from the live environment and fork configuration before calculating balances and signing transactions.

### Stack

This is the second PR in a three-PR stack:

1. #3492 — Expose state-independent transaction validation.
2. #3493 — Resolve implicit transaction test gas limits (this PR).
3. #3494 — Validate transaction test fixtures with EELS.

### Related Issues or PRs

Fixes #3489.

### Testing

- Added coverage for omitted and explicit limits, Osaka's cap, and Amsterdam's state gas reservoir behavior.
- Filled the three affected test modules: 1,178 tests passed.
- Compared fixtures before and after with `hasher compare`: 124 transaction fixture hashes changed because the gas limit and signature changed; none of the 1,178 expected `result` values or exceptions changed.
- Repeated the comparison for Amsterdam: 56 transaction fixture hashes changed and no expected results changed.
- Collected the affected modules under execute mode for Amsterdam and exercised preparation and signing for the nonce-overflow, invalid type-4, and raw-RLP patterns.
- `just static`
- `just test-tests`
- `just json-loader` on the restacked #3494 branch

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` match the applied labels.

### Cute Animal Picture

![A cat](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)
