### PR TITLE
feat(zkevm): Reject noncanonical SSZ and catch guest validation errors

### DIFF
--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -184,36 +184,36 @@ class StatelessValidationResult(SszContainer):
 
     Note: We use return values to denote "public inputs".
 
-    If ``successful_validation`` is ``False``, the remaining fields are
-    only meaningful when the input bytes were decoded successfully. If
-    decoding failed before a ``StatelessInput`` existed,
-    ``run_stateless_guest`` returns a failed result with sentinel defaults.
+    If ``schema_id`` is zero, the guest could not decode the input or
+    produce a validation result, and the remaining fields have sentinel
+    defaults. Otherwise, the fields identify the decoded input, including
+    when execution validation fails.
 
     """
 
     new_payload_request_root: Hash32
     """
-    SSZ root of the decoded ``NewPayloadRequest``. This is zero when
-    ``run_stateless_guest`` cannot decode the input bytes.
+    SSZ root of the decoded ``NewPayloadRequest``. This is zero in the
+    sentinel result.
     """
 
     successful_validation: bool
     """
     Whether the decoded stateless input validated successfully. ``False``
-    means validation failed or the guest input bytes could not be decoded.
+    means validation failed or the guest could not produce a result.
     """
 
     chain_id: U64
     """
-    Chain identifier decoded from the input. This is zero when
-    ``run_stateless_guest`` cannot decode the input bytes.
+    Chain identifier decoded from the input. This is zero in the sentinel
+    result.
     """
 
     schema_id: U16
     """
     Exact input schema decoded and executed by the guest. This uses the
-    invalid-input sentinel when ``run_stateless_guest`` cannot decode the
-    input bytes.
+    zero sentinel when the guest cannot decode the input or produce a
+    validation result.
     """
 
 

--- a/src/ethereum/forks/amsterdam/stateless_guest.py
+++ b/src/ethereum/forks/amsterdam/stateless_guest.py
@@ -40,7 +40,7 @@ def deserialize_stateless_input(data: Bytes) -> StatelessInput:
 
 def _default_failed_stateless_output() -> StatelessValidationResult:
     """
-    Return the sentinel result used when stateless input cannot be decoded.
+    Return the sentinel when the guest cannot produce a validation result.
     """
     return StatelessValidationResult(
         new_payload_request_root=Hash32(b"\0" * 32),
@@ -56,10 +56,9 @@ def run_stateless_guest(input_bytes: Bytes) -> Bytes:
     """
     try:
         stateless_input = deserialize_stateless_input(input_bytes)
+        stateless_output = verify_stateless_new_payload(stateless_input)
     except Exception:
         stateless_output = _default_failed_stateless_output()
-    else:
-        stateless_output = verify_stateless_new_payload(stateless_input)
 
     output_bytes = serialize_stateless_output(stateless_output)
     return output_bytes

--- a/src/ethereum/utils/ssz.py
+++ b/src/ethereum/utils/ssz.py
@@ -136,8 +136,13 @@ class SszContainer:
 
     @classmethod
     def decode_bytes(cls: Type[_C], data: bytes) -> _C:
-        """Decode SSZ bytes into this dataclass type."""
+        """Decode canonical SSZ bytes into this dataclass type."""
         view = _container_type(cls).decode_bytes(data)
+        # The underlying decoder can accept offset gaps and leave bytes
+        # unread. Require the exact encoding, including nested containers,
+        # before exposing the decoded value to validation or hashing.
+        if view.encode_bytes() != data:
+            raise ValueError("Non-canonical SSZ encoding")
         return _from_view(cls, view)
 
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_stateless_input_bytes.py
@@ -74,6 +74,16 @@ def invalid_first_ssz_offset(input_bytes: Bytes) -> Bytes:
     return Bytes(input_bytes[:2] + b"\x01\x00\x00\x00" + input_bytes[6:])
 
 
