### PR TITLE
feat(tests): assert `SYSTEM_ADDRESS` is absent from BAL for EIP-7708 Transfer logs

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7708.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7708.py
@@ -27,6 +27,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
+from ..eip7708_eth_transfer_logs.spec import Spec as Spec7708
 from ..eip7708_eth_transfer_logs.spec import transfer_log
 from .spec import ref_spec_7928
 
@@ -161,6 +162,10 @@ def test_transfer_logs_and_bal_balance_changes(
                         )
                     ],
                 ),
+                # SYSTEM_ADDRESS is touched by EIP-7708 to emit Transfer
+                # logs but its own balance never changes, so it must
+                # appear in the BAL with no field changes.
+                Spec7708.SYSTEM_ADDRESS: None,
                 # The tip is a BAL-only flow: it must never produce a
                 # Transfer log, and the zero-tip second transaction must
                 # not add a second balance change.

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7708.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7708.py
@@ -162,9 +162,9 @@ def test_transfer_logs_and_bal_balance_changes(
                         )
                     ],
                 ),
-                # SYSTEM_ADDRESS is touched by EIP-7708 to emit Transfer
-                # logs but its own balance never changes, so it must
-                # appear in the BAL with no field changes.
+                # System address MUST NOT be included: EIP-7708 emits
+                # Transfer logs from SYSTEM_ADDRESS, but that address is
+                # not itself a BAL account access.
                 Spec7708.SYSTEM_ADDRESS: None,
                 # The tip is a BAL-only flow: it must never produce a
                 # Transfer log, and the zero-tip second transaction must


### PR DESCRIPTION
### Description
Add an explicit assertion that `SYSTEM_ADDRESS` (EIP-7708) is absent from the Block Access List in `test_transfer_logs_and_bal_balance_changes`.

`SYSTEM_ADDRESS` emits Transfer logs during EIP-7708 execution but its own balance never changes, so it must NOT appear as an entry in the BAL. This follows the same pattern used in the EIP-4788 and EIP-2935 cross-tests.

### Related Issues or PRs
Related to #3225 (scenario 5 — 7708 × BAL orthogonality)
Suggested by spencer in #el-testing.

### Checklist
- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture
<img src="https://images.unsplash.com/photo-1552053831-71594a27632d?auto=format&fit=crop&w=800" alt="happy golden retriever" width="400" />