### PR TITLE
fix(test-specs): refuse RLP blockchain fixtures for engine-payload-only block overrides

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -375,6 +375,21 @@ class Block(Header):
             "split via _split_blocks_by_phase first."
         )
 
+    def engine_payload_only_overrides(self) -> List[str]:
+        """
+        Return the names of the settings that only reach the engine payload.
+
+        An RLP block cannot carry them, so a fixture that delivers blocks as
+        RLP would present a valid block while claiming the exception they
+        are meant to cause.
+        """
+        overrides: List[str] = []
+        if self.engine_new_payload_block_access_list is not None:
+            overrides.append("engine_new_payload_block_access_list")
+        if self.engine_new_payload_slot_number is not None:
+            overrides.append("engine_new_payload_slot_number")
+        return overrides
+
     def set_environment(self, env: Environment) -> Environment:
         """
         Create copy of the environment with the characteristics of this
@@ -1158,6 +1173,16 @@ class BlockchainTest(BaseTest):
         t8n: FillerBackend,
     ) -> FillResult:
         """Create a fixture from the blockchain test definition."""
+        for i, block in enumerate(self.blocks):
+            overrides = block.engine_payload_only_overrides()
+            if overrides:
+                raise Exception(
+                    f"test correctness: block {i} sets {', '.join(overrides)}"
+                    ", which only reach the engine payload and cannot be "
+                    "expressed in an RLP blockchain fixture. Mark the test "
+                    "`blockchain_test_engine_only`."
+                )
+
         fixture_blocks: List[FixtureBlock | InvalidFixtureBlock] = []
 
         pre, genesis = self.make_genesis(apply_pre_allocation_blockchain=True)

--- a/packages/testing/src/execution_testing/specs/tests/test_types.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_types.py
@@ -1,5 +1,7 @@
 """Test types from execution_testing.specs."""
 
+from unittest.mock import sentinel
+
 import pytest
 
 from execution_testing.base_types import (
@@ -16,10 +18,10 @@ from execution_testing.fixtures.blockchain import (
     FixtureHeader,
 )
 from execution_testing.forks import Amsterdam
-from execution_testing.test_types import Environment
+from execution_testing.test_types import Alloc, Environment
 from execution_testing.test_types.block_access_list import BlockAccessList
 
-from ..blockchain import BuiltBlock, Header
+from ..blockchain import Block, BlockchainTest, BuiltBlock, Header
 
 fixture_header_ones = FixtureHeader(
     parent_hash=Hash(1),
@@ -256,3 +258,43 @@ class TestDeriveEnginePayloadModifier:
         ).engine_payload_modifier()
         assert isinstance(modifier, FixtureExecutionPayloadModifier)
         assert modifier.block_access_list == Bytes(b"")
+
+
+class TestEnginePayloadOnlyOverrides:
+    """
+    A block setting that only reaches the engine payload cannot be expressed
+    in an RLP blockchain fixture, so ``make_fixture`` refuses to build one.
+    """
+
+    @pytest.mark.parametrize(
+        "block,expected",
+        [
+            pytest.param(Block(), [], id="none"),
+            pytest.param(
+                Block(engine_new_payload_block_access_list=Bytes(b"")),
+                ["engine_new_payload_block_access_list"],
+                id="payload_bal",
+            ),
+            pytest.param(
+                Block(engine_new_payload_slot_number=0),
+                ["engine_new_payload_slot_number"],
+                id="payload_slot_number",
+            ),
+        ],
+    )
+    def test_overrides_are_named(
+        self, block: Block, expected: list[str]
+    ) -> None:
+        """Each payload-only setting is reported by name."""
+        assert block.engine_payload_only_overrides() == expected
+
+    def test_make_fixture_refuses_payload_only_override(self) -> None:
+        """The RLP fixture builder fails before it touches the t8n."""
+        test = BlockchainTest(
+            fork=Amsterdam,
+            pre=Alloc(),
+            post=Alloc(),
+            blocks=[Block(engine_new_payload_slot_number=0)],
+        )
+        with pytest.raises(Exception, match="blockchain_test_engine_only"):
+            test.make_fixture(sentinel.t8n)


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

`engine_new_payload_block_access_list` and `engine_new_payload_slot_number` corrupt only the `engine_newPayload` request, so a plain `blockchain_test` fixture would carry a valid RLP block while claiming the exception. `BlockchainTest.make_fixture` now fails naming the override and the `blockchain_test_engine_only` marker; engine formats are unaffected.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
ethereum/execution-specs#3486 adds a third payload-only path (`BlockAccessListExpectation.modify_rlp`) that should hook into the same check.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWZnZ3E4bmZ0dTBrbmp3Y3V5c2NsZ3Zvc3Y3Zmd1YmJ4MWx6dGRvMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oriO0OEd9QIDdllqo/giphy.gif)
