### PR TITLE
feat(tests): cover EIP-8037 static-call reservoirs and block activation

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -962,36 +962,46 @@ def test_delegatecall_reservoir_passing(
     state_test(pre=pre, post=post, tx=tx)
 
 
-@pytest.mark.parametrize("child_action", ["write_rejected", "read_only"])
+@pytest.mark.parametrize(
+    "child_action,reservoir_shortfall",
+    [
+        pytest.param("write_rejected", 0, id="write_rejected"),
+        pytest.param("read_only", 0, id="read_only"),
+        pytest.param("create", 0, id="create_exact"),
+        pytest.param("create", 1, id="create_one_short"),
+        pytest.param("create2", 0, id="create2_exact"),
+        pytest.param("create2", 1, id="create2_one_short"),
+    ],
+)
 @pytest.mark.valid_from("EIP8037")
 def test_staticcall_passes_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
     child_action: str,
+    reservoir_shortfall: int,
 ) -> None:
-    """
-    Test STATICCALL passes reservoir but cannot use it for state ops.
-
-    The static child is handed the full execution cost of an SSTORE,
-    so only the static-context restriction can stop it, and it halts.
-    The parent then calls a probe handed only its SSTORE's execution
-    cost, so the probe has no `gas_left` to spill from and succeeds
-    only if the rejected write left the reservoir untouched.
-
-    `read_only` returns normally instead of halting, pinning that a
-    successful STATICCALL leaves the reservoir alone just the same.
-    """
+    """Preserve the reservoir across successful and rejected static calls."""
     sstore_state_gas = Op.SSTORE(new_value=1).state_cost(fork)
 
     if child_action == "read_only":
         child_code: Bytecode = Op.POP(Op.SLOAD(0, key_warm=False))
         static_result = 1
-    else:
+    elif child_action == "write_rejected":
         child_code = Op.SSTORE(0, 1)
+        static_result = 0
+    else:
+        create_opcode = Op.CREATE if child_action == "create" else Op.CREATE2
+        child_code = create_opcode(value=0, offset=0, size=0, init_code_size=0)
         static_result = 0
     child = pre.deploy_contract(code=child_code)
     child_gas = child_code.execution_cost(fork)
+    creating = child_action in ("create", "create2")
+    if creating:
+        # Fund a misplaced account charge far enough to expose spill handling.
+        child_gas += child_code.state_cost(fork)
+        assert child_code.state_cost(fork) > sstore_state_gas
+    probe_succeeds = reservoir_shortfall == 0
 
     probe_code = Op.SSTORE(0, 1)
     probe = pre.deploy_contract(code=probe_code)
