### PR TITLE
chore(tests): remove stale EIP-2935 history-window TODOs

### DIFF
--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -104,10 +104,6 @@ def generate_block_check_code(
     return code
 
 
-# TODO: Test at transition: `BLOCKHASH_OLD_WINDOW + 1` blocks before transition
-# TODO: Test post fork: `HISTORY_SERVE_WINDOW` + 1 blocks after transition
-
-
 @pytest.mark.parametrize(
     "blocks_before_fork, blocks_after_fork",
     [


### PR DESCRIPTION
### Description
Removes two obsolete TODOs above `test_block_hashes_history_at_transition`:

- Pre-transition \`BLOCKHASH_OLD_WINDOW + 1\` is already covered by the existing parametrization.
- Post-fork \`HISTORY_SERVE_WINDOW + 1\` was already abandoned as too slow in \`test_block_hashes_history\` (\`pytest.mark.skip(\"Slow test not relevant anymore\")\`).

Leaving the comments implied unfinished work that is either done or intentionally not pursued.

### Related Issues or PRs
N/A.

### Checklist
- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): \`just static\`
- [x] PR title has the form \`<type>(<area>): <title>\`, where \`<type>\` and \`<area>\` come from an appropriate [\`C-<type>\`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [\`A-<area>\`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture
![fox](https://images.unsplash.com/photo-1474511320723-9a56873867b5?auto=format&fit=crop&w=640)