### PR TITLE
chore(test-specs): avoid silent mistakes when writing tests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
@@ -9,11 +9,22 @@ replace the committed bytes. The same block fills as an engine fixture.
 
 A modifier that leaves both the list and its payload encoding unchanged is
 refused as well, since it would label a valid block invalid.
+
+The commitment tests pin what the block hash of a filled engine payload
+commits to: the canonical RLP for `modify_rlp`, the payload RLP for
+`override_rlp` and for content modifiers.
 """
 
+import json
 import textwrap
+from pathlib import Path
+from typing import Any
 
 import pytest
+
+from execution_testing.base_types import Bytes, EmptyTrieRoot
+from execution_testing.fixtures.blockchain import FixtureHeader
+from execution_testing.test_types.block_access_list import BlockAccessList
 
 FORK = "Amsterdam"
 
@@ -26,6 +37,7 @@ MODULE_TEMPLATE = textwrap.dedent(
     import pytest
 
     from execution_testing import (
+        Address,
         Alloc,
         Block,
         BlockAccessList,
@@ -36,10 +48,19 @@ MODULE_TEMPLATE = textwrap.dedent(
         Transaction,
     )
     from execution_testing.test_types.block_access_list.modifiers import (
+        encode_scalar_non_minimally,
         override_rlp,
     )
 
     EMPTY_LIST = Bytes(b"\\xc0")
+    # EIP-2935: written by the pre-execution system call of every block, so
+    # even an empty block's list has a storage value to re-encode.
+    HISTORY_STORAGE_ADDRESS = Address(
+        0x0000F90827F1C53A10CB7A02335B175320002935
+    )
+    RE_ENCODE = encode_scalar_non_minimally(
+        HISTORY_STORAGE_ADDRESS, "storage_value"
+    )
 
     {markers}
     @pytest.mark.valid_at("{fork}")
@@ -51,7 +72,7 @@ MODULE_TEMPLATE = textwrap.dedent(
             post={{}},
             blocks=[
                 Block(
-                    txs=[tx],
+                    txs={txs},
                     exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
                     expected_block_access_list=(
                         BlockAccessListExpectation(){modifier}
@@ -72,6 +93,7 @@ def write_test_module(
     modifier: str,
     markers: str = ENGINE_ONLY_MARKER,
     block_kwargs: str = "",
+    txs: str = "[tx]",
 ) -> str:
     """
     Write a single-test module with the given BAL modifier chain and return
@@ -86,6 +108,7 @@ def write_test_module(
             fork=FORK,
             modifier=modifier,
             block_kwargs=block_kwargs,
+            txs=txs,
         )
     )
     pytester.copy_example(
@@ -115,6 +138,54 @@ def run_fill(
 def output_of(result: pytest.RunResult) -> str:
     """Return the combined output of a fill run."""
     return "\n".join(result.outlines + result.errlines)
+
+
+def only_fixture(fixtures_dir: Path) -> dict[str, Any]:
+    """Return the single fixture a fill of the dummy module produced."""
+    files = [p for p in fixtures_dir.rglob("*.json") if ".meta" not in p.parts]
+    assert len(files) == 1, files
+    fixtures = json.loads(files[0].read_text())
+    assert len(fixtures) == 1, list(fixtures)
+    return next(iter(fixtures.values()))
+
+
+def rebuilt_block_hash(fixture: dict[str, Any], bal_hash: Bytes) -> str:
+    """
+    Recompute the block hash of the fixture's only payload with the header's
+    BAL hash replaced by ``bal_hash``.
+
+    The block is empty, so its transaction and withdrawal roots are the empty
+    trie root and its requests hash is the genesis one.
+    """
+    payload = fixture["engineNewPayloads"][0]
+    execution_payload = payload["params"][0]
+    empty_trie_root = "0x" + EmptyTrieRoot.hex()
+    header = dict(fixture["genesisBlockHeader"])
+    del header["hash"]
+    header.update(
+        {
+            "parentHash": execution_payload["parentHash"],
+            "coinbase": execution_payload["feeRecipient"],
+            "stateRoot": execution_payload["stateRoot"],
+            "transactionsTrie": empty_trie_root,
+            "receiptTrie": execution_payload["receiptsRoot"],
+            "bloom": execution_payload["logsBloom"],
+            "number": execution_payload["blockNumber"],
+            "gasLimit": execution_payload["gasLimit"],
+            "gasUsed": execution_payload["gasUsed"],
+            "timestamp": execution_payload["timestamp"],
+            "extraData": execution_payload["extraData"],
+            "mixHash": execution_payload["prevRandao"],
+            "baseFeePerGas": execution_payload["baseFeePerGas"],
+            "withdrawalsRoot": empty_trie_root,
+            "blobGasUsed": execution_payload["blobGasUsed"],
+            "excessBlobGas": execution_payload["excessBlobGas"],
+            "parentBeaconBlockRoot": payload["params"][2],
+            "slotNumber": execution_payload["slotNumber"],
+            "blockAccessListHash": str(bal_hash),
+        }
+    )
+    return str(FixtureHeader.model_validate(header).block_hash)
 
 
 def test_engine_format_fills_override_rlp(pytester: pytest.Pytester) -> None:
@@ -203,3 +274,56 @@ def test_changed_bal_fills(pytester: pytest.Pytester, modifier: str) -> None:
     result = run_fill(pytester, module_path, "blockchain_test_engine")
 
     result.assert_outcomes(passed=1, failed=0)
+
+
+@pytest.mark.parametrize(
+    "modifier,header_commits_to",
+    [
+        pytest.param(
+            ".modify_rlp(RE_ENCODE)", "canonical_rlp", id="modify_rlp"
+        ),
+        pytest.param(
+            ".modify(override_rlp(RE_ENCODE))",
+            "payload_rlp",
+            id="override_rlp",
+        ),
+        pytest.param(
+            ".modify(lambda _: BlockAccessList([]))",
+            "payload_rlp",
+            id="contents",
+        ),
+    ],
+)
+def test_header_commitment(
+    pytester: pytest.Pytester, modifier: str, header_commits_to: str
+) -> None:
+    """
+    The payload RLP is checked against what the block hash commits to,
+    rebuilt from the fixture itself.
+    """
+    module_path = write_test_module(pytester, modifier=modifier, txs="[]")
+
+    result = run_fill(pytester, module_path, "blockchain_test_engine")
+
+    result.assert_outcomes(passed=1, failed=0)
+    fixture = only_fixture(pytester.path / "fixtures")
+    execution_payload = fixture["engineNewPayloads"][0]["params"][0]
+    payload_rlp = Bytes(execution_payload["blockAccessList"])
+    canonical_rlp = BlockAccessList.from_rlp(payload_rlp).rlp
+    if "RE_ENCODE" in modifier:
+        assert payload_rlp != canonical_rlp, (
+            "re-encoding did not reach the payload"
+        )
+    else:
+        assert payload_rlp == Bytes(b"\xc0")
+    if header_commits_to == "canonical_rlp":
+        committed, other = canonical_rlp, payload_rlp
+    elif header_commits_to == "payload_rlp":
+        committed, other = payload_rlp, canonical_rlp
+    else:
+        raise ValueError(f"Unhandled commitment: {header_commits_to}")
+
+    block_hash = execution_payload["blockHash"]
+    assert rebuilt_block_hash(fixture, committed.keccak256()) == block_hash
+    if other != committed:
+        assert rebuilt_block_hash(fixture, other.keccak256()) != block_hash

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
@@ -6,6 +6,9 @@ once the transition tool has produced the list.
 payload can carry. `fill` therefore refuses the RLP blockchain fixture
 format for such a block, and refuses an explicit payload override that would
 replace the committed bytes. The same block fills as an engine fixture.
+
+A modifier that leaves both the list and its payload encoding unchanged is
+refused as well, since it would label a valid block invalid.
 """
 
 import textwrap
@@ -153,3 +156,50 @@ def test_explicit_payload_bal_with_override_rlp_is_refused(
     output = output_of(result)
     assert "would replace the bytes the header commits to" in output, output
     assert "Keep one" in output, output
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        pytest.param(".modify(lambda bal: bal)", id="identity_contents"),
+        pytest.param(
+            ".modify_rlp(lambda bal: bal.rlp)", id="identity_encoding"
+        ),
+        pytest.param(
+            ".modify(override_rlp(lambda bal: bal.rlp))",
+            id="identity_override",
+        ),
+    ],
+)
+def test_unchanged_bal_is_refused(
+    pytester: pytest.Pytester, modifier: str
+) -> None:
+    """Every modifier kind is checked against the transition tool's list."""
+    module_path = write_test_module(pytester, modifier=modifier)
+
+    result = run_fill(pytester, module_path, "blockchain_test_engine")
+
+    result.assert_outcomes(passed=0, failed=1)
+    output = output_of(result)
+    assert "left the list unchanged" in output, output
+    assert "drop it along with the exception" in output, output
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        pytest.param(
+            ".modify(lambda _: BlockAccessList([]))", id="contents_change"
+        ),
+        pytest.param(
+            ".modify_rlp(lambda _: EMPTY_LIST)", id="encoding_change"
+        ),
+    ],
+)
+def test_changed_bal_fills(pytester: pytest.Pytester, modifier: str) -> None:
+    """A modifier that changes the list or its encoding is accepted."""
+    module_path = write_test_module(pytester, modifier=modifier)
+
+    result = run_fill(pytester, module_path, "blockchain_test_engine")
+
+    result.assert_outcomes(passed=1, failed=0)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
@@ -11,8 +11,7 @@ A modifier that leaves both the list and its payload encoding unchanged is
 refused as well, since it would label a valid block invalid.
 
 The commitment tests pin what the block hash of a filled engine payload
