### PR TITLE
fix(tests): EIP-8037 - drop double-counted hash gas in code deposit guard

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -904,12 +904,7 @@ def test_code_deposit_oog_preserves_parent_reservoir(
     proves the reservoir was not inflated by the failed spill.
     """
     deploy_size = 4096
-    init_code = Op.RETURN(
-        0,
-        deploy_size,
-        new_memory_size=deploy_size,
-        code_deposit_size=deploy_size,
-    )
+    init_code = Op.RETURN(0, deploy_size, new_memory_size=deploy_size)
     create_call = Op.CREATE(
         value=0,
         offset=32 - len(init_code),


### PR DESCRIPTION
### Description

The initcode carried `code_deposit_size`, so its `execution_cost` already included the deposit's hash gas, and the guard added `code_deposit`'s execution cost on top. That overstated the child's pre-deposit execution gas, making the "child must reach code deposit" assert stricter than intended and the state-charge assert weaker.

Drop the metadata from the initcode so it prices the frame's own execution and `code_deposit` prices the deposit. Fixtures are unchanged: the guard is fill-time only.

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.