### PR TITLE
fix(ci): authenticate simulator-build clones with `github.token`

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -144,10 +144,8 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # TODO: restore ethereum/hive@master before merge, once
-          # ethereum/hive#1606 lands
-          repository: danceratopz/hive
-          ref: eels-sim-github-token
+          repository: ethereum/hive
+          ref: master
           path: hive
 
       # Redirect Go's caches to a per-job temp dir so the setup-go cache

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -144,8 +144,10 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ethereum/hive
-          ref: master
+          # TODO: restore ethereum/hive@master before merge, once
+          # ethereum/hive#1606 lands
+          repository: danceratopz/hive
+          ref: eels-sim-github-token
           path: hive
 
       # Redirect Go's caches to a per-job temp dir so the setup-go cache
@@ -185,6 +187,7 @@ jobs:
             --client ${{ env.CLIENT }} \
             --client-file ../execution-specs/.github/configs/hive/${{ env.CLIENT_FILE }} \
             --sim.buildarg fixtures=${{ env.FIXTURES_URL }} \
+            --sim.buildarg github_token=${{ github.token }} \
             --sim.limit="${{ matrix.sim_limit }}" \
             --sim.loglevel=5 \
             --docker.buildoutput \


### PR DESCRIPTION
Passes the Actions job token to the eels simulator image builds in the Hive Consume workflow, so the `git clone` of execution-specs inside those builds authenticates instead of running anonymously.

## Motivation

GitHub rate-limits anonymous git-over-HTTPS per source IP, and the self-hosted runners intermittently hit the limit. When that happens the simulator image build dies before any test runs, e.g. [this Engine job on forks/amsterdam](https://github.com/ethereum/execution-specs/actions/runs/33661674686/job/100355625044):

```
Step 6/13 : RUN git clone --depth 1 https://github.com/ethereum/execution-specs.git && ...
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

The same failure mode has been hitting ethpandaops/hive-tests dashboard runs and other EF repo CI on the same runner pool. GitHub [tightened unauthenticated rate limits in May 2025](https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/) and documents authentication as the remedy.

## Changes

Add `--sim.buildarg github_token=${{ github.token }}` to the simulator invocation. The build-arg is consumed by the eels simulator Dockerfiles via ethereum/hive#1606; the token is job-scoped, works for cloning public repos, expires when the job ends, and is masked by the runner in logs and summaries.

## Validation

An earlier revision of this PR temporarily pinned the Hive checkout to the ethereum/hive#1606 branch; the Engine, RLP and Sync jobs all [built their simulator images with the authenticated clone and passed](https://github.com/ethereum/execution-specs/actions/runs/33741548178). The pin is now removed and the checkout is back on `ethereum/hive` @ `master`.

## Before merge

- [ ] ethereum/hive#1606 merged (until then the build-arg is an inert unused-build-arg warning and the clone stays anonymous)
- [x] Hive checkout restored to `ethereum/hive` @ `master`
