### PR TITLE
chore(test-forks): remove unused zero-defaulted `GasCosts` fields

### DIFF
--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -45,7 +45,6 @@ class GasCosts:
     CALL_STIPEND: int
     NEW_ACCOUNT: int
     ACCOUNT_WRITE: int = 0
-    CREATE_ACCESS: int = 0
     TX_VALUE_COST: int = 0
 
     # Contract Creation
@@ -157,12 +156,5 @@ class GasCosts:
     OPCODE_KECCAK256_PER_WORD: int
 
     # Defined post-Frontier
-    OPCODE_SHL: int = 0
-    OPCODE_SHR: int = 0
-    OPCODE_SAR: int = 0
-    OPCODE_RETURNDATACOPY_BASE: int = 0
-    OPCODE_BLOBHASH: int = 0
-    OPCODE_MCOPY_BASE: int = 0
-    OPCODE_CLZ: int = 0
     OPCODE_TLOAD: int = 0
     OPCODE_TSTORE: int = 0


### PR DESCRIPTION
### Description

`GasCosts` in `packages/testing/src/execution_testing/forks/gas_costs.py` has eight fields that are declared with a zero default, are never assigned by any fork class, and are never read anywhere in `packages/` or `tests/`. `git log -S` over `packages/` finds no commit that has ever read one of them. This removes them.

Seven are per opcode aliases added by #2396:

`OPCODE_SHL`, `OPCODE_SHR`, `OPCODE_SAR`, `OPCODE_RETURNDATACOPY_BASE`, `OPCODE_BLOBHASH`, `OPCODE_MCOPY_BASE`, `OPCODE_CLZ`

They went unused because `opcode_gas_map` prices those opcodes from the tier constant directly and never consults the dedicated field. `Opcodes.SHL`, `Opcodes.SHR` and `Opcodes.SAR` take `gas_costs.VERY_LOW` in `eip_145.py`, `Opcodes.BLOBHASH` takes `gas_costs.VERY_LOW` in `eip_4844.py`, `Opcodes.CLZ` takes `gas_costs.LOW` in `eip_7939.py`, and `Opcodes.MCOPY` and `Opcodes.RETURNDATACOPY` go through `_with_memory_expansion` in `eip_5656.py` and `eip_211.py`.

The eighth is `CREATE_ACCESS`, added by #3052. Within the testing package and `tests/`, the only other mentions of it are prose in docstrings and one code comment in `eip_2780.py`, and both are left alone.

To be clear about scope, all nine names also exist on the spec's own `GasCosts` in `src/ethereum/forks/*/vm/gas.py`, where they are charged normally. That is a different class and nothing under `src/` is touched here.

### What is deliberately kept

Seven other fields also default to zero, and all of them stay:

* `OPCODE_EXTCODEHASH`, `OPCODE_TLOAD` and `OPCODE_TSTORE` are set by the forks that introduce or reprice them and are read only at or after those forks, in `eip_1052.py`, `eip_1153.py`, and one `valid_from("Amsterdam")` test.
* `ACCOUNT_WRITE`, `AUTH_BASE`, `TX_VALUE_COST` and `EXECUTION_PER_AUTH_BASE_COST` are additive charges that do not exist before the repricing that introduces them, so zero is their correct value rather than a stand in for absence. Code depends on that: `tests/ported_static/stEIP2930/test_varied_context.py` is `valid_from("Cancun")` and folds `gas_costs.ACCOUNT_WRITE` into a delta with the comment "the new ACCOUNT_WRITE charge (0 pre-Amsterdam)".

### Context and scope

This came out of looking at #2659, which proposes turning the zero defaults into `int | None` so an absent value has to be asserted at the point of use. I do not think that applies as written. Building `opcode_gas_map` for all 25 forks and looking up the affected opcodes shows that an opcode a fork does not have is absent from the map rather than present at cost zero. Where the opcode exists the entry is either the tier constant or a memory expansion callable, so for these seven a lookup never yields zero. The full findings are in a comment on that issue.

So this takes the narrower reading of #2659, removing the ambiguous zero defaults that are dead rather than adding machinery around them. It does not close the issue, because there is a second option that points the other way: wire the seven opcode fields up so `opcode_gas_map` reads them instead of the shared tier. That would mirror what #2396 and #3464 did on the spec side, and would matter if any of those opcodes is ever repriced away from its tier. I am happy to close this and do that instead if it is preferred.

### One thing to flag

`GasCosts` is exported from `execution_testing`, so this removes public attributes and is technically a breaking change for anything consuming the wheel that reads them. Since they have only ever held zero the practical impact should be nil, but that is a maintainer call rather than mine.

These also do not show up in `just deadcode`, because vulture only scans `src/` and `packages/testing/src/execution_testing/evm_tools/`, not `forks/`.

### Related Issues or PRs

#2659, #2396, #3052, #3464.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.