@@ -1001,7 +1011,9 @@ def test_staticcall_passes_reservoir(
     static_slot = parent_storage.store_next(
         static_result + 1, "staticcall_result"
     )
-    probe_slot = parent_storage.store_next(2, "probe_succeeds")
+    # The probe receives execution gas only: exact reservoir succeeds;
+    # one short must fail, exposing either lost gas or an inflated reservoir.
+    probe_slot = parent_storage.store_next(1 + probe_succeeds, "probe_result")
     parent_code = Op.SSTORE(
         static_slot,
         Op.ADD(Op.STATICCALL(gas=child_gas, address=child), 1),
@@ -1016,7 +1028,7 @@ def test_staticcall_passes_reservoir(
         # gas accounting
         original_value=1,
         current_value=1,
-        new_value=2,
+        new_value=1 + probe_succeeds,
         key_warm=False,
     )
     parent = pre.deploy_contract(
@@ -1029,22 +1041,29 @@ def test_staticcall_passes_reservoir(
         + child_gas
         + probe_gas
     )
-    expected_gas_used = max(execution_gas, sstore_state_gas)
-    assert expected_gas_used == sstore_state_gas, (
-        "expected state gas to dominate execution gas"
-    )
+    state_gas = sstore_state_gas if probe_succeeds else 0
+    expected_gas_used = max(execution_gas, state_gas)
+    if not creating:
+        assert expected_gas_used == state_gas, (
+            "expected state gas to dominate execution gas"
+        )
 
     tx = Transaction(
         to=parent,
-        state_gas_reservoir=sstore_state_gas,
+        state_gas_reservoir=sstore_state_gas - reservoir_shortfall,
         sender=pre.fund_eoa(),
     )
 
-    post = {
+    post: dict[Address, Account | None] = {
         parent: Account(storage=parent_storage),
-        child: Account(storage={0: 0}),
-        probe: Account(storage={0: 1}),
+        child: Account(nonce=1, storage={0: 0}),
+        probe: Account(storage={0: int(probe_succeeds)}),
     }
+    if creating:
+        created = compute_create_address(
+            address=child, nonce=1, salt=0, initcode=b"", opcode=create_opcode
+        )
+        post[created] = Account.NONEXISTENT
     state_test(
         pre=pre,
         post=post,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
@@ -25,6 +25,7 @@ from execution_testing import (
     BlockchainTestFiller,
     Bytecode,
     EIPChecklist,
+    Environment,
     Fork,
     Header,
     Op,
@@ -507,3 +508,92 @@ def test_reservoir_available_after_transition(
     }
 
     blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+@pytest.mark.inclusion_test
+@EIPChecklist.BlockLevelConstraint.Test.ForkTransition.AcceptedBeforeFork()
+@pytest.mark.parametrize(
+    "over_by",
+    [
+        pytest.param(
+            0,
+            id="exact",
+            marks=EIPChecklist.BlockLevelConstraint.Test.ForkTransition.AcceptedAfterFork(),
+        ),
+        pytest.param(
+            1,
+            id="one_above",
+            marks=[
+                pytest.mark.exception_test,
+                EIPChecklist.BlockLevelConstraint.Test.ForkTransition.RejectedAfterFork(),
+            ],
+        ),
+    ],
+)
+def test_block_state_inclusion_at_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    over_by: int,
+) -> None:
+    """Activate the cumulative state-gas gate at the fork boundary."""
+    after = fork.fork_at(timestamp=15_000)
+    code = sum((Op.SSTORE(i, 1) for i in range(16)), Bytecode())
+    execution = (
+        after.transaction_intrinsic_cost_calculator()()
+        + code.execution_cost(after)
+    )
+    state = code.state_cost(after)
+    block_limit = execution + state
+    second_limit = execution + over_by
+    assert execution + second_limit <= block_limit
+    stop = pre.deploy_contract(code=Op.STOP)
+    blocks = []
+    post = {}
+    for timestamp in (14_999, 15_000):
+        pricing = fork.fork_at(timestamp=timestamp)
+        intrinsic = pricing.transaction_intrinsic_cost_calculator()()
+        writer = pre.deploy_contract(code=code)
+        first_execution = intrinsic + code.execution_cost(pricing)
+        first_state = code.state_cost(pricing)
+        assert first_execution + first_state <= block_limit
+        assert second_limit >= intrinsic
+        if timestamp < 15_000:
+            assert first_execution + second_limit <= block_limit
+        error = (
+            TransactionException.GAS_ALLOWANCE_EXCEEDED
+            if timestamp == 15_000 and over_by
+            else None
+        )
+        txs = [
+            Transaction(
+                to=writer, sender=pre.fund_eoa(), gas_limit=block_limit
+            ),
+            Transaction(
+                to=stop,
+                sender=pre.fund_eoa(),
+                gas_limit=second_limit,
+                error=error,
+            ),
+        ]
+        blocks.append(
+            Block(
+                timestamp=timestamp,
+                txs=txs,
+                exception=error,
+                header_verify=None
+                if error
+                else Header(
+                    gas_used=max(first_execution + intrinsic, first_state)
+                ),
+            )
+        )
+        post[writer] = Account(
+            storage={} if error else dict.fromkeys(range(16), 1)
+        )
+    blockchain_test(
+        pre=pre,
+        genesis_environment=Environment(gas_limit=block_limit),
+        blocks=blocks,
+        post=post,
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
@@ -15,18 +15,13 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 
 import pytest
 from execution_testing import (
-    Account,
     Alloc,
     Block,
-    BlockAccessListExpectation,
     BlockchainTestFiller,
     Fork,
     Header,
     Op,
-    StateTestFiller,
-    Storage,
     Transaction,
-    compute_create_address,
 )
 
 from .spec import ref_spec_8037
@@ -174,65 +169,4 @@ def test_state_charge_oog_full_burn_no_state_credit(
         pre=pre,
         blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_gas_limit))],
         post={},
-    )
-
-
-@pytest.mark.with_all_create_opcodes
-@pytest.mark.parametrize(
-    "reservoir_shortfall", [0, 1], ids=["exact", "one_short"]
-)
-@pytest.mark.valid_from("EIP8037")
-def test_static_create_preserves_reservoir(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    fork: Fork,
-    create_opcode: Op,
-    reservoir_shortfall: int,
-) -> None:
-    """Reject static creation before charging or refilling state gas."""
-    creation = create_opcode(value=0, offset=0, size=0, init_code_size=0)
-    creator = pre.deploy_contract(code=creation)
-    created = compute_create_address(
-        address=creator, nonce=1, salt=0, initcode=b"", opcode=create_opcode
-    )
-    probe_code = Op.SSTORE(0, 1)
-    probe = pre.deploy_contract(code=probe_code)
-    reservoir = probe_code.state_cost(fork) - reservoir_shortfall
-    # A misplaced account charge can spill before the static exception.
-    # The probe detects lost reservoir gas or a spill credited to that pool.
-    grant = creation.gas_cost(fork)
-    assert creation.state_cost(fork) > reservoir
-    expected = Storage()
-    static_result = expected.store_next(1)
-    probe_result = expected.store_next(2 if reservoir_shortfall == 0 else 1)
-    caller = pre.deploy_contract(
-        code=Op.SSTORE(
-            static_result, Op.ADD(1, Op.STATICCALL(gas=grant, address=creator))
-        )
-        + Op.SSTORE(
-            probe_result,
-            Op.ADD(
-                1,
-                Op.CALL(gas=probe_code.execution_cost(fork), address=probe),
-            ),
-        ),
-        # Nonzero result slots keep instrumentation out of the reservoir.
-        storage={static_result: 3, probe_result: 3},
-    )
-    tx = Transaction(
-        sender=pre.fund_eoa(), to=caller, state_gas_reservoir=reservoir
-    )
-    state_test(
-        pre=pre,
-        tx=tx,
-        # Rollback can mask late charging; the BAL still exposes target access.
-        expected_block_access_list=BlockAccessListExpectation(
-            account_expectations={created: None}
-        ),
-        post={
-            caller: Account(storage=expected),
-            creator: Account(nonce=1),
-            created: Account.NONEXISTENT,
-            probe: Account(storage={0: int(reservoir_shortfall == 0)}),
-        },
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
@@ -15,13 +15,18 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 
 import pytest
 from execution_testing import (
+    Account,
     Alloc,
     Block,
+    BlockAccessListExpectation,
     BlockchainTestFiller,
     Fork,
     Header,
     Op,
+    StateTestFiller,
+    Storage,
     Transaction,
+    compute_create_address,
 )
 
 from .spec import ref_spec_8037
@@ -169,4 +174,65 @@ def test_state_charge_oog_full_burn_no_state_credit(
         pre=pre,
         blocks=[Block(txs=[tx], header_verify=Header(gas_used=tx_gas_limit))],
         post={},
+    )
+
+
+@pytest.mark.with_all_create_opcodes
+@pytest.mark.parametrize(
+    "reservoir_shortfall", [0, 1], ids=["exact", "one_short"]
+)
+@pytest.mark.valid_from("EIP8037")
+def test_static_create_preserves_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    reservoir_shortfall: int,
+) -> None:
+    """Reject static creation before charging or refilling state gas."""
+    creation = create_opcode(value=0, offset=0, size=0, init_code_size=0)
+    creator = pre.deploy_contract(code=creation)
+    created = compute_create_address(
+        address=creator, nonce=1, salt=0, initcode=b"", opcode=create_opcode
+    )
+    probe_code = Op.SSTORE(0, 1)
+    probe = pre.deploy_contract(code=probe_code)
+    reservoir = probe_code.state_cost(fork) - reservoir_shortfall
+    # A misplaced account charge can spill before the static exception.
+    # The probe detects lost reservoir gas or a spill credited to that pool.
+    grant = creation.gas_cost(fork)
+    assert creation.state_cost(fork) > reservoir
+    expected = Storage()
+    static_result = expected.store_next(1)
+    probe_result = expected.store_next(2 if reservoir_shortfall == 0 else 1)
+    caller = pre.deploy_contract(
+        code=Op.SSTORE(
+            static_result, Op.ADD(1, Op.STATICCALL(gas=grant, address=creator))
+        )
+        + Op.SSTORE(
+            probe_result,
+            Op.ADD(
+                1,
+                Op.CALL(gas=probe_code.execution_cost(fork), address=probe),
+            ),
+        ),
+        # Nonzero result slots keep instrumentation out of the reservoir.
+        storage={static_result: 3, probe_result: 3},
+    )
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=caller, state_gas_reservoir=reservoir
+    )
+    state_test(
+        pre=pre,
+        tx=tx,
+        # Rollback can mask late charging; the BAL still exposes target access.
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={created: None}
+        ),
+        post={
+            caller: Account(storage=expected),
+            creator: Account(nonce=1),
+            created: Account.NONEXISTENT,
+            probe: Account(storage={0: int(reservoir_shortfall == 0)}),
+        },
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -1971,11 +1971,15 @@ def test_auth_sender_billing_after_failure(
     ],
 )
 @pytest.mark.valid_from("EIP8037")
+@pytest.mark.parametrize(
+    "authority_exists", [False, True], ids=["new", "existing"]
+)
 def test_top_level_halt_keeps_intrinsic_auth_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
     inner_shape: str,
+    authority_exists: bool,
 ) -> None:
     """
     Verify a top-level exceptional halt keeps the full authorization
@@ -2000,13 +2004,13 @@ def test_top_level_halt_keeps_intrinsic_auth_state_gas(
     )
 
     delegate = pre.deploy_contract(code=Op.STOP)
-    signer = pre.fund_eoa(amount=0)
+    signer = pre.fund_eoa() if authority_exists else pre.fund_eoa(amount=0)
     authorization_list = [
         AuthorizationTuple(
             address=delegate,
             nonce=0,
             signer=signer,
-            creates_account=True,
+            creates_account=not authority_exists,
             writes_delegation=True,
         ),
     ]
@@ -2021,12 +2025,15 @@ def test_top_level_halt_keeps_intrinsic_auth_state_gas(
         authorization_list=authorization_list,
         sender=pre.fund_eoa(),
         expected_receipt=TransactionReceipt(
+            status=0,
             cumulative_gas_used=gas_limit,
         ),
     )
 
     post = {
-        signer: Account(code=Spec7702.delegation_designation(delegate)),
+        signer: Account(
+            nonce=1, code=Spec7702.delegation_designation(delegate)
+        ),
     }
     state_test(
         pre=pre,


### PR DESCRIPTION
### Description

Add focused EIP-8037 coverage for reservoir preservation, authorization, and block-inclusion cases identified in #3217:

- Extend the existing STATICCALL reservoir test with CREATE and CREATE2, using exact and one-gas-short reservoir probes. Reuse its storage and header assertions; static-check ordering is already covered by the BAL suite.
- Extend the authorization/child-spill/HALT test to existing authorities, pinning the failed receipt status and the persisted authorization nonce alongside its gas accounting.
- Test the block state-gas inclusion limit immediately before and after activation: both budgets are accepted before activation; the exact budget succeeds after activation, while one extra gas is rejected by the state dimension alone.

### Related Issues or PRs

Part of #3217 / #2040. Follow-up to #3511, complements #3524.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, using `C-feat` and `A-tests`. The title matches the intended squash commit message.



