### PR TITLE
fix(test-consume): group test cases by fixture file and bound the per-worker fixture cache

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/consume.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/consume.py
@@ -8,7 +8,7 @@ import tarfile
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, cast
+from typing import Any, List, Optional, Sequence, Tuple, cast
 from urllib.parse import urlparse
 
 import platformdirs
@@ -30,6 +30,7 @@ from execution_testing.fixtures import (
 from execution_testing.fixtures.consume import (
     IndexFile,
     TestCaseBase,
+    TestCaseIndexFile,
     TestCases,
 )
 from execution_testing.forks import (
@@ -591,6 +592,31 @@ def fixtures_source(request: pytest.FixtureRequest) -> FixturesSource:  # noqa: 
     return request.config.fixtures_source  # type: ignore[attr-defined]
 
 
+def group_test_cases_by_fixture_file(
+    test_cases: Sequence[TestCaseBase],
+) -> Sequence[TestCaseBase]:
+    """
+    Return the test cases ordered so that the cases of one fixture file are
+    contiguous.
+
+    A fixture file can hold several test cases interleaved with other files
+    in the index. Grouping improves cache reuse when pytest-xdist assigns
+    contiguous chunks of the collection, but does not guarantee that all
+    tests from a file run on one worker.
+
+    Preserve the order within each file. For release paths, sorting groups
+    cases by format and fork directory in collection order; workers can
+    still execute different forks concurrently. Test cases read from stdin
+    have no file and are returned unchanged.
+    """
+    index_cases = [
+        tc for tc in test_cases if isinstance(tc, TestCaseIndexFile)
+    ]
+    if len(index_cases) != len(test_cases):
+        return test_cases
+    return sorted(index_cases, key=lambda tc: str(tc.json_path))
+
+
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """
     Generate test cases for every test fixture in all the JSON fixture files
@@ -604,6 +630,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     supported_fixture_formats: List[FixtureFormat] = getattr(
         metafunc.config, "supported_fixture_formats", []
     )
+    is_enginex = BlockchainEngineXFixture in supported_fixture_formats
+    if not is_enginex:
+        # EngineX orders its collection by pre-alloc group instead, see
+        # `pytest_collection_modifyitems` in the enginex plugin.
+        test_cases = group_test_cases_by_fixture_file(test_cases)
     param_list = []
     for test_case in test_cases:
         if test_case.format not in supported_fixture_formats:
@@ -629,7 +660,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         return
 
     clients = metafunc.config.hive_execution_clients  # type: ignore[attr-defined]
-    is_enginex = BlockchainEngineXFixture in supported_fixture_formats
     combined = []
     for param in param_list:
         tc = cast(TestCaseBase, param.values[0])

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Generator, Literal
 
@@ -75,44 +76,100 @@ def check_live_port(test_suite_name: str) -> Literal[8545, 8551]:
     )
 
 
-class FixturesDict(Dict[Path, Fixtures]):
+FIXTURE_FILE_CACHE_MAX_BYTES = 256 * 1024 * 1024
+"""
+Default bound of the per-worker fixture file cache, in bytes of fixture JSON
+on disk.
+
+Parsed fixtures take about twice their JSON size in memory for typical
+files, and every pytest-xdist worker holds its own cache for the whole
+session, so the bound must stay well below the memory of the host per
+worker.
+"""
+
+
+class FixtureFileCache:
     """
-    A dictionary that caches loaded fixture files to avoid reloading the same
-    file multiple times.
+    Least-recently-used cache of parsed fixture files, bounded by file size.
+
+    A fixture file holds several test cases, and the tests of one file are
+    spread through the collection order, so a worker needs the same file
+    repeatedly over a run; the cache saves re-reading and re-validating it
+    while it is resident.
+
+    The cache is bounded because it lives for the whole session of every
+    xdist worker: with an unbounded cache each worker gradually holds the
+    parsed form of most of the fixture set, which is gigabytes per worker
+    for a full release and exhausts the memory of the host running the hive
+    simulator. The bound counts the size of the JSON files on disk;
+    the most recently loaded file is always kept, even when it exceeds the
+    bound on its own.
     """
 
-    def __init__(self) -> None:
-        """Initialize the dictionary that caches loaded fixture files."""
-        self._fixtures: Dict[Path, Fixtures] = {}
+    def __init__(self, max_bytes: int = FIXTURE_FILE_CACHE_MAX_BYTES) -> None:
+        """Initialize an empty cache that holds at most `max_bytes` of JSON."""
+        self._max_bytes = max_bytes
+        self._fixtures: OrderedDict[Path, Fixtures] = OrderedDict()
+        self._sizes: Dict[Path, int] = {}
+        self._total_bytes = 0
 
     def __getitem__(self, key: Path) -> Fixtures:
         """
-        Return the fixtures from the index file, if not found, load from disk.
+        Return the fixtures of a fixture file, loading it from disk if it is
+        not cached, and evict the least recently used files over the bound.
         """
         assert key.is_file(), f"Expected a file path, got '{key}'"
-        if key not in self._fixtures:
-            start = time.perf_counter()
-            self._fixtures[key] = Fixtures.model_validate_json(key.read_text())
-            logger.info(
-                f"⏱ phase=fixture_load file={key.name} "
-                f"ms={(time.perf_counter() - start) * 1000:.1f}"
+        if key in self._fixtures:
+            self._fixtures.move_to_end(key)
+            return self._fixtures[key]
+        start = time.perf_counter()
+        fixtures = Fixtures.model_validate_json(key.read_text())
+        logger.info(
+            f"⏱ phase=fixture_load file={key.name} "
+            f"ms={(time.perf_counter() - start) * 1000:.1f}"
+        )
+        self._fixtures[key] = fixtures
+        self._sizes[key] = key.stat().st_size
+        self._total_bytes += self._sizes[key]
+        self._evict()
+        return fixtures
+
+    def __contains__(self, key: object) -> bool:
+        """Return whether the fixture file is currently cached."""
+        return key in self._fixtures
+
+    def __len__(self) -> int:
+        """Return the number of cached fixture files."""
+        return len(self._fixtures)
+
+    @property
+    def cached_bytes(self) -> int:
+        """Return the on-disk size of all cached fixture files."""
+        return self._total_bytes
+
+    def _evict(self) -> None:
+        """Drop least recently used files until within the bound."""
+        while self._total_bytes > self._max_bytes and len(self._fixtures) > 1:
+            path, _ = self._fixtures.popitem(last=False)
+            self._total_bytes -= self._sizes.pop(path)
+            logger.debug(
+                f"evicted fixture file {path.name} from the cache "
+                f"(cached_bytes={self._total_bytes})"
             )
-        return self._fixtures[key]
 
 
 @pytest.fixture(scope="session")
-def fixture_file_loader() -> Dict[Path, Fixtures]:
+def fixture_file_loader() -> FixtureFileCache:
     """
-    Return a singleton dictionary that caches loaded fixture files used in all
-    tests.
+    Return the per-worker cache of parsed fixture files used by all tests.
     """
-    return FixturesDict()
+    return FixtureFileCache()
 
 
 @pytest.fixture(scope="function")
 def fixture(
     fixtures_source: FixturesSource,
-    fixture_file_loader: Dict[Path, Fixtures],
+    fixture_file_loader: FixtureFileCache,
     test_case: TestCaseIndexFile | TestCaseStream,
 ) -> BaseFixture:
     """

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
@@ -90,24 +90,21 @@ worker.
 
 class FixtureFileCache:
     """
-    Least-recently-used cache of parsed fixture files, bounded by file size.
+    Cache parsed fixture files with least-recently-used eviction.
 
-    A fixture file holds several test cases, and the tests of one file are
-    spread through the collection order, so a worker needs the same file
-    repeatedly over a run; the cache saves re-reading and re-validating it
-    while it is resident.
+    Consume groups test cases by fixture file to improve cache reuse, except
+    in EngineX, which groups by pre-allocation. A cached file can serve
+    multiple tests without being read and validated again. Scheduling can
+    still split a file's tests across workers or cause later revisits.
 
-    The cache is bounded because it lives for the whole session of every
-    xdist worker: with an unbounded cache each worker gradually holds the
-    parsed form of most of the fixture set, which is gigabytes per worker
-    for a full release and exhausts the memory of the host running the hive
-    simulator. The bound counts the size of the JSON files on disk;
-    the most recently loaded file is always kept, even when it exceeds the
-    bound on its own.
+    Each xdist worker owns a cache for the whole session. Retaining every
+    loaded file can contribute to memory pressure during long runs. The
+    bound counts JSON bytes on disk, not process memory. The most recently
+    loaded file is always kept, even when it exceeds the bound on its own.
     """
 
     def __init__(self, max_bytes: int = FIXTURE_FILE_CACHE_MAX_BYTES) -> None:
-        """Initialize an empty cache that holds at most `max_bytes` of JSON."""
+        """Initialize an empty cache with a `max_bytes` JSON size budget."""
         self._max_bytes = max_bytes
         self._fixtures: OrderedDict[Path, Fixtures] = OrderedDict()
         self._sizes: Dict[Path, int] = {}

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_fixture_file_cache.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_fixture_file_cache.py
@@ -1,0 +1,111 @@
+"""Tests for the bounded per-worker cache of parsed fixture files."""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from execution_testing.cli.pytest_commands.plugins.consume.simulators import (
+    base,
+)
+
+FixtureFileCache = base.FixtureFileCache
+
+
+class _ParsedFile:
+    """Stand-in for the parsed fixtures of one file."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FixturesStub:
+    """Replacement for `Fixtures` that records every parse."""
+
+    parsed: List[str] = []
+
+    @classmethod
+    def model_validate_json(cls, text: str) -> _ParsedFile:
+        cls.parsed.append(text)
+        return _ParsedFile(text)
+
+
+@pytest.fixture
+def parsed(monkeypatch: pytest.MonkeyPatch) -> List[str]:
+    """Route fixture parsing through the stub and expose the parse log."""
+    _FixturesStub.parsed = []
+    monkeypatch.setattr(base, "Fixtures", _FixturesStub)
+    return _FixturesStub.parsed
+
+
+def _write(tmp_path: Path, name: str, size: int) -> Path:
+    """Create a fixture file of exactly `size` bytes."""
+    path = tmp_path / name
+    path.write_text("x" * size)
+    return path
+
+
+def test_repeated_access_loads_once(tmp_path: Path, parsed: List[str]) -> None:
+    """A cached file is parsed once and the same object is returned."""
+    cache = FixtureFileCache(max_bytes=100)
+    path = _write(tmp_path, "a.json", 10)
+
+    first = cache[path]
+    second = cache[path]
+
+    assert first is second
+    assert parsed == ["x" * 10]
+    assert len(cache) == 1
+    assert cache.cached_bytes == 10
+
+
+def test_evicts_least_recently_used_file(
+    tmp_path: Path, parsed: List[str]
+) -> None:
+    """Exceeding the bound drops the file that was used longest ago."""
+    cache = FixtureFileCache(max_bytes=25)
+    a = _write(tmp_path, "a.json", 10)
+    b = _write(tmp_path, "b.json", 10)
+    c = _write(tmp_path, "c.json", 10)
+
+    cache[a]
+    cache[b]
+    cache[a]  # `a` is now more recently used than `b`.
+    cache[c]
+
+    assert a in cache
+    assert b not in cache
+    assert c in cache
+    assert cache.cached_bytes == 20
+    assert len(parsed) == 3
+
+    cache[b]  # Reloads `b` and evicts `a`, the least recently used file.
+
+    assert a not in cache
+    assert len(parsed) == 4
+
+
+def test_keeps_single_file_over_the_bound(
+    tmp_path: Path, parsed: List[str]
+) -> None:
+    """A file larger than the bound is still cached until the next load."""
+    cache = FixtureFileCache(max_bytes=5)
+    big = _write(tmp_path, "big.json", 50)
+    small = _write(tmp_path, "small.json", 1)
+
+    cache[big]
+    assert big in cache
+    assert cache[big] is cache[big]
+    assert len(parsed) == 1
+
+    cache[small]
+    assert big not in cache
+    assert small in cache
+    assert cache.cached_bytes == 1
+
+
+def test_missing_file_is_rejected(tmp_path: Path) -> None:
+    """Looking up a path that is not a file fails loudly."""
+    cache = FixtureFileCache()
+    with pytest.raises(AssertionError, match="Expected a file path"):
+        cache[tmp_path / "missing.json"]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_test_case_grouping.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_test_case_grouping.py
@@ -1,0 +1,82 @@
+"""Tests for grouping collected test cases by fixture file."""
+
+from pathlib import Path
+from typing import List
+
+from execution_testing.cli.pytest_commands.plugins.consume.consume import (
+    group_test_cases_by_fixture_file,
+)
+from execution_testing.fixtures import BlockchainFixture
+from execution_testing.fixtures.consume import (
+    TestCaseBase,
+    TestCaseIndexFile,
+)
+
+HASH = "0x" + "11" * 32
+
+
+def _case(test_id: str, path: str) -> TestCaseIndexFile:
+    """Create an index test case for `path` with the given id."""
+    return TestCaseIndexFile(
+        id=test_id,
+        fixture_hash=HASH,
+        format=BlockchainFixture,
+        json_path=Path(path),
+    )
+
+
+def test_cases_of_one_file_become_contiguous() -> None:
+    """Interleaved files come out grouped, in file path order."""
+    cases: List[TestCaseBase] = [
+        _case("a1", "for_osaka/x/a.json"),
+        _case("b1", "for_osaka/x/b.json"),
+        _case("a2", "for_osaka/x/a.json"),
+        _case("c1", "for_amsterdam/y/c.json"),
+        _case("b2", "for_osaka/x/b.json"),
+        _case("a3", "for_osaka/x/a.json"),
+    ]
+
+    grouped = group_test_cases_by_fixture_file(cases)
+
+    assert [tc.id for tc in grouped] == ["c1", "a1", "a2", "a3", "b1", "b2"]
+    assert sorted(tc.id for tc in grouped) == sorted(tc.id for tc in cases)
+
+
+def test_order_within_a_file_is_preserved() -> None:
+    """Grouping is stable: the index order inside a file is kept."""
+    cases: List[TestCaseBase] = [
+        _case("z", "f.json"),
+        _case("m", "g.json"),
+        _case("a", "f.json"),
+    ]
+
+    grouped = group_test_cases_by_fixture_file(cases)
+
+    assert [tc.id for tc in grouped] == ["z", "a", "m"]
+
+
+def test_forks_run_one_after_another() -> None:
+    """Fork directories are the leading path component, so forks group."""
+    cases: List[TestCaseBase] = [
+        _case("o1", "for_osaka/x/a.json"),
+        _case("p1", "for_prague/x/a.json"),
+        _case("o2", "for_osaka/x/b.json"),
+        _case("p2", "for_prague/x/b.json"),
+    ]
+
+    forks = [
+        str(tc.json_path).split("/")[0]  # type: ignore[attr-defined]
+        for tc in group_test_cases_by_fixture_file(cases)
+    ]
+
+    assert forks == ["for_osaka", "for_osaka", "for_prague", "for_prague"]
+
+
+def test_cases_without_a_file_keep_their_order() -> None:
+    """Stream test cases carry no path and are returned untouched."""
+    cases: List[TestCaseBase] = [
+        TestCaseBase(id="s2", fixture_hash=HASH, format=BlockchainFixture),
+        TestCaseBase(id="s1", fixture_hash=HASH, format=BlockchainFixture),
+    ]
+
+    assert list(group_test_cases_by_fixture_file(cases)) == cases


### PR DESCRIPTION
### Description

#### Background

The `consume-rlp` (all clients) and `consume-engine` (besu, neth) on the glamsterdam dashboards have recently failed to complete with `SIGKILL`:
```
.../_temp/<id>.sh: line 8: 13313 Killed    ./hive --sim "ethereum/eels/consume-engine" --client "nethermind"
```
The most reasonable explanation appears to be OOM on the runner, see "Supporting Evidence" below.

A likely culprit is `consume`'s fixture cache which holds a copy of all loaded fixtures **per runner** for the duration of the hive process for `consume-rlp` (the size `blockchain_test` fixtures in a Glamsterdam devnet release is 3.7 GB!):
https://github.com/ethereum/execution-specs/blob/ca2b3b18a5d4058b2e2fd517ba7db31e86919a09/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py#L45-L49

#### Changes

To reduce simulator-side memory usage , `consume` now:
1. Groups test cases by the fixture file that contains them (to improve cache reuse).
2. Limits the size of the per-worker cache of parsed fixture files via LRU .

#### Details

A fixture file holds several test cases (8 on average in the mainnet `tests@v20.0.2` release, 1,117 files with ten or more, up to 768), and the index lists the cases of one file in several separate runs (the 8,731 `blockchain_tests` files appear in 39,712 runs). In a six-worker simulation, the unbounded cache and original index order produced a total parse volume of 4.1–4.5 times the release size. Each worker retained every file it parsed for the duration of the pytest session.

Ordering: `pytest_generate_tests` sorts index test cases by `json_path` before parametrizing them (`group_test_cases_by_fixture_file`). The order within a file is preserved. Release paths group cases by format and fork directory in collection order; this does not guarantee that different forks execute sequentially across workers. Test cases read from stdin have no file and keep their order. EngineX is excluded: it sorts its collection largest pre-alloc group first in its own `pytest_collection_modifyitems` for `loadgroup` scheduling, and that order is left untouched.

Cache: `fixture_file_loader` now returns a `FixtureFileCache` that evicts the least recently used files when their combined on-disk size exceeds 256 MiB. The most recently loaded file is always kept, even if it exceeds the bound on its own. An evicted file is loaded again if a later test needs it. Grouping reduced repeated parsing in the simulation, though scheduling can still split a file across workers or cause later revisits.

On the hive.ethpandaops.io glamsterdam dashboard, full `consume rlp` runs currently end for every client about two thirds of the way through the suite, and full `consume engine` runs end for the clients with the largest containers: the `hive` process is killed on the runner and the run is discarded without an upload. This change limits fixture retention during long runs and might resolve those failures. The cache's contribution to them and the effect of this change still need to be verified on a runner; the file-size budget is not a limit on process memory.

The following measurements show how much the unbounded cache can reach and what the ordering saves. Memory was measured on the mainnet `tests@v20.0.2` release with `tracemalloc`, which counts Python allocations, so resident memory is somewhat higher; parse volumes come from a simulation of xdist's `LoadScheduling` (contiguous chunks of the pending list, six workers) over that release's index.

<details>
<summary>Supporting evidence</summary>

**Current Workflow Behavior**

Suite | Clients | Killed after | Tests started at kill | Sample
-- | -- | -- | -- | --
consume-rlp | all seven | 1.2 h (ethrex) to 19 h (besu) | 25.5k to 27.5k | every rlp job 2026-08-26 to 2026-09-08 that got a runner
consume-engine | nethermind | 13 to 16 h | 34.2k to 37.8k of 42.4k | 10 of 10 completed runs since 2026-08-26
consume-engine | besu | 22 to 30 h | 31.9k, 40.7k | 3 of 4 runs killed, one lost its runner, one succeeded (2026-08-26, 32.7 h)
consume-engine | go-ethereum, reth, erigon, ethrex, nimbus-el | never | all 42.4k | complete daily

**Parse volume relative to the release size on disk, six workers**:

| Cache and order | `blockchain_tests` (rlp) | `blockchain_tests_engine` | Busiest worker parsing (rlp) |
| --- | --- | --- | --- |
| unbounded cache, index order (before) | 4.1× | 4.5× | 3.2 min |
| 256 MiB bound, index order | 17.8× | 21.2× | 12.1 min |
| 256 MiB bound, grouped by file (this PR) | 1.1× | 1.2× | 1.0 min |
| no cache, every test parses its file | 114× | 136× | — |

**Parsed size relative to the JSON on disk, by fixture file size class:**

| File size class | Share of release bytes | Parsed size relative to JSON |
| --- | --- | --- |
| under 1 MB | ~20% | 2.5× |
| 1 to 10 MB | ~35% | 1.7× |
| 10 to 50 MB | ~35% | ~1× |
| 50 to 160 MB (RLP-heavy) | ~10% | 0.5× (hex strings become bytes) |

Byte-weighted, parsed fixtures take about 1.5× their JSON size. Applied to the whole release, per fixture format, for the unbounded cache:

| Format | Uncompressed JSON | Parsed, one worker holding every file | Six workers |
| --- | --- | --- | --- |
| `blockchain_tests` (consume rlp) | 3.7 GB in 8,731 files | ~5.5 GB | ~33 GB |
| `blockchain_tests_engine` (consume engine) | 2.3 GB in 7,799 files | ~3.7 GB | ~22 GB |

The six-worker column is a hypothetical upper bound assuming every worker holds every file. Each worker actually retains only the files it touches; the simulation does not establish that this upper bound is reached. These mainnet estimates cannot establish memory use for the glamsterdam devnet release, whose uncompressed per-format sizes and runtime memory use need separate measurement. Fixture retention may contribute to memory pressure on the 30.6 GB runners alongside client containers. After eviction, each cache retains at most 256 MiB of on-disk JSON, or one oversized file. Parsing occurs before eviction, so peak memory also includes the incoming parse.

</details>

Unit tests cover the grouping (contiguity, stable order within a file, fork directories grouped in collection order, stream cases untouched) and the cache (hits, eviction order, oversized files, rejection of missing files).

Deployment note: the devnet dashboards build simulator images from `devnets/glamsterdam/8`, `devnets/focil/0`, and `devnets/frames/0`, so those branches also need the change for the dashboards to use it.

### Related Issues or PRs

Results have also been frequently missing for these test runs, this is solved by:
- https://github.com/ethpandaops/hive-tests/pull/102

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

<img width="512" alt="image" src="https://github.com/user-attachments/assets/1402a87a-ba2d-436f-855c-7714e637f5c3" />
