### PR TITLE
refactor(tests): enhance EIP-8037 test coverage part 4

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/eip_checklist_external_coverage.txt
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/eip_checklist_external_coverage.txt
@@ -1,3 +1,3 @@
 general/code_coverage/eels = TODO: re-run coverage after spec stabilizes. Preliminary: vm/__init__.py 95%, utils/message.py 94%, vm/gas.py 89%, transactions.py 87%, vm/interpreter.py 85%, state.py 84%, vm/instructions/storage.py 77%, vm/instructions/system.py 67%, fork.py 56%
-general/code_coverage/test_coverage = 236 tests pass with --cov; key state gas paths (reservoir, gas splitting, SSTORE/CREATE/CALL/SELFDESTRUCT/SET_CODE state gas charging) are covered
+general/code_coverage/test_coverage = 1742 tests pass with --cov; key state gas paths (reservoir, gas splitting, SSTORE/CREATE/CALL/SELFDESTRUCT/SET_CODE state gas charging) are covered
 general/code_coverage/missed_lines = Missed lines are mostly non-EIP-8037 code: fork.py header validation and PoW functions, system.py EXTCALL/EXTDELEGATECALL paths, storage.py TSTORE/TLOAD, eoa_delegation.py edge-case auth branches

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/eip_checklist_not_applicable.txt
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/eip_checklist_not_applicable.txt
@@ -1,11 +1,13 @@
 opcode = EIP does not introduce a new opcode
 precompile = EIP does not introduce a new precompile
 removed_precompile = EIP does not remove a precompile
-system_contract = EIP does not introduce a new system contract
+system_contract = EIP does not introduce a new system contract; it only changes gas available to calls of existing system contracts
 transaction_type = EIP does not introduce a new transaction type
 block_header_field = EIP does not add any new block header fields
 block_body_field = EIP does not add any new block body fields
+gas_refunds_changes/test/exceptional_abort/non_revertable = EIP-8037 has no non-revertable gas-refund operation; EIP-7702 authorization state charges persist and are not refunds
 blob_count_changes = EIP does not introduce any blob count changes
 execution_layer_request = EIP does not introduce an execution layer request
-new_transaction_validity_constraint = EIP does not introduce a new transaction validity constraint
-block_level_constraint = EIP does not introduce a block-level validation constraint
+new_transaction_validity_constraint = EIP replaces an existing transaction constraint instead of introducing an independent new constraint
+block_level_constraint/test/content/receipts = Receipt encoding size is not an input to the two-dimensional block gas constraint
+block_level_constraint/test/content/withdrawals = Withdrawals do not consume execution or state gas and are not an input to the two-dimensional block gas constraint

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -31,6 +31,7 @@ from execution_testing import (
     add_kzg_version,
     compute_create_address,
 )
+from execution_testing.checklists import EIPChecklist
 
 from ...cancun.eip4844_blobs.spec import Spec as EIP4844_Spec
 from .spec import ref_spec_8037
@@ -147,11 +148,23 @@ def test_block_gas_used_state_dominates(
     )
 
 