-commits to: the canonical RLP for `modify_rlp`, the payload RLP for
-`override_rlp` and for content modifiers.
+commits to.
 """
 
 import json
@@ -26,6 +25,7 @@ from execution_testing.base_types import Bytes, EmptyTrieRoot
 from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.test_types.block_access_list import BlockAccessList
 
+# BALs exist from Amsterdam; the fill needs a fork that emits one.
 FORK = "Amsterdam"
 
 TEST_MODULE_DIR = "tests/amsterdam/dummy_test_module"
@@ -84,7 +84,7 @@ MODULE_TEMPLATE = textwrap.dedent(
     """
 )
 
-OVERRIDE_RLP = ".modify(override_rlp(lambda _: EMPTY_LIST))"
+OVERRIDE_RLP_WITH_EMPTY_LIST = ".modify(override_rlp(lambda _: EMPTY_LIST))"
 
 
 def write_test_module(
@@ -159,38 +159,36 @@ def rebuilt_block_hash(fixture: dict[str, Any], bal_hash: Bytes) -> str:
     """
     payload = fixture["engineNewPayloads"][0]
     execution_payload = payload["params"][0]
-    empty_trie_root = "0x" + EmptyTrieRoot.hex()
-    header = dict(fixture["genesisBlockHeader"])
-    del header["hash"]
-    header.update(
-        {
-            "parentHash": execution_payload["parentHash"],
-            "coinbase": execution_payload["feeRecipient"],
-            "stateRoot": execution_payload["stateRoot"],
-            "transactionsTrie": empty_trie_root,
-            "receiptTrie": execution_payload["receiptsRoot"],
-            "bloom": execution_payload["logsBloom"],
-            "number": execution_payload["blockNumber"],
-            "gasLimit": execution_payload["gasLimit"],
-            "gasUsed": execution_payload["gasUsed"],
-            "timestamp": execution_payload["timestamp"],
-            "extraData": execution_payload["extraData"],
-            "mixHash": execution_payload["prevRandao"],
-            "baseFeePerGas": execution_payload["baseFeePerGas"],
-            "withdrawalsRoot": empty_trie_root,
-            "blobGasUsed": execution_payload["blobGasUsed"],
-            "excessBlobGas": execution_payload["excessBlobGas"],
-            "parentBeaconBlockRoot": payload["params"][2],
-            "slotNumber": execution_payload["slotNumber"],
-            "blockAccessListHash": str(bal_hash),
-        }
+    genesis = FixtureHeader.model_validate(fixture["genesisBlockHeader"])
+    header = genesis.copy(
+        parent_hash=execution_payload["parentHash"],
+        fee_recipient=execution_payload["feeRecipient"],
+        state_root=execution_payload["stateRoot"],
+        transactions_trie=EmptyTrieRoot,
+        receipts_root=execution_payload["receiptsRoot"],
+        logs_bloom=execution_payload["logsBloom"],
+        number=execution_payload["blockNumber"],
+        gas_limit=execution_payload["gasLimit"],
+        gas_used=execution_payload["gasUsed"],
+        timestamp=execution_payload["timestamp"],
+        extra_data=execution_payload["extraData"],
+        prev_randao=execution_payload["prevRandao"],
+        base_fee_per_gas=execution_payload["baseFeePerGas"],
+        withdrawals_root=EmptyTrieRoot,
+        blob_gas_used=execution_payload["blobGasUsed"],
+        excess_blob_gas=execution_payload["excessBlobGas"],
+        parent_beacon_block_root=payload["params"][2],
+        slot_number=execution_payload["slotNumber"],
+        block_access_list_hash=bal_hash,
     )
-    return str(FixtureHeader.model_validate(header).block_hash)
+    return str(header.block_hash)
 
 
 def test_engine_format_fills_override_rlp(pytester: pytest.Pytester) -> None:
     """Positive control: the engine payload can carry the re-encoding."""
-    module_path = write_test_module(pytester, modifier=OVERRIDE_RLP)
+    module_path = write_test_module(
+        pytester, modifier=OVERRIDE_RLP_WITH_EMPTY_LIST
+    )
 
     result = run_fill(pytester, module_path, "blockchain_test_engine")
 
@@ -200,7 +198,7 @@ def test_engine_format_fills_override_rlp(pytester: pytest.Pytester) -> None:
 def test_rlp_format_refuses_override_rlp(pytester: pytest.Pytester) -> None:
     """Block RLP never carries the list, so the fixture cannot deliver it."""
     module_path = write_test_module(
-        pytester, modifier=OVERRIDE_RLP, markers=""
+        pytester, modifier=OVERRIDE_RLP_WITH_EMPTY_LIST, markers=""
     )
 
     result = run_fill(pytester, module_path, "blockchain_test")
@@ -215,12 +213,13 @@ def test_rlp_format_refuses_override_rlp(pytester: pytest.Pytester) -> None:
     "modifier,block_kwargs",
     [
         pytest.param(
-            OVERRIDE_RLP,
+            OVERRIDE_RLP_WITH_EMPTY_LIST,
             'engine_new_payload_block_access_list=Bytes(b"\\x80"),',
             id="explicit_payload_bal",
         ),
         pytest.param(
-            OVERRIDE_RLP + ".modify_rlp(lambda _: Bytes(b'\\x80'))",
+            OVERRIDE_RLP_WITH_EMPTY_LIST
+            + ".modify_rlp(lambda _: Bytes(b'\\x80'))",
             "",
             id="modify_rlp",
         ),
@@ -258,7 +257,7 @@ def test_second_payload_writer_after_override_rlp_is_refused(
 def test_unchanged_bal_is_refused(
     pytester: pytest.Pytester, modifier: str
 ) -> None:
-    """Every modifier kind is checked against the transition tool's list."""
+    """An unchanged list or encoding is caught once the t8n has run."""
     module_path = write_test_module(pytester, modifier=modifier)
 
     result = run_fill(pytester, module_path, "blockchain_test_engine")
@@ -290,25 +289,33 @@ def test_changed_bal_fills(pytester: pytest.Pytester, modifier: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "modifier,header_commits_to",
+    "modifier,header_commits_to,payload_encoding",
     [
         pytest.param(
-            ".modify_rlp(RE_ENCODE)", "canonical_rlp", id="modify_rlp"
+            ".modify_rlp(RE_ENCODE)",
+            "canonical_rlp",
+            "re_encoded",
+            id="modify_rlp",
         ),
         pytest.param(
             ".modify(override_rlp(RE_ENCODE))",
             "payload_rlp",
+            "re_encoded",
             id="override_rlp",
         ),
         pytest.param(
             ".modify(lambda _: BlockAccessList([]))",
             "payload_rlp",
+            "empty_list",
             id="contents",
         ),
     ],
 )
 def test_header_commitment(
-    pytester: pytest.Pytester, modifier: str, header_commits_to: str
+    pytester: pytest.Pytester,
+    modifier: str,
+    header_commits_to: str,
+    payload_encoding: str,
 ) -> None:
     """
     The payload RLP is checked against what the block hash commits to,
@@ -323,12 +330,14 @@ def test_header_commitment(
     execution_payload = fixture["engineNewPayloads"][0]["params"][0]
     payload_rlp = Bytes(execution_payload["blockAccessList"])
     canonical_rlp = BlockAccessList.from_rlp(payload_rlp).rlp
-    if "RE_ENCODE" in modifier:
+    if payload_encoding == "re_encoded":
         assert payload_rlp != canonical_rlp, (
             "re-encoding did not reach the payload"
         )
-    else:
+    elif payload_encoding == "empty_list":
         assert payload_rlp == Bytes(b"\xc0")
+    else:
+        raise ValueError(f"Unhandled payload encoding: {payload_encoding}")
     if header_commits_to == "canonical_rlp":
         committed, other = canonical_rlp, payload_rlp
     elif header_commits_to == "payload_rlp":

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
@@ -211,21 +211,34 @@ def test_rlp_format_refuses_override_rlp(pytester: pytest.Pytester) -> None:
     assert "Mark the test `blockchain_test_engine_only`" in output, output
 
 
-def test_explicit_payload_bal_with_override_rlp_is_refused(
-    pytester: pytest.Pytester,
+@pytest.mark.parametrize(
+    "modifier,block_kwargs",
+    [
+        pytest.param(
+            OVERRIDE_RLP,
+            'engine_new_payload_block_access_list=Bytes(b"\\x80"),',
+            id="explicit_payload_bal",
+        ),
+        pytest.param(
+            OVERRIDE_RLP + ".modify_rlp(lambda _: Bytes(b'\\x80'))",
+            "",
+            id="modify_rlp",
+        ),
+    ],
+)
+def test_second_payload_writer_after_override_rlp_is_refused(
+    pytester: pytest.Pytester, modifier: str, block_kwargs: str
 ) -> None:
-    """The explicit payload bytes would replace the committed ones."""
+    """A second writer of the payload bytes would break the commitment."""
     module_path = write_test_module(
-        pytester,
-        modifier=OVERRIDE_RLP,
-        block_kwargs=('engine_new_payload_block_access_list=Bytes(b"\\x80"),'),
+        pytester, modifier=modifier, block_kwargs=block_kwargs
     )
 
     result = run_fill(pytester, module_path, "blockchain_test_engine")
 
     result.assert_outcomes(passed=0, failed=1)
     output = output_of(result)
-    assert "would replace the bytes the header commits to" in output, output
+    assert "would not carry what the header commits to" in output, output
     assert "Keep one" in output, output
 
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_bal_modifier_guards.py
@@ -1,0 +1,155 @@
+"""
+Test the fill-time checks on block access list modifiers that can only run
+once the transition tool has produced the list.
+
+`override_rlp` commits the header to re-encoded bytes that only the engine
+payload can carry. `fill` therefore refuses the RLP blockchain fixture
+format for such a block, and refuses an explicit payload override that would
+replace the committed bytes. The same block fills as an engine fixture.
+"""
+
+import textwrap
+
+import pytest
+
+FORK = "Amsterdam"
+
+TEST_MODULE_DIR = "tests/amsterdam/dummy_test_module"
+
+ENGINE_ONLY_MARKER = "@pytest.mark.blockchain_test_engine_only"
+
+MODULE_TEMPLATE = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Alloc,
+        Block,
+        BlockAccessList,
+        BlockAccessListExpectation,
+        BlockchainTestFiller,
+        BlockException,
+        Bytes,
+        Transaction,
+    )
+    from execution_testing.test_types.block_access_list.modifiers import (
+        override_rlp,
+    )
+
+    EMPTY_LIST = Bytes(b"\\xc0")
+
+    {markers}
+    @pytest.mark.valid_at("{fork}")
+    @pytest.mark.exception_test
+    def test_case(blockchain_test: BlockchainTestFiller, pre: Alloc) -> None:
+        tx = Transaction(to=pre.fund_eoa(amount=0), sender=pre.fund_eoa())
+        blockchain_test(
+            pre=pre,
+            post={{}},
+            blocks=[
+                Block(
+                    txs=[tx],
+                    exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+                    expected_block_access_list=(
+                        BlockAccessListExpectation(){modifier}
+                    ),
+                    {block_kwargs}
+                )
+            ],
+        )
+    """
+)
+
+OVERRIDE_RLP = ".modify(override_rlp(lambda _: EMPTY_LIST))"
+
+
+def write_test_module(
+    pytester: pytest.Pytester,
+    *,
+    modifier: str,
+    markers: str = ENGINE_ONLY_MARKER,
+    block_kwargs: str = "",
+) -> str:
+    """
+    Write a single-test module with the given BAL modifier chain and return
+    its path relative to the pytester directory.
+    """
+    module_dir = pytester.path / TEST_MODULE_DIR
+    module_dir.mkdir(parents=True)
+    module = module_dir / "test_dummy.py"
+    module.write_text(
+        MODULE_TEMPLATE.format(
+            markers=markers,
+            fork=FORK,
+            modifier=modifier,
+            block_kwargs=block_kwargs,
+        )
+    )
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    return str(module.relative_to(pytester.path))
+
+
+def run_fill(
+    pytester: pytest.Pytester, module_path: str, fixture_format: str
+) -> pytest.RunResult:
+    """Fill the given module, generating only ``fixture_format``."""
+    return pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        FORK,
+        "-m",
+        fixture_format,
+        "--no-html",
+        "--output",
+        "fixtures",
+        module_path,
+    )
+
+
+def output_of(result: pytest.RunResult) -> str:
+    """Return the combined output of a fill run."""
+    return "\n".join(result.outlines + result.errlines)
+
+
+def test_engine_format_fills_override_rlp(pytester: pytest.Pytester) -> None:
+    """Positive control: the engine payload can carry the re-encoding."""
+    module_path = write_test_module(pytester, modifier=OVERRIDE_RLP)
+
+    result = run_fill(pytester, module_path, "blockchain_test_engine")
+
+    result.assert_outcomes(passed=1, failed=0)
+
+
+def test_rlp_format_refuses_override_rlp(pytester: pytest.Pytester) -> None:
+    """Block RLP never carries the list, so the fixture cannot deliver it."""
+    module_path = write_test_module(
+        pytester, modifier=OVERRIDE_RLP, markers=""
+    )
+
+    result = run_fill(pytester, module_path, "blockchain_test")
+
+    result.assert_outcomes(passed=0, failed=1)
+    output = output_of(result)
+    assert "cannot deliver the re-encoded bytes" in output, output
+    assert "Mark the test `blockchain_test_engine_only`" in output, output
+
+
+def test_explicit_payload_bal_with_override_rlp_is_refused(
+    pytester: pytest.Pytester,
+) -> None:
+    """The explicit payload bytes would replace the committed ones."""
+    module_path = write_test_module(
+        pytester,
+        modifier=OVERRIDE_RLP,
+        block_kwargs=('engine_new_payload_block_access_list=Bytes(b"\\x80"),'),
+    )
+
+    result = run_fill(pytester, module_path, "blockchain_test_engine")
+
+    result.assert_outcomes(passed=0, failed=1)
+    output = output_of(result)
+    assert "would replace the bytes the header commits to" in output, output
+    assert "Keep one" in output, output

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -840,7 +840,7 @@ class BlockchainTest(BaseTest):
             ):
                 raise Exception(
                     f"test correctness: block {i} modifies its block access "
-                    "list but declares no `exception` or "
+                    "list or its encoding but declares no `exception` or "
                     "`engine_api_error_code`, so the corrupted block access "
                     "list would be filled as valid. Declare the exception "
                     "the modified block access list must cause, or drop the "
@@ -1124,10 +1124,10 @@ class BlockchainTest(BaseTest):
                 )
             ):
                 raise Exception(
-                    f"test correctness: block {int(env.number)}'s block "
-                    "access list modifier left the list unchanged, so the "
-                    "block would be labelled invalid for no reason. Make the "
-                    "modifier change the list, or drop it along with the "
+                    f"test correctness: block number {int(env.number)}'s "
+                    "block access list modifier left the list unchanged, so "
+                    "the block would be labelled invalid for no reason. Make "
+                    "the modifier change the list, or drop it along with the "
                     "exception."
                 )
             if (
@@ -1135,7 +1135,7 @@ class BlockchainTest(BaseTest):
                 and block.engine_new_payload_block_access_list is not None
             ):
                 raise Exception(
-                    f"test correctness: block {int(env.number)} sets "
+                    f"test correctness: block number {int(env.number)} sets "
                     "`engine_new_payload_block_access_list` and its block "
                     "access list modifier re-encodes the list; the explicit "
                     "payload override would replace the bytes the header "
@@ -1271,7 +1271,7 @@ class BlockchainTest(BaseTest):
         benchmark_gas_used: int | None = None
         benchmark_block_gas_used: int | None = None
         benchmark_opcode_count: OpcodeCount | None = None
-        for block in self.blocks:
+        for i, block in enumerate(self.blocks):
             # This is the most common case, the RLP needs to be constructed
             # based on the transactions to be included in the block.
             # Set the environment according to the block to execute.
@@ -1282,6 +1282,17 @@ class BlockchainTest(BaseTest):
                 previous_alloc=alloc,
             )
             block_number = int(built_block.header.number)
