### PR TITLE
chore(tests): drop stale EIP-8037 fork split in BAL insufficient-funds test

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -2712,9 +2712,6 @@ def test_bal_call_revert_insufficient_funds(
 
     if delegated:
         assert delegation_target is not None
-        # EIP-8037 (always on for this Amsterdam+ file) reads the
-        # delegation target's code before the balance check fails, so
-        # it appears in the BAL.
         account_expectations[delegation_target] = BalAccountExpectation.empty()
 
     block = Block(

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -2631,7 +2631,6 @@ def test_bal_create_contract_init_revert(
 def test_bal_call_revert_insufficient_funds(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,
-    fork: Fork,
     call_opcode: Op,
     delegated: bool,
     target_is_warm: bool,
@@ -2646,7 +2645,7 @@ def test_bal_call_revert_insufficient_funds(
     failure happens after delegation resolution. Under EIP-8037 the
     call family reads the delegation target's code before the balance
     check fails, so both the target and the delegation target appear in
-    the BAL. Pre-8037 forks defer that read, so only the target appears.
+    the BAL.
 
     Access-list warming does NOT add to BAL on its own — only EVM
     access does — so the BAL is identical across warm/cold variants.
@@ -2713,17 +2712,10 @@ def test_bal_call_revert_insufficient_funds(
 
     if delegated:
         assert delegation_target is not None
-        # Under EIP-8037 the call family reads the delegation target's
-        # code before the balance check fails, so it appears in the
-        # BAL. Pre-8037 forks defer that read and it stays out.
-        # TODO: drop this fork split once #2473 (defer get_code into
-        # generic_call) is consolidated into amsterdam.
-        if fork.is_eip_enabled(8037):
-            account_expectations[delegation_target] = (
-                BalAccountExpectation.empty()
-            )
-        else:
-            account_expectations[delegation_target] = None
+        # EIP-8037 (always on for this Amsterdam+ file) reads the
+        # delegation target's code before the balance check fails, so
+        # it appears in the BAL.
+        account_expectations[delegation_target] = BalAccountExpectation.empty()
 
     block = Block(
         txs=[tx],


### PR DESCRIPTION
### Description
Removes the dead `fork.is_eip_enabled(8037)` branch in `test_bal_call_revert_insufficient_funds`.

This file is `valid_from("Amsterdam")`, and Amsterdam always enables EIP-8037, so the pre-8037 `else` path was unreachable. The accompanying TODO waited on #2473 being consolidated into Amsterdam; that PR already merged, and EIP-8037 (#2901) kept the early code-read behavior that this test asserts.

Also drops the unused `fork` fixture argument from the test and updates the docstring/comment to match current Amsterdam behavior.

Filled locally:
```
uv run fill tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py::test_bal_call_revert_insufficient_funds --from Amsterdam --until Amsterdam --clean
```
24 passed.

### Related Issues or PRs
Follow-up cleanup after #2473 and #2901.

### Checklist
- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture
![otter](https://images.unsplash.com/photo-1583212292454-1fe6229603b7?auto=format&fit=crop&w=640)