+@pytest.mark.parametrize(
+    "include_log",
+    [
+        pytest.param(False, id="without_log"),
+        pytest.param(
+            True,
+            id="with_log",
+            marks=EIPChecklist.BlockLevelConstraint.Test.Content.Logs(),
+        ),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_block_gas_used_execution_dominates(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
+    include_log: bool,
 ) -> None:
     """
     Verify block.gas_used = block_execution_gas when execution dominates.
@@ -169,7 +182,12 @@ def test_block_gas_used_execution_dominates(
         # gas accounting
         original_value=0,
         new_value=1,
-    ) + Op.MSTORE8(
+    )
+
+    if include_log:
+        code += Op.LOG0(offset=0, size=0)
+
+    code += Op.MSTORE8(
         sink_memory_size - 1,
         0,
         # gas accounting
@@ -535,18 +553,35 @@ def test_multi_block_dimension_flip(
 @pytest.mark.parametrize(
     "tx_gas_delta, expected_exception",
     [
-        pytest.param(0, None, id="gas_equal"),
+        pytest.param(
+            -1,
+            None,
+            id="gas_one_below",
+            marks=EIPChecklist.BlockLevelConstraint.Test.Boundary.Under(),
+        ),
+        pytest.param(
+            0,
+            None,
+            id="gas_equal",
+            marks=EIPChecklist.BlockLevelConstraint.Test.Boundary.Exact(),
+        ),
         pytest.param(
             1,
             TransactionException.GAS_ALLOWANCE_EXCEEDED,
             id="gas_one_above",
-            marks=pytest.mark.exception_test,
+            marks=[
+                pytest.mark.exception_test,
+                EIPChecklist.BlockLevelConstraint.Test.Boundary.Over(),
+            ],
         ),
         pytest.param(
             2,
             TransactionException.GAS_ALLOWANCE_EXCEEDED,
             id="gas_two_above",
-            marks=pytest.mark.exception_test,
+            marks=[
+                pytest.mark.exception_test,
+                EIPChecklist.BlockLevelConstraint.Test.Boundary.Over(),
+            ],
         ),
     ],
 )
@@ -570,6 +605,7 @@ def test_multi_block_dimension_flip(
         pytest.param(4, False, id="type_4_set_code"),
     ],
 )
+@EIPChecklist.BlockLevelConstraint.Test.Content.TransactionTypes()
 @pytest.mark.valid_from("EIP8037")
 def test_tx_gas_limit_block_boundary(
     blockchain_test: BlockchainTestFiller,
@@ -961,6 +997,105 @@ def test_base_fee_per_gas_follows_dominant_dimension(
         blocks=[
             Block(
                 txs=txs,
+                gas_limit=gas_limit,
+                header_verify=Header(
+                    gas_used=block_1_gas_used,
+                    base_fee_per_gas=block_1_base_fee,
+                ),
+            ),
+            Block(
+                txs=[],
+                gas_limit=gas_limit,
+                header_verify=Header(
+                    gas_used=0,
+                    base_fee_per_gas=block_2_base_fee,
+                ),
+            ),
+        ],
+        post=post,
+    )
+
+
+@pytest.mark.parametrize(
+    "dominant_dimension",
+    [
+        pytest.param("state", id="state_below_target"),
+        pytest.param("execution", id="execution_below_target"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_base_fee_decreases_from_dominant_dimension(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    dominant_dimension: str,
+) -> None:
+    """
+    Verify that a block below gas target lowers the child's base fee.
+
+    The decrease is driven by max(execution_gas, state_gas),
+    so reading either dimension correctly matters.
+    """
+    genesis_base_fee = 10**9
+    gas_limit = 600_000
+    target = gas_limit // fork.base_fee_elasticity_multiplier()
+
+    if dominant_dimension == "state":
+        tx_execution, tx_state = sstore_tx_gas(fork, num_sstores=1)
+        assert tx_state > tx_execution, "state must be the bottleneck"
+
+        storage = Storage()
+        contract = pre.deploy_contract(
+            code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP
+        )
+
+        tx = Transaction(
+            to=contract,
+            gas_limit=tx_execution + tx_state,
+            sender=pre.fund_eoa(),
+            max_fee_per_gas=10**10,
+        )
+
+        block_1_gas_used = tx_state
+        post: dict = {contract: Account(storage=storage)}
+    else:
+        contract = pre.deploy_contract(code=Op.STOP)
+        intrinsic = fork.transaction_intrinsic_cost_calculator()()
+        tx = Transaction(
+            to=contract,
+            gas_limit=intrinsic,
+            sender=pre.fund_eoa(),
+            max_fee_per_gas=10**10,
+        )
+        block_1_gas_used = intrinsic
+        post = {}
+
+    assert block_1_gas_used < target, "block 1 must sit below the target"
+
+    base_fee_calc = fork.base_fee_per_gas_calculator()
+    block_1_base_fee = base_fee_calc(
+        parent_base_fee_per_gas=genesis_base_fee,
+        parent_gas_used=0,
+        parent_gas_limit=gas_limit,
+    )
+    block_2_base_fee = base_fee_calc(
+        parent_base_fee_per_gas=block_1_base_fee,
+        parent_gas_used=block_1_gas_used,
+        parent_gas_limit=gas_limit,
+    )
+    assert block_2_base_fee < block_1_base_fee, (
+        "an under-target block must lower the child's base fee"
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(
+            gas_limit=gas_limit,
+            base_fee_per_gas=genesis_base_fee,
+        ),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
                 gas_limit=gas_limit,
                 header_verify=Header(
                     gas_used=block_1_gas_used,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -44,6 +44,7 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 
+@pytest.mark.parametrize("funding", ["reservoir", "spill"])
 @pytest.mark.parametrize(
     "sufficient_gas",
     ["sufficient_gas", "insufficient_execute", "insufficient_state"],
@@ -54,13 +55,14 @@ def test_child_call_uses_reservoir(
     pre: Alloc,
     fork: Fork,
     sufficient_gas: str,
+    funding: str,
 ) -> None:
     """
     Test child call can use parent's state gas reservoir.
 
-    The parent calls a child contract that performs an SSTORE
-    (zero-to-nonzero). The state gas for the SSTORE is drawn from
-    the reservoir passed from the parent.
+    Parent calls child SSTORE. Test two modes:
+    reservoir (uses parent's state gas) vs spill (uses forwarded gas).
+    Both test behavior when gas runs out.
     """
     child_storage = Storage()
     code = Op.SSTORE(
@@ -79,6 +81,14 @@ def test_child_call_uses_reservoir(
         execution_gas -= 1
     elif sufficient_gas == "insufficient_state":
         state_gas -= 1
+
+    if funding == "spill":
+        child_gas = execution_gas + state_gas
+        reservoir = 0
+    else:
+        child_gas = execution_gas
+        reservoir = state_gas
+
     child = pre.deploy_contract(
         code=code,
     )
@@ -90,14 +100,14 @@ def test_child_call_uses_reservoir(
                 parent_storage.store_next(
                     1 if sufficient_gas == "sufficient_gas" else 0
                 ),
-                Op.CALL(gas=execution_gas, address=child),
+                Op.CALL(gas=child_gas, address=child),
             )
         )
     )
 
     tx = Transaction(
         to=parent,
-        state_gas_reservoir=state_gas,
+        state_gas_reservoir=reservoir,
         sender=pre.fund_eoa(),
     )
 
@@ -108,11 +118,13 @@ def test_child_call_uses_reservoir(
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize("funding", ["spill", "mixed"])
 @pytest.mark.valid_from("EIP8037")
 def test_delegatecall_child_spill_not_double_charged(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    funding: str,
 ) -> None:
     """
     Test DELEGATECALL child state gas paid from `gas_left` is not recharged.
@@ -123,6 +135,9 @@ def test_delegatecall_child_spill_not_double_charged(
     `gas_left`. The parent frame must not charge the same state growth again
     at frame end: the header bills the storage sets once, in the state
     dimension, so a second charge surfaces as inflated `gas_used`.
+
+    `mixed` funds one set from the reservoir and spills the rest, so the
+    header must stay put however the charge is split.
     """
     num_sstores = 6
     child_code = (
@@ -164,9 +179,14 @@ def test_delegatecall_child_spill_not_double_charged(
         "expected state gas to dominate execution gas"
     )
 
+    if funding == "mixed":
+        reservoir = Op.SSTORE(new_value=1).state_cost(fork)
+    else:
+        reservoir = 0
+
     tx = Transaction(
         to=caller,
-        state_gas_reservoir=0,
+        state_gas_reservoir=reservoir,
         sender=pre.fund_eoa(),
     )
 
@@ -356,11 +376,16 @@ def test_reservoir_restored_after_child_spill_and_revert(
     )
 
 
+@pytest.mark.parametrize(
+    "call_opcode",
+    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_reservoir_restored_after_child_spill_and_halt(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    call_opcode: Op,
 ) -> None:
     """
     Test parent gets reservoir back after child spill + halt.
@@ -377,7 +402,7 @@ def test_reservoir_restored_after_child_spill_and_halt(
     """
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
-    child_code = Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.INVALID
+    child_code = Op.SSTORE(0xDEAD, 1) + Op.SSTORE(0xBEAF, 1) + Op.INVALID
     child = pre.deploy_contract(code=child_code)
     # Exactly enough for both SSTOREs: the reservoir funds the first and
     # the second spills, leaving nothing for the INVALID to burn.
@@ -392,7 +417,7 @@ def test_reservoir_restored_after_child_spill_and_halt(
     funded_slot = parent_storage.store_next(1)
     starved_slot = parent_storage.store_next(0)
     parent_code = (
-        Op.POP(Op.CALL(gas=child_gas, address=child))
+        Op.POP(call_opcode(gas=child_gas, address=child))
         + Op.SSTORE(
             funded_slot,
             Op.CALL(gas=probe_gas, address=funded_probe),
@@ -443,8 +468,8 @@ def test_reservoir_restored_after_child_spill_and_halt(
 
     post = {
         parent: Account(storage=parent_storage),
-        funded_probe: Account(storage={0: 1}),
-        starved_probe: Account(storage={0: 0}),
+        funded_probe: Account(storage={funded_slot: 1}),
+        starved_probe: Account(storage={starved_slot: 0}),
     }
     state_test(
         pre=pre,
@@ -693,6 +718,7 @@ def test_nested_calls_reservoir_passing(
     )
 
 
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("EIP8037")
 def test_call_value_transfer_new_account(
     state_test: StateTestFiller,
@@ -749,6 +775,9 @@ def test_call_value_transfer_new_account(
         to=parent,
         state_gas_reservoir=state_gas,
         sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=execution_gas + state_gas
+        ),
     )
 
     post = {
@@ -933,11 +962,13 @@ def test_delegatecall_reservoir_passing(
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize("child_action", ["write_rejected", "read_only"])
 @pytest.mark.valid_from("EIP8037")
 def test_staticcall_passes_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    child_action: str,
 ) -> None:
     """
     Test STATICCALL passes reservoir but cannot use it for state ops.
@@ -947,10 +978,18 @@ def test_staticcall_passes_reservoir(
     The parent then calls a probe handed only its SSTORE's execution
     cost, so the probe has no `gas_left` to spill from and succeeds
     only if the rejected write left the reservoir untouched.
+
+    `read_only` returns normally instead of halting, pinning that a
+    successful STATICCALL leaves the reservoir alone just the same.
     """
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
-    child_code = Op.SSTORE(0, 1)
+    if child_action == "read_only":
+        child_code: Bytecode = Op.POP(Op.SLOAD(0, key_warm=False))
+        static_result = 1
+    else:
+        child_code = Op.SSTORE(0, 1)
+        static_result = 0
     child = pre.deploy_contract(code=child_code)
     child_gas = child_code.execution_cost(fork)
 
@@ -959,7 +998,9 @@ def test_staticcall_passes_reservoir(
     probe_gas = probe_code.execution_cost(fork)
 
     parent_storage = Storage()
-    static_slot = parent_storage.store_next(1, "staticcall_fails")
+    static_slot = parent_storage.store_next(
+        static_result + 1, "staticcall_result"
+    )
     probe_slot = parent_storage.store_next(2, "probe_succeeds")
     parent_code = Op.SSTORE(
         static_slot,
@@ -967,7 +1008,7 @@ def test_staticcall_passes_reservoir(
         # gas accounting
         original_value=1,
         current_value=1,
-        new_value=1,
+        new_value=static_result + 1,
         key_warm=False,
     ) + Op.SSTORE(
         probe_slot,
@@ -1301,73 +1342,6 @@ def test_call_pre_charged_costs_excluded_from_forwarding(
     state_test(pre=pre, tx=tx, post=post)
 
 
-@pytest.mark.valid_from("EIP8037")
-def test_call_new_account_header_gas_used(
-    blockchain_test: BlockchainTestFiller,
-    pre: Alloc,
-    fork: Fork,
-) -> None:
-    """
-    Verify block gas accounting for CALL creating a new account.
-
-    A contract CALLs a non-existent address with value, charging
-    GAS_NEW_ACCOUNT state gas. The block must be accepted with
-    correct 2D max(execution, state) accounting in the header.
-    """
-    target = pre.fund_eoa(amount=0)
-
-    storage = Storage()
-    # Capture the CALL result in a pre-existing slot (2 -> 1) so the
-    # instrumentation SSTORE modifies rather than creates a key and
-    # adds no state gas; the reservoir then covers exactly the CALL's
-    # new-account charge.
-    slot = storage.store_next(1, "call_succeeds")
-    contract_code = Op.SSTORE(
-        slot,
-        Op.CALL(
-            gas=0,
-            address=target,
-            value=1,
-            value_transfer=True,
-            account_new=True,
-        ),
-        original_value=2,
-        current_value=2,
-        new_value=1,
-        key_warm=False,
-    )
-    contract = pre.deploy_contract(
-        code=contract_code, balance=1, storage={slot: 2}
-    )
-
-    state_gas = contract_code.state_cost(fork)
-    # The codeless target returns the forwarded value-call stipend
-    # unused, so it is charged but never consumed.
-    execution_gas = (
-        fork.transaction_intrinsic_cost_calculator()()
-        + contract_code.execution_cost(fork)
-        - fork.call_value_stipend()
-    )
-    expected_gas_used = max(execution_gas, state_gas)
-    assert expected_gas_used == state_gas, (
-        "expected state gas to dominate execution gas"
-    )
-
-    tx = Transaction(
-        to=contract,
-        state_gas_reservoir=state_gas,
-        sender=pre.fund_eoa(),
-    )
-
-    blockchain_test(
-        pre=pre,
-        blocks=[
-            Block(txs=[tx], header_verify=Header(gas_used=expected_gas_used))
-        ],
-        post={contract: Account(storage=storage)},
-    )
-
-
 @pytest.mark.parametrize(
     "create_opcode",
     [
@@ -1375,7 +1349,6 @@ def test_call_new_account_header_gas_used(
         pytest.param(Op.CREATE2, id="create2"),
     ],
 )
-@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("EIP8037")
 def test_call_value_to_self_destructed_same_tx_account(
     state_test: StateTestFiller,
@@ -1935,6 +1908,7 @@ def test_call_new_account_no_execution_account_creation_cost(
     "gas_delta",
     [pytest.param(0, id="exact_fit"), pytest.param(-1, id="one_short")],
 )
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.valid_from("EIP8037")
 def test_call_new_account_state_gas_boundary(
     state_test: StateTestFiller,
@@ -1943,10 +1917,12 @@ def test_call_new_account_state_gas_boundary(
     gas_delta: int,
 ) -> None:
     """
-    Pin the CALL new-account state charge at its exact-fit spill
-    boundary. At `exact_fit` the charge just fits and the target is
-    materialized; one gas short the caller frame goes out of gas, so
-    nothing is created and the value transfer is rolled back.
+    Pin the CALL new-account state charge at its exact-fit boundary.
+
+    With `gas_limit` set explicitly the transaction has no reservoir, so
+    the charge spills from `gas_left`. At `exact_fit` the target is
+    materialized; one gas short the caller frame goes out of gas and the
+    value transfer is rolled back.
     """
     target = pre.nonexistent_account()
     caller_code = (
@@ -1961,10 +1937,13 @@ def test_call_new_account_state_gas_boundary(
     )
     caller = pre.deploy_contract(code=caller_code, balance=1)
 
-    exact_fit = (
+    state_gas = caller_code.state_cost(fork)
+    execution_gas = (
         fork.transaction_intrinsic_cost_calculator()()
-        + caller_code.gas_cost(fork)
+        + caller_code.execution_cost(fork)
     )
+    exact_fit = execution_gas + state_gas
+
     post: dict
     if gas_delta == 0:
         gas_used = exact_fit - fork.call_value_stipend()
@@ -1994,6 +1973,11 @@ def test_call_new_account_state_gas_boundary(
             Op.CALL,
             "call_value_new_account",
             id="call_call_value_new_account_charge",
+        ),
+        pytest.param(
+            Op.DELEGATECALL,
+            "call_value_new_account",
+            id="delegatecall_call_value_new_account_charge",
         ),
     ],
 )
@@ -2033,7 +2017,10 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
         child_balance = 1
     child_state_charge = child_code.state_cost(fork)
 
-    child = pre.deploy_contract(code=child_code, balance=child_balance)
+    delegated = call_opcode == Op.DELEGATECALL
+    child = pre.deploy_contract(
+        code=child_code, balance=0 if delegated else child_balance
+    )
     probe = pre.deploy_contract(probe_code)
     probe_stipend = probe_code.execution_cost(fork)
 
@@ -2042,6 +2029,7 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
             Op.POP(call_opcode(gas=Op.GAS, address=child))
             + Op.POP(call_opcode(gas=probe_stipend, address=probe))
         ),
+        balance=child_balance if delegated else 0,
     )
 
     # Reservoir must cover the child's state charge (refunded on
@@ -2057,7 +2045,7 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     # DELEGATECALL executes the callee in the caller's storage
     # context, so the probe's SSTORE lands on `parent` instead of
     # `probe`.
-    if call_opcode == Op.DELEGATECALL:
+    if delegated:
         post: dict = {parent: Account(storage=probe_storage)}
     else:
         post = {probe: Account(storage=probe_storage)}
@@ -2070,11 +2058,21 @@ def test_child_failure_refunds_state_gas_to_reservoir_not_gas_left(
     )
 
 
+@pytest.mark.parametrize("depth", ["top", "child"])
+@pytest.mark.parametrize(
+    "funding",
+    [
+        pytest.param("reservoir", id="reservoir"),
+        pytest.param("mixed", id="mixed"),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_call_insufficient_balance_refunds_new_account_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    funding: str,
+    depth: str,
 ) -> None:
     """
     Refill NEW_ACCOUNT state gas on a value CALL that fails the balance
@@ -2106,17 +2104,32 @@ def test_call_insufficient_balance_refunds_new_account_state_gas(
     )
 
     new_account_state_gas = value_call.state_cost(fork)
-    assert new_account_state_gas >= sstore_state_gas
-    reservoir = new_account_state_gas
+    assert new_account_state_gas > sstore_state_gas
+    if funding == "mixed":
+        reservoir = sstore_state_gas
+    else:
+        reservoir = new_account_state_gas
+
+    if depth == "child":
+        target = pre.deploy_contract(
+            code=Op.POP(Op.CALL(gas=Op.GAS, address=parent))
+        )
+    else:
+        target = parent
 
     tx = Transaction(
-        to=parent,
+        to=target,
         state_gas_reservoir=reservoir,
         sender=pre.fund_eoa(),
     )
 
     post = {probe: Account(storage=probe_storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    state_test(
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=sstore_state_gas),
+    )
 
 
 @pytest.mark.valid_from("EIP8037")
@@ -2242,7 +2255,7 @@ def test_call_value_new_account_state_gas_consumed_on_caller_halt(
     state_test(pre=pre, post=post, tx=tx)
 
 
-@pytest.mark.parametrize("reservoir", ["in_cap", "over_cap"])
+@pytest.mark.parametrize("reservoir", ["in_cap", "over_cap", "full"])
 @pytest.mark.valid_from("EIP8037")
 def test_call_value_new_account_state_gas_returned_on_caller_revert(
     state_test: StateTestFiller,
@@ -2286,11 +2299,12 @@ def test_call_value_new_account_state_gas_returned_on_caller_revert(
 
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
-    gas_limit = (
-        gas_limit_cap + caller_code.state_cost(fork) // 2
-        if reservoir == "over_cap"
-        else 1_000_000
-    )
+    if reservoir == "full":
+        gas_limit = gas_limit_cap + caller_code.state_cost(fork)
+    elif reservoir == "over_cap":
+        gas_limit = gas_limit_cap + caller_code.state_cost(fork) // 2
+    else:
+        gas_limit = 1_000_000
 
     tx = Transaction(
         to=caller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -366,6 +366,118 @@ def test_calldata_floor_charged_to_sender(
     )
 
 
+@pytest.mark.parametrize(
+    "funding",
+    ["reservoir", "mixed", "spill"],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_calldata_floor_binds_regardless_of_funding(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    funding: str,
+) -> None:
+    """
+    Bind the calldata floor however the state charge is funded.
+
+    The floor is a lower bound on the sender's bill in the execution
+    dimension alone, so splitting the SSTORE-set charge between the
+    reservoir and `gas_left` must not move it. All three fundings bill
+    the sender exactly the floor.
+    """
+    storage = Storage()
+    code = Op.SSTORE(storage.store_next(1), 1, new_value=1)
+    state_cost = code.state_cost(fork)
+
+    calldata = b"\x00" * 5000
+    floor = fork.transaction_data_floor_cost_calculator()(data=calldata)
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata,
+        return_cost_deducted_prior_execution=True,
+    )
+    tx_execution = intrinsic + code.execution_cost(fork)
+    assert floor > tx_execution + state_cost, (
+        "calldata floor must exceed the sender's pre-floor bill"
+    )
+
+    contract = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=contract,
+        data=calldata,
+        state_gas_reservoir={
+            "reservoir": state_cost,
+            "mixed": state_cost // 2,
+            "spill": 0,
+        }[funding],
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=floor),
+    )
+    state_test(
+        pre=pre,
+        post={contract: Account(storage=storage)},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=floor),
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_calldata_floor_survives_state_refund(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify a refund cannot push the sender's bill under the floor.
+
+    The transaction runs a 0 to x to 0 cycle, which both refunds its
+    state charge and earns a write-cost refund, while carrying enough
+    calldata for the floor to bind. The floor is applied after refunds,
+    so the sender still pays it in full.
+    """
+    code = Op.SSTORE(0, 1) + Op.SSTORE(
+        0,
+        0,
+        # gas accounting
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )
+    assert code.refund(fork) > 0, "the cycle must earn a refund"
+
+    calldata = b"\x00" * 5000
+    floor = fork.transaction_data_floor_cost_calculator()(data=calldata)
+    intrinsic = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata,
+        return_cost_deducted_prior_execution=True,
+    )
+    pre_refund_gas = intrinsic + code.execution_cost(fork)
+    execution_refund = code.refund(fork) - code.state_refund(fork)
+    post_refund_gas = pre_refund_gas - min(
+        pre_refund_gas // fork.max_refund_quotient(), execution_refund
+    )
+    assert floor > post_refund_gas, (
+        "the floor must bind after the refund is applied"
+    )
+
+    contract = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=contract,
+        data=calldata,
+        state_gas_reservoir=Op.SSTORE(new_value=1).state_cost(fork),
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=floor),
+    )
+    state_test(
+        pre=pre,
+        post={contract: Account(storage={0: 0})},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=floor),
+    )
+
+
 @pytest.mark.valid_from("EIP8037")
 def test_calldata_floor_binds_with_reservoir(
     state_test: StateTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -319,6 +319,7 @@ def test_code_deposit_state_gas_scales_with_size(
         pytest.param("spill", -1, id="spill_oog"),
     ],
 )
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.valid_from("EIP8037")
 def test_code_deposit_state_gas_exact_fit_boundary(
@@ -1528,6 +1529,7 @@ def test_create_no_double_charge_new_account(
     [
         pytest.param(Op.CALL, id="call_new_account"),
         pytest.param(Op.CREATE, id="inner_create"),
+        pytest.param(Op.SSTORE, id="initcode_sstore"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1571,8 +1573,11 @@ def test_code_deposit_halt_discards_initcode_state_gas(
                 account_new=True,
             )
         )
-    else:
+    elif state_opcode == Op.CREATE:
         state_op = Op.POP(Op.CREATE(value=0, offset=0, size=1))
+    else:
+        state_op = Op.SSTORE(0, 1)
+        subcall_forwarded_value = 0
 
     assert state_op.state_cost(fork) > 0, (
         "initcode must perform a non-zero state-gas operation"
@@ -1626,6 +1631,7 @@ def test_code_deposit_halt_discards_initcode_state_gas(
     ],
 )
 @pytest.mark.pre_alloc_mutable()
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("EIP8037")
 def test_create_tx_header_gas_used(
     blockchain_test: BlockchainTestFiller,
@@ -1914,11 +1920,13 @@ def test_failed_create_header_gas_used(
         pytest.param("insufficient_balance", id="insufficient_balance"),
     ],
 )
+@pytest.mark.with_all_create_opcodes()
 @pytest.mark.valid_from("EIP8037")
 def test_create_silent_failure_refunds_state_gas(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
+    create_opcode: Op,
     failure_mode: str,
 ) -> None:
     """
@@ -1934,10 +1942,18 @@ def test_create_silent_failure_refunds_state_gas(
     mstore_value, size = init_code_at_high_bytes(Op.STOP)
     value = 1 if failure_mode == "insufficient_balance" else 0
 
+    create_call = (
+        Op.CREATE(value=value, offset=0, size=size, init_code_size=size)
+        if create_opcode == Op.CREATE
+        else Op.CREATE2(
+            value=value, offset=0, size=size, salt=0, init_code_size=size
+        )
+    )
+
     storage = Storage()
     factory_code = (
         Op.MSTORE(0, mstore_value)
-        + Op.POP(Op.CREATE(value=value, offset=0, size=size))
+        + Op.POP(create_call)
         + Op.SSTORE(storage.store_next(1, "reservoir_ok"), 1)
     )
     if failure_mode == "nonce_overflow":
@@ -3313,6 +3329,13 @@ def test_inner_create_fail_refunds_in_creation_tx(
 
 
 @pytest.mark.pre_alloc_mutable
+@pytest.mark.parametrize(
+    "parent_ending",
+    [
+        pytest.param("stop", id="parent_succeeds"),
+        pytest.param("revert", id="parent_reverts"),
+    ],
+)
 @pytest.mark.with_all_create_opcodes()
 @pytest.mark.valid_from("EIP8037")
 def test_create_collision_burned_gas_counted_in_block_execution(
@@ -3320,17 +3343,25 @@ def test_create_collision_burned_gas_counted_in_block_execution(
     pre: Alloc,
     fork: Fork,
     create_opcode: Op,
+    parent_ending: str,
 ) -> None:
     """
     Verify gas burned by a CREATE/CREATE2 address collision counts
     toward block execution gas used in the header.
+
+    A REVERT after the collision returns the parent's own leftover gas
+    but cannot un-burn the forwarded grant, so the block still bills it
+    in the execution dimension. The collision target already exists, so
+    no state charge is taken in either ending.
     """
     init_code = Op.STOP
     mstore_value, size = init_code_at_high_bytes(init_code)
     factory_create_code = Op.MSTORE(
         0, mstore_value, new_memory_size=32
     ) + create_opcode(value=0, offset=0, size=size, account_new=False)
-    factory_post_create_code = Op.POP + Op.STOP
+    factory_post_create_code = Op.POP + (
+        Op.STOP if parent_ending == "stop" else Op.REVERT(0, 0)
+    )
     factory_code = factory_create_code + factory_post_create_code
     factory = pre.deploy_contract(code=factory_code)
 
@@ -3392,6 +3423,7 @@ def test_create_collision_burned_gas_counted_in_block_execution(
     ],
 )
 @pytest.mark.with_all_create_opcodes()
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("EIP8037")
 def test_create_account_creation_charge(
     state_test: StateTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -169,6 +169,7 @@ def clearing_probe_code(
         + Op.SSTORE(SLOT_MARKER, 1)
     )
 
+
 @pytest.mark.parametrize("call_opcode", [Op.CALLCODE, Op.DELEGATECALL])
 @pytest.mark.valid_from("EIP8037")
 def test_cross_frame_refund_parks_in_reservoir(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -30,6 +30,7 @@ from execution_testing import (
     Op,
     Opcode,
     StateTestFiller,
+    Storage,
     Transaction,
     TransactionReceipt,
 )
@@ -168,23 +169,25 @@ def clearing_probe_code(
         + Op.SSTORE(SLOT_MARKER, 1)
     )
 
-
+@pytest.mark.parametrize("call_opcode", [Op.CALLCODE, Op.DELEGATECALL])
 @pytest.mark.valid_from("EIP8037")
 def test_cross_frame_refund_parks_in_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    call_opcode: Opcode,
 ) -> None:
     """
     Test a cross-frame refund credits the reservoir, not `gas_left`.
 
     The frame sets a slot with the reservoir empty, spilling the state
-    charge from `gas_left`. A delegated child clears the slot and the
-    credit lands in the reservoir, where it stays through the merge:
+    charge from `gas_left`. A child sharing the caller's storage clears
+    the slot and the credit lands in the reservoir, where it stays
+    through the merge:
     `gas_left` is lower after the clearing call than before it, and
     the clearing window costs the same as a no-op window.
     """
     clearer = pre.deploy_contract(code=Op.SSTORE(SLOT_X, 0))
-    window = Op.POP(Op.DELEGATECALL(address=clearer))
+    window = Op.POP(call_opcode(address=clearer))
     contract = pre.deploy_contract(
         code=clearing_probe_code(Op.SSTORE(SLOT_X, 1), [window] * 3)
     )
@@ -471,6 +474,127 @@ def test_parked_credit_cannot_fund_execution(
     )
 
     post = {contract: Account(storage={SLOT_MARKER: 0, SLOT_X: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "raises_credit",
+    [
+        pytest.param(True, id="credit_funds_probe"),
+        pytest.param(False, id="no_credit_probe_oogs"),
+    ],
+)
+@pytest.mark.parametrize("depth", ["sibling", "grandchild"])
+@pytest.mark.valid_from("EIP8037")
+def test_call_frame_credit_parks_in_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    depth: str,
+    raises_credit: bool,
+) -> None:
+    """
+    Test a credit raised under plain CALL parks in the reservoir.
+
+    The transaction starts with no reservoir. The clearing frame cannot
+    repay the frame that spilled the charge, which has already merged,
+    so the credit lands in the reservoir instead -- the only pool the
+    probe's fixed stipend can reach. Dropping the clear starves the
+    probe, pinning the parked credit as the only funding source.
+    """
+    # A CALL callee owns its storage, so splitting the charge from the
+    # credit needs one contract entered twice rather than two contracts.
+    toggler = pre.deploy_contract(
+        code=Op.SSTORE(SLOT_X, Op.ISZERO(Op.SLOAD(SLOT_X)))
+    )
+    clearing_target = toggler
+    if depth == "grandchild":
+        clearing_target = pre.deploy_contract(
+            code=Op.POP(Op.CALL(gas=Op.GAS, address=toggler))
+        )
+
+    # Without the second entry no credit is raised, which pins the
+    # parked credit as the only thing that can fund the probe.
+    if not raises_credit:
+        clearing_target = pre.deploy_contract(code=Op.STOP)
+
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(
+        probe_storage.store_next(1 if raises_credit else 0, "probe_ran"), 1
+    )
+    probe = pre.deploy_contract(probe_code)
+    probe_stipend = probe_code.execution_cost(fork)
+
+    entry = pre.deploy_contract(
+        code=(
+            Op.POP(Op.CALL(gas=Op.GAS, address=toggler))
+            + Op.POP(Op.CALL(gas=Op.GAS, address=clearing_target))
+            + Op.POP(Op.CALL(gas=probe_stipend, address=probe))
+        )
+    )
+
+    tx = Transaction(
+        to=entry,
+        state_gas_reservoir=0,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {probe: Account(storage=probe_storage)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "clearing_frame_ending",
+    [
+        pytest.param("stop", id="child_succeeds"),
+        pytest.param("revert", id="child_reverts"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_parked_credit_discarded_when_clearing_frame_reverts(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    clearing_frame_ending: str,
+) -> None:
+    """
+    Test a parked credit survives only if its frame does.
+
+    The delegated child clears the caller's slot, parking the credit in
+    the reservoir. When that child instead REVERTs, the clear is rolled
+    back and the credit must go with it, leaving the probe unable to pay.
+    """
+    # sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    credit_survives = clearing_frame_ending == "stop"
+
+    clear = Op.SSTORE.with_metadata(
+        key_warm=True, original_value=0, current_value=1, new_value=0
+    )(SLOT_X, 0)
+    clearer_code = clear + (Op.STOP if credit_survives else Op.REVERT(0, 0))
+    clearer = pre.deploy_contract(code=clearer_code)
+
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(
+        probe_storage.store_next(1 if credit_survives else 0, "probe_ran"), 1
+    )
+    probe = pre.deploy_contract(probe_code)
+    probe_stipend = probe_code.execution_cost(fork)
+
+    entry = pre.deploy_contract(
+        code=(
+            Op.SSTORE(SLOT_X, 1)
+            + Op.POP(Op.DELEGATECALL(gas=Op.GAS, address=clearer))
+            + Op.POP(Op.CALL(gas=probe_stipend, address=probe))
+        )
+    )
+
+    tx = Transaction(
+        to=entry,
+        state_gas_reservoir=0,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {probe: Account(storage=probe_storage)}
     state_test(pre=pre, post=post, tx=tx)
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -258,3 +258,156 @@ def test_delegation_pointer_new_account_state_gas(
             gas_used=max(block_execution, block_state)
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "state_op",
+    [Op.CREATE, Op.CREATE2, Op.SELFDESTRUCT],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_account_state_gas_via_delegation_pointer(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    state_op: Op,
+) -> None:
+    """
+    Test account-creating charges are billed the same via a delegation
+    pointer as they are directly.
+
+    Delegated code runs in the authority's context, so a CREATE takes the
+    authority's nonce and a SELFDESTRUCT moves the authority's balance.
+    Each still bills its state charge from the reservoir, and the header
+    reports it in the state dimension.
+    """
+    if state_op == Op.CREATE:
+        code = Op.POP(Op.CREATE(0, 0, 0))
+    elif state_op == Op.CREATE2:
+        code = Op.POP(Op.CREATE2(0, 0, 0, 0))
+    else:
+        code = Op.SELFDESTRUCT(pre.nonexistent_account(), account_new=True)
+    contract = pre.deploy_contract(code=code)
+
+    delegator = pre.fund_eoa(delegation=contract, amount=1)
+    state_gas = code.state_cost(fork)
+    assert state_gas > 0, "the op must carry a state charge"
+
+    tx = Transaction(
+        to=delegator,
+        state_gas_reservoir=state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=state_gas),
+    )
+
+
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_delegation_pointer_state_gas_on_frame_failure(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    failure_mode: str,
+) -> None:
+    """
+    Test a delegated frame's state charge is undone when it fails.
+
+    The storage the charge pays for belongs to the authority, not the
+    delegated code's own account, so the rollback has to reach the
+    authority's slot. Either failure leaves the state dimension empty.
+    """
+    ending = Op.REVERT(0, 0) if failure_mode == "revert" else Op.INVALID
+    code = Op.SSTORE(0, 1) + ending
+    contract = pre.deploy_contract(code=code)
+
+    delegator = pre.fund_eoa(delegation=contract)
+
+    intrinsic_execution = fork.transaction_intrinsic_cost_calculator()(
+        recipient_type=RecipientType.DELEGATION_7702,
+        return_cost_deducted_prior_execution=True,
+    )
+    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+        recipient_type=RecipientType.DELEGATION_7702,
+        delegation_warm=False,
+    )
+    gas_limit = 200_000
+    # The rolled-back set leaves the state dimension empty, so the
+    # header is the execution total: a halt burns the whole budget, a
+    # revert returns everything the frame did not spend.
+    if failure_mode == "halt":
+        expected_gas_used = gas_limit
+    else:
+        expected_gas_used = (
+            intrinsic_execution
+            + top_frame_execution
+            + code.execution_cost(fork)
+        )
+
+    tx = Transaction(
+        to=delegator,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        post={delegator: Account(storage={0: 0})},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
+    )
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_delegation_pointer_to_delegated_account(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test a pointer aimed at an already-delegated account.
+
+    Delegation resolves only once,
+    so the frame executes the designator bytes (0xef0100 || writer) as code.
+    Since 0xef is undefined, execution halts before reaching writer's SSTORE.
+    The reservoir stays untouched and is refunded, so the bill equals the cap,
+    not the full gas limit.
+    """
+    writer = pre.deploy_contract(code=Op.SSTORE(0, 1))
+    inner = pre.fund_eoa(delegation=writer)
+    outer = pre.fund_eoa(delegation=inner)
+
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    tx = Transaction(
+        to=outer,
+        state_gas_reservoir=sstore_state_gas,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(cumulative_gas_used=gas_limit_cap),
+    )
+
+    state_test(
+        pre=pre,
+        post={
+            outer: Account(storage={}),
+            inner: Account(storage={}),
+            writer: Account(storage={}),
+        },
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=gas_limit_cap),
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
@@ -1,9 +1,9 @@
 """
 State gas fork transition tests for EIP-8037.
 
-Verify that state gas pricing and the modified transaction validity
-constraint (tx.gas can exceed TX_MAX_GAS_LIMIT) activate correctly at
-the EIP-8037 fork boundary.
+Verify that state gas pricing, the modified transaction validity constraint
+(tx.gas can exceed TX_MAX_GAS_LIMIT), and the two-dimensional block inclusion
+constraint activate correctly at the EIP-8037 fork boundary.
 
 Before EIP-8037: no state gas dimension, tx.gas capped at
 TX_MAX_GAS_LIMIT (EIP-7825).
@@ -17,12 +17,16 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
+    Address,
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     EIPChecklist,
     Fork,
+    Header,
     Op,
     Storage,
     Transaction,
@@ -35,6 +39,173 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 pytestmark = pytest.mark.valid_at_transition_to("EIP8037")
+
+
+@EIPChecklist.GasCostChanges.Test.ForkTransition.Before()
+@EIPChecklist.GasCostChanges.Test.ForkTransition.After()
+def test_block_gas_used_dimension_switch_at_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test the block header switches to two-dimensional accounting at the
+    fork boundary.
+
+    The same storage-creating transaction is mined either side of the
+    boundary. Before the fork the header reports the scalar execution
+    total; after it the header reports `max(execution, state)`, which the
+    state charge dominates. Only a header assertion separates the two —
+    the post-state is identical.
+    """
+    before_fork = fork.fork_at(timestamp=14_999)
+    after_fork = fork.fork_at(timestamp=15_000)
+
+    code = Op.SSTORE(0, 1, original_value=0, new_value=1)
+    state_gas = code.state_cost(after_fork)
+    assert code.state_cost(before_fork) == 0, "no state dimension yet"
+
+    before_gas_used = (
+        before_fork.transaction_intrinsic_cost_calculator()()
+        + code.gas_cost(before_fork)
+    )
+    after_execution = (
+        after_fork.transaction_intrinsic_cost_calculator()()
+        + code.execution_cost(after_fork)
+    )
+    assert state_gas > after_execution, (
+        "the state dimension must set the post-fork header"
+    )
+
+    storage_before = Storage()
+    writer_before = pre.deploy_contract(
+        code=Op.SSTORE(storage_before.store_next(1), 1)
+    )
+    storage_after = Storage()
+    writer_after = pre.deploy_contract(
+        code=Op.SSTORE(storage_after.store_next(1), 1)
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                timestamp=14_999,
+                txs=[
+                    Transaction(
+                        to=writer_before,
+                        state_gas_reservoir=0,
+                        sender=pre.fund_eoa(),
+                    )
+                ],
+                header_verify=Header(gas_used=before_gas_used),
+            ),
+            Block(
+                timestamp=15_000,
+                txs=[
+                    Transaction(
+                        to=writer_after,
+                        state_gas_reservoir=0,
+                        sender=pre.fund_eoa(),
+                    )
+                ],
+                header_verify=Header(gas_used=state_gas),
+            ),
+        ],
+        post={
+            writer_before: Account(storage=storage_before),
+            writer_after: Account(storage=storage_after),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "state_op",
+    [Op.CREATE, Op.CREATE2, Op.CALL, Op.SELFDESTRUCT],
+)
+@EIPChecklist.GasCostChanges.Test.ForkTransition.Before()
+@EIPChecklist.GasCostChanges.Test.ForkTransition.After()
+def test_account_state_gas_at_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    state_op: Op,
+) -> None:
+    """
+    Test the account-creating state charges activate at the fork
+    boundary.
+
+    EIP-8037 splits four charges out of the execution dimension; the
+    SSTORE one is covered separately. Each of the remaining three is
+    driven from a sub-call granted only what its own fork prices as
+    execution gas: it completes before the fork and, after it, only when
+    a reservoir carries the new state charge into the child frame.
+    """
+    before_fork = fork.fork_at(timestamp=14_999)
+    after_fork = fork.fork_at(timestamp=15_000)
+
+    def probe() -> tuple[Bytecode, int]:
+        """Return code exercising `state_op` and the balance it needs."""
+        match state_op:
+            case Op.CREATE:
+                return Op.POP(Op.CREATE(0, 0, 0)), 0
+            case Op.CREATE2:
+                return Op.POP(Op.CREATE2(0, 0, 0, 0)), 0
+            case Op.CALL:
+                return Op.POP(
+                    Op.CALL(
+                        gas=0,
+                        address=pre.nonexistent_account(),
+                        value=1,
+                        value_transfer=True,
+                        account_new=True,
+                    )
+                ), 1
+            case _:
+                return (
+                    Op.SELFDESTRUCT(
+                        pre.nonexistent_account(), account_new=True
+                    ),
+                    1,
+                )
+
+    scenarios = [
+        # timestamp, fork pricing the grant, reservoir funded, charge paid
+        (14_999, before_fork, False, True),
+        (15_000, after_fork, True, True),
+        (15_001, after_fork, False, False),
+    ]
+
+    blocks = []
+    post = {}
+    for timestamp, grant_fork, funded, paid in scenarios:
+        # Rebuild so each scenario gets a fresh account to create.
+        target_code, balance = probe()
+        grant = target_code.execution_cost(grant_fork)
+        reservoir = target_code.state_cost(grant_fork) if funded else 0
+        target = pre.deploy_contract(code=target_code, balance=balance)
+        caller = pre.deploy_contract(
+            code=Op.POP(Op.CALL(gas=grant, address=target))
+        )
+        blocks.append(
+            Block(
+                timestamp=timestamp,
+                txs=[
+                    Transaction(
+                        to=caller,
+                        state_gas_reservoir=reservoir,
+                        sender=pre.fund_eoa(),
+                    )
+                ],
+            )
+        )
+        match state_op:
+            case Op.CREATE | Op.CREATE2:
+                post[target] = Account(nonce=2 if paid else 1)
+            case _:
+                post[target] = Account(balance=0 if paid else 1)
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)
 
 
 @EIPChecklist.GasCostChanges.Test.ForkTransition.Before()
@@ -137,34 +308,84 @@ def test_sstore_state_gas_at_transition(
     blockchain_test(pre=pre, blocks=blocks, post=post)
 
 
-@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedBeforeFork()
-@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedBeforeFork()
-@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedAfterFork()
-@EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedAfterFork()
+def _access_list_over_execution_cap(
+    fork: Fork, cap: int
+) -> tuple[list[AccessList], int]:
+    """
+    Return an access list whose intrinsic execution cost exceeds ``cap``,
+    along with that cost.
+    """
+    intrinsic = fork.transaction_intrinsic_cost_calculator()
+    per_address_execution = intrinsic(
+        access_list=[AccessList(address=Address(0x100), storage_keys=[])],
+        return_cost_deducted_prior_execution=True,
+    ) - intrinsic(return_cost_deducted_prior_execution=True)
+    access_list = [
+        AccessList(address=Address(0x10000 + i), storage_keys=[])
+        for i in range(cap // per_address_execution)
+    ]
+    execution_intrinsic = intrinsic(
+        access_list=access_list,
+        return_cost_deducted_prior_execution=True,
+    )
+    assert execution_intrinsic > cap
+    # The floor must stay under the cap so a rejection is attributable to
+    # the execution intrinsic rather than the data floor.
+    assert (
+        fork.transaction_data_floor_cost_calculator()(
+            data=b"", access_list=access_list
+        )
+        <= cap
+    )
+    return access_list, execution_intrinsic
+
+
 @pytest.mark.parametrize(
-    "gas_above_cap",
+    "scenario",
     [
-        pytest.param(False, id="at_cap"),
         pytest.param(
-            True,
-            id="above_cap",
-            marks=pytest.mark.exception_test,
+            "at_cap",
+            id="at_cap",
+            marks=[
+                EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedBeforeFork(),
+                EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedAfterFork(),
+            ],
+        ),
+        pytest.param(
+            "gas_limit_above_cap",
+            id="gas_limit_above_cap",
+            marks=[
+                pytest.mark.exception_test,
+                EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedBeforeFork(),
+                EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedAfterFork(),
+            ],
+        ),
+        pytest.param(
+            "intrinsic_above_cap",
+            id="intrinsic_above_cap",
+            marks=[
+                pytest.mark.exception_test,
+                EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedBeforeFork(),
+                EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedAfterFork(),
+            ],
         ),
     ],
 )
 def test_tx_gas_above_cap_at_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    gas_above_cap: bool,
+    scenario: str,
     fork: Fork,
 ) -> None:
     """
-    Test tx.gas > TX_MAX_GAS_LIMIT validity at the EIP-8037 transition.
+    Test transaction and block gas constraints at the EIP-8037 transition.
 
     Before EIP-8037, EIP-7825 rejects any tx with gas > TX_MAX_GAS_LIMIT.
-    After EIP-8037 it's allowed — the excess feeds the state gas
-    reservoir. This test sends a tx at the cap (always valid) and one
-    above the cap (rejected before, accepted after).
+    After EIP-8037 that gas limit is allowed — the excess feeds the state
+    gas reservoir — but the replacement constraint still rejects a
+    transaction whose intrinsic execution gas exceeds the cap. The scenarios
+    pin acceptance at the cap, the old-rule rejection/new-rule acceptance flip
+    at ``cap + 1``, and rejection by the new transaction rule.
     """
     after_fork = fork.fork_at(timestamp=15_000)
     gas_limit_cap = after_fork.transaction_gas_limit_cap()
@@ -179,14 +400,22 @@ def test_tx_gas_above_cap_at_transition(
         code=(Op.SSTORE(storage_after.store_next(1), 1)),
     )
 
-    gas_limit = gas_limit_cap + 1 if gas_above_cap else gas_limit_cap
-
-    # Before fork: above-cap tx is rejected by EIP-7825
-    before_error = (
-        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM
-        if gas_above_cap
-        else None
-    )
+    tx_kwargs: dict = {}
+    after_error = None
+    if scenario == "at_cap":
+        gas_limit = gas_limit_cap
+        before_error = None
+    elif scenario == "gas_limit_above_cap":
+        gas_limit = gas_limit_cap + 1
+        before_error = TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM
+    else:
+        access_list, execution_intrinsic = _access_list_over_execution_cap(
+            after_fork, gas_limit_cap
+        )
+        gas_limit = execution_intrinsic + 1_000_000
+        before_error = TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM
+        after_error = TransactionException.INTRINSIC_GAS_TOO_LOW
+        tx_kwargs = {"ty": 1, "access_list": access_list}
 
     blocks = [
         Block(
@@ -197,6 +426,7 @@ def test_tx_gas_above_cap_at_transition(
                     gas_limit=gas_limit,
                     sender=pre.fund_eoa(),
                     error=before_error,
+                    **tx_kwargs,
                 ),
             ],
             exception=before_error,
@@ -209,16 +439,21 @@ def test_tx_gas_above_cap_at_transition(
                     to=contract_after,
                     gas_limit=gas_limit,
                     sender=pre.fund_eoa(),
+                    error=after_error,
+                    **tx_kwargs,
                 ),
             ],
+            exception=after_error,
         ),
     ]
 
     post = {
         contract_before: Account(
-            storage=storage_before if not gas_above_cap else {0: 0},
+            storage=storage_before if before_error is None else {0: 0},
         ),
-        contract_after: Account(storage=storage_after),
+        contract_after: Account(
+            storage=storage_after if after_error is None else {0: 0},
+        ),
     }
 
     blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -425,18 +425,18 @@ def test_coinbase_fee_with_state_gas_refund(
     ],
 )
 @pytest.mark.valid_from("EIP8037")
-def test_coinbase_fee_follows_dominant_dimension(
+def test_coinbase_fee_paid_on_execution_and_state(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     dominant_dimension: str,
 ) -> None:
     """
-    Assert the miner is paid on `max(execution, state)`, whichever leads.
+    Assert the miner is paid on execution gas plus state gas.
 
-    The same reporter reads the coinbase balance after one transaction
-    whose bottleneck is either dimension. Billing the miner on the
-    execution dimension alone would underpay whenever state leads.
+    A reporter reads the coinbase balance after a transaction
+    bottlenecked on either dimension. The fee sums both either way;
+    `max(execution, state)` governs the header, not the sender's bill.
     """
     if dominant_dimension == "state":
         body = Op.SSTORE(0, 1)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -16,6 +16,8 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
 """
 
+import math
+
 import pytest
 from execution_testing import (
     Account,
@@ -438,14 +440,17 @@ def test_coinbase_fee_paid_on_execution_and_state(
     bottlenecked on either dimension. The fee sums both either way;
     `max(execution, state)` governs the header, not the sender's bill.
     """
+    state_op = Op.SSTORE(0, 1)
     if dominant_dimension == "state":
-        body = Op.SSTORE(0, 1)
-        reservoir = body.state_cost(fork)
+        body = state_op
     else:
-        # Nothing but the intrinsic, so the execution dimension leads
-        # with a cost the opcode model prices exactly.
-        body = Op.STOP
-        reservoir = 0
+        # Memory cost grows as `words ** 2 // 512`, so this word count
+        # expands past the state charge, leading on execution while the
+        # state dimension stays nonzero.
+        words = math.isqrt(512 * state_op.state_cost(fork))
+        body = state_op + Op.MSTORE(
+            (words - 1) * 32, 0, new_memory_size=words * 32
+        )
     contract = pre.deploy_contract(code=body)
 
     execution = (
@@ -454,10 +459,11 @@ def test_coinbase_fee_paid_on_execution_and_state(
     )
     state = body.state_cost(fork)
     expected_coinbase = execution + state
+    assert state > 0
     if dominant_dimension == "state":
         assert state > execution
     else:
-        assert state == 0
+        assert execution > state
 
     reporter_storage = Storage()
     reporter = pre.deploy_contract(
@@ -474,7 +480,7 @@ def test_coinbase_fee_paid_on_execution_and_state(
                 txs=[
                     Transaction(
                         to=contract,
-                        state_gas_reservoir=reservoir,
+                        state_gas_reservoir=state,
                         max_priority_fee_per_gas=1,
                         max_fee_per_gas=8,
                         sender=pre.fund_eoa(),

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -338,3 +338,156 @@ def test_multi_block_observed_coinbase_balance(
         reporter2: Account(storage={0: reporter2_observes}),
     }
     blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+@pytest.mark.valid_from("EIP8037")
+def test_coinbase_fee_with_state_gas_refund(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Assert the coinbase is paid on the post-refund gas, not the charge.
+
+    A 0 to x to 0 cycle refunds its state charge to the reservoir, so
+    the sender is billed execution gas alone and the miner is paid on
+    that same figure. Paying the miner on the pre-refund total would
+    hand it the whole storage set for free.
+    """
+    cycle_code = Op.SSTORE(0, 1) + Op.SSTORE(
+        0,
+        0,
+        # gas accounting
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    cycle = pre.deploy_contract(code=cycle_code)
+
+    # The cycle nets to no state growth, so only execution gas is billed,
+    # less the write-cost refund the restoration earns (capped at the
+    # usual fraction of the pre-refund total).
+    pre_refund_gas = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + cycle_code.execution_cost(fork)
+    )
+    execution_refund = cycle_code.refund(fork) - cycle_code.state_refund(fork)
+    expected_coinbase = pre_refund_gas - min(
+        pre_refund_gas // fork.max_refund_quotient(), execution_refund
+    )
+
+    reporter_storage = Storage()
+    reporter = pre.deploy_contract(
+        code=(
+            Op.SSTORE(
+                reporter_storage.store_next(expected_coinbase, "coinbase"),
+                Op.BALANCE(Op.COINBASE),
+            )
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[
+                    Transaction(
+                        to=cycle,
+                        state_gas_reservoir=sstore_state_gas,
+                        max_priority_fee_per_gas=1,
+                        max_fee_per_gas=8,
+                        sender=pre.fund_eoa(),
+                    ),
+                    Transaction(
+                        to=reporter,
+                        state_gas_reservoir=0,
+                        max_priority_fee_per_gas=1,
+                        max_fee_per_gas=8,
+                        sender=pre.fund_eoa(),
+                    ),
+                ],
+            )
+        ],
+        post={
+            cycle: Account(storage={0: 0}),
+            reporter: Account(storage=reporter_storage),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "dominant_dimension",
+    [
+        pytest.param("state", id="state_dominates"),
+        pytest.param("execution", id="execution_dominates"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_coinbase_fee_follows_dominant_dimension(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    dominant_dimension: str,
+) -> None:
+    """
+    Assert the miner is paid on `max(execution, state)`, whichever leads.
+
+    The same reporter reads the coinbase balance after one transaction
+    whose bottleneck is either dimension. Billing the miner on the
+    execution dimension alone would underpay whenever state leads.
+    """
+    if dominant_dimension == "state":
+        body = Op.SSTORE(0, 1)
+        reservoir = body.state_cost(fork)
+    else:
+        # Nothing but the intrinsic, so the execution dimension leads
+        # with a cost the opcode model prices exactly.
+        body = Op.STOP
+        reservoir = 0
+    contract = pre.deploy_contract(code=body)
+
+    execution = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + body.execution_cost(fork)
+    )
+    state = body.state_cost(fork)
+    expected_coinbase = execution + state
+    if dominant_dimension == "state":
+        assert state > execution
+    else:
+        assert state == 0
+
+    reporter_storage = Storage()
+    reporter = pre.deploy_contract(
+        code=Op.SSTORE(
+            reporter_storage.store_next(expected_coinbase, "coinbase"),
+            Op.BALANCE(Op.COINBASE),
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[
+                    Transaction(
+                        to=contract,
+                        state_gas_reservoir=reservoir,
+                        max_priority_fee_per_gas=1,
+                        max_fee_per_gas=8,
+                        sender=pre.fund_eoa(),
+                    ),
+                    Transaction(
+                        to=reporter,
+                        state_gas_reservoir=0,
+                        max_priority_fee_per_gas=1,
+                        max_fee_per_gas=8,
+                        sender=pre.fund_eoa(),
+                    ),
+                ],
+            )
+        ],
+        post={reporter: Account(storage=reporter_storage)},
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
@@ -99,3 +99,74 @@ def test_create_oog_full_burn_no_state_credit(
         ],
         post={},
     )
+
+
+@pytest.mark.parametrize(
+    "state_op_kind",
+    [
+        pytest.param("sstore", id="sstore_set"),
+        pytest.param("call_new_account", id="call_new_account"),
+        pytest.param("selfdestruct", id="selfdestruct_beneficiary"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_state_charge_oog_full_burn_no_state_credit(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    state_op_kind: str,
+) -> None:
+    """
+    Verify every state charge burns the whole tx gas_limit when it OOGs.
+
+    The CREATE path is covered by
+    ``test_create_oog_full_burn_no_state_credit``; the same tx-end rule
+    has to hold for the other three charges. Each frame is handed one gas
+    less than its charge needs, so it runs out mid-charge and no
+    state-gas leftover may be credited back at settlement.
+    """
+    if state_op_kind == "sstore":
+        body = Op.SSTORE(0, 1)
+        contract = pre.deploy_contract(body)
+    elif state_op_kind == "call_new_account":
+        body = Op.POP(
+            Op.CALL(
+                gas=0,
+                address=pre.nonexistent_account(),
+                value=1,
+                value_transfer=True,
+                account_new=True,
+            )
+        )
+        contract = pre.deploy_contract(body, balance=1)
+    else:
+        body = Op.SELFDESTRUCT(pre.nonexistent_account(), account_new=True)
+        contract = pre.deploy_contract(body, balance=1)
+
+    assert body.state_cost(fork) > 0, "the op must carry a state charge"
+
+    # One gas short of the full two-dimension cost, so the charge itself
+    # is what runs out. The value call forwards a stipend the codeless
+    # recipient returns unused, so that part is never needed.
+    unused_stipend = (
+        fork.call_value_stipend() if state_op_kind == "call_new_account" else 0
+    )
+    tx_gas_limit = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + body.gas_cost(fork)
+        - unused_stipend
+        - 1
+    )
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract,
+        gas_limit=tx_gas_limit,
+        state_gas_reservoir=0,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_gas_limit))],
+        post={},
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -713,6 +713,70 @@ def test_create_state_gas_scales_with_cpsb(
 
 @pytest.mark.parametrize("block_gas_limit", BLOCK_GAS_LIMITS)
 @pytest.mark.valid_from("EIP8037")
+def test_code_deposit_state_gas_scales_with_cpsb(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    block_gas_limit: int,
+    fork: Fork,
+) -> None:
+    """
+    Test the code-deposit state gas holds across block gas limits.
+
+    Code deposit is the only charge billed per byte rather than per
+    account or slot, so it is the most sensitive to the state-byte
+    price. A creation transaction deposits a fixed body and the header
+    must report the state dimension at every block gas limit.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    env = Environment(gas_limit=block_gas_limit)
+
+    code_size = 512
+    init_code = Op.RETURN(
+        0,
+        code_size,
+        # gas accounting
+        code_deposit_size=code_size,
+        new_memory_size=code_size,
+    )
+    deposit_state_gas = init_code.state_cost(fork)
+    assert deposit_state_gas > 0, "the deposit must carry a state charge"
+
+    intrinsic_execution = fork.transaction_intrinsic_cost_calculator()(
+        calldata=bytes(init_code),
+        contract_creation=True,
+        return_cost_deducted_prior_execution=True,
+    )
+    state_gas = (
+        fork.transaction_top_frame_state_gas(contract_creation=True)
+        + deposit_state_gas
+    )
+    execution_gas = intrinsic_execution + init_code.execution_cost(fork)
+    expected_gas_used = max(execution_gas, state_gas)
+    assert expected_gas_used == state_gas, (
+        "expected state gas to dominate execution gas"
+    )
+
+    sender = pre.fund_eoa()
+    created = compute_create_address(address=sender, nonce=0)
+    tx = Transaction(
+        to=None,
+        data=init_code,
+        gas_limit=min(execution_gas + state_gas, block_gas_limit),
+        sender=sender,
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={created: Account(code=b"\x00" * code_size)},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
+    )
+
+
+@pytest.mark.parametrize("block_gas_limit", BLOCK_GAS_LIMITS)
+@pytest.mark.valid_from("EIP8037")
 def test_call_new_account_state_gas_scales_with_cpsb(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -32,6 +32,7 @@ from execution_testing import (
     Transaction,
     TransactionException,
     TransactionReceipt,
+    compute_create_address,
 )
 from execution_testing.checklists import EIPChecklist
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -1953,3 +1953,112 @@ def test_subcall_set_clear_revert_pays_no_state_gas(
         tx=tx,
         blockchain_test_header_verify=Header(gas_used=expected_cumulative),
     )
+
+
+@pytest.mark.parametrize(
+    "funding",
+    [
+        pytest.param("reservoir", id="reservoir"),
+        pytest.param("mixed", id="mixed"),
+        pytest.param("spill", id="spill"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_block_state_dimension_counts_full_charge(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    funding: str,
+) -> None:
+    """
+    Verify the block counts a state charge in full however it is funded.
+
+    The same storage sets are paid entirely from the reservoir, entirely
+    by spilling into `gas_left`, or half from each. The block's state
+    dimension is the charge itself, not the part any one pool covered, so
+    the header must report the same `gas_used` in all three.
+    """
+    num_slots = 3
+    storage = Storage()
+    code = Bytecode()
+    for _ in range(num_slots):
+        code += Op.SSTORE(storage.store_next(1), 1)
+
+    state_gas = code.state_cost(fork)
+    execution_gas = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + code.execution_cost(fork)
+    )
+    assert state_gas > execution_gas, "state must set the header"
+
+    contract = pre.deploy_contract(code=code)
+    tx = Transaction(
+        to=contract,
+        state_gas_reservoir={
+            "reservoir": state_gas,
+            "mixed": state_gas // 2,
+            "spill": 0,
+        }[funding],
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=execution_gas + state_gas
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx], header_verify=Header(gas_used=state_gas))],
+        post={contract: Account(storage=storage)},
+    )
+
+
+@pytest.mark.parametrize(
+    "num_access_list_entries",
+    [
+        pytest.param(1, id="one_entry"),
+        pytest.param(20, id="twenty_entries"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_access_list_cost_does_not_consume_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_access_list_entries: int,
+) -> None:
+    """
+    Verify the access-list charge is taken from execution gas only.
+
+    An access list is priced in the execution dimension, so however
+    large it grows it must not eat into the reservoir. The reservoir
+    holds exactly one storage set and a probe handed only its SSTORE's
+    execution cost draws on it: the probe lands at either list size.
+    """
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(probe_storage.store_next(1, "probe_ran"), 1)
+    probe = pre.deploy_contract(probe_code)
+    probe_stipend = probe_code.execution_cost(fork)
+
+    caller = pre.deploy_contract(
+        code=Op.POP(Op.CALL(gas=probe_stipend, address=probe))
+    )
+
+    access_list = [
+        AccessList(address=Address(0x10000 + i), storage_keys=[])
+        for i in range(num_access_list_entries)
+    ]
+
+    tx = Transaction(
+        to=caller,
+        access_list=access_list,
+        state_gas_reservoir=sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        pre=pre,
+        post={probe: Account(storage=probe_storage)},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -24,8 +24,10 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionReceipt,
     compute_create_address,
 )
+from execution_testing.checklists import EIPChecklist
 
 from .spec import init_code_at_high_bytes, ref_spec_8037
 
@@ -33,7 +35,8 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 
-@pytest.mark.parametrize("funding", ["reservoir", "spill"])
+@pytest.mark.parametrize("funding", ["reservoir", "spill", "mixed"])
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("EIP8037")
 def test_selfdestruct_new_beneficiary_state_gas(
     state_test: StateTestFiller,
@@ -47,8 +50,9 @@ def test_selfdestruct_new_beneficiary_state_gas(
     A contract with nonzero balance self-destructs to a non-alive
     beneficiary, charging new-account state gas. The charge is billed
     identically whether drawn from the reservoir (out-of-cap tx) or
-    spilled into `gas_left` (in-cap tx): the block bills NEW_ACCOUNT in
-    the state dimension and the beneficiary is created.
+    spilled into `gas_left` (in-cap tx), or split between the two: the
+    block bills NEW_ACCOUNT in the state dimension and the beneficiary
+    is created.
     """
     beneficiary = pre.nonexistent_account()
     code = Op.SELFDESTRUCT(beneficiary, account_new=True)
@@ -58,7 +62,11 @@ def test_selfdestruct_new_beneficiary_state_gas(
     tx = Transaction(
         to=contract,
         sender=pre.fund_eoa(),
-        state_gas_reservoir=(state_cost if funding == "reservoir" else 0),
+        state_gas_reservoir={
+            "reservoir": state_cost,
+            "mixed": state_cost // 2,
+            "spill": 0,
+        }[funding],
     )
 
     state_test(
@@ -69,6 +77,125 @@ def test_selfdestruct_new_beneficiary_state_gas(
         },
         tx=tx,
         blockchain_test_header_verify=Header(gas_used=state_cost),
+    )
+
+
+@pytest.mark.parametrize(
+    "gas_delta",
+    [pytest.param(0, id="exact_fit"), pytest.param(-1, id="one_short")],
+)
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_new_beneficiary_state_gas_boundary(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_delta: int,
+) -> None:
+    """
+    Pin the SELFDESTRUCT beneficiary charge at its exact-fit boundary.
+
+    With `gas_limit` set explicitly the transaction has no reservoir, so
+    the charge spills from `gas_left` and the limit is the whole budget.
+    At `exact_fit` the beneficiary is created and the balance moves; one
+    gas short the frame runs out and both are rolled back.
+    """
+    beneficiary = pre.nonexistent_account()
+    code = Op.SELFDESTRUCT(beneficiary, account_new=True)
+    state_gas = code.state_cost(fork)
+    execution_only = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + code.execution_cost(fork)
+    )
+
+    contract = pre.deploy_contract(code=code, balance=1)
+
+    tx = Transaction(
+        to=contract,
+        sender=pre.fund_eoa(),
+        gas_limit=execution_only + state_gas + gas_delta,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=execution_only + state_gas + gas_delta
+        ),
+    )
+
+    if gas_delta == 0:
+        post: dict = {
+            beneficiary: Account(balance=1),
+            contract: Account(balance=0),
+        }
+    else:
+        post = {
+            beneficiary: Account.NONEXISTENT,
+            contract: Account(balance=1),
+        }
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_selfdestruct_new_beneficiary_charge_on_frame_failure(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    failure_mode: str,
+) -> None:
+    """
+    Verify the beneficiary charge is undone when its own frame fails.
+
+    A child self-destructs to a fresh beneficiary and its caller then
+    REVERTs or exceptionally halts. Either way no account is created, so
+    the block's state dimension must stay empty and the header reports
+    the execution total alone.
+    """
+    beneficiary = pre.nonexistent_account()
+    destructor_code = Op.SELFDESTRUCT(beneficiary, account_new=True)
+    destructor = pre.deploy_contract(code=destructor_code, balance=1)
+    child_budget = destructor_code.gas_cost(fork)
+
+    ending = Op.REVERT(0, 0) if failure_mode == "revert" else Op.INVALID
+    caller_code = (
+        Op.POP(Op.CALL(gas=child_budget, address=destructor)) + ending
+    )
+    caller = pre.deploy_contract(code=caller_code)
+
+    gas_limit = 1_000_000
+    if failure_mode == "halt":
+        expected_gas_used = gas_limit
+    else:
+        # The revert refunds the beneficiary charge, so the child's
+        # forwarded budget is consumed down to its execution cost alone.
+        expected_gas_used = (
+            fork.transaction_intrinsic_cost_calculator()()
+            + caller_code.execution_cost(fork)
+            + destructor_code.execution_cost(fork)
+        )
+
+    tx = Transaction(
+        to=caller,
+        sender=pre.fund_eoa(),
+        gas_limit=gas_limit,
+        state_gas_reservoir=0,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=expected_gas_used
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        post={
+            beneficiary: Account.NONEXISTENT,
+            destructor: Account(balance=1),
+        },
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
     )
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -53,6 +53,7 @@ from execution_testing import (
 from execution_testing import (
     Macros as Om,
 )
+from execution_testing.checklists import EIPChecklist
 
 from tests.prague.eip7702_set_code_tx.spec import Spec as Spec7702
 
@@ -119,6 +120,7 @@ def _receipt_and_header(
         pytest.param(3, id="three_auths"),
     ],
 )
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("EIP8037")
 def test_authorization_state_gas_scaling(
     state_test: StateTestFiller,
@@ -175,6 +177,145 @@ def test_authorization_state_gas_scaling(
         post=post,
         tx=tx,
         blockchain_test_header_verify=Header(gas_used=header_gas_used),
+    )
+
+
+@pytest.mark.parametrize(
+    "reservoir_delta",
+    [pytest.param(0, id="exact_fit"), pytest.param(-1, id="one_short")],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_auth_state_gas_drawn_from_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    reservoir_delta: int,
+) -> None:
+    """
+    Verify the top-frame authorization charge is drawn from the state gas
+    reservoir before `gas_left`.
+
+    The reservoir holds the authorization's charge plus one storage set.
+    A probe in a child frame is handed only its SSTORE's execution cost,
+    so it can reach the reservoir but not the caller's `gas_left`: one
+    gas short of that sizing it cannot pay, which happens only if the
+    authorization took its own charge from the reservoir first.
+    """
+    sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
+    probe_ran = reservoir_delta == 0
+
+    probe_storage = Storage()
+    probe_code = Op.SSTORE(
+        probe_storage.store_next(1 if probe_ran else 0, "probe_ran"), 1
+    )
+    probe = pre.deploy_contract(probe_code)
+    probe_stipend = probe_code.execution_cost(fork)
+
+    recipient = pre.deploy_contract(
+        code=Op.POP(Op.CALL(gas=probe_stipend, address=probe))
+    )
+
+    signer = pre.fund_eoa()
+    authorization_list = [
+        AuthorizationTuple(
+            address=recipient,
+            nonce=0,
+            signer=signer,
+            creates_account=False,
+            writes_delegation=True,
+        )
+    ]
+
+    _, _, top_frame_state = _auth_gas(fork, authorization_list)
+    assert top_frame_state > 0, (
+        "the authorization must carry a top-frame state charge"
+    )
+    reservoir = top_frame_state + sstore_state_gas + reservoir_delta
+
+    tx = Transaction(
+        to=recipient,
+        authorization_list=authorization_list,
+        state_gas_reservoir=reservoir,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        signer: Account(code=Spec7702.delegation_designation(recipient)),
+        probe: Account(storage=probe_storage),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_pre_delegated_authority_no_charge_after_failure(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    failure_mode: str,
+) -> None:
+    """
+    Verify re-delegating an already-delegated authority carries no
+    top-frame state charge, whether or not the top frame then fails.
+
+    The indicator is not net-new, so ``set_delegation`` charges no
+    ``AUTH_BASE``. A failing top frame must not turn that into a charge:
+    the state dimension stays empty and the header reports the execution
+    total alone.
+    """
+    first = pre.deploy_contract(code=Op.STOP)
+
+    ending = Op.REVERT(0, 0) if failure_mode == "revert" else Op.INVALID
+    recipient = pre.deploy_contract(code=ending)
+
+    signer = pre.fund_eoa(delegation=first)
+    authorization_list = [
+        AuthorizationTuple(
+            address=recipient,
+            # The delegation setup already moved the nonce to 1.
+            nonce=1,
+            signer=signer,
+            creates_account=False,
+            writes_delegation=False,
+            first_write=False,
+        )
+    ]
+
+    intrinsic_execution, top_frame_execution, top_frame_state = _auth_gas(
+        fork, authorization_list
+    )
+    assert top_frame_state == 0, (
+        "re-delegating an existing indicator is not net-new state"
+    )
+
+    # A failing top frame burns its whole budget, so pin the limit and
+    # expect the sender to pay all of it with nothing in the state
+    # dimension.
+    gas_limit = intrinsic_execution + top_frame_execution + 50_000
+
+    tx = Transaction(
+        to=signer,
+        authorization_list=authorization_list,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        signer: Account(code=Spec7702.delegation_designation(recipient)),
+    }
+    state_test(
+        pre=pre,
+        post=post,
+        tx=tx,
+        blockchain_test_header_verify=Header(
+            gas_used=gas_limit if failure_mode == "halt" else None
+        ),
     )
 
 
@@ -1144,6 +1285,7 @@ def test_auth_with_multiple_sstores(
         ),
     ],
 )
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.valid_from("EIP8037")
 def test_authorization_exact_state_gas_boundary(
     blockchain_test: BlockchainTestFiller,
@@ -1892,6 +2034,7 @@ def test_top_level_halt_keeps_intrinsic_auth_state_gas(
         pytest.param(-1, id="one_short"),
     ],
 )
+@EIPChecklist.GasCostChanges.Test.OutOfGas()
 @pytest.mark.valid_from("EIP8037")
 def test_auth_and_execution_state_oog_boundary(
     state_test: StateTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -283,27 +283,40 @@ def test_pre_delegated_authority_no_charge_after_failure(
             signer=signer,
             creates_account=False,
             writes_delegation=False,
-            first_write=False,
+            first_write=True,
         )
     ]
 
     intrinsic_execution, top_frame_execution, top_frame_state = _auth_gas(
-        fork, authorization_list
+        fork,
+        authorization_list,
+        recipient_type=RecipientType.DELEGATION_7702,
     )
     assert top_frame_state == 0, (
         "re-delegating an existing indicator is not net-new state"
     )
 
-    # A failing top frame burns its whole budget, so pin the limit and
-    # expect the sender to pay all of it with nothing in the state
-    # dimension.
     gas_limit = intrinsic_execution + top_frame_execution + 50_000
+
+    if failure_mode == "halt":
+        # An exceptional halt burns the whole budget.
+        expected_gas_used = gas_limit
+    else:
+        # REVERT returns the gas it did not spend.
+        expected_gas_used = (
+            intrinsic_execution
+            + top_frame_execution
+            + ending.execution_cost(fork)
+        )
 
     tx = Transaction(
         to=signer,
         authorization_list=authorization_list,
         gas_limit=gas_limit,
         sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            status=0, cumulative_gas_used=expected_gas_used
+        ),
     )
 
     post = {
@@ -313,9 +326,7 @@ def test_pre_delegated_authority_no_charge_after_failure(
         pre=pre,
         post=post,
         tx=tx,
-        blockchain_test_header_verify=Header(
-            gas_used=gas_limit if failure_mode == "halt" else None
-        ),
+        blockchain_test_header_verify=Header(gas_used=expected_gas_used),
     )
 
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -134,49 +134,125 @@ def test_sstore_nonzero_to_nonzero(
     )
 
 
+@EIPChecklist.GasRefundsChanges.Test.ExceptionalAbort.Revertable()
+@pytest.mark.parametrize(
+    "abort_mode",
+    [
+        pytest.param("success", id="success_refund_applied"),
+        pytest.param(
+            "revert",
+            marks=EIPChecklist.GasRefundsChanges.Test.ExceptionalAbort.Revertable.Revert(),
+        ),
+        pytest.param(
+            "out_of_gas",
+            marks=EIPChecklist.GasRefundsChanges.Test.ExceptionalAbort.Revertable.OutOfGas(),
+        ),
+        pytest.param(
+            "invalid_opcode",
+            marks=EIPChecklist.GasRefundsChanges.Test.ExceptionalAbort.Revertable.InvalidOpcode(),
+        ),
+        pytest.param(
+            "upper_revert",
+            marks=EIPChecklist.GasRefundsChanges.Test.ExceptionalAbort.Revertable.UpperRevert(),
+        ),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_sstore_nonzero_to_zero(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    abort_mode: str,
 ) -> None:
     """
-    Test SSTORE nonzero-to-zero charges no state gas.
+    Test SSTORE nonzero-to-zero charging and refund rollback.
 
     Clearing a storage slot (setting to zero) does not grow state and
-    earns an execution gas refund (GAS_STORAGE_CLEAR_REFUND).
+    earns an execution gas refund (GAS_STORAGE_CLEAR_REFUND). The success
+    arm retains the original refund assertion. The other arms verify that
+    the same refund is discarded if its frame REVERTs, runs out of gas, or
+    executes INVALID, and if a successful child is rolled back by its caller.
     """
     storage = Storage()
-    code = Op.SSTORE(
+    clear = Op.SSTORE(
         storage.store_next(0),
         0,
+        # gas accounting
         original_value=1,
         current_value=1,
         new_value=0,
-    )
-    assert code.state_cost(fork) == 0, "clearing a slot grows no state"
-    assert code.refund(fork) > 0, "clearing a slot must earn a refund"
-    pre_refund_gas = (
-        fork.transaction_intrinsic_cost_calculator()()
-        + code.execution_cost(fork)
+        key_warm=False,
     )
 
-    contract = pre.deploy_contract(code=code, storage={0: 1})
+    assert clear.state_cost(fork) == 0, "clearing a slot grows no state"
+    assert clear.state_refund(fork) == 0
+    assert clear.refund(fork) > 0, "clearing a slot must earn a refund"
+
+    intrinsic = fork.transaction_intrinsic_cost_calculator()()
+
+    if abort_mode == "success":
+        code = clear
+        contract = pre.deploy_contract(code=code, storage={0: 1})
+        pre_refund_gas = intrinsic + code.execution_cost(fork)
+        gas_limit = None
+        expected_cumulative = sender_gas_used(fork, pre_refund_gas, code)
+        expected_header_gas = pre_refund_gas
+        post = {contract: Account(storage=storage)}
+    elif abort_mode == "revert":
+        code = clear + Op.REVERT(0, 0)
+        contract = pre.deploy_contract(code=code, storage={0: 1})
+        gas_limit = intrinsic + code.execution_cost(fork)
+        expected_cumulative = gas_limit
+        expected_header_gas = expected_cumulative
+        post = {contract: Account(storage={0: 1})}
+    elif abort_mode == "out_of_gas":
+        # The clear consumes the whole frame budget; the following one-gas
+        # opcode aborts only after the refund has been accrued.
+        code = clear + Op.JUMPDEST
+        contract = pre.deploy_contract(code=code, storage={0: 1})
+        gas_limit = intrinsic + clear.execution_cost(fork)
+        expected_cumulative = gas_limit
+        expected_header_gas = expected_cumulative
+        post = {contract: Account(storage={0: 1})}
+    elif abort_mode == "invalid_opcode":
+        code = clear + Op.INVALID
+        contract = pre.deploy_contract(code=code, storage={0: 1})
+        gas_limit = intrinsic + clear.execution_cost(fork) + 1_000
+        expected_cumulative = gas_limit
+        expected_header_gas = expected_cumulative
+        post = {contract: Account(storage={0: 1})}
+    else:
+        child_code = clear + Op.STOP
+        child = pre.deploy_contract(code=child_code, storage={0: 1})
+        child_execution = child_code.execution_cost(fork)
+        code = Op.POP(Op.CALL(gas=child_execution, address=child)) + Op.REVERT(
+            0, 0
+        )
+        contract = pre.deploy_contract(code=code)
+        expected_cumulative = (
+            intrinsic + code.execution_cost(fork) + child_execution
+        )
+        # Leave enough headroom for EIP-150's 63/64 rule so the child really
+        # completes its clear before the upper frame rolls it back.
+        gas_limit = expected_cumulative + 1_000
+        expected_header_gas = expected_cumulative
+        post = {child: Account(storage={0: 1})}
 
     tx = Transaction(
         to=contract,
+        gas_limit=gas_limit,
         state_gas_reservoir=0,
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(
-            cumulative_gas_used=sender_gas_used(fork, pre_refund_gas, code)
+            cumulative_gas_used=expected_cumulative,
         ),
     )
 
     state_test(
         pre=pre,
-        post={contract: Account(storage=storage)},
+        post=post,
         tx=tx,
-        blockchain_test_header_verify=Header(gas_used=pre_refund_gas),
+        blockchain_test_header_verify=Header(gas_used=expected_header_gas),
     )
 
 
@@ -466,6 +542,75 @@ def test_sstore_clear_refund_reversal(
         post={contract: Account(storage={0: 2})},
         tx=tx,
         blockchain_test_header_verify=Header(gas_used=tx_execution),
+    )
+
+
+@pytest.mark.parametrize(
+    "initial_value,post_value",
+    [
+        pytest.param(2, 0, id="dirty_clear"),
+        pytest.param(0, 1, id="clear_then_restore_original"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_sstore_dirty_slot_refund(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    initial_value: int,
+    post_value: int,
+) -> None:
+    """
+    Test the refund for a second write to a slot already changed in the
+    same transaction.
+
+    The write cost was paid by the first change, so the second write is
+    charged the warm access alone. Clearing a dirty slot still earns the
+    storage-clear refund; clearing and then writing the original value
+    back reverses that refund and returns the write cost instead.
+    """
+    original = 1
+    code = Op.SSTORE(
+        0,
+        initial_value,
+        # gas accounting
+        original_value=original,
+        current_value=original,
+        new_value=initial_value,
+    ) + Op.SSTORE(
+        0,
+        post_value,
+        # gas accounting
+        key_warm=True,
+        original_value=original,
+        current_value=initial_value,
+        new_value=post_value,
+    )
+    assert code.state_cost(fork) == 0, "a nonzero slot grows no state"
+    assert code.state_refund(fork) == 0, "no state charge, no state refund"
+    assert code.refund(fork) > 0, "the dirty second write earns a refund"
+
+    pre_refund_gas = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + code.execution_cost(fork)
+    )
+
+    contract = pre.deploy_contract(code=code, storage={0: original})
+
+    tx = Transaction(
+        to=contract,
+        state_gas_reservoir=0,
+        sender=pre.fund_eoa(),
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=sender_gas_used(fork, pre_refund_gas, code)
+        ),
+    )
+
+    state_test(
+        pre=pre,
+        post={contract: Account(storage={0: post_value})},
+        tx=tx,
+        blockchain_test_header_verify=Header(gas_used=pre_refund_gas),
     )
 
 


### PR DESCRIPTION
## Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Enhancing EIP-8037 testing coverage:

For each test file: (1) define suite scope, (2) analyze existing cases, (3) identify gaps, (4) filter impossible scenarios, (5) add missing tests, in order to expand EIP-8037 test coverage for state-gas pricing, reservoir accounting, refund behavior, transaction validity, and two-dimensional block gas accounting.

**Changes**

- Expand two-dimensional block accounting coverage:
  - state- and execution-dominant blocks
  - under, exact, and over block-boundary cases
  - supported transaction types and log-bearing transactions
  - base-fee increases and decreases
- Extend fork-transition coverage for:
  - SSTORE state gas
  - CREATE, CREATE2, CALL new-account, and SELFDESTRUCT charges
  - the modified transaction gas-limit constraint
- Add state-gas boundary and failure coverage for:
  - CALL-family operations
  - CREATE/CREATE2 and code deposit
  - SELFDESTRUCT
  - EIP-7702 authorization processing
  - delegation-designation execution
- Expand state-reservoir coverage across:
  - reservoir, spill, and mixed funding
  - nested calls
  - cross-frame refunds
  - reverted and exceptional frames
- Add refund and calldata-floor interactions.
- Verify sender and coinbase charging across execution and state dimensions.
- Add EIP checklist markers and clarify non-applicable checklist sections.


The changes primarily extend existing test matrices and parameterize related execution paths so that shared setup is reused and equivalent scenarios are not duplicated.

Expected values verify:

- receipt gas uses the combined execution and state charges after refunds;
- block header `gas_used` uses `max(block_execution, block_state)`;
- state charges are returned or discarded according to frame success;
- state-reservoir funding does not change the block state dimension;
- fork-transition behavior changes only at EIP-8037 activation.

## Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

## Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