+            if (
+                built_block.block_access_list is not None
+                and built_block.block_access_list.has_rlp_override
+            ):
+                raise Exception(
+                    f"test correctness: block {i}'s block access list "
+                    "modifier re-encodes the list, but block RLP does not "
+                    "carry the block access list, so an RLP blockchain "
+                    "fixture cannot deliver the re-encoded bytes. Mark the "
+                    "test `blockchain_test_engine_only`."
+                )
             is_last_block = block is self.blocks[-1]
             if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
                 benchmark_gas_used = built_block.cumulative_gas_used()
@@ -1297,18 +1308,6 @@ class BlockchainTest(BaseTest):
                 if block.include_receipts_in_output is not None
                 else self.include_tx_receipts_in_output
             )
-            if (
-                built_block.block_access_list is not None
-                and built_block.block_access_list.has_rlp_override
-            ):
-                raise Exception(
-                    f"test correctness: block {block_number}'s block access "
-                    "list modifier re-encodes the list, but block RLP does "
-                    "not carry the block access list, so an RLP blockchain "
-                    "fixture cannot deliver the re-encoded bytes. Mark the "
-                    "test `blockchain_test_engine_only`."
-                )
-
             fixture_blocks.append(
                 built_block.get_fixture_block(
                     include_receipts=include_receipts

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1130,19 +1130,19 @@ class BlockchainTest(BaseTest):
                     "the modifier change the list, or drop it along with the "
                     "exception."
                 )
-            if (
-                bal.has_rlp_override
-                and block.engine_new_payload_block_access_list is not None
+            if bal.has_rlp_override and (
+                block.engine_new_payload_block_access_list is not None
+                or bal_rlp_override is not None
             ):
                 raise Exception(
-                    f"test correctness: block number {int(env.number)} sets "
-                    "`engine_new_payload_block_access_list` and its block "
-                    "access list modifier re-encodes the list; the explicit "
-                    "payload override would replace the bytes the header "
-                    "commits to. Keep one: "
+                    f"test correctness: block number {int(env.number)} "
+                    "re-encodes the block access list with `override_rlp` "
+                    "and also replaces the payload bytes, so the payload "
+                    "would not carry what the header commits to. Keep one: "
+                    "`override_rlp` commits the header to its re-encoding, "
+                    "`modify_rlp` re-encodes the payload only, "
                     "`engine_new_payload_block_access_list` delivers "
-                    "arbitrary bytes, `override_rlp` re-encodes the list and "
-                    "commits the header to it."
+                    "arbitrary bytes."
                 )
 
         built_block_kwargs: Dict[str, Any] = dict(

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1116,6 +1116,20 @@ class BlockchainTest(BaseTest):
             bal_rlp_override = block.expected_block_access_list.modified_rlp(
                 bal
             )
+            if (
+                bal.has_rlp_override
+                and block.engine_new_payload_block_access_list is not None
+            ):
+                raise Exception(
+                    f"test correctness: block {int(env.number)} sets "
+                    "`engine_new_payload_block_access_list` and its block "
+                    "access list modifier re-encodes the list; the explicit "
+                    "payload override would replace the bytes the header "
+                    "commits to. Keep one: "
+                    "`engine_new_payload_block_access_list` delivers "
+                    "arbitrary bytes, `override_rlp` re-encodes the list and "
+                    "commits the header to it."
+                )
 
         built_block_kwargs: Dict[str, Any] = dict(
             header=header,
@@ -1269,6 +1283,18 @@ class BlockchainTest(BaseTest):
                 if block.include_receipts_in_output is not None
                 else self.include_tx_receipts_in_output
             )
+            if (
+                built_block.block_access_list is not None
+                and built_block.block_access_list.has_rlp_override
+            ):
+                raise Exception(
+                    f"test correctness: block {block_number}'s block access "
+                    "list modifier re-encodes the list, but block RLP does "
+                    "not carry the block access list, so an RLP blockchain "
+                    "fixture cannot deliver the re-encoded bytes. Mark the "
+                    "test `blockchain_test_engine_only`."
+                )
+
             fixture_blocks.append(
                 built_block.get_fixture_block(
                     include_receipts=include_receipts

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -842,7 +842,23 @@ class BlockchainTest(BaseTest):
                     f"test correctness: block {i} modifies its block access "
                     "list but declares no `exception` or "
                     "`engine_api_error_code`, so the corrupted block access "
-                    "list would be filled as valid."
+                    "list would be filled as valid. Declare the exception "
+                    "the modified block access list must cause, or drop the "
+                    "modifier."
+                )
+            if (
+                block.engine_new_payload_block_access_list is not None
+                and expectation is not None
+                and expectation.has_rlp_modifier
+            ):
+                raise Exception(
+                    f"test correctness: block {i} sets "
+                    "`engine_new_payload_block_access_list` and re-encodes "
+                    "the block access list with `modify_rlp`; the explicit "
+                    "payload override would discard the re-encoding. Keep "
+                    "one: `engine_new_payload_block_access_list` delivers "
+                    "arbitrary bytes, `modify_rlp` re-encodes the list the "
+                    "transition tool produced."
                 )
 
     def get_genesis_environment(self) -> Environment:

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -1117,6 +1117,20 @@ class BlockchainTest(BaseTest):
                 bal
             )
             if (
+                block.expected_block_access_list.has_modifier
+                and bal.rlp == t8n_bal.rlp
+                and (
+                    bal_rlp_override is None or bal_rlp_override == t8n_bal.rlp
+                )
+            ):
+                raise Exception(
+                    f"test correctness: block {int(env.number)}'s block "
+                    "access list modifier left the list unchanged, so the "
+                    "block would be labelled invalid for no reason. Make the "
+                    "modifier change the list, or drop it along with the "
+                    "exception."
+                )
+            if (
                 bal.has_rlp_override
                 and block.engine_new_payload_block_access_list is not None
             ):

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -830,6 +830,20 @@ class BlockchainTest(BaseTest):
                         "last transaction of the last block, but block "
                         f"{i} contains an invalid transaction elsewhere"
                     )
+        for i, block in enumerate(self.blocks):
+            expectation = block.expected_block_access_list
+            if (
+                expectation is not None
+                and expectation.has_modifier
+                and not block.exception
+                and block.engine_api_error_code is None
+            ):
+                raise Exception(
+                    f"test correctness: block {i} modifies its block access "
+                    "list but declares no `exception` or "
+                    "`engine_api_error_code`, so the corrupted block access "
+                    "list would be filled as valid."
+                )
 
     def get_genesis_environment(self) -> Environment:
         """Get the genesis environment for pre-allocation groups."""

--- a/packages/testing/src/execution_testing/specs/tests/test_types.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_types.py
@@ -400,3 +400,63 @@ class TestBalModifierRequiresException:
         BlockchainTest(
             fork=Amsterdam, pre=Alloc(), post=Alloc(), blocks=[block]
         )
+
+
+class TestConflictingPayloadOverrides:
+    """
+    An explicit engine payload BAL wins over `modify_rlp`, so setting both
+    would silently drop the re-encoding.
+    """
+
+    def test_explicit_payload_bal_with_modify_rlp_is_refused(self) -> None:
+        """Both payload-only settings on one block fail at construction."""
+        block = Block(
+            engine_new_payload_block_access_list=Bytes(b"\xc0"),
+            expected_block_access_list=(
+                BlockAccessListExpectation().modify_rlp(lambda bal: bal.rlp)
+            ),
+            exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+        )
+        with pytest.raises(Exception, match="discard the re-encoding"):
+            BlockchainTest(
+                fork=Amsterdam, pre=Alloc(), post=Alloc(), blocks=[block]
+            )
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            pytest.param(
+                Block(
+                    engine_new_payload_block_access_list=Bytes(b"\xc0"),
+                    exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+                ),
+                id="explicit_payload_bal_only",
+            ),
+            pytest.param(
+                Block(
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify_rlp(
+                            lambda bal: bal.rlp
+                        )
+                    ),
+                    exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+                ),
+                id="modify_rlp_only",
+            ),
+            pytest.param(
+                Block(
+                    engine_new_payload_block_access_list=Bytes(b"\xc0"),
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify(lambda bal: bal)
+                    ),
+                    exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+                ),
+                id="explicit_payload_bal_with_content_modifier",
+            ),
+        ],
+    )
+    def test_single_payload_path_is_accepted(self, block: Block) -> None:
+        """One payload path at a time, or a content modifier, is fine."""
+        BlockchainTest(
+            fork=Amsterdam, pre=Alloc(), post=Alloc(), blocks=[block]
+        )

