### PR TITLE
feat(ci): validate filled blockchain fixtures with EELS

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -76,6 +76,18 @@ runs:
         if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 5 ]; then
           exit "$EXIT_CODE"
         fi
+    - name: Validate blockchain fixtures with EELS
+      if: inputs.split_label != '' && steps.evm-builder.outputs.impl == 'eels'
+      shell: bash
+      env:
+        PYTEST_XDIST_AUTO_NUM_WORKERS: ${{ steps.evm-builder.outputs.xdist }}
+      run: |
+        FIXTURES="fixtures_${{ inputs.release_name }}/blockchain_tests"
+        if [ ! -d "$FIXTURES" ]; then
+          echo "No blockchain_tests fixtures to validate."
+          exit 0
+        fi
+        just validate-blocks "$FIXTURES" --no-cov
     - name: Generate Benchmark Genesis Files
       if: inputs.split_label == '' && contains(inputs.release_name, 'benchmark')
       uses: ./.github/actions/build-benchmark-genesis

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,10 +113,14 @@ jobs:
           -m "not slow and primary_format"
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
+      - name: Validate blockchain fixtures with EELS (${{ matrix.label }})
+        run: just validate-blocks .just/fill/fixtures/blockchain_tests
+        env:
+          PYTEST_XDIST_AUTO_NUM_WORKERS: auto
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
-          files: .just/fill/coverage.xml
+          files: .just/fill/coverage.xml,.just/validate-blocks/coverage.xml
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/Justfile
+++ b/Justfile
@@ -160,6 +160,22 @@ fill *args: (_tmp-logs "fill")
         "$@" \
         tests
 
+# Run blockchain_tests fixtures through EELS block validation with coverage
+[group('consensus tests')]
+validate-blocks fixtures_dir *args: (_tmp "validate-blocks")
+    COVERAGE_FILE="{{ output_dir }}/validate-blocks/.coverage" uv run python -m pytest \
+        -p tests.json_loader.conftest \
+        -c pyproject.toml \
+        --allow-post-state-hash \
+        -n {{ xdist_workers }} --dist=loadfile \
+        --cov-config=pyproject.toml \
+        --cov=ethereum \
+        --cov-report=term \
+        --cov-report "xml:{{ output_dir }}/validate-blocks/coverage.xml" \
+        --cov-branch \
+        --basetemp="{{ output_dir }}/validate-blocks/tmp" \
+        "$@"
+
 # Callers append the feature params, fork range and output; last flag wins.
 # Fill fixtures with the flags shared by all fixture releases
 [group('consensus tests')]

--- a/Justfile
+++ b/Justfile
@@ -164,7 +164,7 @@ fill *args: (_tmp-logs "fill")
 [group('consensus tests')]
 validate-blocks fixtures_dir *args: (_tmp "validate-blocks")
     COVERAGE_FILE="{{ output_dir }}/validate-blocks/.coverage" uv run python -m pytest \
-        -p tests.json_loader.conftest \
+        -p tests.json_loader.conftest --noconftest \
         -c pyproject.toml \
         --allow-post-state-hash \
         -n {{ xdist_workers }} --dist=loadfile \


### PR DESCRIPTION
### Description

Filling never runs the EELS block validator. The t8n path calls `process_transaction` and the block-level helpers, but the test framework assembles the block header itself, so `state_transition`, `execute_block`, `validate_header` and `apply_body` are only reached when a fixture is consumed. Header-level invalid blocks (`rlp_modifier`, requests and BAL overrides) are also exempt from t8n exception verification during fill.

This PR takes @spencer-tb's idea from #3526 to add a `just validate-blocks <blockchain_tests dir> [pytest args]` recipe, which runs an existing `blockchain_tests` directory through the `tests/json_loader` path. In contrast to #3526, the conftest is loaded as a pytest plugin, so any fixture directory can be passed directly and no symlink under `tests/json_loader` is needed. Coverage data is written under `.just/validate-blocks/`; `--no-cov` skips it.

This PR then additionally makes these CI changes:

- `test.yaml`: each fill matrix job validates the fixtures it just filled and uploads the validation coverage next to the fill coverage, so codecov sees the union.
- `build-fixtures` action: each split EELS release build validates its `blockchain_tests` before uploading the artifact. Unsplit (tarball) and non-EELS builds are skipped.

#### Cost on the CI runners

The tables compare the fill matrix jobs of the `Python Specification` workflow without and with the new step. The two baseline runs are the two most recent `forks/amsterdam` push runs, which have no validation step. The two PR runs are the runs on this branch; both commits have the same tree and differ only in the first commit message. Durations are job and step `started_at` to `completed_at` from the Actions API, so runner queue time is excluded. Fixture counts are the pytest summary lines of the new step.

Fill job duration:

