### PR TITLE
refactor(spec-specs,tests): clarify top-frame gas and derive `CALL_VALUE`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -712,22 +712,14 @@ class Alloc(SharedAlloc):
                     first_write=True,
                 )
             ]
-            auth_fund_gas_limit = (
-                intrinsic_calc(
-                    authorization_list_or_count=1,
-                    sends_value=True,
-                    recipient_type=RecipientType.EMPTY_ACCOUNT,
-                )
-                + fork.transaction_top_frame_gas_calculator()(
-                    sends_value=True,
-                    recipient_type=RecipientType.EMPTY_ACCOUNT,
-                    authorizations=worst_case_auth,
-                )
-                + fork.transaction_top_frame_state_gas(
-                    sends_value=True,
-                    recipient_type=RecipientType.EMPTY_ACCOUNT,
-                    authorizations=worst_case_auth,
-                )
+            auth_fund_gas_limit = intrinsic_calc(
+                authorization_list_or_count=1,
+                sends_value=True,
+                recipient_type=RecipientType.EMPTY_ACCOUNT,
+            ) + fork.transaction_top_frame_gas_calculator()(
+                sends_value=True,
+                recipient_type=RecipientType.EMPTY_ACCOUNT,
+                authorizations=worst_case_auth,
             )
 
             if storage is not None:

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -182,18 +182,12 @@ class AuthorizationGasInfo(Protocol):
 
 class TopFrameGasCalculator(Protocol):
     """
-    A protocol to calculate the additional execution gas charged at the
-    top-level transaction frame, after intrinsic gas is deducted but
-    before EVM execution begins.
+    Calculate total execution and state gas charged at the top-level frame,
+    after intrinsic gas is deducted and before EVM execution begins.
 
-    Returns only the execution-gas portion of the post-intrinsic
-    state-aware preparation (e.g. the delegated-recipient access
-    charge). The state-gas portion is exposed separately by
-    ``BaseFork.transaction_top_frame_state_gas`` so tests can model the
-    two-dimensional reservoir explicitly or sum the two via
-    ``oog_budget_lift`` when targeting the spillover boundary.
-
-    Returns 0 for forks that do not perform any such preparation.
+    Use ``transaction_top_frame_execution_gas`` and
+    ``transaction_top_frame_state_gas`` when accounting for each dimension
+    separately. Return zero for forks without top-frame preparation.
     """
 
     def __call__(
@@ -206,14 +200,13 @@ class TopFrameGasCalculator(Protocol):
         authorizations: Sequence[AuthorizationGasInfo] = (),
     ) -> int:
         """
-        Return the execution gas consumed by top-frame preparation for a
+        Return the total gas consumed by top-frame preparation for a
         transaction at this fork.
 
         Args:
           contract_creation: Whether the transaction creates a contract.
-                             Top-frame charges are zero for creates;
-                             equivalent charges are paid via intrinsic
-                             gas.
+                             Account creation may consume top-frame
+                             state gas.
           sends_value: Whether the transaction transfers a non-zero
                        value.
           recipient_type: Category of the transaction recipient.
@@ -822,14 +815,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     def transaction_top_frame_gas_calculator(
         cls,
     ) -> TopFrameGasCalculator:
-        """
-        Return a callable that calculates the additional execution gas
-        charged at the top-level transaction frame, after intrinsic
-        gas is deducted but before EVM execution begins.
-
-        Defaults to returning 0 for forks that do not perform such
-        post-intrinsic preparation.
-        """
+        """Return a calculator for total execution and state top-frame gas."""
 
         def fn(
             *,
@@ -839,11 +825,42 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
             delegation_warm: bool = False,
             authorizations: Sequence[AuthorizationGasInfo] = (),
         ) -> int:
-            del contract_creation, sends_value, recipient_type
-            del delegation_warm, authorizations
-            return 0
+            return cls.transaction_top_frame_execution_gas(
+                contract_creation=contract_creation,
+                sends_value=sends_value,
+                recipient_type=recipient_type,
+                delegation_warm=delegation_warm,
+                authorizations=authorizations,
+            ) + cls.transaction_top_frame_state_gas(
+                contract_creation=contract_creation,
+                sends_value=sends_value,
+                recipient_type=recipient_type,
+                authorizations=authorizations,
+            )
 
         return fn
+
+    @classmethod
+    def transaction_top_frame_execution_gas(
+        cls,
+        *,
+        contract_creation: bool = False,
+        sends_value: bool = False,
+        recipient_type: RecipientType = RecipientType.CONTRACT,
+        delegation_warm: bool = False,
+        authorizations: Sequence[AuthorizationGasInfo] = (),
+    ) -> int:
+        """
+        Return the additional execution gas charged at the top-level
+        transaction frame, after intrinsic gas is deducted but before
+        EVM execution begins.
+
+        Defaults to returning 0 for forks that do not perform such
+        post-intrinsic preparation.
+        """
+        del contract_creation, sends_value, recipient_type
+        del delegation_warm, authorizations
+        return 0
 
     @classmethod
     def transaction_top_frame_state_gas(
@@ -857,7 +874,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         """
         Return the state gas charged at the top-level transaction
         frame, after intrinsic gas is deducted but before EVM execution
-        begins. Companion to ``transaction_top_frame_gas_calculator``;
+        begins. Companion to ``transaction_top_frame_execution_gas``;
         tests targeting the spillover boundary feed this through
         ``oog_budget_lift`` to get the equivalent execution-gas budget.
 

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_2780.py
@@ -19,7 +19,6 @@ from ....base_fork import (
     AuthorizationGasInfo,
     BaseFork,
     RefundTypes,
-    TopFrameGasCalculator,
     TransactionDataFloorCostCalculator,
     TransactionIntrinsicCostCalculator,
 )
@@ -166,9 +165,15 @@ class EIP2780(BaseFork):
         return fn
 
     @classmethod
-    def transaction_top_frame_gas_calculator(
+    def transaction_top_frame_execution_gas(
         cls,
-    ) -> TopFrameGasCalculator:
+        *,
+        contract_creation: bool = False,
+        sends_value: bool = False,
+        recipient_type: RecipientType = RecipientType.CONTRACT,
+        delegation_warm: bool = False,
+        authorizations: Sequence[AuthorizationGasInfo] = (),
+    ) -> int:
         """
         Return the additional execution gas charged at the top-level
         transaction frame, after intrinsic gas is deducted but before
@@ -184,32 +189,21 @@ class EIP2780(BaseFork):
         returned separately by ``transaction_top_frame_state_gas``.
         """
         gas_costs = cls.gas_costs()
+        del sends_value
+        if contract_creation:
+            return 0
 
-        def fn(
-            *,
-            contract_creation: bool = False,
-            sends_value: bool = False,
-            recipient_type: RecipientType = RecipientType.CONTRACT,
-            delegation_warm: bool = False,
-            authorizations: Sequence[AuthorizationGasInfo] = (),
-        ) -> int:
-            del sends_value
-            if contract_creation:
-                return 0
-
-            execution = 0
-            if recipient_type == RecipientType.DELEGATION_7702:
-                execution += (
-                    gas_costs.WARM_ACCESS
-                    if delegation_warm
-                    else gas_costs.COLD_ACCOUNT_ACCESS
-                )
-            for auth in authorizations:
-                if auth.first_write:
-                    execution += gas_costs.ACCOUNT_WRITE
-            return execution
-
-        return fn
+        execution = 0
+        if recipient_type == RecipientType.DELEGATION_7702:
+            execution += (
+                gas_costs.WARM_ACCESS
+                if delegation_warm
+                else gas_costs.COLD_ACCOUNT_ACCESS
+            )
+        for auth in authorizations:
+            if auth.first_write:
+                execution += gas_costs.ACCOUNT_WRITE
+        return execution
 
     @classmethod
     def transaction_top_frame_state_gas(

--- a/packages/testing/src/execution_testing/forks/tests/test_top_frame_gas.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_top_frame_gas.py
@@ -1,0 +1,78 @@
+"""Verify total and dimension-specific top-frame gas accounting."""
+
+from typing import Any
+
+import pytest
+
+from execution_testing import AuthorizationTuple, RecipientType
+from execution_testing.forks import Amsterdam, Fork, Osaka
+
+
+@pytest.mark.parametrize("fork", [Osaka, Amsterdam])
+@pytest.mark.parametrize("contract_creation", [False, True])
+def test_top_frame_account_creation(
+    fork: Fork, contract_creation: bool
+) -> None:
+    """Include account creation in the total without execution-gas charges."""
+    kwargs: dict[str, Any] = {
+        "contract_creation": contract_creation,
+        "sends_value": True,
+        "recipient_type": RecipientType.EMPTY_ACCOUNT,
+    }
+    expected_state = fork.gas_costs().NEW_ACCOUNT if fork == Amsterdam else 0
+
+    assert fork.transaction_top_frame_execution_gas(**kwargs) == 0
+    assert fork.transaction_top_frame_state_gas(**kwargs) == expected_state
+    assert (
+        fork.transaction_top_frame_gas_calculator()(**kwargs) == expected_state
+    )
+
+
+@pytest.mark.parametrize("delegation_warm", [False, True])
+@pytest.mark.parametrize("first_write", [False, True])
+def test_top_frame_authorization_and_delegation(
+    delegation_warm: bool, first_write: bool
+) -> None:
+    """Include authorization state growth alongside delegated access costs."""
+    fork = Amsterdam
+    costs = fork.gas_costs()
+    authorizations = [
+        AuthorizationTuple(
+            address=0x100,
+            v=0,
+            r=0,
+            s=0,
+            creates_account=first_write,
+            writes_delegation=True,
+            first_write=first_write,
+        )
+    ]
+    expected_execution = (
+        costs.WARM_ACCESS if delegation_warm else costs.COLD_ACCOUNT_ACCESS
+    ) + (costs.ACCOUNT_WRITE if first_write else 0)
+    expected_state = (
+        costs.NEW_ACCOUNT if first_write else 0
+    ) + costs.AUTH_BASE
+
+    assert (
+        fork.transaction_top_frame_execution_gas(
+            recipient_type=RecipientType.DELEGATION_7702,
+            delegation_warm=delegation_warm,
+            authorizations=authorizations,
+        )
+        == expected_execution
+    )
+    assert (
+        fork.transaction_top_frame_state_gas(
+            authorizations=authorizations,
+        )
+        == expected_state
+    )
+    assert (
+        fork.transaction_top_frame_gas_calculator()(
+            recipient_type=RecipientType.DELEGATION_7702,
+            delegation_warm=delegation_warm,
+            authorizations=authorizations,
+        )
+        == expected_execution + expected_state
+    )

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -1080,7 +1080,7 @@ class IteratingBytecode(Bytecode):
                     iteration_count=iteration_count,
                     start_iteration=start_iteration,
                 )
-        top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        top_frame_gas = fork.transaction_top_frame_execution_gas(
             **{
                 key: intrinsic_cost_kwargs[key]
                 for key in TOP_FRAME_COST_KWARGS

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -91,10 +91,9 @@ class GasCosts:
     STORAGE_WRITE: Final[ExecutionGas] = ExecutionGas(Uint(10000))
 
     # Call
-    # ACCOUNT_WRITE + CALL_STIPEND
-    CALL_VALUE: Final[ExecutionGas] = ExecutionGas(Uint(11300))
     CALL_STIPEND: Final[ExecutionGas] = ExecutionGas(Uint(2300))
     ACCOUNT_WRITE: Final[ExecutionGas] = ExecutionGas(Uint(9000))
+    CALL_VALUE: Final[ExecutionGas] = ACCOUNT_WRITE + CALL_STIPEND
 
     # Contract Creation
     CODE_DEPOSIT_PER_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(200))

--- a/src/ethereum/forks/arrow_glacier/vm/gas.py
+++ b/src/ethereum/forks/arrow_glacier/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/berlin/vm/gas.py
+++ b/src/ethereum/forks/berlin/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/byzantium/vm/gas.py
+++ b/src/ethereum/forks/byzantium/vm/gas.py
@@ -44,8 +44,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/cancun/vm/gas.py
+++ b/src/ethereum/forks/cancun/vm/gas.py
@@ -48,8 +48,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/constantinople/vm/gas.py
+++ b/src/ethereum/forks/constantinople/vm/gas.py
@@ -44,8 +44,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/dao_fork/vm/gas.py
+++ b/src/ethereum/forks/dao_fork/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/frontier/vm/gas.py
+++ b/src/ethereum/forks/frontier/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/gray_glacier/vm/gas.py
+++ b/src/ethereum/forks/gray_glacier/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/homestead/vm/gas.py
+++ b/src/ethereum/forks/homestead/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/istanbul/vm/gas.py
+++ b/src/ethereum/forks/istanbul/vm/gas.py
@@ -44,8 +44,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/london/vm/gas.py
+++ b/src/ethereum/forks/london/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/muir_glacier/vm/gas.py
+++ b/src/ethereum/forks/muir_glacier/vm/gas.py
@@ -44,8 +44,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/paris/vm/gas.py
+++ b/src/ethereum/forks/paris/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -49,8 +49,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/shanghai/vm/gas.py
+++ b/src/ethereum/forks/shanghai/vm/gas.py
@@ -46,8 +46,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/spurious_dragon/vm/gas.py
+++ b/src/ethereum/forks/spurious_dragon/vm/gas.py
@@ -44,8 +44,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/src/ethereum/forks/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/gas.py
@@ -44,8 +44,8 @@ class GasCosts:
     COLD_STORAGE_WRITE: Final[Uint] = Uint(5000)
 
     # Call
-    CALL_VALUE: Final[Uint] = Uint(9000)
     CALL_STIPEND: Final[Uint] = Uint(2300)
+    CALL_VALUE: Final[Uint] = Uint(9000)
     NEW_ACCOUNT: Final[Uint] = Uint(25000)
 
     # Contract Creation

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/helpers.py
@@ -208,15 +208,10 @@ def authorization_transaction_cost(
         authorization_list_or_count=authorization_list,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    return intrinsic_gas + fork.transaction_top_frame_gas_calculator()(
         recipient_type=RecipientType.CONTRACT,
         authorizations=authorization_list,
     )
-    top_frame_state = fork.transaction_top_frame_state_gas(
-        recipient_type=RecipientType.CONTRACT,
-        authorizations=authorization_list,
-    )
-    return intrinsic_gas + top_frame_execution + top_frame_state
 
 
 def setup_target(

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_charges.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_charges.py
@@ -377,7 +377,7 @@ def test_account_write_authority_is_recipient(
     # delegation.
     recipient_type = RecipientType.DELEGATION_7702
     authorizations = [authorization]
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=recipient_type,
         authorizations=authorizations,
     )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_oog.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_oog.py
@@ -82,7 +82,7 @@ def _auth_top_frame_charges(fork: Fork, authorizations: list) -> int:
     ``AUTH_BASE``. Under the zero state reservoir these all draw from
     ``gas_left``.
     """
-    execution = fork.transaction_top_frame_gas_calculator()(
+    execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.CONTRACT,
         authorizations=authorizations,
     )
@@ -1251,7 +1251,7 @@ def test_auth_state_gas_in_header_on_dispatch_revert(
     intrinsic_execution = _intrinsic_execution(
         fork, authorization_list, recipient_type=RecipientType.CONTRACT
     )
-    auth_execution = fork.transaction_top_frame_gas_calculator()(
+    auth_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.CONTRACT,
         authorizations=authorization_list,
     )
@@ -1336,7 +1336,7 @@ def test_reverted_dispatch_state_gas_counts_toward_block_limit(
     intrinsic_execution = _intrinsic_execution(
         fork, authorization_list, recipient_type=RecipientType.CONTRACT
     )
-    auth_execution = fork.transaction_top_frame_gas_calculator()(
+    auth_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.CONTRACT,
         authorizations=authorization_list,
     )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_calldata_floor.py
@@ -364,7 +364,7 @@ def test_calldata_floor_with_authorizations(
 
     intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     floor_calc = fork.transaction_data_floor_cost_calculator()
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.CONTRACT,
         authorizations=authorization_list,
     )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_eip_mainnet.py
@@ -64,7 +64,7 @@ def test_transaction_gas(
         recipient_type=recipient_type,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=recipient_type,
     )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py
@@ -325,7 +325,7 @@ def test_setcode_tx_across_amsterdam_transition(
             authorization_list_or_count=[authorization],
             return_cost_deducted_prior_execution=True,
         )
-        top_frame_gas = sub_fork.transaction_top_frame_gas_calculator()(
+        top_frame_gas = sub_fork.transaction_top_frame_execution_gas(
             recipient_type=RecipientType.CONTRACT,
             authorizations=[authorization],
         )

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_top_frame_charges.py
@@ -579,7 +579,7 @@ def test_top_frame_execution_charge(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
     )
@@ -937,7 +937,7 @@ def test_receipt_status_top_frame_oog_between_successful_txs(
             recipient_type=RecipientType.DELEGATION_7702,
             return_cost_deducted_prior_execution=True,
         )
-        top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+        top_frame_gas = fork.transaction_top_frame_execution_gas(
             recipient_type=RecipientType.DELEGATION_7702,
         )
         assert top_frame_gas > 0, (

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_transactions.py
@@ -89,7 +89,7 @@ def test_value_moving_transactions(
         recipient_type=recipient_type,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=recipient_type,
     )
@@ -173,7 +173,7 @@ def test_self_transfer_with_delegated_sender(
         recipient_type=intrinsic_recipient_type,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=True,
         recipient_type=top_frame_recipient_type,
         delegation_warm=delegation_warm,
@@ -235,7 +235,7 @@ def test_intrinsic_decomposition_across_tx_types(
         authorization_list_or_count=authorizations,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=True,
         recipient_type=RecipientType.EOA,
         authorizations=authorizations,

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_with_tx_delegation.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_value_moving_with_tx_delegation.py
@@ -106,7 +106,7 @@ def test_tx_installs_delegation_on_funded_recipient(
         authorization_list_or_count=authorization_list,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=False,
@@ -203,7 +203,7 @@ def test_tx_installs_delegation_on_empty_recipient(
         authorization_list_or_count=authorization_list,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=False,
@@ -333,7 +333,7 @@ def test_tx_installs_delegation_on_sender(
         authorization_list_or_count=authorization_list,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=top_frame_recipient_type,
         delegation_warm=False,

--- a/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
+++ b/tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_warmth_invariants.py
@@ -259,7 +259,7 @@ def test_top_frame_charges_delegation_in_access_list(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=True,
@@ -360,7 +360,7 @@ def test_top_frame_charges_delegation_is_coinbase(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=True,
@@ -488,7 +488,7 @@ def test_top_frame_charges_delegation_is_sender(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=True,
@@ -555,7 +555,7 @@ def test_top_frame_charges_delegation_is_recipient(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=True,
@@ -630,7 +630,7 @@ def test_top_frame_charges_self_delegation_oog(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=True,
@@ -703,7 +703,7 @@ def test_top_frame_charges_delegation_is_precompile(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         sends_value=bool(value),
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=True,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7702.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7702.py
@@ -517,7 +517,7 @@ def test_bal_7702_top_frame_delegation_oog(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_gas = fork.transaction_top_frame_gas_calculator()(
+    top_frame_gas = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.DELEGATION_7702,
     )
 
@@ -597,7 +597,7 @@ def test_bal_7702_recipient_excluded_on_authorization_oog(
         authority_expectation = BalAccountExpectation.empty()
         expected_authority = auth.original_account
     else:
-        top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+        top_frame_execution = fork.transaction_top_frame_execution_gas(
             recipient_type=RecipientType.CONTRACT,
             authorizations=authorization_list,
         )

--- a/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_additional_coverage.py
+++ b/tests/amsterdam/eip7976_increase_calldata_floor_cost/test_additional_coverage.py
@@ -765,7 +765,7 @@ class TestAuthorizationListGasCost:
         # (execution) and AUTH_BASE (state) each at the top frame; the
         # STOP recipient does no execution, so the receipt is
         # max(execution + state, floor).
-        top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+        top_frame_execution = fork.transaction_top_frame_execution_gas(
             authorizations=authorization_list,
         )
         top_frame_state = fork.transaction_top_frame_state_gas(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -474,7 +474,7 @@ def test_block_gas_used_create_tx(
     create_execution = intrinsic_calc(
         calldata=init_code,
         contract_creation=True,
-    ) + fork.transaction_top_frame_gas_calculator()(contract_creation=True)
+    ) + fork.transaction_top_frame_execution_gas(contract_creation=True)
     create_state = fork.transaction_top_frame_state_gas(contract_creation=True)
     stop_execution = intrinsic_calc()
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -74,7 +74,7 @@ def test_create_charges_state_gas(
 
     expected_execution = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + code.execution_cost(fork)
         + init_code.gas_cost(fork)
     )
@@ -962,7 +962,7 @@ def test_code_deposit_oog_preserves_parent_reservoir(
 
     expected_execution = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + caller_code.execution_cost(fork)
         + factory_create_code.execution_cost(fork)
         + create_child_gas
@@ -1324,7 +1324,7 @@ def test_sstore_oog_no_reservoir_inflation(
             calldata=bytes(initcode),
             return_cost_deducted_prior_execution=True,
         )
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + caller_code.execution_cost(fork)
         + factory_gas
         - gas_shortfall

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -774,7 +774,7 @@ def test_cross_frame_refund_after_delegation_spill(
             authorization_list_or_count=authorization_list,
             return_cost_deducted_prior_execution=True,
         )
-        + fork.transaction_top_frame_gas_calculator()(
+        + fork.transaction_top_frame_execution_gas(
             authorizations=authorization_list
         )
         + fork.transaction_top_frame_state_gas(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -67,7 +67,7 @@ def test_sstore_via_delegation_pointer(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=False,
         authorizations=[authorization],
@@ -128,7 +128,7 @@ def test_sstore_direct_call_same_contract(
     intrinsic_execution = fork.transaction_intrinsic_cost_calculator()(
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.CONTRACT,
     )
     top_frame_state = fork.transaction_top_frame_state_gas(
@@ -211,7 +211,7 @@ def test_delegation_pointer_new_account_state_gas(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=False,
         authorizations=[authorization],
@@ -337,7 +337,7 @@ def test_delegation_pointer_state_gas_on_frame_failure(
         recipient_type=RecipientType.DELEGATION_7702,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=RecipientType.DELEGATION_7702,
         delegation_warm=False,
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -83,7 +83,7 @@ def test_pricing_at_various_gas_limits(
 
     gas_limit = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()()
+        + fork.transaction_top_frame_execution_gas()
         + code.gas_cost(fork)
     )
 
@@ -404,7 +404,7 @@ def test_refund_with_reservoir_state_gas(
     refund_counter = code.refund(fork) - code.state_refund(fork)
     gas_used_before_refund = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + code.execution_cost(fork)
         + net_state_gas
     )
@@ -935,7 +935,7 @@ def test_sstore_refund_scales_with_cpsb(
 
     gas_used_before_refund = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + code.execution_cost(fork)
         + net_state_gas
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -221,7 +221,7 @@ def test_selfdestruct_existing_beneficiary_no_state_gas(
 
     gas_limit = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + code.execution_cost(fork)
     )
 
@@ -262,7 +262,7 @@ def test_selfdestruct_zero_balance_no_state_gas(
 
     gas_limit = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + code.execution_cost(fork)
     )
 
@@ -551,7 +551,7 @@ def test_create_selfdestruct_no_refund_code_deposit_state_gas(
     total_state_gas = factory_code.state_cost(fork) + initcode.state_cost(fork)
     total_execution_gas = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + factory_code.execution_cost(fork)
         + initcode.execution_cost(fork)
     )
@@ -624,7 +624,7 @@ def test_create_selfdestruct_code_deposit_no_refund_header_check(
 
     baseline_block_execution = (
         fork.transaction_intrinsic_cost_calculator()()
-        + fork.transaction_top_frame_gas_calculator()(contract_creation=False)
+        + fork.transaction_top_frame_execution_gas(contract_creation=False)
         + factory_code.execution_cost(fork)
         + initcode.execution_cost(fork)
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -79,7 +79,7 @@ def _auth_gas(
         sends_value=sends_value,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         recipient_type=recipient_type,
         sends_value=sends_value,
         delegation_warm=delegation_warm,

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_gas.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_gas.py
@@ -445,7 +445,7 @@ def test_mixed_validity_multi_auth_receipt_gas(
         authorization_list_or_count=n,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         authorizations=authorization_list,
     )
     top_frame_state = fork.transaction_top_frame_state_gas(
@@ -605,9 +605,7 @@ def test_many_auths_block_limit(
     )
     per_auth_total = (
         _execution_per_auth(fork)
-        + fork.transaction_top_frame_gas_calculator()(
-            authorizations=[probe_auth]
-        )
+        + fork.transaction_top_frame_execution_gas(authorizations=[probe_auth])
         + fork.transaction_top_frame_state_gas(authorizations=[probe_auth])
     )
     base = fork.transaction_intrinsic_cost_calculator()(

--- a/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_refunds.py
+++ b/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_set_code_auth_refunds.py
@@ -98,7 +98,7 @@ def test_existing_authority_no_new_account_charge(
         authorization_list_or_count=n,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         authorizations=authorization_list,
     )
     top_frame_state = fork.transaction_top_frame_state_gas(
@@ -173,7 +173,7 @@ def test_clearing_delegation_no_state_charge(
         authorization_list_or_count=n,
         return_cost_deducted_prior_execution=True,
     )
-    top_frame_execution = fork.transaction_top_frame_gas_calculator()(
+    top_frame_execution = fork.transaction_top_frame_execution_gas(
         authorizations=authorization_list,
     )
     top_frame_state = fork.transaction_top_frame_state_gas(

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -205,7 +205,7 @@ def test_ether_transfers(
         access_list=warm_list,
         sends_value=sends_value,
         recipient_type=recipient_type,
-    ) + fork.transaction_top_frame_gas_calculator()(
+    ) + fork.transaction_top_frame_execution_gas(
         sends_value=sends_value,
         recipient_type=recipient_type,
     )
@@ -556,7 +556,7 @@ def test_auth_transaction(
 ) -> None:
     """Test an auth block."""
     intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    top_frame_calc = fork.transaction_top_frame_gas_calculator()
+    top_frame_calc = fork.transaction_top_frame_execution_gas
 
     code = Op.INVALID * fork.max_code_size()
     auth_target = (

--- a/tests/benchmark/stateful/bloatnet/test_transaction_types.py
+++ b/tests/benchmark/stateful/bloatnet/test_transaction_types.py
@@ -160,7 +160,7 @@ def test_ether_transfers_onchain_receivers(
             sends_value=sends_value,
             recipient_type=recipient_type,
         )
-        + fork.transaction_top_frame_gas_calculator()(
+        + fork.transaction_top_frame_execution_gas(
             sends_value=sends_value,
             recipient_type=recipient_type,
         )


### PR DESCRIPTION
### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

`transaction_top_frame_gas_calculator()` currently returns only execution gas despite its generic name. Make it return execution plus state gas, add `transaction_top_frame_execution_gas(...)` alongside the existing state-gas accessor, and migrate execution-only callers.

Funding and authorization helpers that already summed both dimensions use the total calculator directly. External callers requiring the old execution-only result should migrate to the explicit accessor.

Derive Amsterdam `GasCosts.CALL_VALUE` as `ACCOUNT_WRITE + CALL_STIPEND` instead of a literal. Move the existing `CALL_STIPEND` declaration before `CALL_VALUE` consistently across fork files so the derivation satisfies Python class-body scoping and the existing PatchHygiene lint.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Closes #3149.
Closes #3014.
Part of 8037 finalization.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