--- a/packages/testing/src/execution_testing/specs/tests/test_types.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_types.py
@@ -13,6 +13,7 @@ from execution_testing.base_types import (
 )
 from execution_testing.client_clis import Result
 from execution_testing.client_clis.cli_types import LazyAllocStr
+from execution_testing.exceptions import BlockException, EngineAPIError
 from execution_testing.fixtures.blockchain import (
     FixtureExecutionPayloadModifier,
     FixtureHeader,
@@ -321,3 +322,81 @@ class TestEnginePayloadOnlyOverrides:
         )
         with pytest.raises(Exception, match="blockchain_test_engine_only"):
             test.make_fixture(sentinel.t8n)
+
+
+class TestBalModifierRequiresException:
+    """A block that rewrites its BAL must declare how the block fails."""
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            pytest.param(
+                Block(
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify(lambda bal: bal)
+                    ),
+                ),
+                id="contents",
+            ),
+            pytest.param(
+                Block(
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify_rlp(
+                            lambda bal: bal.rlp
+                        )
+                    ),
+                ),
+                id="encoding",
+            ),
+            pytest.param(
+                Block(
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify(lambda bal: bal)
+                    ),
+                    exception=[],
+                ),
+                id="empty_exception_list",
+            ),
+        ],
+    )
+    def test_modifier_without_declared_failure_is_refused(
+        self, block: Block
+    ) -> None:
+        """The check runs at construction, before any t8n call."""
+        with pytest.raises(Exception, match="declares no `exception`"):
+            BlockchainTest(
+                fork=Amsterdam, pre=Alloc(), post=Alloc(), blocks=[block]
+            )
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            pytest.param(
+                Block(expected_block_access_list=BlockAccessListExpectation()),
+                id="no_modifier",
+            ),
+            pytest.param(
+                Block(
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify(lambda bal: bal)
+                    ),
+                    exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
+                ),
+                id="exception",
+            ),
+            pytest.param(
+                Block(
+                    expected_block_access_list=(
+                        BlockAccessListExpectation().modify(lambda bal: bal)
+                    ),
+                    engine_api_error_code=EngineAPIError.InvalidParams,
+                ),
+                id="engine_api_error",
+            ),
+        ],
+    )
+    def test_declared_failure_is_accepted(self, block: Block) -> None:
+        """Modifiers paired with a declared failure construct normally."""
+        BlockchainTest(
+            fork=Amsterdam, pre=Alloc(), post=Alloc(), blocks=[block]
+        )

