### PR TITLE
feat(test-specs,tests): exercise the EIP-8141 expiry verifier install at the fork transition

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -149,6 +149,9 @@ def build_genesis_header(
     )
     if base_pre is not None:
         pre_alloc = Alloc.merge(pre_alloc, base_pre)
+    pre_alloc = pre_alloc.with_installed_code(
+        genesis_fork.activation_code_installs()
+    )
     if empty_accounts := pre_alloc.empty_accounts():
         raise Exception(f"Empty accounts in pre state: {empty_accounts}")
     pre_alloc.migrate_state_commitment(

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -577,6 +577,10 @@ class PreAllocGroupBuilders(EthereumTestRootModel):
                         fork.transitions_to().pre_allocation_blockchain()
                     ),
                     pre,
+                ).with_installed_code(
+                    fork.fork_at(
+                        block_number=0, timestamp=0
+                    ).activation_code_installs()
                 ),
             )
             self.root[pre_alloc_hash] = group

--- a/packages/testing/src/execution_testing/forks/__init__.py
+++ b/packages/testing/src/execution_testing/forks/__init__.py
@@ -29,6 +29,7 @@ from .forks.forks import (
     TangerineWhistle,
 )
 from .forks.transition import (
+    AmsterdamToBogotaAtTime15k,
     BerlinToLondonAt5,
     BPO1ToBPO2AtTime15k,
     BPO2ToAmsterdamAtTime15k,
@@ -92,6 +93,7 @@ __all__ = [
     "TransitionForkOrNoneAdapter",
     "RefundTypes",
     "Amsterdam",
+    "AmsterdamToBogotaAtTime15k",
     "ArrowGlacier",
     "Berlin",
     "BerlinToLondonAt5",

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -1376,6 +1376,22 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         """
         pass
 
+    @classmethod
+    @abstractmethod
+    def activation_code_installs(cls) -> Mapping:
+        """
+        Return the runtime code this fork installs when it activates, keyed
+        by address.
+
+        Unlike `pre_allocation_blockchain`, which describes accounts that
+        already exist at genesis, these installs happen at the first block
+        of the fork: only the code is written, and the nonce, balance and
+        storage the account had before the fork are kept. In a blockchain
+        test that starts at a fork already including them, the installs are
+        applied to the genesis allocation instead.
+        """
+        pass
+
     # Engine API information abstract methods
     @classmethod
     @abstractmethod

--- a/packages/testing/src/execution_testing/forks/forks/eips/bogota/eip_8141.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/bogota/eip_8141.py
@@ -306,13 +306,15 @@ class EIP8141(BaseFork):
         } | super(EIP8141, cls).pre_allocation()  # type: ignore
 
     @classmethod
-    def pre_allocation_blockchain(cls) -> Mapping:
-        """Pre-allocate the expiry verifier contract."""
+    def activation_code_installs(cls) -> Mapping:
+        """
+        Install the expiry verifier's runtime code when the fork activates.
+
+        Blockchain tests get the code from this hook rather than from
+        `pre_allocation_blockchain`, so a fixture that crosses the fork
+        boundary exercises the install itself: the account appears at the
+        fork block with the code and nothing else changed.
+        """
         return {
-            EXPIRY_VERIFIER_ADDRESS: {
-                # EIP-8141 installs only the runtime code at
-                # activation; the nonce stays zero.
-                "nonce": 0,
-                "code": EXPIRY_VERIFIER_BYTECODE,
-            }
-        } | super(EIP8141, cls).pre_allocation_blockchain()  # type: ignore
+            EXPIRY_VERIFIER_ADDRESS: EXPIRY_VERIFIER_BYTECODE,
+        } | super(EIP8141, cls).activation_code_installs()  # type: ignore

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1288,6 +1288,15 @@ class Frontier(BaseFork):
         return {}
 
     @classmethod
+    def activation_code_installs(cls) -> Mapping:
+        """
+        Return the runtime code installed when the fork activates.
+
+        Frontier installs no code at activation.
+        """
+        return {}
+
+    @classmethod
     def build_default_block_header(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> FixtureHeader:

--- a/packages/testing/src/execution_testing/forks/forks/transition.py
+++ b/packages/testing/src/execution_testing/forks/forks/transition.py
@@ -8,6 +8,7 @@ from .forks import (
     BPO4,
     Amsterdam,
     Berlin,
+    Bogota,
     Cancun,
     London,
     Osaka,
@@ -88,5 +89,12 @@ class BPO2ToBPO3AtTime15k(TransitionBaseClass):
 @transition_fork(to_fork=BPO4, from_fork=BPO3, at_timestamp=15_000)
 class BPO3ToBPO4AtTime15k(TransitionBaseClass):
     """BPO3 to BPO4 transition at Timestamp 15k."""
+
+    pass
+
+
+@transition_fork(to_fork=Bogota, from_fork=Amsterdam, at_timestamp=15_000)
+class AmsterdamToBogotaAtTime15k(TransitionBaseClass):
+    """Amsterdam to Bogota transition at Timestamp 15k."""
 
     pass

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -987,11 +987,15 @@ class BlockchainTest(BaseTest):
             block_number=env.number - 1, timestamp=env.parent_timestamp
         )
         if fork != parent_fork:
-            inherited = parent_fork.activation_code_installs()
+            parent_installs = parent_fork.activation_code_installs()
+            inherited = {
+                Address(address): code
+                for address, code in parent_installs.items()
+            }
             new_installs = {
                 address: code
                 for address, code in fork.activation_code_installs().items()
-                if inherited.get(address) != code
+                if inherited.get(Address(address)) != code
             }
             if new_installs:
                 if isinstance(previous_alloc, LazyAlloc):

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -894,6 +894,14 @@ class BlockchainTest(BaseTest):
                 ),
                 pre_alloc,
             )
+            # Code a fork installs at activation is part of genesis only when
+            # that fork is already active there. A transition test gets it at
+            # the fork block instead, in `generate_block_data`.
+            pre_alloc = pre_alloc.with_installed_code(
+                self.fork.fork_at(
+                    block_number=0, timestamp=0
+                ).activation_code_installs()
+            )
         if empty_accounts := pre_alloc.empty_accounts():
             raise Exception(f"Empty accounts in pre state: {empty_accounts}")
         if pre_alloc.state_commitment() is None:
@@ -967,6 +975,29 @@ class BlockchainTest(BaseTest):
                 raise Exception(
                     "test correctness: the transaction that produces an "
                     "exception must be the last transaction in the block"
+                )
+
+        # A fork activating at this block installs its code before the block
+        # executes. The parent's fork tells whether this is that block, and
+        # which installs are new rather than inherited from an earlier fork.
+        assert env.parent_timestamp is not None, (
+            "parent_timestamp is required to resolve the parent's fork"
+        )
+        parent_fork = self.fork.fork_at(
+            block_number=env.number - 1, timestamp=env.parent_timestamp
+        )
+        if fork != parent_fork:
+            inherited = parent_fork.activation_code_installs()
+            new_installs = {
+                address: code
+                for address, code in fork.activation_code_installs().items()
+                if inherited.get(address) != code
+            }
+            if new_installs:
+                if isinstance(previous_alloc, LazyAlloc):
+                    previous_alloc = previous_alloc.materialize()
+                previous_alloc = previous_alloc.with_installed_code(
+                    new_installs
                 )
 
         transition_tool_output = t8n.evaluate(

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -13,6 +13,7 @@ from typing import (
     Iterator,
     List,
     Literal,
+    Mapping,
     Optional,
     Self,
 )
@@ -282,6 +283,29 @@ class Alloc(BaseAlloc):
     def items(self) -> ItemsView[Address, Account | None]:
         """Return iterator over the allocation items."""
         return self.root.items()
+
+    def with_installed_code(self, installs: Mapping) -> "Alloc":
+        """
+        Return a copy of this allocation with the runtime code in `installs`
+        written at each address.
+
+        Only the code changes: an account that already exists keeps its
+        nonce, balance and storage, and one that does not is created with
+        all three zero. This is how a fork installs code when it activates
+        (EIP-8141's expiry verifier), as opposed to a predeploy that is part
+        of the genesis allocation.
+        """
+        if not installs:
+            return self
+        root: Dict[Address, Account | None] = dict(self.root)
+        for address, code in installs.items():
+            address = Address(address)
+            root[address] = Account.merge(
+                root.get(address), Account(code=code)
+            )
+        installed = Alloc(root)
+        installed.migrate_state_commitment(self.state_commitment())
+        return installed
 
     def __getitem__(
         self, address: Address | FixedSizeBytesConvertible

--- a/tests/amsterdam/eip8141_frame_transactions/test_fork_transition.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_fork_transition.py
@@ -1,0 +1,172 @@
+"""
+Tests for the EIP-8141 fork transition.
+
+The fork installs the expiry verifier's runtime code at
+`Spec.EXPIRY_VERIFIER` when it activates. Every other EIP-8141 test
+starts at a fork where the code is already in the genesis allocation, so
+these tests are the only ones that exercise the install itself: what the
+account looks like before the fork block, and what changes at it.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    FrameReceipt,
+    Op,
+    Transaction,
+    TransactionReceipt,
+)
+
+from .helpers import expiry_frame, sender_frame, verify_frame
+from .spec import Spec, ref_spec_8141
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8141.version
+
+pytestmark = pytest.mark.valid_at_transition_to("EIP8141")
+
+FORK_TIMESTAMP = 15_000
+"""Timestamp at which the transition fork activates EIP-8141."""
+
+SLOT_EXECUTED = 0x01
+"""Storage slot used by target contracts to record execution."""
+
+
+@pytest.mark.pre_alloc_mutable
+@pytest.mark.parametrize(
+    "pre_fork_nonce,pre_fork_balance",
+    [
+        pytest.param(None, None, id="absent_before_fork"),
+        pytest.param(0, 1, id="balance_before_fork"),
+        pytest.param(7, 1, id="nonce_and_balance_before_fork"),
+    ],
+)
+@pytest.mark.parametrize(
+    "transfer_before_fork",
+    [
+        pytest.param(False, id="no_transfer"),
+        pytest.param(True, id="transfer_before_fork"),
+    ],
+)
+def test_expiry_verifier_installed_at_fork_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    pre_fork_nonce: int | None,
+    pre_fork_balance: int | None,
+    transfer_before_fork: bool,
+) -> None:
+    """
+    Install the expiry verifier's code at the fork block and nothing else.
+
+    A probe contract records `EXTCODESIZE` of the verifier address keyed
+    by block number, so each block's view is visible in the post-state:
+
+    * block 1 (pre-fork): no code yet, and a transaction sent to the
+      address runs nothing.
+    * block 2 (transition): the runtime code is present from the first
+      post-fork block.
+    * block 3 (post-fork): the code stays.
+
+    The account's other fields are left as they were before the fork. An
+    address nobody touched ends with a zero nonce and balance; an account
+    that already existed keeps its nonce and its balance, whether that
+    balance was in the genesis allocation or arrived by a pre-fork
+    transfer. Installing the account with a nonce of one, as a genesis
+    predeploy would have, changes the state root of the fork block.
+    """
+    sender = pre.fund_eoa()
+    probe = pre.deploy_contract(
+        Op.SSTORE(Op.NUMBER, Op.EXTCODESIZE(Spec.EXPIRY_VERIFIER)) + Op.STOP
+    )
+    if pre_fork_nonce is not None and pre_fork_balance is not None:
+        pre[Spec.EXPIRY_VERIFIER] = Account(
+            nonce=pre_fork_nonce, balance=pre_fork_balance
+        )
+
+    pre_fork_txs = [
+        Transaction(sender=sender, to=probe),
+        # Before the fork there is no code at the address: the call is a
+        # plain transfer of whatever value it carries.
+        Transaction(
+            sender=sender,
+            to=Spec.EXPIRY_VERIFIER,
+            value=1 if transfer_before_fork else 0,
+        ),
+    ]
+    blocks = [
+        Block(timestamp=FORK_TIMESTAMP - 1, txs=pre_fork_txs),
+        Block(
+            timestamp=FORK_TIMESTAMP,
+            txs=[Transaction(sender=sender, to=probe)],
+        ),
+        Block(
+            timestamp=FORK_TIMESTAMP + 1,
+            txs=[Transaction(sender=sender, to=probe)],
+        ),
+    ]
+
+    code_size = len(Spec.EXPIRY_VERIFIER_CODE)
+    expected_balance = (pre_fork_balance or 0) + (
+        1 if transfer_before_fork else 0
+    )
+    post = {
+        probe: Account(
+            storage={
+                1: 0,
+                2: code_size,
+                3: code_size,
+            },
+        ),
+        Spec.EXPIRY_VERIFIER: Account(
+            nonce=pre_fork_nonce or 0,
+            balance=expected_balance,
+            code=Spec.EXPIRY_VERIFIER_CODE,
+        ),
+    }
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+def test_expiry_frame_in_first_post_fork_block(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Execute an expiry verifier frame in the block that activates the fork.
+
+    The verifier's code is installed before the block's transactions run,
+    so a frame transaction carrying an expiry frame in that same block
+    finds the predeploy in place and executes.
+    """
+    sender = pre.fund_eoa()
+    target = pre.deploy_contract(code=Op.SSTORE(SLOT_EXECUTED, 1) + Op.STOP)
+    tx = Transaction(
+        sender=sender,
+        frames=[
+            verify_frame(),
+            expiry_frame(),
+            sender_frame(target=target),
+        ],
+        expected_receipt=TransactionReceipt(
+            payer=sender,
+            frame_receipts=[
+                FrameReceipt(status=Spec.STATUS_SUCCESS) for _ in range(3)
+            ],
+        ),
+    )
+    blocks = [
+        Block(timestamp=FORK_TIMESTAMP - 1),
+        Block(timestamp=FORK_TIMESTAMP, txs=[tx]),
+    ]
+    post = {
+        Spec.EXPIRY_VERIFIER: Account(
+            nonce=0,
+            code=Spec.EXPIRY_VERIFIER_CODE,
+        ),
+        target: Account(storage={SLOT_EXECUTED: 1}),
+    }
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip8141_frame_transactions/test_fork_transition.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_fork_transition.py
@@ -6,13 +6,30 @@ The fork installs the expiry verifier's runtime code at
 starts at a fork where the code is already in the genesis allocation, so
 these tests are the only ones that exercise the install itself: what the
 account looks like before the fork block, and what changes at it.
+
+They cover the verifier install, not the activation block as a whole. A
+passing fixture says the code appeared at the fork block, that nothing
+else about the account changed, and that the install left no trace in the
+block access list. It says nothing about the rest of the transition.
+
+A transition test that exercises pre-fork Amsterdam behaviour is not
+possible yet. EIP-8141 is implemented inside the `amsterdam` spec package,
+and `Bogota` is a test-side label for it rather than a separate fork
+module, so the transition tool runs every block of a transition fixture
+with EIP-8141 enabled, the pre-fork blocks included. These tests work
+because their pre-fork blocks contain nothing Amsterdam and Bogota
+disagree on: a plain transfer and an `EXTCODESIZE` probe. Anything that
+needs the pre-fork rules, such as a frame transaction being rejected
+before the fork, has to wait for a dedicated `bogota` spec package.
 """
 
 import pytest
 from execution_testing import (
     Account,
     Alloc,
+    BalAccountExpectation,
     Block,
+    BlockAccessListExpectation,
     BlockchainTestFiller,
     FrameReceipt,
     Op,
@@ -26,7 +43,7 @@ from .spec import Spec, ref_spec_8141
 REFERENCE_SPEC_GIT_PATH = ref_spec_8141.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8141.version
 
-pytestmark = pytest.mark.valid_at_transition_to("EIP8141")
+pytestmark = pytest.mark.valid_at_transition_to("Bogota")
 
 FORK_TIMESTAMP = 15_000
 """Timestamp at which the transition fork activates EIP-8141."""
@@ -34,14 +51,39 @@ FORK_TIMESTAMP = 15_000
 SLOT_EXECUTED = 0x01
 """Storage slot used by target contracts to record execution."""
 
+SLOT_PRE_FORK = 0x10
+"""Storage slot the verifier address may already hold before the fork."""
+
+VERIFIER_WITHOUT_CODE_CHANGE = BlockAccessListExpectation(
+    account_expectations={
+        Spec.EXPIRY_VERIFIER: BalAccountExpectation(code_changes=[]),
+    }
+)
+"""
+The verifier is in the block access list, reached by a transaction, and
+records no code change. The install is not a block-level operation, so
+it never appears there, not even in the block that performs it.
+"""
+
+VERIFIER_UNTOUCHED = BlockAccessListExpectation(
+    account_expectations={
+        Spec.EXPIRY_VERIFIER: BalAccountExpectation.empty(),
+    }
+)
+"""
+The verifier is in the block access list, read by a transaction, and
+records no change of any kind.
+"""
+
 
 @pytest.mark.pre_alloc_mutable
 @pytest.mark.parametrize(
-    "pre_fork_nonce,pre_fork_balance",
+    "pre_fork_nonce,pre_fork_balance,pre_fork_storage",
     [
-        pytest.param(None, None, id="absent_before_fork"),
-        pytest.param(0, 1, id="balance_before_fork"),
-        pytest.param(7, 1, id="nonce_and_balance_before_fork"),
+        pytest.param(None, None, None, id="absent_before_fork"),
+        pytest.param(0, 1, None, id="balance_before_fork"),
+        pytest.param(7, 1, None, id="nonce_and_balance_before_fork"),
+        pytest.param(0, 1, {SLOT_PRE_FORK: 0xA5}, id="storage_before_fork"),
     ],
 )
 @pytest.mark.parametrize(
@@ -56,6 +98,7 @@ def test_expiry_verifier_installed_at_fork_transition(
     pre: Alloc,
     pre_fork_nonce: int | None,
     pre_fork_balance: int | None,
+    pre_fork_storage: dict[int, int] | None,
     transfer_before_fork: bool,
 ) -> None:
     """
@@ -72,10 +115,14 @@ def test_expiry_verifier_installed_at_fork_transition(
 
     The account's other fields are left as they were before the fork. An
     address nobody touched ends with a zero nonce and balance; an account
-    that already existed keeps its nonce and its balance, whether that
+    that already existed keeps its nonce, its balance, whether that
     balance was in the genesis allocation or arrived by a pre-fork
-    transfer. The post-state pins all three fields, so an install that
-    writes anything other than the code fails here.
+    transfer, and its storage. The post-state pins all of them, so an
+    install that writes anything other than the code fails here.
+
+    Each block's access list pins the same from the other side: the
+    verifier appears in it only through the transactions that touch it,
+    and never with a code change, in the fork block included.
     """
     sender = pre.fund_eoa()
     probe = pre.deploy_contract(
@@ -83,7 +130,9 @@ def test_expiry_verifier_installed_at_fork_transition(
     )
     if pre_fork_nonce is not None and pre_fork_balance is not None:
         pre[Spec.EXPIRY_VERIFIER] = Account(
-            nonce=pre_fork_nonce, balance=pre_fork_balance
+            nonce=pre_fork_nonce,
+            balance=pre_fork_balance,
+            storage=pre_fork_storage or {},
         )
 
     pre_fork_txs = [
@@ -97,14 +146,20 @@ def test_expiry_verifier_installed_at_fork_transition(
         ),
     ]
     blocks = [
-        Block(timestamp=FORK_TIMESTAMP - 1, txs=pre_fork_txs),
+        Block(
+            timestamp=FORK_TIMESTAMP - 1,
+            txs=pre_fork_txs,
+            expected_block_access_list=VERIFIER_WITHOUT_CODE_CHANGE,
+        ),
         Block(
             timestamp=FORK_TIMESTAMP,
             txs=[Transaction(sender=sender, to=probe)],
+            expected_block_access_list=VERIFIER_UNTOUCHED,
         ),
         Block(
             timestamp=FORK_TIMESTAMP + 1,
             txs=[Transaction(sender=sender, to=probe)],
+            expected_block_access_list=VERIFIER_UNTOUCHED,
         ),
     ]
 
@@ -124,6 +179,7 @@ def test_expiry_verifier_installed_at_fork_transition(
             nonce=pre_fork_nonce or 0,
             balance=expected_balance,
             code=Spec.EXPIRY_VERIFIER_CODE,
+            storage=pre_fork_storage or {},
         ),
     }
 
@@ -139,7 +195,8 @@ def test_expiry_frame_in_first_post_fork_block(
 
     The verifier's code is installed before the block's transactions run,
     so a frame transaction carrying an expiry frame in that same block
-    finds the predeploy in place and executes.
+    finds the predeploy in place and executes. The block's access list
+    shows the verifier as executed code, not as a code change.
     """
     sender = pre.fund_eoa()
     target = pre.deploy_contract(code=Op.SSTORE(SLOT_EXECUTED, 1) + Op.STOP)
@@ -159,7 +216,11 @@ def test_expiry_frame_in_first_post_fork_block(
     )
     blocks = [
         Block(timestamp=FORK_TIMESTAMP - 1),
-        Block(timestamp=FORK_TIMESTAMP, txs=[tx]),
+        Block(
+            timestamp=FORK_TIMESTAMP,
+            txs=[tx],
+            expected_block_access_list=VERIFIER_WITHOUT_CODE_CHANGE,
+        ),
     ]
     post = {
         Spec.EXPIRY_VERIFIER: Account(

--- a/tests/amsterdam/eip8141_frame_transactions/test_fork_transition.py
+++ b/tests/amsterdam/eip8141_frame_transactions/test_fork_transition.py
@@ -74,8 +74,8 @@ def test_expiry_verifier_installed_at_fork_transition(
     address nobody touched ends with a zero nonce and balance; an account
     that already existed keeps its nonce and its balance, whether that
     balance was in the genesis allocation or arrived by a pre-fork
-    transfer. Installing the account with a nonce of one, as a genesis
-    predeploy would have, changes the state root of the fork block.
+    transfer. The post-state pins all three fields, so an install that
+    writes anything other than the code fails here.
     """
     sender = pre.fund_eoa()
     probe = pre.deploy_contract(


### PR DESCRIPTION
### Description

EIP-8141 installs the expiry verifier's runtime code at `0x…8141` when the fork activates, and leaves the account's nonce and balance as they were ([EIPs@b75cbe6](https://github.com/ethereum/EIPs/blob/b75cbe61150f09a44c38843be916417283d5b7bf/EIPS/eip-8141.md), "Expiry verifier contract"; `apply_fork` in the Amsterdam spec module on this branch). No fixture exercised that install: every EIP-8141 test starts at Bogota with the account already in the genesis allocation, so a client that installs it with any nonce, balance or timing passes the whole suite and can still diverge on the state root of the activation block.

Three things stood in the way of a transition fixture. There was no transition fork into Bogota. `make_genesis` seeds `transitions_to().pre_allocation_blockchain()`, so even a transition fixture would have carried the code at genesis. And nothing in the filler applies a fork's activation-time state change (`apply_fork` is only called by `ethereum_spec_tools.sync`), which no fork since the DAO fork has needed.

This PR adds `BaseFork.activation_code_installs()`, the runtime code a fork writes when it activates, keyed by address. `EIP8141` moves the verifier from `pre_allocation_blockchain` to this hook; state tests keep `pre_allocation`, having no activation to cross. `Alloc.with_installed_code` applies such installs changing only the code. The blockchain filler applies the genesis fork's installs at genesis and, in `generate_block_data`, the installs new to a block's fork relative to its parent's fork before the block executes. The hive `execute` genesis and the engine_x pre-alloc groups apply the genesis-side installs the same way. `AmsterdamToBogotaAtTime15k` is added; the consume ruleset picks it up on its own.

`test_fork_transition.py` adds two tests. A probe records `EXTCODESIZE` of the verifier per block, none before the fork and the code from the fork block on, with the account absent, funded by a pre-fork transfer, or already present with a nonce and balance that must survive the install. And a frame transaction carrying an expiry frame executes in the activation block itself. A pre-fork type-6 rejection test is not possible while Bogota shares Amsterdam's spec module.

Verification, on the committed tree:

- `tests/amsterdam/eip8141_frame_transactions` filled at Bogota with `--generate-all-formats` on the unmodified and on the modified tree: 943 fixtures, all hash-identical; the new tests add 21 (7 cases in 3 formats).
- `just static` passes; the forks, fork-marker, specs and fixtures unit tests pass (571).

### Related Issues or PRs

Related to #3532, the `tests-frames-devnet@v0.3.0` tracker; the existing EIP-8141 fixtures are unchanged from that release.

### Checklist

- [x] Ran fast static checks to avoid CI fails: `just static`
- [x] PR title has the form `<type>(<area>): <title>`

### Cute Animal Picture

![](https://thumb.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/330px-Cat_November_2010-1a.jpg)
