### PR TITLE
refactor(spec-specs): move `REFUND_AUTH` and `TX_MAX_GAS_LIMIT` into GasCosts

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -53,8 +53,6 @@ class IntrinsicGasCost:
     """
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
 BLOB_COUNT_LIMIT = 6
 """
 Maximum number of blobs a single transaction may carry.
@@ -615,6 +613,7 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
@@ -657,11 +656,11 @@ def validate_transaction(tx: Transaction, sender: Address) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient intrinsic gas")
     if intrinsic.calldata_floor > tx.gas:
         raise InsufficientTransactionGasError("Insufficient calldata floor")
-    if intrinsic.execution > TX_MAX_GAS_LIMIT:
+    if intrinsic.execution > GasCosts.TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
             "Intrinsic execution gas exceeds TX_MAX_GAS_LIMIT"
         )
-    if intrinsic.calldata_floor > TX_MAX_GAS_LIMIT:
+    if intrinsic.calldata_floor > GasCosts.TX_MAX_GAS_LIMIT:
         raise InsufficientTransactionGasError(
             "Intrinsic calldata floor exceeds TX_MAX_GAS_LIMIT"
         )

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -161,7 +161,6 @@ class GasCosts:
     TX_ACCESS_LIST_STORAGE_KEY: Final[ExecutionGas] = (
         COLD_STORAGE_ACCESS - WARM_ACCESS
     )