--- a/packages/testing/src/execution_testing/test_types/block_access_list/expectations.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/expectations.py
@@ -183,9 +183,16 @@ class BlockAccessListExpectation(CamelModel):
             The potentially transformed BlockAccessList for the fixture
 
         """
-        if self._modifier:
-            return self._modifier(t8n_bal)
-        return t8n_bal
+        if self._modifier is None:
+            return t8n_bal
+        modified = self._modifier(t8n_bal)
+        if not isinstance(modified, BlockAccessList):
+            raise TypeError(
+                "`modify` expects a content modifier returning a "
+                f"BlockAccessList, got {type(modified).__name__}. Use "
+                "`modify_rlp` or `override_rlp` for encoders."
+            )
+        return modified
 
     def modify_rlp(
         self, modifier: Callable[["BlockAccessList"], Bytes]
@@ -212,9 +219,16 @@ class BlockAccessListExpectation(CamelModel):
 
     def modified_rlp(self, bal: "BlockAccessList") -> Bytes | None:
         """Return the re-encoded payload BAL, or None if unmodified."""
-        if self._rlp_modifier:
-            return self._rlp_modifier(bal)
-        return None
+        if self._rlp_modifier is None:
+            return None
+        encoded = self._rlp_modifier(bal)
+        if not isinstance(encoded, bytes):
+            raise TypeError(
+                "`modify_rlp` expects an encoder returning bytes, got "
+                f"{type(encoded).__name__}. Use `modify` for content "
+                "modifiers."
+            )
+        return Bytes(encoded)
 
     @property
     def has_modifier(self) -> bool:

--- a/packages/testing/src/execution_testing/test_types/block_access_list/expectations.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/expectations.py
@@ -160,6 +160,12 @@ class BlockAccessListExpectation(CamelModel):
             ).modify(remove_nonces(alice))
 
         """
