### PR TITLE
refactor(tests): use `GasConsumer` for the remaining manual gas sinks

### DIFF
--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -1153,15 +1153,22 @@ def test_contract_log_and_transfer_ordering(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
-@pytest.mark.parametrize(
-    "reverting_code",
-    [
+def reverting_codes(fork: Fork) -> List[ParameterSet]:
+    """
+    Return codes that fail the transaction, one way per case.
+
+    The out-of-gas case is sized against the fork's memory pricing, so the
+    cases cannot be built before the fork is known.
+    """
+    return [
         pytest.param(Op.REVERT(0, 0), id="revert"),
         pytest.param(Op.INVALID, id="invalid_opcode"),
         pytest.param(Op.ADD, id="stack_underflow"),
-        pytest.param(Op.MSTORE(2**256 - 1, 0), id="out_of_gas"),
-    ],
-)
+        pytest.param(GasConsumer.out_of_gas(fork), id="out_of_gas"),
+    ]
+
+
+@pytest.mark.parametrize_by_fork("reverting_code", reverting_codes)
 def test_reverted_transaction_no_log(
     state_test: StateTestFiller,
     env: Environment,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -893,9 +893,10 @@ def test_base_fee_per_gas_follows_dominant_dimension(
     Verify the child block's base fee follows the bottleneck dimension.
 
     Block 1 exceeds the gas target on one dimension only: state, via
-    SSTORE-set txs that spill, or execution, via STOP/MSTORE txs. Its header
-    gas_used = max(execution, state) is then set by that dimension alone,
-    which lifts empty block 2's base fee under the EIP-1559 update.
+    SSTORE-set txs that spill, or execution, via STOP txs or a single tx
+    that burns its whole gas limit. Its header gas_used = max(execution,
+    state) is then set by that dimension alone, which lifts empty block 2's
+    base fee under the EIP-1559 update.
     """
     genesis_base_fee = 10**9
     max_fee_per_gas = 10**10
@@ -932,7 +933,7 @@ def test_base_fee_per_gas_follows_dominant_dimension(
             num_txs = 1
             # Just consume all gas
             execution_contract = pre.deploy_contract(
-                code=Op.MSTORE(offset=2**256 - 1, value=1) + Op.STOP
+                code=GasConsumer.out_of_gas(fork) + Op.STOP
             )
             tx_gas_limit = target + 1
         else:

--- a/tests/ported_static/stCreateTest/test_create_address_warm_after_fail.py
+++ b/tests/ported_static/stCreateTest/test_create_address_warm_after_fail.py
@@ -27,6 +27,7 @@ from execution_testing import (
     Address,
     Alloc,
     CodeGasMeasure,
+    GasConsumer,
     Hash,
     StateTestFiller,
     Transaction,
@@ -218,20 +219,12 @@ def test_create_address_warm_after_fail(
             outcome = CONSTRUCTOR_OUT_OF_GAS
 
         elif initcode_outcome == "oog-post-constr":
-            # Run OOG at the JUMPDEST
+            # Run OOG after the constructor has returned. The sink is
+            # unpayable at any gas limit, so it does not have to be sized
+            # against the memory prices of a particular fork.
             gas = initcode_success_gas
             callee_code_suffix = (
-                Op.MSTORE(
-                    2**12,
-                    1,
-                    old_memory_size=32,
-                    new_memory_size=2**12,
-                )
-                + Op.STOP
-            )
-            assert callee_code_suffix.gas_cost(fork) > (
-                gas
-                - (pre_create_code.gas_cost(fork) + initcode.gas_cost(fork))
+                GasConsumer.out_of_gas(fork, previous_memory_size=32) + Op.STOP
             )
             # Callee runs out of gas, the created contract warming is reverted.
             outcome = CALLEE_OUT_OF_GAS


### PR DESCRIPTION
### Description

`GasConsumer` landed in #3497, which converted the non ported static tests that were sizing a gas burn by hand. Three call sites were left behind and this picks them up.

Two of them, in `test_block_2d_gas_accounting` and `test_transfer_logs`, deployed `Op.MSTORE(2**256 - 1, ...)` to make a frame consume everything it was given. `GasConsumer.out_of_gas` says that outright and sizes the expansion against the fork's own memory pricing, so it no longer rests on one hard coded offset staying unpayable if those prices move.

`test_reverted_transaction_no_log` cannot build its case before the fork is known, so it moves to `parametrize_by_fork`. That reorders the segments of its test ids and puts the case id ahead of the fixture format suffix. #3497 already did the same to the two functions it converted in that file. No case is added or removed.

The third is `test_create_address_warm_after_fail`. Its `oog-post-constr` sink was sized to 2**12 bytes of memory and followed by an assert that the cost exceeded the gas left in the frame. The new sink is unpayable at any limit, which makes that assert trivially true, so it goes. On the question raised in the issue, `CodeGasMeasure` sits in the entry contract rather than in the callee, so it covers this branch the same way it covers the rest.

I left the memory bound tests under `stMemoryStressTest` and `stMemoryTest` alone. There the `MSTORE` offset is the subject of the test rather than an incidental way to burn gas.

Gas does not change anywhere.

### Related Issues or PRs

Fixes #3538.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
