### PR TITLE
fix(execute): derive the EOA start key instead of randomising it

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -1,10 +1,10 @@
 """Pre-allocation fixtures used for test filling."""
 
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from itertools import count
 from pathlib import Path
-from random import randint
 from typing import Any, Dict, Generator, Iterator, List, Literal, Tuple
 
 import pytest
@@ -39,6 +39,7 @@ from execution_testing.test_types import (
     Transaction,
     TransactionTestMetadata,
     compute_deterministic_create2_address,
+    keccak256,
 )
 from execution_testing.test_types import Alloc as BaseAlloc
 from execution_testing.tools import Initcode
@@ -56,6 +57,45 @@ from .contracts import (
 logger = get_logger(__name__)
 
 
+def eoa_iterator_start(config: pytest.Config) -> int:
+    """
+    Return the private key that this process starts handing out EOAs from.
+
+    Derived rather than random, so that a run can be repeated: the default was
+    `randint(0, 2**256)`, which gave every run a different set of
+    `pre.fund_eoa()` addresses. A prestate built twice from one snapshot
+    therefore diverged at its first test EOA and at every block after it, which
+    is what makes a filled prestate shippable only as a datadir or a replay
+    bundle.
+
+    Two things that randomness did protect have to survive being pinned, so
+    both go into the derivation:
+
+    - xdist workers. Every worker process evaluates the option default for
+      itself, so a random one handed each its own range. Nothing else offsets
+      them, and `session_worker_key` takes the first key from this iterator.
+    - concurrent runs against one network. Two runs sharing a range would race
+      each other's nonces. The seed key is already documented as belonging to a
+      single command, so it separates them whenever one is set.
+
+    The result is 248 bits: never the invalid key zero, and far enough below
+    the secp256k1 order that counting upwards from it stays valid.
+    """
+    configured = config.getoption("eoa_iterator_start")
+    if configured is not None:
+        return int(configured)
+
+    material = (
+        b"eoa-start:" + os.getenv("PYTEST_XDIST_WORKER", "main").encode()
+    )
+    seed_key = config.getoption("rpc_seed_key", None) or os.environ.get(
+        "RPC_SEED_KEY"
+    )
+    if seed_key is not None:
+        material += b":" + str(seed_key).encode()
+    return int.from_bytes(keccak256(material), "big") >> 8
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add command-line options to pytest."""
     pre_alloc_group = parser.getgroup(
@@ -66,9 +106,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--eoa-start",
         action="store",
         dest="eoa_iterator_start",
-        default=randint(0, 2**256),
+        default=None,
         type=int,
-        help="The start private key from which tests will deploy EOAs.",
+        help=(
+            "The start private key from which tests will deploy EOAs. "
+            "Defaults to a value derived from the seed key and the worker id, "
+            "so that a run can be repeated; pass it explicitly to reproduce a "
+            "run made with a different one."
+        ),
     )
     pre_alloc_group.addoption(
         "--skip-cleanup",
@@ -84,7 +129,7 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
     """Pytest hook called to obtain the report header."""
     bold = "\033[1m"
     reset = "\033[39;49m"
-    eoa_start = config.getoption("eoa_iterator_start")
+    eoa_start = eoa_iterator_start(config)
     header = [
         (bold + f"Start seed for EOA: {hex(eoa_start)} " + reset),
     ]
@@ -132,7 +177,7 @@ def skip_cleanup(request: pytest.FixtureRequest) -> bool:
 @pytest.fixture(scope="session")
 def eoa_iterator(request: pytest.FixtureRequest) -> Iterator[EOA]:
     """Return an iterator that generates EOAs."""
-    eoa_start = request.config.getoption("eoa_iterator_start")
+    eoa_start = eoa_iterator_start(request.config)
     print(f"Starting EOA index: {hex(eoa_start)}")
     logger.info(
         f"Initializing EOA iterator with start index: {hex(eoa_start)}"

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_pre_alloc.py
@@ -7,7 +7,7 @@ import pytest
 from execution_testing.base_types import Address, Hash
 
 from ...shared.address_stubs import StubAddress, StubEOA
-from ..pre_alloc import AddressStubs
+from ..pre_alloc import AddressStubs, eoa_iterator_start
 
 ADDR_1 = Address("0x0000000000000000000000000000000000000001")
 DEPOSIT_ADDR = Address("0x00000000219ab540356cbb839cbe05303d7705fa")
@@ -119,3 +119,104 @@ def test_address_stubs_is_eoa() -> None:
     assert not stubs.is_eoa("contract")
     assert stubs.is_eoa("eoa")
     assert not stubs.is_eoa("nonexistent")
+
+
+class StubConfig:
+    """A pytest config exposing only the options eoa_iterator_start reads."""
+
+    def __init__(
+        self, *, eoa_start: int | None = None, seed_key: str | None = None
+    ) -> None:
+        """Record the two option values to answer with."""
+        self._options: dict[str, Any] = {
+            "eoa_iterator_start": eoa_start,
+            "rpc_seed_key": seed_key,
+        }
+
+    def getoption(self, name: str, default: Any = None) -> Any:
+        """Mimic `pytest.Config.getoption`, defaulting unknown names."""
+        return self._options.get(name, default)
+
+
+SEED_KEY_A = "0x" + "01".rjust(64, "0")
+SEED_KEY_B = "0x" + "02".rjust(64, "0")
+
+# Below the secp256k1 group order, so every key counted from a start is valid.
+SECP256K1N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+
+def test_eoa_start_explicit_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicitly passed --eoa-start is used as given."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.delenv("RPC_SEED_KEY", raising=False)
+    config = StubConfig(eoa_start=0x1234, seed_key=SEED_KEY_A)
+    assert eoa_iterator_start(config) == 0x1234  # type: ignore[arg-type]
+
+
+def test_eoa_start_is_reproducible(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The derived default repeats, which a random one could not."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.delenv("RPC_SEED_KEY", raising=False)
+    config = StubConfig(seed_key=SEED_KEY_A)
+    first = eoa_iterator_start(config)  # type: ignore[arg-type]
+    assert first == eoa_iterator_start(config)  # type: ignore[arg-type]
+
+
+def test_eoa_start_differs_per_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Each xdist worker gets a range of its own.
+
+    Nothing else offsets the workers, and `session_worker_key` takes the first
+    key from this iterator, so two workers sharing a start would share an
+    account.
+    """
+    config = StubConfig(seed_key=SEED_KEY_A)
+    monkeypatch.delenv("RPC_SEED_KEY", raising=False)
+    starts = {}
+    for worker in ("main", "gw0", "gw1", "gw2"):
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", worker)
+        starts[worker] = eoa_iterator_start(config)  # type: ignore[arg-type]
+    assert len(set(starts.values())) == len(starts)
+
+
+def test_eoa_start_differs_per_seed_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two runs funded by different seed keys never share a range."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.delenv("RPC_SEED_KEY", raising=False)
+    a = eoa_iterator_start(StubConfig(seed_key=SEED_KEY_A))  # type: ignore[arg-type]
+    b = eoa_iterator_start(StubConfig(seed_key=SEED_KEY_B))  # type: ignore[arg-type]
+    assert a != b
+
+
+def test_eoa_start_reads_seed_key_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RPC_SEED_KEY separates runs just as --rpc-seed-key does."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.setenv("RPC_SEED_KEY", SEED_KEY_A)
+    from_env = eoa_iterator_start(StubConfig())  # type: ignore[arg-type]
+    monkeypatch.delenv("RPC_SEED_KEY")
+    from_flag = eoa_iterator_start(StubConfig(seed_key=SEED_KEY_A))  # type: ignore[arg-type]
+    assert from_env == from_flag
+
+
+def test_eoa_start_is_a_usable_private_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Every derived start is a valid key, with room to count upwards from.
+
+    Zero is not a private key, and a start too close to the group order would
+    walk past it partway through a run.
+    """
+    monkeypatch.delenv("RPC_SEED_KEY", raising=False)
+    config = StubConfig(seed_key=SEED_KEY_A)
+    for i in range(64):
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", f"gw{i}")
+        start = eoa_iterator_start(config)  # type: ignore[arg-type]
+        assert 0 < start
+        assert start + 2**40 < SECP256K1N


### PR DESCRIPTION
`--eoa-start` defaulted to `randint(0, 2**256)`, so every run handed `pre.fund_eoa()` a different set of addresses and nothing in the configuration could pin them. `fill-stateful` loads this plugin too, which makes a filled prestate unreproducible: two builds from one snapshot agree until the first test EOA appears and diverge on every block after it. Measured on snapshot 24,402,727, two 7,736-payload builds shared blocks 24,402,728 and 24,402,729 -- neither uses a test EOA -- then split at 24,402,730 on transactions identical in length, nonce, gas price, gas limit and value, differing only in recipient. A prestate can therefore only be shipped as a datadir or a replay bundle, and fixtures record `snapshotBlockHash`, so a suite filled against one build is rejected against an equivalent rebuild of it.

Derive the default instead. Two properties the randomness did provide have to survive being pinned, so both go into the derivation:

- xdist workers. Each worker process evaluates the option default for itself, so a random one gave every worker a range of its own. Nothing else offsets them and `session_worker_key` takes the first key from this iterator, so a bare constant would have every worker funding and spending one account.
- concurrent runs against a shared network. Two runs sharing a range would race each other's nonces. The seed key already has to belong to a single command, so it separates runs whenever one is set, by flag or by RPC_SEED_KEY.

`keccak256(b"eoa-start:<worker>[:<seed key>]") >> 8` gives 248 bits: never the invalid key zero, and far enough below the secp256k1 group order that counting upwards from it stays valid for any run length. An explicit `--eoa-start` still wins, which is what reproduces a run made before this change.

Two fill-stateful sessions with RPC_SEED_KEY=0x..01 now both report 0x4f4b0f0b0af2385d3ff86ac2ba5d9e2529cd9bc5415aefce34b9f848e9e66f, and 0x..02 reports a different one.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
