### PR TITLE
refactor(tests): size gas-boundary cases with fork calculators

### DIFF
--- a/packages/testing/src/execution_testing/__init__.py
+++ b/packages/testing/src/execution_testing/__init__.py
@@ -117,6 +117,7 @@ from .tools import (
     gas_test,
     generate_system_contract_deploy_test,
     generate_system_contract_error_test,
+    max_count_with_gas_limit,
 )
 from .vm import (
     Bytecode,
@@ -244,6 +245,7 @@ __all__ = (
     "CreatePreimageLayout",
     "extend_with_defaults",
     "gas_test",
+    "max_count_with_gas_limit",
     "generate_system_contract_deploy_test",
     "generate_system_contract_error_test",
     "keccak256",

--- a/packages/testing/src/execution_testing/tools/__init__.py
+++ b/packages/testing/src/execution_testing/tools/__init__.py
@@ -20,6 +20,7 @@ from .tools_code import (
     While,
     WhileGas,
 )
+from .utility.gas import max_count_with_gas_limit
 from .utility.generators import (
     DeploymentTestType,
     gas_test,
@@ -49,6 +50,7 @@ __all__ = (
     "WhileGas",
     "extend_with_defaults",
     "gas_test",
+    "max_count_with_gas_limit",
     "generate_system_contract_deploy_test",
     "generate_system_contract_error_test",
     "get_current_commit_hash_or_tag",

--- a/packages/testing/src/execution_testing/tools/utility/gas.py
+++ b/packages/testing/src/execution_testing/tools/utility/gas.py
@@ -1,0 +1,39 @@
+"""Search for gas-bounded test inputs using fork-aware cost calculators."""
+
+from typing import Callable
+
+
+def max_count_with_gas_limit(
+    cost_fn: Callable[[int], int],
+    gas_limit: int,
+    *,
+    max_count: int | None = None,
+) -> int:
+    """
+    Return the largest affordable count for a nondecreasing cost function.
+
+    Require count zero to fit. Without ``max_count``, the cost must eventually
+    exceed ``gas_limit``. Supply a bound for inputs limited by protocol rules
+    such as maximum initcode size.
+    """
+    if max_count is not None and max_count < 0:
+        raise ValueError("max_count must be nonnegative")
+    if cost_fn(0) > gas_limit:
+        raise ValueError("Gas limit does not cover the cost at count zero")
+
+    low = 0
+    if max_count is None:
+        high = 1
+        while cost_fn(high) <= gas_limit:
+            low = high
+            high *= 2
+    else:
+        high = max_count
+
+    while low < high:
+        mid = (low + high + 1) // 2
+        if cost_fn(mid) <= gas_limit:
+            low = mid
+        else:
+            high = mid - 1
+    return low

--- a/packages/testing/src/execution_testing/tools/utility/tests/test_gas.py
+++ b/packages/testing/src/execution_testing/tools/utility/tests/test_gas.py
@@ -1,0 +1,41 @@
+"""Test gas-budget searches independently of fork gas schedules."""
+
+import pytest
+
+from execution_testing import max_count_with_gas_limit
+
+
+@pytest.mark.parametrize(
+    "gas_limit,expected", [(20, 0), (29, 0), (30, 1), (50, 3)]
+)
+def test_base_cost(gas_limit: int, expected: int) -> None:
+    """Include fixed costs and find exact and in-between boundaries."""
+    assert (
+        max_count_with_gas_limit(lambda n: 20 + 10 * n, gas_limit) == expected
+    )
+
+
+def test_step_cost() -> None:
+    """Find the last count on a cost plateau."""
+    assert max_count_with_gas_limit(lambda n: (n // 3) * 10, 20) == 8
+
+
+@pytest.mark.parametrize("max_count", [0, 2, 100])
+def test_input_bound(max_count: int) -> None:
+    """Respect a protocol bound even when every input is affordable."""
+    assert (
+        max_count_with_gas_limit(lambda _: 0, 0, max_count=max_count)
+        == max_count
+    )
+
+
+def test_insufficient_gas() -> None:
+    """Reject a budget that cannot cover the fixed cost."""
+    with pytest.raises(ValueError, match="count zero"):
+        max_count_with_gas_limit(lambda n: 20 + n, 19)
+
+
+def test_negative_bound() -> None:
+    """Reject a negative input bound."""
+    with pytest.raises(ValueError, match="nonnegative"):
+        max_count_with_gas_limit(lambda n: n, 20, max_count=-1)

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -9,7 +9,7 @@ allows tx.gas_limit > TX_MAX_GAS_LIMIT with excess going to
 state_gas_reservoir, changing the expected validation behavior.
 """
 
-from typing import Callable, List
+from typing import List
 
 import pytest
 from execution_testing import (
@@ -30,7 +30,9 @@ from execution_testing import (
     Storage,
     Transaction,
     TransactionException,
+    TransactionReceipt,
     add_kzg_version,
+    max_count_with_gas_limit,
 )
 
 from .spec import Spec, ref_spec_7825
@@ -38,27 +40,6 @@ from .spec import Spec, ref_spec_7825
 # Update reference spec constants
 REFERENCE_SPEC_GIT_PATH = ref_spec_7825.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7825.version
-
-
-def max_count_with_intrinsic_cost_at_most(
-    cost_fn: Callable[[int], int], gas_limit: int
-) -> int:
-    """Return the largest count where cost_fn(count) <= gas_limit."""
-    low = 0
-    high = 1
-
-    while cost_fn(high) <= gas_limit:
-        low = high
-        high *= 2
-
-    while low < high:
-        mid = (low + high + 1) // 2
-        if cost_fn(mid) <= gas_limit:
-            low = mid
-        else:
-            high = mid - 1
-
-    return low
 
 
 def tx_gas_limit_cap_tests(fork: Fork) -> List[ParameterSet]:
@@ -74,6 +55,12 @@ def tx_gas_limit_cap_tests(fork: Fork) -> List[ParameterSet]:
             pytest.param(
                 Spec.tx_gas_limit_cap + 1, None, id="tx_gas_limit_cap_none"
             ),
+        ]
+
+    if fork.state_gas_reservoir_enabled():
+        return [
+            pytest.param(fork_tx_gas_limit_cap, None, id="at_cap"),
+            pytest.param(fork_tx_gas_limit_cap + 1, None, id="above_cap"),
         ]
 
     return [
@@ -269,71 +256,75 @@ def test_maximum_gas_refund(
     exceed_gas_refund_limit: bool,
 ) -> None:
     """Test the maximum gas refund behavior according to EIP-3529."""
-    gas_costs = fork.gas_costs()
     tx_gas_limit_cap = fork.transaction_gas_limit_cap()
-    assert tx_gas_limit_cap is not None, (
-        "Fork does not have a transaction gas limit cap"
+    assert tx_gas_limit_cap is not None
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
+    refund_quotient = fork.max_refund_quotient()
+
+    def memory_expansion(words: int) -> Bytecode:
+        return Op.MSTORE.with_metadata(
+            new_memory_size=32 * (words + 1), old_memory_size=0
+        )(32 * words, 0)
+
+    # Spend half the cap without generating refunds, then find the storage
+    # clearing count immediately below or above the actual refund ceiling.
+    memory_words = max_count_with_gas_limit(
+        lambda words: intrinsic_cost + memory_expansion(words).gas_cost(fork),
+        tx_gas_limit_cap // 2,
     )
-    max_refund_quotient = fork.max_refund_quotient()
+    burn_code = memory_expansion(memory_words)
+    base_cost = intrinsic_cost + burn_code.gas_cost(fork)
 
-    storage = Storage()
+    def clear_storage(count: int) -> Bytecode:
+        return sum(
+            (
+                Op.SSTORE.with_metadata(
+                    key_warm=False, original_value=1, new_value=0
+                )(slot, Op.PUSH0)
+                for slot in range(count)
+            ),
+            Bytecode(),
+        )
 
-    # Base Operation: SSTORE(slot, 0)
-    iteration_cost = (
-        Op.SSTORE(key_warm=True, original_value=1, new_value=0)
-        + Op.PUSH0
-        + Op.PUSH1(0)
-    ).gas_cost(fork)
-    gas_refund = gas_costs.REFUND_STORAGE_CLEAR
-
-    # EIP-3529: Reduction in refunds
-    storage_count = tx_gas_limit_cap // iteration_cost
-    gas_used = storage_count * iteration_cost
-
-    maximum_gas_refund = gas_used // max_refund_quotient
-    gas_refund_count = maximum_gas_refund // gas_refund
-
-    # Base case: operations that fit within the refund limit
-    iteration_count = min(
-        storage_count, gas_refund_count + int(exceed_gas_refund_limit)
+    max_storage_count = max_count_with_gas_limit(
+        lambda count: base_cost + clear_storage(count).gas_cost(fork),
+        tx_gas_limit_cap,
     )
-
-    assert iteration_cost * iteration_count <= tx_gas_limit_cap, (
-        "Iteration cost exceeds tx gas limit cap"
+    # refund <= gas_used // quotient iff refund * quotient <= gas_used.
+    refund_boundary = max_count_with_gas_limit(
+        lambda count: clear_storage(count).refund(fork) * refund_quotient
+        - clear_storage(count).gas_cost(fork),
+        base_cost,
+        max_count=max_storage_count - 1,
     )
-
-    opcode = sum(
-        (
-            Op.SSTORE(storage.store_next(0), Op.PUSH0)
-            for _ in range(iteration_count)
-        ),
-        Bytecode(),
-    )
-    assert len(opcode) <= fork.max_code_size(), (
-        "code size exceeds max code size"
-    )
+    iteration_count = refund_boundary + int(exceed_gas_refund_limit)
+    opcode = burn_code + clear_storage(iteration_count)
+    gas_used = intrinsic_cost + opcode.gas_cost(fork)
+    refund = opcode.refund(fork)
+    maximum_refund = gas_used // refund_quotient
+    assert (refund > maximum_refund) == exceed_gas_refund_limit
+    assert gas_used <= tx_gas_limit_cap
+    assert len(opcode) <= fork.max_code_size()
 
     contract = pre.deploy_contract(
         code=opcode,
-        storage={Hash(i): Hash(1) for i in range(iteration_count)},
+        storage=dict.fromkeys(range(iteration_count), 1),
     )
-
     tx = Transaction(
         to=contract,
         sender=pre.fund_eoa(),
         gas_limit=tx_gas_limit_cap,
+        expected_receipt=TransactionReceipt(
+            cumulative_gas_used=gas_used - min(refund, maximum_refund)
+        ),
     )
-
-    post = {contract: Account(storage=storage)}
-
-    state_test(pre=pre, post=post, tx=tx)
-
-
-@pytest.fixture
-def total_cost_floor_per_token(fork: Fork) -> int:
-    """Total cost floor per token."""
-    gas_costs = fork.gas_costs()
-    return gas_costs.TX_DATA_TOKEN_FLOOR
+    state_test(
+        pre=pre,
+        post={
+            contract: Account(storage=dict.fromkeys(range(iteration_count), 0))
+        },
+        tx=tx,
+    )
 
 
 @pytest.mark.inclusion_test
@@ -366,7 +357,7 @@ def test_tx_gas_limit_cap_full_calldata(
         "Fork does not have a transaction gas limit cap"
     )
     byte_data = b"\x00" if zero_byte else b"\xff"
-    max_num_of_bytes = max_count_with_intrinsic_cost_at_most(
+    max_num_of_bytes = max_count_with_gas_limit(
         lambda calldata_size: intrinsic_cost(
             calldata=byte_data * calldata_size
         ),
@@ -412,19 +403,13 @@ def test_tx_gas_limit_cap_full_calldata(
 
 
 @pytest.mark.inclusion_test
-@pytest.mark.parametrize(
-    "exceed_tx_gas_limit",
-    [
-        pytest.param(True),
-        pytest.param(False),
-    ],
-)
+@pytest.mark.parametrize_by_fork("tx_gas_limit,error", tx_gas_limit_cap_tests)
 @pytest.mark.valid_from("Osaka")
 def test_tx_gas_limit_cap_contract_creation(
     state_test: StateTestFiller,
     pre: Alloc,
-    total_cost_floor_per_token: int,
-    exceed_tx_gas_limit: bool,
+    tx_gas_limit: int,
+    error: TransactionException | None,
     fork: Fork,
 ) -> None:
     """Test the transaction gas limit cap behavior for contract creation."""
@@ -433,45 +418,40 @@ def test_tx_gas_limit_cap_contract_creation(
     assert tx_gas_limit_cap is not None, (
         "Fork does not have a transaction gas limit cap"
     )
-    gas_available = tx_gas_limit_cap - intrinsic_cost(contract_creation=True)
-
-    max_tokens_in_calldata = gas_available // total_cost_floor_per_token
-    num_of_bytes = (max_tokens_in_calldata // 4) + int(exceed_tx_gas_limit)
-
-    # Cannot exceed max contract code size
-    num_of_bytes = min(num_of_bytes, fork.max_code_size())
-
-    code = Op.JUMPDEST * num_of_bytes
-
-    # Craft a contract creation transaction that exceeds the transaction gas
-    # limit cap
-    #
-    # Total cost =
-    # intrinsic cost (base tx cost + contract creation cost)
-    # + calldata cost + init code execution cost
-    #
-    # The contract body is filled with JUMPDEST instructions, so:
-    # total cost = intrinsic cost + calldata cost + (num_of_jumpdest * 1 gas)
-    #
-    # If the total cost exceeds the tx limit cap, the transaction should fail
-
-    total_cost = (
-        intrinsic_cost(contract_creation=True, calldata=code) + num_of_bytes
+    top_frame_cost = fork.transaction_top_frame_gas_calculator()(
+        contract_creation=True
     )
 
+    def creation_cost(size: int) -> int:
+        initcode = Op.JUMPDEST * size
+        return max(
+            intrinsic_cost(contract_creation=True, calldata=initcode),
+            intrinsic_cost(
+                contract_creation=True,
+                calldata=initcode,
+                return_cost_deducted_prior_execution=True,
+            )
+            + top_frame_cost
+            + initcode.gas_cost(fork),
+        )
+
+    num_of_bytes = max_count_with_gas_limit(
+        creation_cost,
+        tx_gas_limit_cap,
+        max_count=fork.max_initcode_size(),
+    )
     tx = Transaction(
         to=None,
-        data=code,
-        gas_limit=tx_gas_limit_cap,
+        data=Op.JUMPDEST * num_of_bytes,
+        gas_limit=tx_gas_limit,
         sender=pre.fund_eoa(),
-        error=TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
-        if total_cost > tx_gas_limit_cap
-        else None,
+        error=error,
     )
-
     state_test(
         pre=pre,
-        post={},
+        post={tx.created_contract: Account(nonce=1, code=b"")}
+        if error is None
+        else {},
         tx=tx,
     )
 
@@ -515,7 +495,7 @@ def test_tx_gas_limit_cap_access_list_with_diff_keys(
             ]
         )
 
-    num_storage_keys = max_count_with_intrinsic_cost_at_most(
+    num_storage_keys = max_count_with_gas_limit(
         intrinsic_cost_for_num_storage_keys, tx_gas_limit_cap
     ) + int(exceed_tx_gas_limit)
     storage_keys = [Hash(i) for i in range(num_storage_keys)]
@@ -604,7 +584,7 @@ def test_tx_gas_limit_cap_access_list_with_diff_addr(
     def intrinsic_cost_for_num_accounts(account_count: int) -> int:
         return intrinsic_cost(access_list=make_access_list(account_count))
 
-    account_num = max_count_with_intrinsic_cost_at_most(
+    account_num = max_count_with_gas_limit(
         intrinsic_cost_for_num_accounts, tx_gas_limit_cap
     ) + int(exceed_tx_gas_limit)
     access_list = make_access_list(account_num)
@@ -687,7 +667,7 @@ def test_tx_gas_limit_cap_authorized_tx(
         )
         return cost
 
-    auth_list_length = max_count_with_intrinsic_cost_at_most(
+    auth_list_length = max_count_with_gas_limit(
         capped_intrinsic_cost, tx_gas_limit_cap
     ) + int(exceed_tx_gas_limit)
 

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -24,6 +24,7 @@ from execution_testing import (
     Bytecode,
     ChainConfig,
     CodeGasMeasure,
+    Environment,
     Fork,
     Op,
     StateTestFiller,
@@ -32,11 +33,9 @@ from execution_testing import (
     TransactionException,
     TransactionReceipt,
     extend_with_defaults,
+    max_count_with_gas_limit,
 )
 
-from ...amsterdam.eip8037_state_creation_gas_cost_increase.spec import (
-    Spec as Spec8037,
-)
 from .helpers import AddressType, ChainIDType
 from .spec import Spec, ref_spec_7702
 
@@ -94,6 +93,22 @@ class AccessListType(Enum):
             AccessListType.CONTAINS_SET_CODE_ADDRESS,
             AccessListType.CONTAINS_AUTHORITY_AND_SET_CODE_ADDRESS,
         }
+
+
+@pytest.fixture
+def authorizations_count(request: pytest.FixtureRequest, fork: Fork) -> int:
+    """Size authorization lists using the active fork's intrinsic gas cost."""
+    if isinstance(request.param, int):
+        return request.param
+    max_gas = fork.transaction_gas_limit_cap() or Environment().gas_limit
+    if request.param == "many_with_execution":
+        # Reserve gas for the execution assertions in test_gas_cost.
+        max_gas -= 1_000_000
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    return max_count_with_gas_limit(
+        lambda count: intrinsic_cost(authorization_list_or_count=count),
+        max_gas,
+    )
 
 
 # Fixtures used to parametrize the tests
@@ -798,26 +813,8 @@ def gas_test_parameter_args(
         ]
 
     if include_many:
-        # Fit as many authorizations as possible within the
-        # transaction gas limit cap. Under EIP-8037 the per-auth
-        # intrinsic grows with cpsb; on older forks it is
-        # `Spec.AUTH_PER_EMPTY_ACCOUNT`. Divide by the larger so the
-        # count fits at any fork — older forks simply exercise fewer
-        # authorizations than the cap allows.
-        eip_8037_auth_cost = (
-            Spec8037.PER_AUTH_BASE_COST
-            + (
-                Spec8037.STATE_BYTES_PER_NEW_ACCOUNT
-                + Spec8037.STATE_BYTES_PER_AUTH_BASE
-            )
-            * Spec8037.COST_PER_STATE_BYTE
-        )
-        max_gas = Spec8037.TX_MAX_GAS_LIMIT - 21_000  # TX_BASE
-        if execution_gas_allowance:
-            # Leave some gas for the execution of the test code.
-            max_gas -= 1_000_000
-        many_authorizations_count = max_gas // max(
-            Spec.AUTH_PER_EMPTY_ACCOUNT, eip_8037_auth_cost
+        many_authorizations_count = (
+            "many_with_execution" if execution_gas_allowance else "many"
         )
         cases += [
             pytest.param(
@@ -846,7 +843,9 @@ def gas_test_parameter_args(
             ),
         ]
     return extend_with_defaults(
-        cases=cases, defaults=defaults, indirect=["authorize_to_address"]
+        cases=cases,
+        defaults=defaults,
+        indirect=["authorize_to_address", "authorizations_count"],
     )
 
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -47,6 +47,7 @@ from execution_testing import (
     add_kzg_version,
     call_return_code,
     compute_create_address,
+    max_count_with_gas_limit,
 )
 from execution_testing import Macros as Om
 from execution_testing.base_types import HexNumber
@@ -4180,18 +4181,7 @@ def test_many_delegations(
     pre: Alloc,
     signer_balance: int,
 ) -> None:
-    """
-    Perform as many delegations as possible in a transaction using the entire
-    block gas limit.
-
-    Every delegation comes from a different signer.
-
-    The account of can be empty or not depending on the `signer_balance`
-    parameter.
-
-    The transaction is expected to succeed and the state after the transaction
-    is expected to have the code of the entry contract set to 1.
-    """
+    """Fill the gas budget with distinct delegations and execute a write."""
     env = Environment()
     tx_gas_limit_cap = fork.transaction_gas_limit_cap()
     if tx_gas_limit_cap is not None:
@@ -4201,16 +4191,31 @@ def test_many_delegations(
 
     success_slot = 1
     entry_code = Op.SSTORE(success_slot, 1) + Op.STOP
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    top_frame_cost = fork.transaction_top_frame_gas_calculator()
     entry_code_gas = entry_code.gas_cost(fork)
-    gas_for_delegations = max_gas - intrinsic_gas - entry_code_gas
-
-    gas_costs = fork.gas_costs()
-    delegation_count = gas_for_delegations // gas_costs.AUTH_PER_EMPTY_ACCOUNT
+    first_signer = pre.fund_eoa(signer_balance)
+    authorization = AuthorizationTuple(
+        address=Address(1),
+        nonce=0,
+        signer=first_signer,
+        creates_account=signer_balance == 0,
+        writes_delegation=True,
+        first_write=True,
+    )
+    delegation_count = max_count_with_gas_limit(
+        lambda count: intrinsic_cost(authorization_list_or_count=count)
+        + top_frame_cost(authorizations=[authorization] * count)
+        + entry_code_gas,
+        max_gas,
+    )
 
     entry_address = pre.deploy_contract(entry_code)
 
-    signers = [pre.fund_eoa(signer_balance) for _ in range(delegation_count)]
+    assert delegation_count > 0
+    signers = [first_signer] + [
+        pre.fund_eoa(signer_balance) for _ in range(delegation_count - 1)
+    ]
 
     tx = Transaction(
         gas_limit=max_gas,
@@ -4221,6 +4226,9 @@ def test_many_delegations(
                 address=Address(i + 1),
                 nonce=0,
                 signer=signer,
+                creates_account=signer_balance == 0,
+                writes_delegation=True,
+                first_write=True,
             )
             for (i, signer) in enumerate(signers)
         ],


### PR DESCRIPTION
### Description

Size the remaining EIP-7825 and EIP-7702 gas-boundary cases using the active fork's calculators instead of dividing a budget by individual gas constants.

- Promote the existing binary search to `max_count_with_gas_limit`, with an optional input bound and unit coverage for fixed costs, cost plateaus, exact boundaries, and invalid budgets.
- Calculate EIP-7702 “many” counts at fixture time. Intrinsic-validity tests retain their exact-intrinsic/one-gas-short behavior; the delegation execution test includes intrinsic, top-frame, and bytecode costs. On Amsterdam, the funded-authority case now fits 320 delegations instead of 70 while still executing its storage write.
- Repair the creation cap cases: previously both parameters were clamped to identical initcode and exercised the same outcome. Size legal initcode with the complete cost calculation and `max_initcode_size()`, then test transaction gas limits at the cap and cap + 1. Assert successful creation where accepted; Osaka rejects cap + 1, while Amsterdam permits the excess in its state-gas reservoir.
- Make the refund cases straddle the actual refund ceiling. Account for intrinsic gas, cold storage accesses, and generated bytecode, and check the charged gas in the receipt as well as cleared storage. The previous test did not assert the refund paid.


### Related Issues or PRs

Part of #2289.

The remaining mixed access-list/calldata benchmark rewrite is already in open #3411.

Uses the total top-frame calculator provided by #3527 for execution cases.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