+        if self._modifier is not None:
+            raise ValueError(
+                "This expectation already has a content modifier; a second "
+                "`modify` call would replace it. Pass every modifier to a "
+                "single `modify` call instead."
+            )
         new_instance = self.model_copy(deep=True)
         new_instance._modifier = compose(*modifiers)
         return new_instance
@@ -194,6 +200,12 @@ class BlockAccessListExpectation(CamelModel):
         Only the engine payload can carry the re-encoding, so the test must
         be marked `blockchain_test_engine_only`.
         """
+        if self._rlp_modifier is not None:
+            raise ValueError(
+                "This expectation already re-encodes the block access list; "
+                "a second `modify_rlp` call would replace the first. Keep a "
+                "single `modify_rlp` call."
+            )
         new_instance = self.model_copy(deep=True)
         new_instance._rlp_modifier = modifier
         return new_instance

--- a/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
@@ -160,7 +160,7 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         """Return the list for RLP encoding per EIP-7928."""
         return to_serializable_element(self.root)
 
-    def with_rlp_override(self, rlp: Bytes) -> "BlockAccessList":
+    def with_rlp_override(self, rlp: bytes) -> "BlockAccessList":
         """
         Return a BAL with the same contents whose serialization is ``rlp``,
         mirroring ``RLPSerializable.rlp_override``.
