### PR TITLE
fix(fill): re-anchor start_block under `--no-reset-between-tests`

### DIFF
--- a/docs/filling_tests/fill_stateful.md
+++ b/docs/filling_tests/fill_stateful.md
@@ -123,6 +123,7 @@ Optional:
 - `--output PATH` — default `./fixtures`.
 - `--clean` — wipe the output dir before filling.
 - `--extract-opcode-count` — after building each block, trace it via `debug_traceBlockByHash` (a JS opcode-counting tracer) and record per-opcode execution counts (execution-phase blocks only) in the fixture's `_info.metadata.opcode_counts` — an array with one entry per `engineNewPayloads` block (`opcode_counts[i]` is the count for `engineNewPayloads[i]`, or `null` if its trace was unavailable), so multi-block benchmarks keep per-payload granularity. When a benchmark test declares a target opcode count (`fixed_opcode_count`/`expected_opcode_count`), the live-client count is verified against it and the fill fails on >5% divergence. Requires the `debug` namespace with JS tracer support. Adds a full re-execution trace per block, so it is slow and opt-in.
+- `--no-reset-between-tests` — skip the between-test rewind to `start_block`, so each test builds on the state the previous one left behind and the client head accumulates upward. Used to pre-populate a datadir (e.g. deploy setup contracts) whose persisted state a later run builds on. The written fixtures are unchanged — each still records its own `start_block` — so a fixture produced this way is only valid to replay against a client already at that `start_block`; do not mix accumulate-state fills and normal single-anchor fills in one output dir.
 
 ## Output layout
 
