### PR TITLE
fix(fill): warn and discard a partial opcode trace instead of reporting it

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/client_backend.py
+++ b/packages/testing/src/execution_testing/client_clis/client_backend.py
@@ -13,7 +13,7 @@ info, block boundaries, and pre-alloc declarations flow unchanged.
 
 import re
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 from execution_testing.base_types import Bytes, Hash
 from execution_testing.exceptions import ExceptionBase, ExceptionMapper
@@ -97,9 +97,17 @@ def _normalize_opcode_name(name: str) -> str | None:
     return None
 
 
-def _opcode_count_from_js_tracer(traces: Any) -> OpcodeCount:
-    """Aggregate the per-tx ``{opcode: count}`` maps the JS tracer emits."""
+def _opcode_count_from_js_tracer(traces: Any) -> Tuple[OpcodeCount, int]:
+    """
+    Aggregate the per-tx ``{opcode: count}`` maps the JS tracer emits.
+
+    Also returns how many entries actually contributed, so the caller can
+    check the trace covered every transaction. An entry whose trace failed
+    carries an error instead of a ``result`` and contributes nothing; without
+    that count the shortfall is invisible.
+    """
     counts: Dict[str, int] = {}
+    covered = 0
     for entry in traces or []:
         if not isinstance(entry, dict):
             continue
@@ -107,17 +115,24 @@ def _opcode_count_from_js_tracer(traces: Any) -> OpcodeCount:
         # Clients that ignore the JS tracer echo struct logs.
         if not isinstance(tx_counts, dict) or "structLogs" in tx_counts:
             continue
+        covered += 1
         for opcode, count in tx_counts.items():
             key = _normalize_opcode_name(opcode)
             if key is None or not isinstance(count, int):
                 continue
             counts[key] = counts.get(key, 0) + count
-    return OpcodeCount.model_validate(counts)
+    return OpcodeCount.model_validate(counts), covered
 
 
-def _opcode_count_from_struct_logs(traces: Any) -> OpcodeCount:
-    """Count ``structLogs[].op`` entries, one per executed opcode."""
+def _opcode_count_from_struct_logs(traces: Any) -> Tuple[OpcodeCount, int]:
+    """
+    Count ``structLogs[].op`` entries, one per executed opcode.
+
+    Returns the tally and the number of entries that carried struct logs, for
+    the same coverage check as the JS tracer path.
+    """
     counts: Dict[str, int] = {}
+    covered = 0
     for entry in traces or []:
         if not isinstance(entry, dict):
             continue
@@ -125,6 +140,9 @@ def _opcode_count_from_struct_logs(traces: Any) -> OpcodeCount:
         result = entry.get("result")
         if not isinstance(result, dict):
             result = entry
+        if "structLogs" not in result:
+            continue
+        covered += 1
         for step in result.get("structLogs") or []:
             if not isinstance(step, dict):
                 continue
@@ -135,7 +153,7 @@ def _opcode_count_from_struct_logs(traces: Any) -> OpcodeCount:
             if key is None:
                 continue
             counts[key] = counts.get(key, 0) + 1
-    return OpcodeCount.model_validate(counts)
+    return OpcodeCount.model_validate(counts), covered
 
 
 class ClientBackendExceptionMapper(ExceptionMapper):
@@ -328,7 +346,7 @@ class ClientBackend:
         return self.eth_rpc.get_alloc(expected, block_number=block_number)
 
     def extract_block_opcode_count(
-        self, block_hash: Hash
+        self, block_hash: Hash, transaction_count: int | None = None
     ) -> OpcodeCount | None:
         """
         Tally executed opcodes for a block via ``debug_traceBlockByHash``.
@@ -337,25 +355,62 @@ class ClientBackend:
         fails (logged, never fatal). Prefers the JS tracer; a client
         that rejects it falls back to struct logs for the session,
         while transient errors only skip the block.
+
+        ``transaction_count`` enables a coverage check. The trace returns one
+        entry per transaction, and an entry whose trace failed carries an
+        error instead of a result. Aggregating what is left yields a
+        well-formed tally that is silently short by whole transactions, which
+        then fails a downstream count assertion that has nothing to do with
+        tracing. A partial tally is therefore discarded rather than returned:
+        the fixture is still produced, it simply carries no opcode count.
         """
         if not self.extract_opcode_count or self.debug_rpc is None:
             return None
 
         try:
+            covered: int
+            opcode_count: OpcodeCount
             if not self._js_tracer_unsupported:
                 try:
                     traces = self._trace_block(
                         block_hash, {"tracer": OPCODE_COUNT_TRACER_JS}
                     )