@@ -168,8 +168,13 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         A fresh instance is built rather than a copy so that no cached
         canonical encoding is carried over.
         """
+        if not isinstance(rlp, bytes):
+            raise TypeError(
+                "`with_rlp_override` expects the serialization as bytes, got "
+                f"{type(rlp).__name__}. Pass the encoded block access list."
+            )
         new_instance = BlockAccessList(root=self.root)
-        new_instance._rlp_override = rlp
+        new_instance._rlp_override = Bytes(rlp)
         return new_instance
 
     @property

--- a/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
@@ -160,7 +160,7 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         """Return the list for RLP encoding per EIP-7928."""
         return to_serializable_element(self.root)
 
-    def with_rlp_override(self, rlp: bytes) -> "BlockAccessList":
+    def with_rlp_override(self, rlp: bytes | str) -> "BlockAccessList":
         """
         Return a BAL with the same contents whose serialization is ``rlp``,
         mirroring ``RLPSerializable.rlp_override``.
@@ -168,10 +168,11 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         A fresh instance is built rather than a copy so that no cached
         canonical encoding is carried over.
         """
-        if not isinstance(rlp, bytes):
+        if not isinstance(rlp, (bytes, str)):
             raise TypeError(
-                "`with_rlp_override` expects the serialization as bytes, got "
-                f"{type(rlp).__name__}. Pass the encoded block access list."
+                "`with_rlp_override` expects the serialization as bytes or "
+                f"a hex string, got {type(rlp).__name__}. Pass the encoded "
+                "block access list."
             )
         new_instance = BlockAccessList(root=self.root)
         new_instance._rlp_override = Bytes(rlp)

--- a/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
@@ -172,6 +172,11 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         new_instance._rlp_override = rlp
         return new_instance
 
+    @property
+    def has_rlp_override(self) -> bool:
+        """Return whether ``rlp`` is an override rather than the encoding."""
+        return self._rlp_override is not None
+
     @cached_property
     def rlp(self) -> Bytes:
         """Return the RLP encoded block access list for hash verification."""

--- a/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/t8n.py
@@ -1,11 +1,11 @@
 """Block Access List (BAL) for t8n tool communication and fixtures."""
 
 from functools import cached_property
-from typing import Any, Callable, List, Sequence, Union
+from typing import Any, Callable, List, Self, Sequence, Union
 
 import ethereum_rlp as eth_rlp
 from ethereum_rlp import Simple
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, validate_call
 
 from execution_testing.base_types import (
     Address,
@@ -160,7 +160,8 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         """Return the list for RLP encoding per EIP-7928."""
         return to_serializable_element(self.root)
 
-    def with_rlp_override(self, rlp: bytes | str) -> "BlockAccessList":
+    @validate_call
+    def with_rlp_override(self, rlp: Bytes) -> Self:
         """
         Return a BAL with the same contents whose serialization is ``rlp``,
         mirroring ``RLPSerializable.rlp_override``.
@@ -168,14 +169,8 @@ class BlockAccessList(EthereumTestRootModel[List[BalAccountChange]]):
         A fresh instance is built rather than a copy so that no cached
         canonical encoding is carried over.
         """
-        if not isinstance(rlp, (bytes, str)):
-            raise TypeError(
-                "`with_rlp_override` expects the serialization as bytes or "
-                f"a hex string, got {type(rlp).__name__}. Pass the encoded "
-                "block access list."
-            )
-        new_instance = BlockAccessList(root=self.root)
-        new_instance._rlp_override = Bytes(rlp)
+        new_instance = type(self)(root=self.root)
+        new_instance._rlp_override = rlp
         return new_instance
 
     @property

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_expectation.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_expectation.py
@@ -1226,6 +1226,36 @@ def test_modify_rlp_chains_with_modify() -> None:
     assert both.modified_rlp(actual_bal) == actual_bal.rlp
 
 
+def test_modify_chains_with_modify_rlp() -> None:
+    """A content modifier may follow an earlier `modify_rlp`."""
+    both = (
+        BlockAccessListExpectation()
+        .modify_rlp(lambda bal: bal.rlp)
+        .modify(lambda _: BlockAccessList([]))
+    )
+
+    assert both.has_rlp_modifier
+    assert both.modify_if_invalid_test(BlockAccessList([])) == (
+        BlockAccessList([])
+    )
+
+
+def test_second_modify_is_refused() -> None:
+    """A second `modify` would silently replace the first."""
+    expectation = BlockAccessListExpectation().modify(lambda bal: bal)
+
+    with pytest.raises(ValueError, match="already has a content modifier"):
+        expectation.modify(lambda bal: bal)
+
+
+def test_second_modify_rlp_is_refused() -> None:
+    """A second `modify_rlp` would silently replace the first."""
+    expectation = BlockAccessListExpectation().modify_rlp(lambda bal: bal.rlp)
+
+    with pytest.raises(ValueError, match="already re-encodes"):
+        expectation.modify_rlp(lambda bal: bal.rlp)
+
+
 def test_validate_any_change_mutual_exclusion_with_slot_changes() -> None:
     """
     validate_any_change=True and non-empty slot_changes raises ValueError.

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_expectation.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_expectation.py
@@ -1256,6 +1256,24 @@ def test_second_modify_rlp_is_refused() -> None:
         expectation.modify_rlp(lambda bal: bal.rlp)
 
 
