### PR TITLE
fix(spec-specs): wipe pre-existing storage on contract creation from Cancun onward

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -599,19 +599,22 @@ def _get_pre_tx_account(
 
 
 def _get_pre_tx_storage(
-    pre_tx_storage: Dict[Address, Dict[Bytes32, U256]],
-    pre_state: PreState,
+    block_state: BlockState,
     address: Address,
     key: Bytes32,
 ) -> U256:
     """
     Look up a storage value in cumulative state, falling back to `pre_state`.
 
-    Returns `0` if not set.
+    Returns `0` if not set, or if the storage at `address` was wiped
+    earlier in the block.
     """
-    if address in pre_tx_storage and key in pre_tx_storage[address]:
-        return pre_tx_storage[address][key]
-    return pre_state.get_storage(address, key)
+    if address in block_state.storage_writes:
+        if key in block_state.storage_writes[address]:
+            return block_state.storage_writes[address][key]
+    if address in block_state.storage_clears:
+        return U256(0)
+    return block_state.pre_state.get_storage(address, key)
 
 
 def update_builder_from_tx(
@@ -662,9 +665,7 @@ def update_builder_from_tx(
     # Compare storage writes against block cumulative state
     for address, slots in tx_state.storage_writes.items():
         for key, post_value in slots.items():
-            pre_value = _get_pre_tx_storage(
-                block_state.storage_writes, pre_state, address, key
-            )
+            pre_value = _get_pre_tx_storage(block_state, address, key)
             if pre_value != post_value:
                 # Convert slot from internal Bytes32 format to U256 for BAL.
                 # EIP-7928 uses U256 as it's more space-efficient in RLP.

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -49,6 +49,12 @@ class BlockState:
 
     ``account_reads`` and ``storage_reads`` accumulate across all
     transactions for BAL generation.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -61,6 +67,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -87,6 +94,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -267,9 +275,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -297,6 +309,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -507,7 +521,8 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
 
     Convert storage writes to reads before deleting so that accesses
     from created-then-destroyed accounts appear in the Block Access
-    List. Only supports same transaction destruction.
+    List. Record the address in ``storage_clears`` so that reads no
+    longer fall back to earlier block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -521,6 +536,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
         for key in tx_state.storage_writes[address]:
             tx_state.storage_reads.add((address, key))
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -743,6 +759,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
         storage_reads=tx_state.storage_reads,
         account_reads=tx_state.account_reads,
@@ -766,6 +783,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -806,6 +824,10 @@ def incorporate_tx_into_block(
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -817,6 +839,7 @@ def incorporate_tx_into_block(
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
     tx_state.storage_reads = set()
     tx_state.account_reads = set()
@@ -841,4 +864,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/bpo1/state_tracker.py
+++ b/src/ethereum/forks/bpo1/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/bpo2/state_tracker.py
+++ b/src/ethereum/forks/bpo2/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/bpo3/state_tracker.py
+++ b/src/ethereum/forks/bpo3/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/bpo4/state_tracker.py
+++ b/src/ethereum/forks/bpo4/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/bpo5/state_tracker.py
+++ b/src/ethereum/forks/bpo5/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/cancun/state_tracker.py
+++ b/src/ethereum/forks/cancun/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/osaka/state_tracker.py
+++ b/src/ethereum/forks/osaka/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/forks/prague/state_tracker.py
+++ b/src/ethereum/forks/prague/state_tracker.py
@@ -43,6 +43,12 @@ class BlockState:
     Accumulate committed transaction-level changes across a block.
 
     Read chain: block writes -> pre_state.
+
+    ``storage_clears`` records addresses whose pre-existing storage
+    was wiped earlier in the block, so later reads must not fall back
+    to ``pre_state``. Contract creation over a storage-only account
+    and deletion of an empty account that still holds storage both
+    wipe storage.
     """
 
     pre_state: PreState
@@ -53,6 +59,7 @@ class BlockState:
         default_factory=dict
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
+    storage_clears: Set[Address] = field(default_factory=set)
 
 
 @final
@@ -73,6 +80,7 @@ class TransactionState:
     )
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
+    storage_clears: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -186,9 +194,13 @@ def get_storage(
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
+    if address in tx_state.storage_clears:
+        return U256(0)
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -216,6 +228,8 @@ def get_storage_original(
     if address in tx_state.parent.storage_writes:
         if key in tx_state.parent.storage_writes[address]:
             return tx_state.parent.storage_writes[address][key]
+    if address in tx_state.parent.storage_clears:
+        return U256(0)
     return tx_state.parent.pre_state.get_storage(address, key)
 
 
@@ -401,7 +415,9 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     Completely remove the storage at ``address``.
 
-    Only supports same transaction destruction.
+    Drop this transaction's writes and record the address in
+    ``storage_clears`` so that reads no longer fall back to earlier
+    block writes or ``pre_state``.
 
     Parameters
     ----------
@@ -413,6 +429,7 @@ def destroy_storage(tx_state: TransactionState, address: Address) -> None:
     """
     if address in tx_state.storage_writes:
         del tx_state.storage_writes[address]
+    tx_state.storage_clears.add(address)
 
 
 def mark_account_created(tx_state: TransactionState, address: Address) -> None:
@@ -634,6 +651,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
         },
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
+        storage_clears=set(tx_state.storage_clears),
         transient_storage=dict(tx_state.transient_storage),
     )
 
@@ -655,6 +673,7 @@ def restore_tx_state(
     tx_state.account_writes = snapshot.account_writes
     tx_state.storage_writes = snapshot.storage_writes
     tx_state.code_writes = snapshot.code_writes
+    tx_state.storage_clears = snapshot.storage_clears
     tx_state.transient_storage = snapshot.transient_storage
 
 
@@ -676,6 +695,10 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     for address, account in tx_state.account_writes.items():
         block.account_writes[address] = account
 
+    for address in tx_state.storage_clears:
+        block.storage_clears.add(address)
+        block.storage_writes.pop(address, None)
+
     for address, slots in tx_state.storage_writes.items():
         if address not in block.storage_writes:
             block.storage_writes[address] = {}
@@ -687,6 +710,7 @@ def incorporate_tx_into_block(tx_state: TransactionState) -> None:
     tx_state.storage_writes.clear()
     tx_state.code_writes.clear()
     tx_state.created_accounts.clear()
+    tx_state.storage_clears.clear()
     tx_state.transient_storage.clear()
 
 
@@ -709,4 +733,5 @@ def extract_block_diff(block_state: BlockState) -> BlockDiff:
         account_changes=block_state.account_writes,
         storage_changes=block_state.storage_writes,
         code_changes=block_state.code_writes,
+        storage_clears=block_state.storage_clears,
     )

--- a/src/ethereum/state.py
+++ b/src/ethereum/state.py
@@ -79,9 +79,11 @@ class BlockDiff:
     storage_clears: Set[Address] = field(default_factory=set)
     """
     Addresses whose pre-existing storage was wiped during block
-    execution (via a pre-EIP-6780 `SELFDESTRUCT`). Their storage
-    tries are dropped before [`storage_changes`][sc] is applied, so any
-    post-wipe writes begin from empty storage.
+    execution: a pre-EIP-6780 `SELFDESTRUCT`, a contract creation
+    over a storage-only account, or the deletion of an empty account
+    that still held storage. Their storage tries are dropped before
+    [`storage_changes`][sc] is applied, so any post-wipe writes begin
+    from empty storage.
 
     [sc]: ref:ethereum.state.BlockDiff.storage_changes
     """

--- a/tests/frontier/create/test_create_collision.py
+++ b/tests/frontier/create/test_create_collision.py
@@ -1,7 +1,7 @@
 """
 Test collision in CREATE/CREATE2 account creation, where the existing
 account has non-empty code or nonce (EIP-684), and that an account
-with only a balance is deployable.
+with only a balance or only storage is deployable.
 """
 
 from typing import Dict
@@ -38,10 +38,9 @@ CORRECT_INITCODE = Initcode(
 
 # Every account shape where creation must abort under EIP-684: the
 # product of nonce, code, storage and balance with non-empty code or
-# nonce. Cells with zero nonce and empty code are excluded: with
-# non-empty storage the behavior is undefined in protocol (EIP-7610
-# was declined for inclusion in Glamsterdam), and with empty storage
-# the account is deployable (see the balance-only tests). Cells with
+# nonce. Cells with zero nonce and empty code are excluded because
+# the account is deployable (see the balance-only and storage-only
+# tests). Cells with
 # empty storage catch clients that incorrectly abort on storage
 # instead of code or nonce; cells with non-empty storage also check
 # that the aborted creation neither wipes the storage nor runs the
@@ -340,6 +339,117 @@ def test_create_opcode_balance_only_target(
                 balance=1,
                 code=CORRECT_INITCODE.deploy_code,
                 storage={0x00: 0x01},
+            ),
+            contract_creator_address: Account(
+                storage={0x01: created_contract_address}
+            ),
+        },
+        tx=tx,
+    )
+
+
+# Initcode for the storage-only tests. Slot 0x00 records one more than
+# the value the initcode reads from slot 0x01, which the target account
+# pre-seeds: a wiped target stores 1, a retained one stores 2, and an
+# aborted creation stores nothing.
+STORAGE_PROBE_INITCODE = Initcode(
+    deploy_code=Op.STOP,
+    initcode_prefix=Op.SSTORE(0, Op.ADD(Op.SLOAD(1), 1)),
+)
+STORAGE_ONLY_PRE_STORAGE = {0x01: 0x01, 0x02: 0x02}
+STORAGE_ONLY_POST_STORAGE = {0x00: 0x01, 0x01: 0x00, 0x02: 0x00}
+
+
+@pytest.mark.parametrize("balance", [0, 1])
+@pytest.mark.with_all_contract_creating_tx_types
+def test_create_tx_storage_only_target(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx_type: int,
+    balance: int,
+) -> None:
+    """
+    Test that a contract creation transaction succeeds when the target
+    address has zero nonce and no code but non-empty storage: EIP-684
+    does not consider storage, and the pre-existing storage is wiped
+    before the initcode runs.
+    """
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        ty=tx_type,
+        to=None,
+        data=STORAGE_PROBE_INITCODE,
+        protected=False,
+    )
+
+    created_contract_address = tx.created_contract
+
+    pre[created_contract_address] = Account(
+        balance=balance, storage=STORAGE_ONLY_PRE_STORAGE
+    )
+
+    state_test(
+        pre=pre,
+        post={
+            created_contract_address: Account(
+                balance=balance,
+                code=STORAGE_PROBE_INITCODE.deploy_code,
+                storage=STORAGE_ONLY_POST_STORAGE,
+            ),
+        },
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize("balance", [0, 1])
+@pytest.mark.with_all_create_opcodes
+def test_create_opcode_storage_only_target(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    create_opcode: Op,
+    balance: int,
+) -> None:
+    """
+    Test that a contract creation opcode succeeds when the target
+    address has zero nonce and no code but non-empty storage: EIP-684
+    does not consider storage, and the pre-existing storage is wiped
+    before the initcode runs.
+    """
+    initcode = STORAGE_PROBE_INITCODE
+    assert len(initcode) <= 32
+    contract_creator_code = (
+        # Stores the created address, which is non-zero on success.
+        Op.MSTORE(0, Op.PUSH32(bytes(initcode).ljust(32, b"\0")))
+        + Op.SSTORE(0x01, create_opcode(value=0, offset=0, size=len(initcode)))
+        + Op.STOP
+    )
+    contract_creator_address = pre.deploy_contract(contract_creator_code)
+
+    created_contract_address = compute_create_address(
+        address=contract_creator_address,
+        nonce=1,
+        salt=0,
+        initcode=initcode,
+        opcode=create_opcode,
+    )
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract_creator_address,
+        protected=False,
+    )
+
+    pre[created_contract_address] = Account(
+        balance=balance, storage=STORAGE_ONLY_PRE_STORAGE
+    )
+
+    state_test(
+        pre=pre,
+        post={
+            created_contract_address: Account(
+                balance=balance,
+                code=STORAGE_PROBE_INITCODE.deploy_code,
+                storage=STORAGE_ONLY_POST_STORAGE,
             ),
             contract_creator_address: Account(
                 storage={0x01: created_contract_address}


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

#### Quick context

7610 says: reject contract creation if the destination already has storage.

Without 7610: [EIP-684](https://eips.ethereum.org/EIPS/eip-684) allows creation when nonce is zero and code is empty.

The Yellow Paper says to clear the old storage before running initcode -> [here](https://ethereum.github.io/yellowpaper/paper.pdf#page=11)
> “The account’s nonce is initially defined as one, the balance as the value passed, the storage as empty”

My PR makes contract creation clear the destinations old storage before initcode runs, following the Yellow Paper!

Why wasn't this found before?
> 7610 was masking it, creation was rejected before the faulty storage clearing path could run. Removing that rejection exposed the bug.

Why the Cancun boundary?
> Earlier fork trackers remember that an account’s entire storage was cleared, but Cancun onward only discarded writes made in the current transaction. Reads could still retrieve old storage. This fits Cancun's restricted SELFDESTRUCT behavior where deletion normally concerns contracts created in that same transaction.

#### More Context

Contract creation over an account with zero nonce, no code and non-empty storage kept the old storage from Cancun onward, while Frontier through Shanghai wipe it. The older trackers record wiped addresses in `storage_clears` so reads stop falling back to earlier block writes or the pre-state; the trackers from Cancun onward never had it, and `destroy_storage` only dropped same-transaction writes. The case became reachable in the spec when #3417 removed the EIP-7610 storage check from `account_deployable`.

Port `storage_clears` to the nine trackers from Cancun to Amsterdam so every fork follows the Yellow Paper, which sets the created account's storage to the empty trie, and make the Amsterdam BAL builder read cleared storage as zero when diffing later transactions. The same path covers the deletion of an empty account that still holds storage.

Add storage-only creation tests to `test_create_collision.py` for the creation transaction and the create opcodes. The initcode stores one more than it loads from a pre-seeded slot, so a wiped target stores 1, a retained one stores 2 and an aborted creation deploys nothing. These are the first fixtures that fail a client still enforcing EIP-7610. That EIP was never activated in any fork: ethereum/tests applied it retroactively in 2024 and clients and EELS followed, so the tests are valid from Frontier like the removal itself.

There is no way to test the removal without also deciding what happens to the old storage. A fixture pins the state and receipts roots, and even an initcode that overwrites every old slot pays different SSTORE gas for a wiped slot than for a retained one. This PR decides for the Yellow Paper wipe. Reading current client code (not verified against binaries): geth master has already dropped the check and keeps the old storage, Nethermind keeps it for a funded target and clears it for an EIP-161-dead one, and Erigon, Besu, Nimbus and EthereumJS clear it. Geth and Nethermind would fail these fixtures today.

The case is unreachable on any live chain. The 28 mainnet accounts of this shape date from before Spurious Dragon, their creator nonces are spent, and reaching one needs a keccak preimage. EIP-8253 (proposed for Hegotá) bumps their nonces so EIP-684 rejects the creation in every client, which ends the question. Until then the fixtures only decide what clients agree to for tests. Slots wiped by the creation that the transaction never touches do not appear in the BAL, since the pre-state cannot enumerate storage; the slot the initcode reads shows up as a storage read.

The new tests pass from Frontier to Amsterdam with the fix and fail on Cancun and Amsterdam without it. The restored pre-EIP-7610 Cancun fixtures from ethereum/legacytests#18 pass through `tests/json_loader` with the fix, where the Cancun cases failed before.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to #3417 and #3425. Related to ethereum/legacytests#17, ethereum/legacytests#18 and EIP-8253.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