-                    return _opcode_count_from_js_tracer(traces)
+                    opcode_count, covered = _opcode_count_from_js_tracer(
+                        traces
+                    )
+                    return self._checked_opcode_count(
+                        opcode_count, covered, transaction_count, block_hash
+                    )
                 except JSONRPCError as e:
                     logger.info(f"JS tracer rejected ({e}); using struct logs")
                     self._js_tracer_unsupported = True
             traces = self._trace_block(block_hash, STRUCT_LOG_TRACER_CONFIG)
-            return _opcode_count_from_struct_logs(traces)
+            opcode_count, covered = _opcode_count_from_struct_logs(traces)
+            return self._checked_opcode_count(
+                opcode_count, covered, transaction_count, block_hash
+            )
         except Exception as e:
             logger.warning(f"opcode trace failed for block {block_hash}: {e}")
             return None
+
+    @staticmethod
+    def _checked_opcode_count(
+        opcode_count: OpcodeCount,
+        covered: int,
+        transaction_count: int | None,
+        block_hash: Hash,
+    ) -> OpcodeCount | None:
+        """Discard a tally that does not cover every transaction."""
+        if transaction_count is None or covered == transaction_count:
+            return opcode_count
+        logger.warning(
+            f"opcode trace for block {block_hash} covered {covered} of "
+            f"{transaction_count} transactions; {transaction_count - covered} "
+            "transaction(s) returned no usable trace. Discarding the partial "
+            "count -- the fixture is still valid, it just carries no opcode "
+            "count. Re-run to obtain one."
+        )
+        return None
 
     def _trace_block(
         self, block_hash: Hash, tracer_config: Dict[str, Any]

--- a/packages/testing/src/execution_testing/client_clis/tests/test_opcode_count_coverage.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_opcode_count_coverage.py
@@ -1,0 +1,134 @@
+"""
+Tests that a partial opcode trace is discarded rather than reported.
+
+`debug_traceBlockByHash` returns one entry per transaction. When a single
+transaction's trace fails, its entry carries an error instead of a result.
+Aggregating what remains yields a well-formed tally that is silently short by
+whole transactions -- which then fails a downstream opcode-count assertion that
+has nothing to do with tracing.
+
+Observed while filling the compute benchmarks: a 300M block of 18 transactions
+executed fully (299.998M gas used, all 18 present) but the tally came back
+exactly 94,698 identity calls short, which is precisely one transaction's
+worth. The same case passes when re-run.
+"""
+
+from execution_testing.base_types import Hash
+from execution_testing.client_clis.client_backend import (
+    ClientBackend,
+    _opcode_count_from_js_tracer,
+    _opcode_count_from_struct_logs,
+)
+
+BLOCK_HASH = Hash("0x" + "11" * 32)
+
+
+def _js(counts: dict[str, int]) -> dict:
+    """A JS-tracer entry for one successfully traced transaction."""
+    return {"result": dict(counts)}
+
+
+def _js_error() -> dict:
+    """An entry for a transaction whose trace failed: no ``result`` key."""
+    return {"txHash": "0x" + "ab" * 32, "error": "execution timeout"}
+
+
+def _struct(ops: list[str]) -> dict:
+    """A struct-log entry for one successfully traced transaction."""
+    return {"result": {"structLogs": [{"op": op} for op in ops]}}
+
+
+def test_js_tracer_reports_covered_transactions() -> None:
+    """Every usable entry counts toward coverage."""
+    opcode_count, covered = _opcode_count_from_js_tracer(
+        [_js({"MSTORE": 5}), _js({"MSTORE": 7})]
+    )
+    assert covered == 2
+    assert sum(opcode_count.root.values()) == 12
+
+
+def test_js_tracer_errored_entry_does_not_count_as_covered() -> None:
+    """An entry carrying an error contributes nothing, including coverage."""
+    opcode_count, covered = _opcode_count_from_js_tracer(
+        [_js({"MSTORE": 5}), _js_error(), _js({"MSTORE": 5})]
+    )
+    assert covered == 2, "the errored entry must not count as covered"
+    assert sum(opcode_count.root.values()) == 10
+
+
+def test_struct_logs_report_covered_transactions() -> None:
+    """The struct-log path reports coverage the same way."""
+    opcode_count, covered = _opcode_count_from_struct_logs(
+        [_struct(["MSTORE", "MLOAD"]), _struct(["MSTORE"])]
+    )
+    assert covered == 2
+    assert sum(opcode_count.root.values()) == 3
+
+
+def test_struct_logs_entry_without_logs_is_not_covered() -> None:
+    """An entry with no struct logs is a failed trace, not an empty one."""
+    _, covered = _opcode_count_from_struct_logs(
+        [_struct(["MSTORE"]), {"txHash": "0x00", "error": "boom"}]
+    )
+    assert covered == 1
+
+
+def test_complete_coverage_is_returned() -> None:
+    """A tally covering every transaction is used as-is."""
+    opcode_count, covered = _opcode_count_from_js_tracer(
+        [_js({"MSTORE": 5}), _js({"MSTORE": 5})]
+    )
+    assert (
+        ClientBackend._checked_opcode_count(
+            opcode_count, covered, 2, BLOCK_HASH
+        )
+        is opcode_count
+    )
+
+
+def test_partial_coverage_is_discarded() -> None:
+    """
+    A tally missing a transaction is dropped, not returned.
+
+    Returning it is what turns a tracing hiccup into a bogus count-mismatch
+    failure elsewhere. Dropping it leaves the fixture valid but without an
+    opcode count, which is recoverable by re-running.
+    """
+    opcode_count, covered = _opcode_count_from_js_tracer(
+        [_js({"MSTORE": 5}), _js_error(), _js({"MSTORE": 5})]
+    )
+    assert covered == 2
+    assert (
+        ClientBackend._checked_opcode_count(
+            opcode_count, covered, 3, BLOCK_HASH
+        )
+        is None
+    )
+
+
+def test_missing_transaction_count_keeps_previous_behaviour() -> None:
+    """Without a transaction count there is nothing to check against."""
+    opcode_count, covered = _opcode_count_from_js_tracer(
+        [_js({"MSTORE": 5}), _js_error()]
+    )
+    assert (
+        ClientBackend._checked_opcode_count(
+            opcode_count, covered, None, BLOCK_HASH
+        )
+        is opcode_count
+    )
+
+
+def test_partial_coverage_warns_loudly(caplog) -> None:  # type: ignore[no-untyped-def]
+    """The discard must be visible: it is the only signal of the loss."""
+    opcode_count, covered = _opcode_count_from_js_tracer(
+        [_js({"MSTORE": 5}), _js_error(), _js({"MSTORE": 5})]
+    )
+    with caplog.at_level("WARNING"):
+        ClientBackend._checked_opcode_count(
+            opcode_count, covered, 3, BLOCK_HASH
+        )
+    assert any(
+        "covered 2 of 3 transactions" in record.message
+        for record in caplog.records
+    ), f"expected a warning naming the shortfall, got {caplog.records}"

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1568,7 +1568,10 @@ class BlockchainTest(BaseTest):
             else:
                 execution_payloads.append(payload)
                 block_opcode_count = t8n.extract_block_opcode_count(
-                    client_hash
+                    client_hash,
+                    len(
+                        built_block.engine_payload.payload_response.execution_payload.transactions
+                    ),
                 )
                 execution_opcode_counts.append(
                     block_opcode_count.model_dump()


### PR DESCRIPTION
`debug_traceBlockByHash` returns one entry per transaction. When a single transaction's trace fails, its entry carries an error instead of a `result`, and the aggregation loop skipped it silently -- returning a well-formed tally that is short by whole transactions, with no exception and no log line. The caller could not tell 17 traced transactions from 18.

That surfaced while filling the compute benchmarks. test_identity_uncachable[size_32, 300M] failed with

    Target opcode IDENTITY count mismatch: expected ~1693322 (+-5.0%),
    got 1598624

The deficit is 94,698, which is exactly the calls one full-cap transaction makes: (16777216 - 15512 - 17) // 177. The block itself was fine -- all 18 transactions present, 299.998M of 300M gas used -- and the same case passes on re-run (verified four times). Nothing was wrong with the benchmark; one transaction's trace was lost and the shortfall was reported as if it were a real count.

It read as a benchmark bug for exactly as long as it took to notice the count was one whole transaction short. The test's own model is correct: across the ten gas values that passed, its predicted transaction counts match the fixtures exactly and its predicted gas matches to within the 128-143 gas per transaction that WhileGas necessarily strands.

So the aggregators now report how many entries contributed, and a tally that does not cover every transaction is discarded with a warning naming the shortfall. It is not fatal: a missing trace should not throw away a block that filled correctly, and the count can be recovered by re-running. The fixture is still written, it just carries no opcode count.

Struct-log aggregation had the same hole and gets the same treatment; an entry with no `structLogs` key is a failed trace, not an empty one.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