-
     TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Authorization

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -33,7 +33,6 @@ from ..fork_types import (
     VersionedHash,
 )
 from ..transactions import (
-    TX_MAX_GAS_LIMIT,
     BlobTransaction,
     IntrinsicGasCost,
     Transaction,
@@ -162,6 +161,8 @@ class GasCosts:
     TX_ACCESS_LIST_STORAGE_KEY: Final[ExecutionGas] = (
         COLD_STORAGE_ACCESS - WARM_ACCESS
     )
+
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Authorization
     AUTH_TUPLE_BYTES: Final[Uint] = Uint(101)
@@ -1078,7 +1079,7 @@ def check_block_gas_capacity(
     BlobGasLimitExceededError :
         If the transaction exceeds the block's remaining blob gas.
 
-    [`TX_MAX_GAS_LIMIT`]: ref:ethereum.forks.amsterdam.transactions.TX_MAX_GAS_LIMIT
+    [`TX_MAX_GAS_LIMIT`]: ref:ethereum.forks.amsterdam.vm.gas.GasCosts.TX_MAX_GAS_LIMIT
 
     """  # noqa: E501
     execution_gas_available = (
@@ -1089,7 +1090,7 @@ def check_block_gas_capacity(
     )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
-    if min(TX_MAX_GAS_LIMIT, tx_gas) > execution_gas_available:
+    if min(GasCosts.TX_MAX_GAS_LIMIT, tx_gas) > execution_gas_available:
         raise GasUsedExceedsLimitError("execution gas used exceeds limit")
 
     if tx_gas > state_gas_available:
@@ -1142,7 +1143,7 @@ def allocate_evm_gas(
 
     """
     evm_gas = tx_gas - Uint(intrinsic.execution)
-    execution_gas_budget = TX_MAX_GAS_LIMIT - intrinsic.execution
+    execution_gas_budget = GasCosts.TX_MAX_GAS_LIMIT - intrinsic.execution
     execution_gas = ExecutionGas(min(execution_gas_budget, evm_gas))
     state_gas_reservoir = StateGas(evm_gas - execution_gas)
     return EvmGasAllocation(execution_gas, state_gas_reservoir)

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -42,9 +42,6 @@ class IntrinsicGasCost:
     """Minimum gas cost based on calldata size per [EIP-7623]."""
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -570,6 +567,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
@@ -577,7 +575,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient gas")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/bpo1/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo1/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -217,7 +216,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -106,6 +107,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(10)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -42,9 +42,6 @@ class IntrinsicGasCost:
     """Minimum gas cost based on calldata size per [EIP-7623]."""
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -570,6 +567,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
@@ -577,7 +575,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient gas")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/bpo2/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo2/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -217,7 +216,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -106,6 +107,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(10)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -42,9 +42,6 @@ class IntrinsicGasCost:
     """Minimum gas cost based on calldata size per [EIP-7623]."""
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -570,6 +567,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
@@ -577,7 +575,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient gas")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/bpo3/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo3/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -217,7 +216,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -106,6 +107,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(10)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -42,9 +42,6 @@ class IntrinsicGasCost:
     """Minimum gas cost based on calldata size per [EIP-7623]."""
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -570,6 +567,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
@@ -577,7 +575,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient gas")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/bpo4/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo4/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -217,7 +216,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -106,6 +107,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(10)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -42,9 +42,6 @@ class IntrinsicGasCost:
     """Minimum gas cost based on calldata size per [EIP-7623]."""
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -570,6 +567,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
@@ -577,7 +575,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient gas")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/bpo5/vm/eoa_delegation.py
+++ b/src/ethereum/forks/bpo5/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -217,7 +216,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -106,6 +107,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(10)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -46,9 +46,6 @@ class IntrinsicGasCost:
     """
 
 
-TX_MAX_GAS_LIMIT = Uint(16_777_216)
-
-
 @final
 @slotted_freezable
 @dataclass
@@ -574,6 +571,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
+    from .vm.gas import GasCosts
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic = calculate_intrinsic_cost(tx)
@@ -581,7 +579,7 @@ def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
         raise InsufficientTransactionGasError("Insufficient gas")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
-    if tx.gas > TX_MAX_GAS_LIMIT:
+    if tx.gas > GasCosts.TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")

--- a/src/ethereum/forks/osaka/vm/eoa_delegation.py
+++ b/src/ethereum/forks/osaka/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -218,7 +217,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)
@@ -106,6 +107,7 @@ class GasCosts:
     TX_DATA_TOKEN_FLOOR: Final[Uint] = Uint(10)
     TX_ACCESS_LIST_ADDRESS: Final[Uint] = Uint(2400)
     TX_ACCESS_LIST_STORAGE_KEY: Final[Uint] = Uint(1900)
+    TX_MAX_GAS_LIMIT: Final[Uint] = Uint(16_777_216)
 
     # Block
     LIMIT_ADJUSTMENT_FACTOR: Final[Uint] = Uint(1024)

--- a/src/ethereum/forks/prague/vm/eoa_delegation.py
+++ b/src/ethereum/forks/prague/vm/eoa_delegation.py
@@ -29,7 +29,6 @@ SET_CODE_TX_MAGIC = b"\x05"
 EOA_DELEGATION_MARKER = b"\xef\x01\x00"
 EOA_DELEGATION_MARKER_LENGTH = len(EOA_DELEGATION_MARKER)
 EOA_DELEGATED_CODE_LENGTH = 23
-REFUND_AUTH_PER_EXISTING_ACCOUNT = 12500
 NULL_ADDRESS = hex_to_address("0x0000000000000000000000000000000000000000")
 
 
@@ -217,7 +216,7 @@ def set_delegation(message: Message) -> U256:
         if account_exists(tx_state, authority):
             refund_counter += U256(
                 GasCosts.AUTH_PER_EMPTY_ACCOUNT
-                - REFUND_AUTH_PER_EXISTING_ACCOUNT
+                - GasCosts.REFUND_AUTH_PER_EXISTING_ACCOUNT
             )
 
         if auth.address == NULL_ADDRESS:

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -67,6 +67,7 @@ class GasCosts:
 
     # Refunds
     REFUND_STORAGE_CLEAR: Final[int] = 4800
+    REFUND_AUTH_PER_EXISTING_ACCOUNT: Final[int] = 12500
 
     # Precompiles
     PRECOMPILE_ECRECOVER: Final[Uint] = Uint(3000)


### PR DESCRIPTION
### Description
Moves `REFUND_AUTH_PER_EXISTING_ACCOUNT` and `TX_MAX_GAS_LIMIT` into `GasCosts` so they live with the other gas constants (same direction as #2396).

- `REFUND_AUTH_PER_EXISTING_ACCOUNT` → `GasCosts` in Prague through BPO5 (Amsterdam no longer has this refund under EIP-2780)
- `TX_MAX_GAS_LIMIT` → `GasCosts` in Osaka through Amsterdam
- Call sites updated; `transactions.validate_transaction` uses a local import to avoid circular imports with `vm.gas`

Fresh take on closed #2700 against current `forks/amsterdam`.

### Related Issues or PRs
Fixes #2680

### Checklist
- [x] Ran fast static checks to avoid CI fails: `just static`
- [x] PR title has the form `<type>(<area>): <title>`

### Cute Animal Picture

![red panda](https://images.unsplash.com/photo-1615812214207-34e3be6812df?auto=format&fit=crop&w=640)