### PR TITLE
feat(spec-tests): validate transaction test fixtures against EELS

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -200,7 +200,7 @@ fill-pypy *args: (_tmp-logs "fill-pypy")
 [group('integration tests')]
 json-loader *args: (_tmp "json-loader")
     uv run fill \
-        -m "eels_base_coverage and primary_format" \
+        -m "(eels_base_coverage or transaction_test) and primary_format" \
         --until "{{ latest_fork }}" \
         -n {{ xdist_workers }} --dist=loadgroup \
         --skip-index \

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_primary_format_marker.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_primary_format_marker.py
@@ -65,6 +65,16 @@ NORMAL_STATE_MODULE = textwrap.dedent(
     """
 )
 
+TRANSACTION_MODULE = textwrap.dedent(
+    f"""\
+    import pytest
+
+    @pytest.mark.valid_at("{FORK}")
+    def test_case(transaction_test) -> None:
+        pass
+    """
+)
+
 TEST_MODULE_DIR = "tests/prague/dummy_test_module"
 
 
@@ -130,6 +140,26 @@ def test_primary_format_selects_first_survivor(
     assert result.ret == 0, f"Collection failed:\n{result.outlines}"
     result.stdout.fnmatch_lines([f"*{present}"])
     result.stdout.no_fnmatch_line(f"*{absent}")
+
+
+def test_transaction_format_union_selects_unmarked_source_test(
+    pytester: pytest.Pytester,
+) -> None:
+    """Select transaction fixtures without an EELS source marker."""
+    write_test_module(pytester, TRANSACTION_MODULE)
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--collect-only",
+        "-q",
+        "-m",
+        "(eels_base_coverage or transaction_test) and primary_format",
+        TEST_MODULE_DIR,
+    )
+
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.fnmatch_lines(["*test_case*transaction_test*", "*1 test*"])
 
 
 def test_pre_alloc_group_session_generates_one_format_per_test(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,7 @@ markers = [
     "bigmem: marks tests as big memory (deselect with '-m \"not bigmem\"')",
     "json_blockchain_tests: marks tests as json_blockchain_tests (deselect with '-m \"not json_blockchain_tests\"')",
     "json_state_tests: marks tests as json_state_tests (deselect with '-m \"not json_state_tests\"')",
+    "json_transaction_tests: marks tests as json_transaction_tests (deselect with '-m \"not json_transaction_tests\"')",
     "vm_test: marks tests as vm_test (deselect with '-m \"not vm_test\"')",
     "eels_base_coverage: Minimized subset selected to preserve high EELS line-coverage parity (select with '-m eels_base_coverage')",
     "fork: marks JSON fixture tests by fork",

--- a/tests/json_loader/helpers/__init__.py
+++ b/tests/json_loader/helpers/__init__.py
@@ -3,10 +3,12 @@
 from .fixtures import ALL_FIXTURE_TYPES, Fixture, FixturesFile, FixtureTestItem
 from .load_blockchain_tests import BlockchainTestFixture
 from .load_state_tests import StateTestFixture
+from .load_transaction_tests import TransactionTestFixture
 from .load_vm_tests import VmTestFixture
 
 ALL_FIXTURE_TYPES.append(BlockchainTestFixture)
 ALL_FIXTURE_TYPES.append(StateTestFixture)
+ALL_FIXTURE_TYPES.append(TransactionTestFixture)
 ALL_FIXTURE_TYPES.append(VmTestFixture)
 
 __all__ = ["ALL_FIXTURE_TYPES", "Fixture", "FixturesFile", "FixtureTestItem"]

--- a/tests/json_loader/helpers/load_transaction_tests.py
+++ b/tests/json_loader/helpers/load_transaction_tests.py
@@ -1,0 +1,138 @@
+"""Helpers to load and run transaction tests from JSON files."""
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, Tuple
+
+import pytest
+from _pytest.config import Config
+from ethereum_rlp.exceptions import RLPException
+
+from ethereum.exceptions import EthereumException
+from ethereum.utils.hexadecimal import hex_to_bytes
+
+from ..stash_keys import desired_forks_key
+from .fixtures import Fixture, FixturesFile, FixtureTestItem
+from .transaction_test_adapter import validate_raw_transaction
+
+
+def _fixture_format(test_dict: Mapping[str, Any]) -> str | None:
+    """Return the fixture format declared in metadata, if present."""
+    info = test_dict.get("_info")
+    if not isinstance(info, Mapping):
+        return None
+    return info.get("fixture-format") or info.get("fixture_format")
+
+
+def _fixture_fork_name(test_dict: Mapping[str, Any]) -> str:
+    """Return the single fork declared by a transaction fixture."""
+    result = test_dict.get("result")
+    if not isinstance(result, Mapping) or len(result) != 1:
+        raise ValueError(
+            "transaction_test fixtures must contain exactly one result fork"
+        )
+    return next(iter(result))
+
+
+def _hex_number(value: Any) -> int:
+    """Parse a fixture JSON integer or hexadecimal string."""
+    if isinstance(value, str):
+        return int(value, 0)
+    return int(value)
+
+
+def run_transaction_test_fixture(test_dict: Mapping[str, Any]) -> None:
+    """Validate one transaction fixture against EELS."""
+    fork_name = _fixture_fork_name(test_dict)
+    result_by_fork = test_dict["result"]
+    assert isinstance(result_by_fork, Mapping)
+    expected_result = result_by_fork[fork_name]
+    assert isinstance(expected_result, Mapping)
+
+    raw_value = test_dict["txbytes"]
+    assert isinstance(raw_value, str)
+    raw = hex_to_bytes(raw_value)
+    expected_exception = expected_result.get("exception")
+
+    try:
+        actual = validate_raw_transaction(fork_name, raw)
+    except (EthereumException, RLPException) as exception:
+        if expected_exception is not None:
+            return
+        raise AssertionError(
+            "EELS rejected a transaction fixture declared valid with "
+            f"{type(exception).__name__}: {exception}"
+        ) from exception
+
+    assert expected_exception is None, (
+        "EELS accepted a transaction fixture declared invalid: "
+        f"expected {expected_exception}"
+    )
+
+    expected_sender = expected_result.get("sender")
+    expected_hash = expected_result.get("hash")
+    expected_intrinsic_gas = expected_result.get("intrinsicGas")
+    assert expected_sender is not None
+    assert expected_hash is not None
+    assert expected_intrinsic_gas is not None
+
+    assert actual.sender == hex_to_bytes(expected_sender)
+    assert actual.transaction_hash == hex_to_bytes(expected_hash)
+    assert actual.intrinsic_gas == _hex_number(expected_intrinsic_gas)
+
+
+class TransactionTestFixture(Fixture, FixtureTestItem):
+    """Single transaction test fixture from a JSON file."""
+
+    fork_name: str
+
+    def __init__(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a transaction fixture item."""
+        super().__init__(*args, **kwargs)
+        self.fork_name = _fixture_fork_name(self.test_dict)
+        self.add_marker(pytest.mark.fork(self.fork_name))
+        self.add_marker("json_transaction_tests")
+
+    @property
+    def fixtures_file(self) -> FixturesFile:
+        """Fixtures file from which this transaction was collected."""
+        parent = self.parent
+        assert parent is not None
+        assert isinstance(parent, FixturesFile)
+        return parent
+
+    @property
+    def test_dict(self) -> Dict[str, Any]:
+        """Load the transaction fixture from disk."""
+        loaded_file = self.fixtures_file.data
+        return loaded_file[self.test_key]
+
+    def runtest(self) -> None:
+        """Run a transaction fixture against EELS."""
+        run_transaction_test_fixture(self.test_dict)
+
+    def reportinfo(self) -> Tuple[Path, int, str]:
+        """Return information for test reporting."""
+        return self.path, 1, self.name
+
+    @classmethod
+    def is_format(cls, test_dict: Dict[str, Any]) -> bool:
+        """Return whether the object is a transaction-test fixture."""
+        fixture_format = _fixture_format(test_dict)
+        if fixture_format is not None:
+            return fixture_format == "transaction_test"
+        return "txbytes" in test_dict and "result" in test_dict
+
+    @classmethod
+    def has_desired_fork(
+        cls, test_dict: Dict[str, Any], config: Config
+    ) -> bool:
+        """Return whether the fixture belongs to a requested fork."""
+        desired_forks = config.stash.get(desired_forks_key, None)
+        return (
+            desired_forks is None
+            or _fixture_fork_name(test_dict) in desired_forks
+        )

--- a/tests/json_loader/helpers/transaction_test_adapter.py
+++ b/tests/json_loader/helpers/transaction_test_adapter.py
@@ -1,0 +1,87 @@
+"""Normalize raw transaction validation across EELS forks."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes
+from ethereum_types.numeric import U64, Uint
+
+from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.state import Address
+
+from .. import FORKS
+
+
+@dataclass(frozen=True)
+class ValidTransactionResult:
+    """Result of successfully validating a raw transaction."""
+
+    sender: Address
+    transaction_hash: Hash32
+    intrinsic_gas: Uint
+
+
+def _decode_transaction(transactions: Any, raw: bytes) -> Any:
+    """Decode a raw transaction using the fork's transaction types."""
+    legacy_transaction = getattr(transactions, "LegacyTransaction", None)
+    if legacy_transaction is None:
+        return rlp.decode_to(transactions.Transaction, raw)
+
+    if raw and raw[0] < 0xC0:
+        return transactions.decode_transaction(Bytes(raw))
+    return rlp.decode_to(legacy_transaction, raw)
+
+
+def _validate_chain_id(
+    hardfork: Any,
+    transactions: Any,
+    transaction: Any,
+    expected_chain_id: int,
+) -> None:
+    """Validate the chain ID when the fork supports EIP-155."""
+    chain_id = getattr(transactions, "chain_id", None)
+    if chain_id is None:
+        return
+
+    actual_chain_id = chain_id(transaction)
+    if actual_chain_id is None:
+        return
+
+    expected = U64(expected_chain_id)
+    if actual_chain_id != expected:
+        exceptions = hardfork.module("exceptions")
+        raise exceptions.WrongChainIdError(
+            expected=expected,
+            actual=actual_chain_id,
+        )
+
+
+def _normalize_intrinsic_gas(intrinsic_gas: Any) -> Uint:
+    """Normalize scalar and split intrinsic-gas return types."""
+    if hasattr(intrinsic_gas, "regular"):
+        return Uint(max(intrinsic_gas.regular, intrinsic_gas.calldata_floor))
+    if hasattr(intrinsic_gas, "execution"):
+        return Uint(max(intrinsic_gas.execution, intrinsic_gas.calldata_floor))
+    return Uint(intrinsic_gas)
+
+
+def validate_raw_transaction(
+    fork_name: str,
+    raw: bytes,
+    chain_id: int = 1,
+) -> ValidTransactionResult:
+    """Decode and statically validate a raw transaction for a fork."""
+    hardfork = FORKS[fork_name]
+    transactions = hardfork.module("transactions")
+
+    transaction = _decode_transaction(transactions, raw)
+    _validate_chain_id(hardfork, transactions, transaction, chain_id)
+    sender = transactions.recover_sender(transaction)
+    intrinsic_gas = transactions.validate_transaction(transaction)
+
+    return ValidTransactionResult(
+        sender=sender,
+        transaction_hash=keccak256(raw),
+        intrinsic_gas=_normalize_intrinsic_gas(intrinsic_gas),
+    )

--- a/tests/json_loader/test_transaction_test_loader.py
+++ b/tests/json_loader/test_transaction_test_loader.py
@@ -1,0 +1,264 @@
+"""Test the EELS transaction-test fixture consumer."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from _pytest.config import Config
+from ethereum_rlp.exceptions import RLPException
+from execution_testing import TestAddress
+from execution_testing.fixtures import TransactionFixture
+from execution_testing.forks import (
+    Amsterdam,
+    Berlin,
+    Fork,
+    Frontier,
+    London,
+    Osaka,
+    Prague,
+    Shanghai,
+)
+from execution_testing.specs.transaction import TransactionTest
+from execution_testing.test_types import Transaction
+
+from ethereum.exceptions import EthereumException
+
+from .helpers import load_transaction_tests
+from .helpers.load_transaction_tests import (
+    TransactionTestFixture,
+    run_transaction_test_fixture,
+)
+from .helpers.transaction_test_adapter import validate_raw_transaction
+from .stash_keys import desired_forks_key
+
+
+def _transaction_fixture(
+    fork: Fork,
+    transaction: Transaction,
+) -> TransactionFixture:
+    """Generate a transaction fixture with context-dependent defaults."""
+    fixture = (
+        TransactionTest(tx=transaction, fork=fork)
+        .generate(
+            t8n=None,  # type: ignore[arg-type]
+            fixture_format=TransactionFixture,
+        )
+        .fixture
+    )
+    assert isinstance(fixture, TransactionFixture)
+    return fixture
+
+
+def _raw_transaction(fork: Fork, transaction: Transaction) -> bytes:
+    """Generate and return the raw transaction bytes from a fixture."""
+    return bytes(_transaction_fixture(fork, transaction).transaction)
+
+
+@pytest.mark.parametrize(
+    "fork,transaction,expected_intrinsic_gas",
+    [
+        pytest.param(
+            Frontier,
+            Transaction(protected=False),
+            21_000,
+            id="pre_berlin_legacy",
+        ),
+        pytest.param(
+            Berlin,
+            Transaction(ty=1),
+            21_000,
+            id="typed_transaction",
+        ),
+        pytest.param(
+            Prague,
+            Transaction(),
+            21_000,
+            id="prague_split_intrinsic_gas",
+        ),
+        pytest.param(
+            Osaka,
+            Transaction(),
+            21_000,
+            id="osaka_split_intrinsic_gas",
+        ),
+        pytest.param(
+            Amsterdam,
+            Transaction(to=TestAddress),
+            12_000,
+            id="amsterdam_sender_dependent_intrinsic_gas",
+        ),
+    ],
+)
+def test_validate_raw_transaction(
+    fork: Fork,
+    transaction: Transaction,
+    expected_intrinsic_gas: int,
+) -> None:
+    """Validate generated fixtures through each public validation path."""
+    fixture = _transaction_fixture(fork, transaction)
+    raw = bytes(fixture.transaction)
+
+    result = validate_raw_transaction(fork.name(), raw)
+
+    expected_result = next(iter(fixture.result.values()))
+    assert expected_result.sender is not None
+    assert expected_result.hash is not None
+    assert result.sender == bytes(expected_result.sender)
+    assert result.transaction_hash == bytes(expected_result.hash)
+    assert result.intrinsic_gas == expected_intrinsic_gas
+    assert result.intrinsic_gas == int(expected_result.intrinsic_gas)
+
+
+def test_reject_typed_transaction_before_berlin() -> None:
+    """Reject typed transaction envelopes on unsupported forks."""
+    raw = _raw_transaction(Berlin, Transaction(ty=1))
+
+    with pytest.raises(RLPException):
+        validate_raw_transaction("Frontier", raw)
+
+
+def test_reject_malformed_legacy_rlp() -> None:
+    """Reject a malformed legacy transaction list."""
+    with pytest.raises(RLPException):
+        validate_raw_transaction("Frontier", b"\xc0")
+
+
+def test_reject_semantically_invalid_transaction() -> None:
+    """Reject a decoded transaction whose nonce overflows."""
+    raw = _raw_transaction(
+        Frontier,
+        Transaction(nonce=2**64 - 1, protected=False),
+    )
+
+    with pytest.raises(EthereumException):
+        validate_raw_transaction("Frontier", raw)
+
+
+def test_reject_wrong_chain_id() -> None:
+    """Reject a transaction protected for a different chain."""
+    raw = _raw_transaction(London, Transaction(chain_id=2))
+
+    with pytest.raises(EthereumException, match="expected chain_id `1`"):
+        validate_raw_transaction("London", raw)
+
+
+@pytest.mark.parametrize("fork", [Prague, Osaka])
+def test_reject_empty_authorization_list(fork: Fork) -> None:
+    """Apply the fork's public state-independent transaction validation."""
+    raw = _raw_transaction(fork, Transaction(authorization_list=[]))
+
+    with pytest.raises(EthereumException, match="empty authorization list"):
+        validate_raw_transaction(fork.name(), raw)
+
+
+def _valid_fixture() -> dict[str, Any]:
+    """Create a valid transaction fixture for runner tests."""
+    fixture = _transaction_fixture(Shanghai, Transaction())
+    return fixture.json_dict_with_info()
+
+
+def test_run_valid_transaction_fixture() -> None:
+    """Compare all declared fields for a valid fixture."""
+    run_transaction_test_fixture(_valid_fixture())
+
+
+def test_run_invalid_transaction_fixture() -> None:
+    """Accept a fixture rejection only for known protocol errors."""
+    fixture = {
+        "result": {
+            "Frontier": {
+                "exception": "TR_RLP_TOO_FEW_ELEMENTS",
+                "intrinsicGas": "0x00",
+            }
+        },
+        "txbytes": "0xc0",
+    }
+
+    run_transaction_test_fixture(fixture)
+
+
+def test_unexpected_implementation_error_is_not_a_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not treat unrelated Python errors as expected rejection."""
+    fixture = {
+        "result": {
+            "Frontier": {
+                "exception": "TR_RLP_TOO_FEW_ELEMENTS",
+                "intrinsicGas": "0x00",
+            }
+        },
+        "txbytes": "0xc0",
+    }
+
+    def fail_unexpectedly(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise TypeError("implementation bug")
+
+    monkeypatch.setattr(
+        load_transaction_tests,
+        "validate_raw_transaction",
+        fail_unexpectedly,
+    )
+
+    with pytest.raises(TypeError, match="implementation bug"):
+        run_transaction_test_fixture(fixture)
+
+
+@pytest.mark.parametrize("metadata_key", ["fixture-format", "fixture_format"])
+def test_recognize_transaction_fixture_metadata(metadata_key: str) -> None:
+    """Recognize both fixture-format metadata spellings."""
+    test_dict = {
+        "_info": {metadata_key: "transaction_test"},
+        "result": {"Frontier": {}},
+        "txbytes": "0xc0",
+    }
+
+    assert TransactionTestFixture.is_format(test_dict)
+
+
+def test_recognize_structural_transaction_fixture() -> None:
+    """Recognize older transaction fixtures without format metadata."""
+    assert TransactionTestFixture.is_format(
+        {"result": {"Frontier": {}}, "txbytes": "0xc0"}
+    )
+
+
+def test_do_not_override_other_fixture_metadata() -> None:
+    """Do not use the structural fallback for another declared format."""
+    test_dict = {
+        "_info": {"fixture_format": "state_test"},
+        "result": {"Frontier": {}},
+        "txbytes": "0xc0",
+    }
+
+    assert not TransactionTestFixture.is_format(test_dict)
+
+
+def test_filter_transaction_fixture_fork() -> None:
+    """Collect transaction fixtures only for requested forks."""
+    test_dict = {"result": {"London": {}}, "txbytes": "0xc0"}
+    config = cast(
+        Config,
+        SimpleNamespace(stash={desired_forks_key: ["London"]}),
+    )
+
+    assert TransactionTestFixture.has_desired_fork(test_dict, config)
+
+    config.stash[desired_forks_key] = ["Frontier"]
+    assert not TransactionTestFixture.has_desired_fork(test_dict, config)
+
+
+def test_require_single_result_fork() -> None:
+    """Reject ambiguous transaction fixtures containing multiple forks."""
+    test_dict = {
+        "result": {"Frontier": {}, "Homestead": {}},
+        "txbytes": "0xc0",
+    }
+    config = cast(
+        Config,
+        SimpleNamespace(stash={desired_forks_key: ["Frontier"]}),
+    )
+
+    with pytest.raises(ValueError, match="exactly one result fork"):
+        TransactionTestFixture.has_desired_fork(test_dict, config)


### PR DESCRIPTION
### Description

Transaction test fixtures were generated but not exercised by the repository's JSON loader. That left their raw transaction bytes and expected results unchecked against EELS.

This PR adds a fork-aware adapter that decodes each raw transaction and uses EELS to validate its chain ID, signature, and state-independent transaction rules. It compares the resulting exception, transaction hash, sender, and intrinsic gas with the fixture. The JSON loader now discovers transaction fixtures from both checked-in files and filler output.

The adapter uses the common `validate_transaction(transaction)` interface introduced by the first PR in this stack. It does not duplicate fork validation rules.

### Stack

This is the final PR in a three-PR stack:

1. #3492 — Expose state-independent transaction validation.
2. #3493 — Resolve implicit transaction test gas limits.
3. #3494 — Validate transaction test fixtures with EELS (this PR).

### Related Issues or PRs

Follows #3156, which added the transaction tests and fixtures this loader validates.

### Testing

- Added focused coverage for valid and invalid fixtures across supported forks.
- Verified fixture discovery from JSON loader inputs and filler output.
- `just static` at each commit boundary.
- `just test-tests` at each commit boundary.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` match the applied labels.

### Cute Animal Picture

![A cat](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)
