### PR TITLE
chore(tests): clean up EIP-7928 spec.py ``Spec`` class

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/spec.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/spec.py
@@ -18,26 +18,4 @@ ref_spec_7928 = ReferenceSpec(
 
 
 class Spec:
-    """Constants and parameters from EIP-7928."""
-
-    # RLP encoding is used for block access list data structures
-    BAL_ENCODING_FORMAT: str = "RLP"
-
-    # Maximum limits for block access list data structures
-    TARGET_MAX_GAS_LIMIT = 600_000_000
-    MAX_TXS: int = 30_000
-    MAX_SLOTS: int = 300_000
-    MAX_ACCOUNTS: int = 300_000
-    # TODO: Use this as a function of the current fork.
-    MAX_CODE_SIZE: int = 24_576  # 24 KiB
-
-    # Type size constants
-    ADDRESS_SIZE: int = 20  # Ethereum address size in bytes
-    STORAGE_KEY_SIZE: int = 32  # Storage slot key size in bytes
-    STORAGE_VALUE_SIZE: int = 32  # Storage value size in bytes
-    HASH_SIZE: int = 32  # Hash size in bytes
-
-    # Numeric type limits
-    MAX_TX_INDEX: int = 2**32 - 1  # uint32 max value
-    MAX_BALANCE: int = 2**128 - 1  # uint128 max value
-    MAX_NONCE: int = 2**64 - 1  # uint64 max value
+    """Constants from EIP-7928."""

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -43,7 +43,9 @@ from execution_testing import (
 )
 from execution_testing import Macros as Om
 
-from .spec import Spec, ref_spec_7928
+from tests.frontier.eip2681_limit_account_nonce.spec import Spec as Spec2681
+
+from .spec import ref_spec_7928
 from .test_block_access_lists_eip4788 import SYSTEM_ADDRESS
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7928.git_path
@@ -3576,8 +3578,8 @@ def test_bal_create_early_failure(
 @pytest.mark.parametrize(
     "factory_nonce",
     [
-        pytest.param(Spec.MAX_NONCE, id="nonce_at_max"),
-        pytest.param(Spec.MAX_NONCE - 1, id="nonce_below_max"),
+        pytest.param(Spec2681.max_nonce, id="nonce_at_max"),
+        pytest.param(Spec2681.max_nonce - 1, id="nonce_below_max"),
     ],
 )
 def test_bal_create_nonce_overflow(
@@ -3635,15 +3637,15 @@ def test_bal_create_nonce_overflow(
     target_expectation: BalAccountExpectation | None
     target_post: Account | None
 
-    if factory_nonce == Spec.MAX_NONCE:
+    if factory_nonce == Spec2681.max_nonce:
         create_result = 0
         factory_nonce_changes = []
         target_expectation = None
         target_post = Account.NONEXISTENT
-    elif factory_nonce == Spec.MAX_NONCE - 1:
+    elif factory_nonce == Spec2681.max_nonce - 1:
         create_result = 1
         factory_nonce_changes = [
-            BalNonceChange(block_access_index=1, post_nonce=Spec.MAX_NONCE)
+            BalNonceChange(block_access_index=1, post_nonce=Spec2681.max_nonce)
         ]
         target_expectation = BalAccountExpectation(
             nonce_changes=[BalNonceChange(block_access_index=1, post_nonce=1)],
@@ -3662,7 +3664,7 @@ def test_bal_create_nonce_overflow(
             # At the boundary the nonce is unchanged; one below, it is
             # incremented into it. Both arms end at the maximum.
             factory: Account(
-                nonce=Spec.MAX_NONCE, storage={0x00: create_result}
+                nonce=Spec2681.max_nonce, storage={0x00: create_result}
             ),
             target: target_post,
         },


### PR DESCRIPTION
### Description

No spec-specific constants were useful to keep in ``Spec`` class for BALs. This may change but the import from the relevant spec is preferred over adding them here if they are not BALs specific.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Relevant mention from [ETH R&D Discord](https://discord.com/channels/595666850260713488/753271902520213625/1544323210772746270)

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

🐻‍❄️ 