| label | [push 80edd40](https://github.com/ethereum/execution-specs/actions/runs/34099530991) | [push 903b48f](https://github.com/ethereum/execution-specs/actions/runs/33883920342) | [PR run 1](https://github.com/ethereum/execution-specs/actions/runs/34328299130) | [PR run 2](https://github.com/ethereum/execution-specs/actions/runs/34328724568) |
|---|---|---|---|---|
| pre-shanghai | 2m21s | 2m23s | 2m47s | 2m37s |
| shanghai-cancun | 2m13s | 2m11s | 2m37s | 2m23s |
| prague | 2m17s | 2m12s | 2m29s | 2m26s |
| osaka | 2m20s | 2m15s | 2m36s | 2m32s |
| amsterdam | 3m09s | 3m04s | 3m36s | 3m40s |

The "Run fill" step itself is unchanged within noise (amsterdam 2m48s to 2m52s across the four runs), and the codecov upload with two files still takes 3 to 4 s.

The new step on its own:

| label | step, PR run 1 | step, PR run 2 | fixtures validated | share of the fill step, run 2 |
|---|---|---|---|---|
| pre-shanghai | 14 s | 13 s | 2,475 | 10% |
| shanghai-cancun | 14 s | 12 s | 1,706 | 11% |
| prague | 16 s | 14 s | 2,318 | 12% |
| osaka | 18 s | 17 s | 2,402 | 14% |
| amsterdam | 33 s | 33 s | 5,781 | 19% |

All 14,682 fixtures passed EELS block validation. Coverage instrumentation is most of the step's cost: locally a 95-fixture sample took 16 s with coverage and 5 s with `--no-cov`.

#### Coverage change

Codecov merges the uploads of all fill jobs and the json-loader job under the `unittests` flag. The tables compare the codecov report of the base commit with the report of this PR's head, both read from the codecov API (`/report/?sha=<commit>`). No source or test file changed, so the whole difference comes from the validation upload. The [PR report](https://app.codecov.io/gh/ethereum/execution-specs/pull/3552) shows the same totals.

| | [base 0cc100e](https://app.codecov.io/gh/ethereum/execution-specs/commit/0cc100eb190b64b23baba72dac0165652eaec252) | [head 6ac3c33](https://app.codecov.io/gh/ethereum/execution-specs/commit/6ac3c33b35dc821b17ad478eb9878876ccad5e93) | delta |
|---|---|---|---|
| coverage | 94.01% | 94.38% | +0.37 |
| hits | 34,717 | 34,855 | +138 |
| misses | 1,533 | 1,460 | -73 |
| partials | 677 | 612 | -65 |

Every file whose hit count changed:

| file | base | head | delta | hits | partials |
|---|---|---|---|---|---|
| `src/ethereum/forks/amsterdam/fork.py` | 80.20% | 85.57% | +5.37 | +16 | -8 |
| `src/ethereum/forks/osaka/fork.py` | 79.86% | 85.32% | +5.46 | +16 | -8 |
| `src/ethereum/forks/prague/fork.py` | 80.63% | 85.56% | +4.93 | +14 | -7 |
| `src/ethereum/forks/cancun/fork.py` | 76.73% | 81.63% | +4.90 | +12 | -6 |
| `src/ethereum/forks/shanghai/fork.py` | 70.64% | 75.62% | +4.98 | +10 | -5 |
| `src/ethereum/forks/london/fork.py` | 61.17% | 64.10% | +2.93 | +8 | -4 |
| `src/ethereum/forks/paris/fork.py` | 68.94% | 73.15% | +4.21 | +8 | -4 |
| `src/ethereum/forks/berlin/fork.py` | 61.60% | 64.13% | +2.53 | +6 | -3 |
| `src/ethereum/forks/byzantium/fork.py` | 60.26% | 62.88% | +2.62 | +6 | -3 |
| `src/ethereum/forks/constantinople/fork.py` | 60.26% | 62.88% | +2.62 | +6 | -3 |
| `src/ethereum/forks/frontier/fork.py` | 60.08% | 62.78% | +2.70 | +6 | -3 |
| `src/ethereum/forks/homestead/fork.py` | 59.72% | 62.44% | +2.72 | +6 | -3 |
| `src/ethereum/forks/istanbul/fork.py` | 60.26% | 62.88% | +2.62 | +6 | -3 |
| `src/ethereum/forks/cancun/transactions.py` | 95.02% | 97.23% | +2.21 | +4 | -2 |
| `src/ethereum/forks/prague/transactions.py` | 95.94% | 97.74% | +1.80 | +4 | -2 |
| `src/ethereum/forks/berlin/transactions.py` | 94.06% | 95.76% | +1.70 | +2 | +0 |
| `src/ethereum/forks/london/transactions.py` | 92.51% | 93.87% | +1.36 | +2 | +0 |
| `src/ethereum/forks/paris/transactions.py` | 92.51% | 93.87% | +1.36 | +2 | +0 |
| `src/ethereum/forks/shanghai/transactions.py` | 92.66% | 94.00% | +1.34 | +2 | +0 |
| `src/ethereum/state_mpt.py` | 95.18% | 97.59% | +2.41 | +2 | -1 |

Every gain is in `fork.py` (the header comparison branches, `validate_header` and `apply_body`), in transaction RLP decoding, or in the MPT state root path. The gain is smaller than a fill-only comparison would suggest because the json-loader job already reports the base-coverage subset through `state_transition`. The new step adds the lines reached only by fixtures outside that subset, for every fork range.

Notes:

- Transition fixtures (`network` such as `OsakaToAmsterdamAtTime15k`) are skipped by the loader, as before.
- The release step only runs on `release_fixtures` dispatch or the nightly schedule, so this PR's checks do not exercise it.

### Related Issues or PRs

Complements #3526, which uses the same json_loader path for per-EIP coverage measurement.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

<img width="860" height="535" alt="image" src="https://github.com/user-attachments/assets/142a2fb3-3d60-476e-879d-d5bde356b76f" />