+def test_modify_rlp_with_content_modifier_is_refused() -> None:
+    """An encoder must return bytes, not a rewritten list."""
+    content_modifier: Any = lambda bal: bal  # noqa: E731
+    expectation = BlockAccessListExpectation().modify_rlp(content_modifier)
+
+    with pytest.raises(TypeError, match="returning bytes"):
+        expectation.modified_rlp(BlockAccessList([]))
+
+
+def test_modify_with_encoder_is_refused() -> None:
+    """A content modifier must return a list, not bytes."""
+    encoder: Any = lambda bal: bal.rlp  # noqa: E731
+    expectation = BlockAccessListExpectation().modify(encoder)
+
+    with pytest.raises(TypeError, match="returning a BlockAccessList"):
+        expectation.modify_if_invalid_test(BlockAccessList([]))
+
+
 def test_validate_any_change_mutual_exclusion_with_slot_changes() -> None:
     """
     validate_any_change=True and non-empty slot_changes raises ValueError.

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_expectation.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_expectation.py
@@ -1227,7 +1227,18 @@ def test_modify_rlp_chains_with_modify() -> None:
 
 
 def test_modify_chains_with_modify_rlp() -> None:
-    """A content modifier may follow an earlier `modify_rlp`."""
+    """An encoding modifier survives a later `modify`."""
+    alice = Address(0xA)
+    actual_bal = BlockAccessList(
+        [
+            BalAccountChange(
+                address=alice,
+                nonce_changes=[
+                    BalNonceChange(block_access_index=1, post_nonce=1)
+                ],
+            ),
+        ]
+    )
     both = (
         BlockAccessListExpectation()
         .modify_rlp(lambda bal: bal.rlp)
@@ -1235,9 +1246,8 @@ def test_modify_chains_with_modify_rlp() -> None:
     )
 
     assert both.has_rlp_modifier
-    assert both.modify_if_invalid_test(BlockAccessList([])) == (
-        BlockAccessList([])
-    )
+    assert both.modify_if_invalid_test(actual_bal) == BlockAccessList([])
+    assert both.modified_rlp(actual_bal) == actual_bal.rlp
 
 
 def test_second_modify_is_refused() -> None:

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
@@ -8,6 +8,7 @@ format, particularly zero-padded hex strings.
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from execution_testing.base_types import Address, Bytes
 from execution_testing.test_types.block_access_list import (
@@ -113,18 +114,12 @@ def test_bal_rlp_override_replaces_serialization_only() -> None:
     assert original.rlp == canonical
 
 
-@pytest.mark.parametrize(
-    "rlp",
-    [
-        pytest.param(None, id="none"),
-        pytest.param(BlockAccessList([]), id="list"),
-        pytest.param(0xC0, id="int"),
-    ],
-)
-def test_bal_rlp_override_refuses_non_bytes(rlp: Any) -> None:
-    """The override bypasses validation, so its type is checked here."""
-    with pytest.raises(TypeError, match="expects the serialization as bytes"):
-        BlockAccessList([]).with_rlp_override(rlp)
+def test_bal_rlp_override_rejects_unconvertible_input() -> None:
+    """``validate_call`` rejects what ``Bytes`` cannot coerce."""
+    unconvertible: Any = None
+
+    with pytest.raises(ValidationError):
+        BlockAccessList([]).with_rlp_override(unconvertible)
 
 
 @pytest.mark.parametrize(

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
@@ -116,9 +116,9 @@ def test_bal_rlp_override_replaces_serialization_only() -> None:
 @pytest.mark.parametrize(
     "rlp",
     [
-        pytest.param("0xc0", id="str"),
         pytest.param(None, id="none"),
         pytest.param(BlockAccessList([]), id="list"),
+        pytest.param(0xC0, id="int"),
     ],
 )
 def test_bal_rlp_override_refuses_non_bytes(rlp: Any) -> None:
@@ -127,9 +127,13 @@ def test_bal_rlp_override_refuses_non_bytes(rlp: Any) -> None:
         BlockAccessList([]).with_rlp_override(rlp)
 
 
-def test_bal_rlp_override_accepts_plain_bytes() -> None:
-    """Plain bytes are coerced so ``rlp_hash`` keeps working."""
-    overridden = BlockAccessList([]).with_rlp_override(b"\xc0")
+@pytest.mark.parametrize(
+    "rlp",
+    [pytest.param(b"\xc0", id="bytes"), pytest.param("0xc0", id="hex_str")],
+)
+def test_bal_rlp_override_coerces_to_bytes(rlp: Any) -> None:
+    """Plain bytes and hex strings are coerced so ``rlp_hash`` works."""
+    overridden = BlockAccessList([]).with_rlp_override(rlp)
 
     assert overridden.rlp == Bytes(b"\xc0")
     assert overridden.rlp_hash == Bytes(b"\xc0").keccak256()

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
@@ -5,6 +5,10 @@ These tests verify that BAL models serialize to JSON with the correct
 format, particularly zero-padded hex strings.
 """
 
+from typing import Any
+
+import pytest
+
 from execution_testing.base_types import Address, Bytes
 from execution_testing.test_types.block_access_list import (
     BalAccountChange,
@@ -107,3 +111,25 @@ def test_bal_rlp_override_replaces_serialization_only() -> None:
     assert overridden.rlp_hash == Bytes(b"\xc0").keccak256()
     assert overridden.to_list() == original.to_list()
     assert original.rlp == canonical
+
+
+@pytest.mark.parametrize(
+    "rlp",
+    [
+        pytest.param("0xc0", id="str"),
+        pytest.param(None, id="none"),
+        pytest.param(BlockAccessList([]), id="list"),
+    ],
+)
+def test_bal_rlp_override_refuses_non_bytes(rlp: Any) -> None:
+    """The override bypasses validation, so its type is checked here."""
+    with pytest.raises(TypeError, match="expects the serialization as bytes"):
+        BlockAccessList([]).with_rlp_override(rlp)
+
+
+def test_bal_rlp_override_accepts_plain_bytes() -> None:
+    """Plain bytes are coerced so ``rlp_hash`` keeps working."""
+    overridden = BlockAccessList([]).with_rlp_override(b"\xc0")
+
+    assert overridden.rlp == Bytes(b"\xc0")
+    assert overridden.rlp_hash == Bytes(b"\xc0").keccak256()

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_serialization.py
@@ -101,6 +101,8 @@ def test_bal_rlp_override_replaces_serialization_only() -> None:
     canonical = original.rlp
     overridden = original.with_rlp_override(Bytes(b"\xc0"))
 
+    assert overridden.has_rlp_override
+    assert not original.has_rlp_override
     assert overridden.rlp == b"\xc0"
     assert overridden.rlp_hash == Bytes(b"\xc0").keccak256()
     assert overridden.to_list() == original.to_list()


### PR DESCRIPTION
### Description

On a review of #3486, I asked one of the Claude agents to sweep the related framework for gotchas that could lead to silent `fill` for the wrong reasons. It came back with some hits but fell our of scope for that PR, so I'm adding these here with unit tests. This is also important for DevEx but it's mostly important as a security so we don't end up with footguns that can  `fill` tests but end up with unintended JSON fixtures because of silent overrides of certain things the test itself didn't mean to create.

This shouldn't change anything related to the current state of the tests but I did run `hasher compare` on a fill of eip7928 module at the current `forks/amsterdam` and on this branch, just as a sanity check, and it's exact.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

<img width="874" height="591" alt="Screenshot 2026-09-02 at 13 39 58" src="https://github.com/user-attachments/assets/54821140-7346-4f54-be62-f860391bd9de" />