+def shifted_ssz_offsets(input_bytes: Bytes) -> Bytes:
+    """Shift every top-level offset and leave an extra byte at the end."""
+    encoded = bytearray(input_bytes)
+    for offset in (2, 6, 18):
+        value = int.from_bytes(encoded[offset : offset + 4], "little")
+        encoded[offset : offset + 4] = (value + 1).to_bytes(4, "little")
+    encoded.append(0xFF)
+    return Bytes(bytes(encoded))
+
+
 @pytest.mark.parametrize(
     "modifier",
     [
@@ -88,6 +98,7 @@ def invalid_first_ssz_offset(input_bytes: Bytes) -> Bytes:
         pytest.param(truncated_ssz_body, id="truncated_ssz_body"),
         pytest.param(trailing_garbage, id="trailing_garbage"),
         pytest.param(invalid_first_ssz_offset, id="invalid_first_ssz_offset"),
+        pytest.param(shifted_ssz_offsets, id="shifted_ssz_offsets"),
     ],
 )
 def test_invalid_stateless_input_bytes_are_rejected(

--- a/tests/json_loader/test_ssz.py
+++ b/tests/json_loader/test_ssz.py
@@ -36,6 +36,16 @@ class _Envelope(SszContainer):
     progressive_items: _ProgressiveItems
 
 
+@dataclass(frozen=True)
+class _ByteLists(SszContainer):
+    bounded: Annotated[
+        Tuple[Annotated[bytes, byte_list(16)], ...], ssz_list(2)
+    ]
+    progressive: Annotated[
+        Tuple[Annotated[bytes, byte_list(16)], ...], progressive_list()
+    ]
+
+
 def test_nested_containers_roundtrip() -> None:
     """Restore Python types after standard and progressive SSZ decoding."""
     item = _Item(key=Bytes32(b"\x11" * 32), value=U16(3))
@@ -84,3 +94,46 @@ def test_fixed_width_integer_roundtrip() -> None:
     assert recovered.count == Uint(2**63)
     assert type(recovered.count) is Uint
     assert U64(recovered.count) == U64(2**63)
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_container_offset_gap_rejected(nested: bool) -> None:
+    """Reject offset gaps in both standard and progressive containers."""
+    original = _Envelope(
+        count=Uint(0),
+        payload=b"",
+        fixed_items=(),
+        progressive_items=_ProgressiveItems(items=()),
+    )
+    encoded = bytearray(original.encode_bytes())
+    offsets: tuple[int, ...]
+    if nested:
+        # The final field is a progressive container with one offset.
+        offsets = (int.from_bytes(encoded[16:20], "little"),)
+    else:
+        offsets = (8, 12, 16)
+    for offset in offsets:
+        value = int.from_bytes(encoded[offset : offset + 4], "little")
+        encoded[offset : offset + 4] = (value + 1).to_bytes(4, "little")
+    encoded.append(0xFF)
+
+    with pytest.raises(ValueError, match="Non-canonical SSZ encoding"):
+        _Envelope.decode_bytes(bytes(encoded))
+
+
+@pytest.mark.parametrize("progressive", [False, True])
+@pytest.mark.parametrize("trailing", [b"", b"ignored"])
+def test_nonempty_list_with_zero_first_offset_rejected(
+    progressive: bool, trailing: bytes
+) -> None:
+    """An empty variable-element list must have a zero-byte encoding."""
+    invalid_list = b"\x00" * 4 + trailing
+    second_offset = 8 if progressive else 8 + len(invalid_list)
+    encoded = (
+        (8).to_bytes(4, "little")
+        + second_offset.to_bytes(4, "little")
+        + invalid_list
+    )
+
+    with pytest.raises(ValueError):
+        _ByteLists.decode_bytes(encoded)

--- a/tests/json_loader/test_stateless_guest.py
+++ b/tests/json_loader/test_stateless_guest.py
@@ -568,6 +568,50 @@ class TestSerializeStatelessOutput:
 class TestRunStatelessGuest:
     """Test stateless guest input and output handling."""
 
+    def test_request_commitment_failure_returns_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failure to compute the public commitment must fail closed."""
+        stateless_input = _make_stateless_input()
+        input_bytes = serialize_stateless_input(stateless_input)
+
+        def fail_hash_tree_root(self: NewPayloadRequest) -> bytes:
+            raise RuntimeError("Request commitment unavailable")
+
+        monkeypatch.setattr(
+            NewPayloadRequest, "hash_tree_root", fail_hash_tree_root
+        )
+        result = deserialize_stateless_output(run_stateless_guest(input_bytes))
+
+        assert result == StatelessValidationResult(
+            new_payload_request_root=Hash32(b"\0" * 32),
+            successful_validation=False,
+            chain_id=U64(0),
+            schema_id=U16(0),
+        )
+
+    def test_noncanonical_ssz_returns_sentinel_failure(self) -> None:
+        """Reject shifted container offsets that leave trailing data unread."""
+        stateless_input = _make_stateless_input()
+        encoded = bytearray(serialize_stateless_input(stateless_input))
+        # After the schema prefix: request offset, witness offset, chain ID,
+        # and public-key offset. Shift all three offsets by one byte.
+        for offset in (2, 6, 18):
+            value = int.from_bytes(encoded[offset : offset + 4], "little")
+            encoded[offset : offset + 4] = (value + 1).to_bytes(4, "little")
+        encoded.append(0xFF)
+
+        result = deserialize_stateless_output(
+            run_stateless_guest(Bytes(encoded))
+        )
+
+        assert result == StatelessValidationResult(
+            new_payload_request_root=Hash32(b"\0" * 32),
+            successful_validation=False,
+            chain_id=U64(0),
+            schema_id=U16(0),
+        )
+
     def test_invalid_input_bytes_return_failed_validation(self) -> None:
         """Malformed input returns a failed result with sentinel fields."""
         encoded = run_stateless_guest(Bytes(b""))


### PR DESCRIPTION
### Description
The SSZ decoder accepted shifted offsets and ignored an appended byte. For an otherwise valid payload, the guest returned `successful_validation=True` for this malformed input.

The shared SSZ decoder now re-encodes the decoded value and requires an exact match with the input bytes. This rejects noncanonical encodings, including offset gaps in nested containers. This check adds one serialization pass to SSZ decoding.

The guest also catches exceptions from `verify_stateless_new_payload`. If request root computation fails, the guest now returns the sentinel result with `successful_validation=False`. The result documentation describes this behavior.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