@@ -198,6 +199,7 @@ Both backends satisfy `FillerBackend` (`client_clis/filler_backend.py`). `Client
 |---|---|---|
 | `--snapshot-block` | `fill-stateful` | Anchor by 32-byte hash (reorg-safe) or block number; defaults to `latest`. |
 | `--rpc-seed-key` | `fill-stateful` | Pin the seed EOA; otherwise generated + funded via CL withdrawal. |
+| `--no-reset-between-tests` | `fill-stateful` | Skip the between-test rewind so tests accumulate state on the live client (pre-populate a datadir a later run builds on). |
 | `--default-gas-price`, `--default-max-fee-per-gas`, `--default-max-priority-fee-per-gas`, `--default-max-fee-per-blob-gas` | `shared/live_client_flags` | Pin per-session fees; defaults bump a one-shot live query by `1.5x`. |
 | `--max-gas-per-test`, `--max-tx-per-batch`, `--transaction-gas-limit`, ... | `shared/live_client_flags` | Generic live-client knobs reused across commands. |
 

--- a/packages/testing/src/execution_testing/__init__.py
+++ b/packages/testing/src/execution_testing/__init__.py
@@ -50,6 +50,7 @@ from .specs import (
 )
 from .test_types import (
     DETERMINISTIC_FACTORY_ADDRESS,
+    DETERMINISTIC_FACTORY_BYTECODE,
     EOA,
     Alloc,
     AuthorizationTuple,
@@ -132,6 +133,7 @@ from .vm import (
 
 __all__ = (
     "DETERMINISTIC_FACTORY_ADDRESS",
+    "DETERMINISTIC_FACTORY_BYTECODE",
     "AccessList",
     "Account",
     "Address",

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -174,6 +174,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "This flag checks every account at start_block.)"
         ),
     )
+    group.addoption(
+        "--no-reset-between-tests",
+        action="store_true",
+        dest="no_reset_between_tests",
+        default=False,
+        help=(
+            "Accumulate state across tests (don't rewind between them). Useful"
+            "for pre-populating datadir. Fixtures remain valid only from their"
+            "recorded start_block. Don't mix with single-anchor fills."
+        ),
+    )
 
 
 def _resolve_session_fork(
@@ -530,6 +541,12 @@ def opcode_count_trace_timeout(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="session")
+def no_reset_between_tests(request: pytest.FixtureRequest) -> bool:
+    """Whether --no-reset-between-tests state accumulation is enabled."""
+    return request.config.getoption("no_reset_between_tests")
+
+
+@pytest.fixture(scope="session")
 def client_backend(
     eth_rpc: ChainBuilderEthRPC,
     debug_rpc: DebugRPC,
@@ -794,6 +811,7 @@ def _reset_chain_between_tests(
     client_backend: ClientBackend,
     debug_rpc: DebugRPC,
     eth_rpc: "ChainBuilderEthRPC",
+    no_reset_between_tests: bool,
 ) -> Generator[None, None, None]:
     """
     Rewind to start_block after each test so the chain is identical for
@@ -805,6 +823,8 @@ def _reset_chain_between_tests(
     drifted (e.g. a live reorg).
     """
     yield
+    if no_reset_between_tests:
+        return
     if client_backend.start_block is None:
         return
     start_hex = client_backend.start_block["number"]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -828,7 +828,28 @@ def _reset_chain_between_tests(
     so the client reorgs onto it even without a debug rewind. Afterwards we
     verify the block at the start_block number matches and fail loudly if it
     drifted (e.g. a live reorg).
+
+    Under ``--no-reset-between-tests`` there is no rewind, so re-anchor on
+    the live head before each test instead.
     """
+    if no_reset_between_tests:
+        # The session captured start_block once, at the head that followed
+        # the global setup. With the rewind skipped, the chain keeps moving,
+        # so that anchor goes stale the moment the first test builds a block
+        # — and every later test would still chain its first block from it.
+        # The client rejects that parent outright once it is no longer the
+        # head ("parentHash is not current head"), or, on a long enough run
+        # against a non-archive client, once its state has been pruned
+        # ("historical state ... is not available").
+        #
+        # Re-reading the head here keeps each test anchored to what the
+        # previous test actually left behind, which is the chain the
+        # accumulating mode is built around. Consumers are unaffected: they
+        # route pre-run setup by directory (``pre_run/*.json``, applied once
+        # per session), not by matching a fixture's ``start_block_hash``.
+        head = eth_rpc.get_block_by_number("latest")
+        if head is not None:
+            client_backend.start_block = head
     yield
     if no_reset_between_tests:
         return

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/fill_stateful/fill_stateful.py
@@ -452,6 +452,7 @@ def worker_key(
     eth_rpc: EthRPC,
     session_worker_key: EOA,
     client_backend: ClientBackend,
+    no_reset_between_tests: bool,
 ) -> EOA:
     """Sync seed key nonce before each test."""
     # Read the nonce at the reset head (start_block), not "latest": a client
@@ -459,8 +460,14 @@ def worker_key(
     # the previous test's tip (e.g. nethermind's debug_resetHead) would
     # otherwise report a stale, too-high nonce and get every funding tx
     # rejected ("Invalid nonce - expected 0").
+    #
+    # This inverts under --no-reset-between-tests: there is no rewind, so
+    # `latest` is reliable, the seed key's nonce has advanced past start_block
+    # (earlier tests funded senders with it), and start_block's historical
+    # state gets pruned on a long accumulating run against a non-archive
+    # client ("historical state ... is not available"). Read at `latest` then.
     start = client_backend.start_block
-    if start is None:
+    if no_reset_between_tests or start is None:
         account = eth_rpc.get_account(session_worker_key, skip_code=True)
     else:
         account = eth_rpc.get_account(

--- a/tests/benchmark/helper/account_creator.py
+++ b/tests/benchmark/helper/account_creator.py
@@ -160,7 +160,7 @@ class JochemnetPredeployContractInitcode(ContractInitcode):
 
     code_size: int
 
-    def __new__(cls, *, code_size: int = DEFAULT_CODE_SIZE) -> Self:
+    def __new__(cls, *, code_size: int = Osaka.max_code_size()) -> Self:
         """Assemble the initcode."""
         # Each MCOPY doubles the JUMPDEST-filled span (the first copy is
         # MCOPY(32, 0, 32), since 1 << 5 = 32) until it covers code_size.
@@ -329,7 +329,7 @@ class AccountCreator:
                 )
             case AccountMode.EXISTING_CONTRACT_JUMPDEST:
                 return JochemnetPredeployContractInitcode(
-                    code_size=self.code_size
+                    code_size=Osaka.max_code_size()
                 )
             case _:
                 raise ValueError(f"{self.mode.name} is not a contract")

--- a/tests/benchmark/helper/account_creator.py
+++ b/tests/benchmark/helper/account_creator.py
@@ -146,6 +146,9 @@ class JochemnetPredeployContractInitcode(ContractInitcode):
     """
     Initcode whose deployed runtime embeds its own contract ADDRESS.
 
+    If `code_size` is not supplied, Osaka max code size will be used,
+    resulting in:
+
         offset    size   contents
         ------    ----   --------------------------------
         0x0000       4   PUSH2 0x5FFF; JUMP   <- entry

--- a/tests/benchmark/helper/account_creator.py
+++ b/tests/benchmark/helper/account_creator.py
@@ -160,7 +160,7 @@ class JochemnetPredeployContractInitcode(ContractInitcode):
 
     code_size: int
 
-    def __new__(cls, *, code_size: int = Osaka.max_code_size()) -> Self:
+    def __new__(cls, *, code_size: int = DEFAULT_CODE_SIZE) -> Self:
         """Assemble the initcode."""
         # Each MCOPY doubles the JUMPDEST-filled span (the first copy is
         # MCOPY(32, 0, 32), since 1 << 5 = 32) until it covers code_size.
@@ -329,7 +329,7 @@ class AccountCreator:
                 )
             case AccountMode.EXISTING_CONTRACT_JUMPDEST:
                 return JochemnetPredeployContractInitcode(
-                    code_size=Osaka.max_code_size()
+                    code_size=self.code_size
                 )
             case _:
                 raise ValueError(f"{self.mode.name} is not a contract")

--- a/tests/benchmark/helper/account_sender_receiver.py
+++ b/tests/benchmark/helper/account_sender_receiver.py
@@ -9,6 +9,7 @@ from execution_testing import (
     EOA,
     Address,
     Alloc,
+    Hash,
     compute_create2_address,
     compute_create_address,
     keccak256,
@@ -25,12 +26,6 @@ from tests.prague.eip7702_set_code_tx.spec import Spec
 # the accounts stay uncached.
 SENDER_BASE_KEY = int.from_bytes(
     keccak256(b"gas-repricings-private-key"), "big"
-)
-
-# Deterministic EIP-7702 delegate authorities:
-# Authority i delegates to EXISTING_CONTRACT_DIFF_MAX receiver i.
-DELEGATE_BASE_KEY = int.from_bytes(
-    keccak256(b"gas-repricings-7702-delegate"), "big"
 )
 
 # Bittrex controller mainnet address: it created 1.5M contracts via CREATE with
@@ -82,10 +77,26 @@ def yield_distinct_nonexistent_receiver() -> Generator[Address, None, None]:
         yield Address(address)
 
 
-def yield_distinct_delegate_receiver() -> Generator[Address, None, None]:
+def delegate_base_key(code_size: int) -> int:
+    """
+    Return the key base of the delegate authorities for *code_size*.
+
+    Authority i delegates to the EXISTING_CONTRACT_DIFF_MAX receiver i
+    deployed at *code_size*; each code size needs its own range because
+    an authority can only carry one delegation.
+    """
+    return int.from_bytes(
+        keccak256(b"gas-repricings-7702-delegate" + Hash(code_size)), "big"
+    )
+
+
+def yield_distinct_delegate_receiver(
+    code_size: int,
+) -> Generator[Address, None, None]:
     """Yield EOA delegating to a distinct EXISTING_CONTRACT_DIFF_MAX."""
+    base_key = delegate_base_key(code_size)
     for i in itertools.count(0):
-        yield EOA(key=DELEGATE_BASE_KEY + i)
+        yield EOA(key=base_key + i)
 
 
 def expected_delegation() -> AccountExpectation:
@@ -124,16 +135,18 @@ def register_delegate_targets(
     pre: Alloc,
     count: int,
     *,
+    code_size: int,
     verified_accounts: dict[Hashable, int],
 ) -> None:
     """Register the first *count* delegated authorities (7702 designator)."""
+    base_key = delegate_base_key(code_size)
     register_target_range(
         pre,
-        key="delegate_authority",
+        key=("delegate_authority", code_size),
         count=count,
         expectation=expected_delegation(),
         address_of=lambda index: Address(
-            EOA(key=DELEGATE_BASE_KEY + index), label="delegate_authority"
+            EOA(key=base_key + index), label="delegate_authority"
         ),
         verified_accounts=verified_accounts,
     )

--- a/tests/benchmark/helper/transactions.py
+++ b/tests/benchmark/helper/transactions.py
@@ -177,7 +177,7 @@ def pack_transactions_with_cost_into_blocks(
             current_state = 0
 
         current_txs.append(tx)
-        current_regular += tx.regular_cost
+        current_regular += tx.execution_cost
         current_state += tx.state_cost
 
     if current_txs:

--- a/tests/benchmark/helper/transactions.py
+++ b/tests/benchmark/helper/transactions.py
@@ -10,6 +10,7 @@ from execution_testing import (
     Fork,
     Hash,
     Transaction,
+    TransactionWithCost,
 )
 
 from .enums import CacheStrategy
@@ -133,6 +134,51 @@ def pack_transactions_into_blocks(
 
         current_txs.append(tx)
         current_gas += tx_gas_limit
+
+    if current_txs:
+        blocks.append(Block(txs=current_txs))
+
+    return blocks
+
+
+def pack_transactions_with_cost_into_blocks(
+    transactions: list[TransactionWithCost],
+    gas_limit: int,
+) -> list[Block]:
+    """
+    Pack transactions into blocks, tracking both gas dimensions.
+
+    A transaction is includable only while its gas limit still fits the
+    room left in the regular and in the state dimension alike, so the
+    room a block has left is measured against the larger of the two
+    running totals. Raise when a single transaction cannot fit an empty
+    block, which no packing can rescue.
+    """
+    if not transactions:
+        return []
+
+    blocks: list[Block] = []
+    current_txs: list[TransactionWithCost] = []
+    current_regular = 0
+    current_state = 0
+
+    for tx in transactions:
+        tx_gas_limit = int(tx.gas_limit)
+        if tx_gas_limit > gas_limit:
+            raise ValueError(
+                f"transaction gas limit {tx_gas_limit} exceeds the "
+                f"{gas_limit} block gas limit"
+            )
+        room = gas_limit - max(current_regular, current_state)
+        if tx_gas_limit > room and current_txs:
+            blocks.append(Block(txs=current_txs))
+            current_txs = []
+            current_regular = 0
+            current_state = 0
+
+        current_txs.append(tx)
+        current_regular += tx.regular_cost
+        current_state += tx.state_cost
 
     if current_txs:
         blocks.append(Block(txs=current_txs))

--- a/tests/benchmark/stateful/bloatnet/test_account_query.py
+++ b/tests/benchmark/stateful/bloatnet/test_account_query.py
@@ -17,6 +17,7 @@ from execution_testing import (
     Transaction,
     While,
 )
+from execution_testing.forks import Amsterdam, Osaka
 
 from tests.benchmark.helper.account_creator import (
     AccountCreator,
@@ -143,6 +144,9 @@ def account_access_params() -> list:
 @pytest.mark.parametrize(
     "opcode,value_sent,account_mode,overhead_baseline", account_access_params()
 )
+@pytest.mark.parametrize(
+    "code_size", [Osaka.max_code_size(), Amsterdam.max_code_size()]
+)
 def test_account_access(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -154,10 +158,11 @@ def test_account_access(
     account_mode: AccountMode,
     overhead_baseline: bool,
     cache_strategy: CacheStrategy,
+    code_size: int,
     verified_accounts: dict,
 ) -> None:
     """Benchmark account access with caching strategies."""
-    account_creator = AccountCreator(account_mode)
+    account_creator = AccountCreator(account_mode, code_size=code_size)
     address_source = account_creator.address_source(Op.CALLDATALOAD(0))
     increment_op = address_source.next_op()
 

--- a/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
+++ b/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
@@ -24,7 +24,7 @@ from tests.benchmark.helper.account_creator import (
     AccountMode,
 )
 from tests.benchmark.helper.account_sender_receiver import (
-    DELEGATE_BASE_KEY,
+    delegate_base_key,
 )
 from tests.benchmark.helper.transactions import (
     pack_transactions_with_cost_into_blocks,
@@ -40,7 +40,6 @@ RECEIVER_CONTRACT_COUNT = int(
 )
 
 CONTRACT_MODES = [
-    AccountMode.EXISTING_CONTRACT_MINIMAL,
     AccountMode.EXISTING_CONTRACT_SAME_MAX,
     AccountMode.EXISTING_CONTRACT_DIFF_MAX,
 ]
@@ -120,6 +119,10 @@ def test_deploy_existing_contracts(
     Delegate deterministic EOAs to EXISTING_CONTRACT_DIFF_MAX receivers.
     """
     contract_modes = list(CONTRACT_MODES)
+    # One STOP byte: same initcode and CREATE2 address at every code size,
+    # so a second deployment would collide and revert the factory.
+    if code_size == Osaka.max_code_size():
+        contract_modes.append(AccountMode.EXISTING_CONTRACT_MINIMAL)
     if code_size == Amsterdam.max_code_size():
         contract_modes.append(AccountMode.EXISTING_CONTRACT_JUMPDEST)
 
@@ -161,9 +164,10 @@ def test_deploy_existing_contracts(
         AccountMode.EXISTING_CONTRACT_DIFF_MAX, code_size=code_size
     ).initcode
 
+    base_key = delegate_base_key(code_size)
     authorizations = []
     for i in range(RECEIVER_CONTRACT_COUNT):
-        authority = EOA(key=DELEGATE_BASE_KEY + i)
+        authority = EOA(key=base_key + i)
         target = compute_create2_address(
             address=DETERMINISTIC_FACTORY_ADDRESS,
             salt=i,

--- a/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
+++ b/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
@@ -12,7 +12,7 @@ from execution_testing import (
     Fork,
     Hash,
     Op,
-    Transaction,
+    TransactionWithCost,
     compute_create2_address,
 )
 
@@ -24,7 +24,7 @@ from tests.benchmark.helper.account_sender_receiver import (
     DELEGATE_BASE_KEY,
 )
 from tests.benchmark.helper.transactions import (
-    pack_transactions_into_blocks,
+    pack_transactions_with_cost_into_blocks,
 )
 from tests.prague.eip7702_set_code_tx.spec import Spec as Spec7702
 
@@ -47,13 +47,17 @@ CONTRACT_MODES = [
 EXECUTION_GAS_BUFFER = 50_000
 
 
-def deployment_gas_limit(
+def deployment_gas(
     fork: Fork, initcode: bytes, runtime_size: int
-) -> int:
+) -> tuple[int, int]:
     """
-    Return the gas limit for one CREATE2 deployment, derived from the
-    intrinsic, CREATE2, and code-deposit costs with a margin for the
-    factory and initcode execution.
+    Return the (regular, state) gas for one CREATE2 deployment, derived
+    from the intrinsic, CREATE2, and code-deposit costs with a margin
+    for the factory and initcode execution.
+
+    The opcode costs are two-dimensional totals, so the state gas the
+    account creation and the code deposit charge is split back out; the
+    margin lands on the regular side, which is what it pays for.
     """
     intrinsic = fork.transaction_intrinsic_cost_calculator()(
         calldata=b"\xff" * 32 + initcode
@@ -71,7 +75,9 @@ def deployment_gas_limit(
         code_deposit_size=runtime_size,
     ).gas_cost(fork)
     base = intrinsic + create_cost + deposit_cost
-    return base + base // 16 + EXECUTION_GAS_BUFFER
+    state = fork.create_state_gas(code_size=runtime_size)
+    regular = base - state + base // 16 + EXECUTION_GAS_BUFFER
+    return regular, state
 
 
 def test_deploy_existing_contracts(
@@ -92,15 +98,19 @@ def test_deploy_existing_contracts(
     for account_mode in CONTRACT_MODES:
         creator = AccountCreator(account_mode)
         initcode = creator.initcode
-        gas_limit = deployment_gas_limit(fork, initcode, creator.runtime_size)
+        regular_gas, state_gas = deployment_gas(
+            fork, initcode, creator.runtime_size
+        )
         sender = pre.fund_eoa()
         for salt in range(RECEIVER_CONTRACT_COUNT):
             txs.append(
-                Transaction(
+                TransactionWithCost(
                     to=DETERMINISTIC_FACTORY_ADDRESS,
                     data=Hash(salt) + initcode,
-                    gas_limit=gas_limit,
+                    gas_limit=regular_gas + state_gas,
                     sender=sender,
+                    regular_cost=regular_gas,
+                    state_cost=state_gas,
                 )
             )
         # Nonce 1 at the CREATE2-derived address proves deployment.
@@ -115,51 +125,77 @@ def test_deploy_existing_contracts(
     # Delegate authority i to the i-th DIFF receiver (EIP-7702).
     delegation_sender = pre.fund_eoa()
     intrinsic = fork.transaction_intrinsic_cost_calculator()
+    top_frame = fork.transaction_top_frame_gas_calculator()
     # DIFF receivers share one initcode; build it once for CREATE2 derivation.
     diff_initcode = AccountCreator(
         AccountMode.EXISTING_CONTRACT_DIFF_MAX
     ).initcode
 
-    base_gas = intrinsic(authorization_list_or_count=0)
-    per_auth_gas = intrinsic(authorization_list_or_count=1) - base_gas
+    authorizations = []
+    for i in range(RECEIVER_CONTRACT_COUNT):
+        authority = EOA(key=DELEGATE_BASE_KEY + i)
+        target = compute_create2_address(
+            address=DETERMINISTIC_FACTORY_ADDRESS,
+            salt=i,
+            initcode=diff_initcode,
+        )
+        authorizations.append(
+            AuthorizationTuple(
+                address=target,
+                nonce=0,
+                signer=authority,
+                # The authorities are deterministic and never funded, so
+                # applying the delegation is what brings them into being.
+                creates_account=True,
+            )
+        )
+        if i == 0 or i == RECEIVER_CONTRACT_COUNT - 1:
+            post[authority] = Account(
+                nonce=1,
+                code=Spec7702.delegation_designation(target),
+            )
+
+    def authorization_gas(
+        authorization_list: list[AuthorizationTuple],
+    ) -> tuple[int, int]:
+        """Return the (regular, state) gas an authorization list costs."""
+        regular = intrinsic(
+            authorization_list_or_count=len(authorization_list)
+        ) + top_frame(authorizations=authorization_list)
+        state = fork.transaction_top_frame_state_gas(
+            authorizations=authorization_list
+        )
+        return regular, state
+
     gas_buffer = 100_000
+    base_regular, base_state = authorization_gas([])
+    one_regular, one_state = authorization_gas(authorizations[:1])
+    per_auth_gas = (one_regular + one_state) - (base_regular + base_state)
     auths_per_tx = max(
-        1, (tx_gas_limit - gas_buffer - base_gas) // per_auth_gas
+        1,
+        (tx_gas_limit - gas_buffer - base_regular - base_state)
+        // per_auth_gas,
     )
 
     for start in range(0, RECEIVER_CONTRACT_COUNT, auths_per_tx):
-        count = min(auths_per_tx, RECEIVER_CONTRACT_COUNT - start)
-        authorization_list = []
-        for i in range(start, start + count):
-            authority = EOA(key=DELEGATE_BASE_KEY + i)
-            target = compute_create2_address(
-                address=DETERMINISTIC_FACTORY_ADDRESS,
-                salt=i,
-                initcode=diff_initcode,
-            )
-            authorization_list.append(
-                AuthorizationTuple(address=target, nonce=0, signer=authority)
-            )
-            if i == 0 or i == RECEIVER_CONTRACT_COUNT - 1:
-                post[authority] = Account(
-                    nonce=1,
-                    code=Spec7702.delegation_designation(target),
-                )
-
+        authorization_list = authorizations[start : start + auths_per_tx]
+        regular_gas, state_gas = authorization_gas(authorization_list)
         txs.append(
-            Transaction(
+            TransactionWithCost(
                 to=delegation_sender,
-                gas_limit=(
-                    intrinsic(authorization_list_or_count=count) + gas_buffer
-                ),
+                gas_limit=regular_gas + state_gas + gas_buffer,
                 sender=delegation_sender,
                 authorization_list=authorization_list,
+                regular_cost=regular_gas + gas_buffer,
+                state_cost=state_gas,
             )
         )
 
     benchmark_test(
         post=post,
-        blocks=pack_transactions_into_blocks(txs, gas_benchmark_value),
+        blocks=pack_transactions_with_cost_into_blocks(
+            txs, gas_benchmark_value
+        ),
         skip_gas_used_validation=True,
         expected_receipt_status=1,
     )

--- a/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
+++ b/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
@@ -2,8 +2,10 @@
 
 import os
 
+import pytest
 from execution_testing import (
     DETERMINISTIC_FACTORY_ADDRESS,
+    DETERMINISTIC_FACTORY_BYTECODE,
     EOA,
     Account,
     Alloc,
@@ -59,27 +61,46 @@ def deployment_gas(
     account creation and the code deposit charge is split back out; the
     margin lands on the regular side, which is what it pays for.
     """
+    initcode_size = len(initcode)
     intrinsic = fork.transaction_intrinsic_cost_calculator()(
         calldata=b"\xff" * 32 + initcode
     )
     create_cost = Op.CREATE2(
         value=0,
         offset=0,
-        size=len(initcode),
+        size=initcode_size,
         salt=0,
-        init_code_size=len(initcode),
+        # Gas accounting
+        init_code_size=initcode_size,
     ).gas_cost(fork)
+    # The factory frame wrapped around that CREATE2: its own bytecode,
+    # less the CREATE2 already counted above, plus the copy of the
+    # initcode out of the calldata that the bytecode alone cannot size.
+    factory_cost = (
+        DETERMINISTIC_FACTORY_BYTECODE.gas_cost(fork)
+        - Op.CREATE2(value=0, offset=0, size=0, salt=0).gas_cost(fork)
+        + Op.CALLDATACOPY(
+            dest_offset=0,
+            offset=32,
+            size=initcode_size,
+            # Gas accounting
+            data_size=initcode_size,
+            old_memory_size=0,
+            new_memory_size=initcode_size,
+        ).gas_cost(fork)
+    )
     deposit_cost = Op.RETURN(
         0,
         runtime_size,
         code_deposit_size=runtime_size,
     ).gas_cost(fork)
-    base = intrinsic + create_cost + deposit_cost
+    base = intrinsic + factory_cost + create_cost + deposit_cost
     state = fork.create_state_gas(code_size=runtime_size)
     regular = base - state + base // 16 + EXECUTION_GAS_BUFFER
     return regular, state
 
 
+@pytest.mark.valid_from("Amsterdam")
 def test_deploy_existing_contracts(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,

--- a/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
+++ b/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
@@ -119,9 +119,13 @@ def test_deploy_existing_contracts(
 
     Delegate deterministic EOAs to EXISTING_CONTRACT_DIFF_MAX receivers.
     """
+    contract_modes = list(CONTRACT_MODES)
+    if code_size == Amsterdam.max_code_size():
+        contract_modes.append(AccountMode.EXISTING_CONTRACT_JUMPDEST)
+
     txs = []
     post: dict = {}
-    for account_mode in CONTRACT_MODES:
+    for account_mode in contract_modes:
         creator = AccountCreator(account_mode, code_size=code_size)
         initcode = creator.initcode
         regular_gas, state_gas = deployment_gas(

--- a/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
+++ b/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
@@ -1,0 +1,165 @@
+"""Deploy the CREATE2 contracts for benchmarks."""
+
+import os
+
+from execution_testing import (
+    DETERMINISTIC_FACTORY_ADDRESS,
+    EOA,
+    Account,
+    Alloc,
+    AuthorizationTuple,
+    BenchmarkTestFiller,
+    Fork,
+    Hash,
+    Op,
+    Transaction,
+    compute_create2_address,
+)
+
+from tests.benchmark.helper.account_creator import (
+    AccountCreator,
+    AccountMode,
+)
+from tests.benchmark.helper.account_sender_receiver import (
+    DELEGATE_BASE_KEY,
+)
+from tests.benchmark.helper.transactions import (
+    pack_transactions_into_blocks,
+)
+from tests.prague.eip7702_set_code_tx.spec import Spec as Spec7702
+
+# Number of CREATE2 receiver contracts deployed per mode. Overridable via
+# BLOATNET_RECEIVER_CONTRACT_COUNT so a smoke/plumbing run (e.g. benchmarkoor
+# pre_runs) can deploy a small set for fast iteration; defaults to the full
+# 100k benchmark set.
+RECEIVER_CONTRACT_COUNT = int(
+    os.environ.get("BLOATNET_RECEIVER_CONTRACT_COUNT", "100000")
+)
+
+CONTRACT_MODES = [
+    AccountMode.EXISTING_CONTRACT_MINIMAL,
+    AccountMode.EXISTING_CONTRACT_SAME_MAX,
+    AccountMode.EXISTING_CONTRACT_DIFF_MAX,
+]
+
+# Factory-frame and initcode execution costs (CALLDATACOPY, the MCOPY
+# doubling loop, memory expansion) plus CREATE2's 63/64 retention.
+EXECUTION_GAS_BUFFER = 50_000
+
+
+def deployment_gas_limit(
+    fork: Fork, initcode: bytes, runtime_size: int
+) -> int:
+    """
+    Return the gas limit for one CREATE2 deployment, derived from the
+    intrinsic, CREATE2, and code-deposit costs with a margin for the
+    factory and initcode execution.
+    """
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=b"\xff" * 32 + initcode
+    )
+    create_cost = Op.CREATE2(
+        value=0,
+        offset=0,
+        size=len(initcode),
+        salt=0,
+        init_code_size=len(initcode),
+    ).gas_cost(fork)
+    deposit_cost = Op.RETURN(
+        0,
+        runtime_size,
+        code_deposit_size=runtime_size,
+    ).gas_cost(fork)
+    base = intrinsic + create_cost + deposit_cost
+    return base + base // 16 + EXECUTION_GAS_BUFFER
+
+
+def test_deploy_existing_contracts(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+) -> None:
+    """
+    Deploy the contracts behind the `AccountMode.EXISTING_CONTRACT_*`
+    receivers via the deterministic CREATE2 factory.
+
+    Delegate deterministic EOAs to EXISTING_CONTRACT_DIFF_MAX receivers.
+    """
+    txs = []
+    post: dict = {}
+    for account_mode in CONTRACT_MODES:
+        creator = AccountCreator(account_mode)
+        initcode = creator.initcode
+        gas_limit = deployment_gas_limit(fork, initcode, creator.runtime_size)
+        sender = pre.fund_eoa()
+        for salt in range(RECEIVER_CONTRACT_COUNT):
+            txs.append(
+                Transaction(
+                    to=DETERMINISTIC_FACTORY_ADDRESS,
+                    data=Hash(salt) + initcode,
+                    gas_limit=gas_limit,
+                    sender=sender,
+                )
+            )
+        # Nonce 1 at the CREATE2-derived address proves deployment.
+        for salt in (0, RECEIVER_CONTRACT_COUNT - 1):
+            contract = compute_create2_address(
+                address=DETERMINISTIC_FACTORY_ADDRESS,
+                salt=salt,
+                initcode=initcode,
+            )
+            post[contract] = Account(nonce=1)
+
+    # Delegate authority i to the i-th DIFF receiver (EIP-7702).
+    delegation_sender = pre.fund_eoa()
+    intrinsic = fork.transaction_intrinsic_cost_calculator()
+    # DIFF receivers share one initcode; build it once for CREATE2 derivation.
+    diff_initcode = AccountCreator(
+        AccountMode.EXISTING_CONTRACT_DIFF_MAX
+    ).initcode
+
+    base_gas = intrinsic(authorization_list_or_count=0)
+    per_auth_gas = intrinsic(authorization_list_or_count=1) - base_gas
+    gas_buffer = 100_000
+    auths_per_tx = max(
+        1, (tx_gas_limit - gas_buffer - base_gas) // per_auth_gas
+    )
+
+    for start in range(0, RECEIVER_CONTRACT_COUNT, auths_per_tx):
+        count = min(auths_per_tx, RECEIVER_CONTRACT_COUNT - start)
+        authorization_list = []
+        for i in range(start, start + count):
+            authority = EOA(key=DELEGATE_BASE_KEY + i)
+            target = compute_create2_address(
+                address=DETERMINISTIC_FACTORY_ADDRESS,
+                salt=i,
+                initcode=diff_initcode,
+            )
+            authorization_list.append(
+                AuthorizationTuple(address=target, nonce=0, signer=authority)
+            )
+            if i == 0 or i == RECEIVER_CONTRACT_COUNT - 1:
+                post[authority] = Account(
+                    nonce=1,
+                    code=Spec7702.delegation_designation(target),
+                )
+
+        txs.append(
+            Transaction(
+                to=delegation_sender,
+                gas_limit=(
+                    intrinsic(authorization_list_or_count=count) + gas_buffer
+                ),
+                sender=delegation_sender,
+                authorization_list=authorization_list,
+            )
+        )
+
+    benchmark_test(
+        post=post,
+        blocks=pack_transactions_into_blocks(txs, gas_benchmark_value),
+        skip_gas_used_validation=True,
+        expected_receipt_status=1,
+    )

--- a/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
+++ b/tests/benchmark/stateful/bloatnet/test_setup_contracts.py
@@ -17,6 +17,7 @@ from execution_testing import (
     TransactionWithCost,
     compute_create2_address,
 )
+from execution_testing.forks import Amsterdam, Osaka
 
 from tests.benchmark.helper.account_creator import (
     AccountCreator,
@@ -101,12 +102,16 @@ def deployment_gas(
 
 
 @pytest.mark.valid_from("Amsterdam")
+@pytest.mark.parametrize(
+    "code_size", [Osaka.max_code_size(), Amsterdam.max_code_size()]
+)
 def test_deploy_existing_contracts(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
     tx_gas_limit: int,
+    code_size: int,
 ) -> None:
     """
     Deploy the contracts behind the `AccountMode.EXISTING_CONTRACT_*`
@@ -117,7 +122,7 @@ def test_deploy_existing_contracts(
     txs = []
     post: dict = {}
     for account_mode in CONTRACT_MODES:
-        creator = AccountCreator(account_mode)
+        creator = AccountCreator(account_mode, code_size=code_size)
         initcode = creator.initcode
         regular_gas, state_gas = deployment_gas(
             fork, initcode, creator.runtime_size
@@ -130,7 +135,7 @@ def test_deploy_existing_contracts(
                     data=Hash(salt) + initcode,
                     gas_limit=regular_gas + state_gas,
                     sender=sender,
-                    regular_cost=regular_gas,
+                    execution_cost=regular_gas,
                     state_cost=state_gas,
                 )
             )
@@ -149,7 +154,7 @@ def test_deploy_existing_contracts(
     top_frame = fork.transaction_top_frame_gas_calculator()
     # DIFF receivers share one initcode; build it once for CREATE2 derivation.
     diff_initcode = AccountCreator(
-        AccountMode.EXISTING_CONTRACT_DIFF_MAX
+        AccountMode.EXISTING_CONTRACT_DIFF_MAX, code_size=code_size
     ).initcode
 
     authorizations = []
@@ -207,7 +212,7 @@ def test_deploy_existing_contracts(
                 gas_limit=regular_gas + state_gas + gas_buffer,
                 sender=delegation_sender,
                 authorization_list=authorization_list,
-                regular_cost=regular_gas + gas_buffer,
+                execution_cost=regular_gas + gas_buffer,
                 state_cost=state_gas,
             )
         )

--- a/tests/benchmark/stateful/bloatnet/test_transaction_types.py
+++ b/tests/benchmark/stateful/bloatnet/test_transaction_types.py
@@ -14,6 +14,7 @@ from execution_testing import (
     RecipientType,
     Transaction,
 )
+from execution_testing.forks import Amsterdam, Osaka
 
 from tests.benchmark.helper.account_creator import (
     AccountCreator,
@@ -47,11 +48,15 @@ from tests.benchmark.helper.account_sender_receiver import (
     ],
 )
 @pytest.mark.parametrize("transfer_amount", [0, 1])
+@pytest.mark.parametrize(
+    "code_size", [Osaka.max_code_size(), Amsterdam.max_code_size()]
+)
 def test_ether_transfers_onchain_receivers(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     case_id: str,
     transfer_amount: int,
+    code_size: int,
     fork: Fork,
     gas_benchmark_value: int,
     verified_accounts: dict,
@@ -126,7 +131,9 @@ def test_ether_transfers_onchain_receivers(
                 label=case_id,
             )
         case "diff_to_contract_same_max":
-            creator = AccountCreator(AccountMode.EXISTING_CONTRACT_SAME_MAX)
+            creator = AccountCreator(
+                AccountMode.EXISTING_CONTRACT_SAME_MAX, code_size=code_size
+            )
             receivers = yield_distinct_create2_receiver(creator.initcode)
             register_targets = partial(
                 creator.register_targets,
@@ -135,7 +142,9 @@ def test_ether_transfers_onchain_receivers(
                 label=case_id,
             )
         case "diff_to_contract_diff_max":
-            creator = AccountCreator(AccountMode.EXISTING_CONTRACT_DIFF_MAX)
+            creator = AccountCreator(
+                AccountMode.EXISTING_CONTRACT_DIFF_MAX, code_size=code_size
+            )
             receivers = yield_distinct_create2_receiver(creator.initcode)
             register_targets = partial(
                 creator.register_targets,

--- a/tests/benchmark/stateful/bloatnet/test_transaction_types.py
+++ b/tests/benchmark/stateful/bloatnet/test_transaction_types.py
@@ -112,7 +112,9 @@ def test_ether_transfers_onchain_receivers(
                 verified_accounts=verified_accounts,
             )
         case "diff_to_unique_code_jumpdest_contract":
-            creator = AccountCreator(AccountMode.EXISTING_CONTRACT_JUMPDEST)
+            creator = AccountCreator(
+                AccountMode.EXISTING_CONTRACT_JUMPDEST, code_size=code_size
+            )
             receivers = yield_distinct_create2_receiver(creator.initcode)
             receiver_execution_gas = creator.execution_code.gas_cost(fork)
             register_targets = partial(
@@ -153,11 +155,12 @@ def test_ether_transfers_onchain_receivers(
                 label=case_id,
             )
         case "diff_to_delegated_contract_diff":
-            receivers = yield_distinct_delegate_receiver()
+            receivers = yield_distinct_delegate_receiver(code_size)
             recipient_type = RecipientType.DELEGATION_7702
             register_targets = partial(
                 register_delegate_targets,
                 pre,
+                code_size=code_size,
                 verified_accounts=verified_accounts,
             )
         case _:


### PR DESCRIPTION
### Description

## Problem

`--no-reset-between-tests` keeps the chain moving between fills, but the
session anchor never moves with it.

`_session_pre_run` captures `start_block` once, from `latest`, after the
global setup:

```python
@pytest.fixture(scope="session", autouse=True)
def _session_pre_run(...):
    ...
    # 4. Capture start block (head after global setup).
    start_block = eth_rpc.get_block_by_number("latest")
    client_backend.start_block = start_block
```

That is the only production write to `client_backend.start_block`. Every
test then chains its first block from it, in `make_stateful_fixture`.

Normally the invariant holds because `_reset_chain_between_tests` rewinds
the chain back to that block after each test. Under
`--no-reset-between-tests` the rewind is skipped and nothing takes its
place, so the anchor goes stale as soon as the first test builds a block.

The nonce side of the flag was already adapted — `worker_key` reads at
`latest` under the flag, with a comment explaining the inversion. The
anchor side was missed.

### Related Issues or PRs

Stacked on #3304, which introduces the `--no-reset-between-tests` flag this fixes. Until that PR merges, the diff here includes its commits; the change in this PR is the single commit on top, by @skylenet. See also https://github.com/jochem-brouwer/execution-specs/pull/6

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
