### PR TITLE
feat(testing): add blockchain_test_engine_reorg format and consume reorg simulator

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -56,6 +56,7 @@
               * [Blockchain Engine X Tests](running_tests/test_formats/blockchain_test_engine_x.md)
               * [Transaction Tests](running_tests/test_formats/transaction_test.md)
               * [Blockchain Sync Tests](running_tests/test_formats/blockchain_test_sync.md)
+              * [Blockchain Engine Reorg Tests](running_tests/test_formats/blockchain_test_engine_reorg.md)
               * [Common Types](running_tests/test_formats/common_types.md)
               * [Exceptions](running_tests/test_formats/exceptions.md)
           * [Hive](running_tests/hive/index.md)

--- a/docs/running_tests/running.md
+++ b/docs/running_tests/running.md
@@ -16,6 +16,7 @@ Both `consume` and `execute` provide sub-commands which correspond to different 
 | [`consume engine`](#engine)             | Client imports blocks via Engine API `EngineNewPayload` in Hive                         | EVM, block processing, Engine API                            | Staging, Hive | System test                       |
 | [`consume enginex`](#enginex)           | Client imports blocks via Engine API in Hive, optimized by client reuse            | EVM, block processing, Engine API, chain reorgs (implicit\*\*) | Staging, Hive | System test                       |
 | [`consume sync`](#sync)                 | Client syncs from another client using Engine API in Hive                               | EVM, block processing, Engine API, P2P sync                  | Staging, Hive | System test                       |
+| [`consume reorg`](#reorg)               | Client is driven through a DAG of payloads and forkchoice updates in Hive                | EVM, block processing, Engine API, chain reorgs               | Staging, Hive | System test                       |
 | [`consume rlp`](#rlp)                   | Client imports RLP-encoded blocks upon start-up in Hive                                 | EVM, block processing, RLP import (sync\*)                   | Staging, Hive | System test                       |
 | [`build-block`](#block-building)        | Client builds blocks via `testing_buildBlockV1` in Hive, validated against fixture       | EVM, block production, Engine API (testing namespace)        | Staging, Hive | System test                       |
 | [`execute hive`](./execute/hive.md)     | Tests executed against a client via JSON RPC `eth_sendRawTransaction` in Hive           | EVM, JSON RPC, mempool                                       | Staging, Hive | System test                       |
@@ -172,6 +173,25 @@ The `consume sync` command:
 4. **Triggers synchronization** by sending the target block to the sync client via `engine_newPayload` followed by `engine_forkchoiceUpdated` requests.
 5. **Monitors sync progress** and validates that the sync client reaches the same state.
 6. **Verifies final state** matches between both clients.
+
+## Reorg
+
+| Nomenclature   |                                 |
+| -------------- | ------------------------------- |
+| Command        | `consume reorg`                 |
+| Simulator      | `eels/consume-reorg`            |
+| Fixture format | `blockchain_test_engine_reorg`  |
+
+The consume reorg method drives a client through a DAG of Engine API payloads and forkchoice updates to test chain reorganization behavior directly, rather than as a side effect of client reuse (see [Implicit Chain Reorg Coverage](#implicit-chain-reorg-coverage)). Each test describes a block DAG (side chains are first-class, identified by label) and an ordered, branching script of `engine_newPayloadVX`/`engine_forkchoiceUpdatedVX`/JSON-RPC steps together with every outcome the [execution-apis](https://github.com/ethereum/execution-apis) specification allows a conformant client to return.
+
+The `consume reorg` command:
+
+1. **Initializes the client under test** with genesis state, plus any additional clients declared by the fixture, peered with the main client via `admin_addPeer` (for reorgs delivered by sync rather than direct submission).
+2. **Sends an initial forkchoice update** to genesis and verifies the client's genesis block hash via `eth_getBlockByNumber(0)`.
+3. **Runs the fixture's step script** against the labeled clients: sends each request verbatim, selects the first outcome (of possibly several spec-legal ones) that matches the observed response, and runs that outcome's branch steps.
+4. **Fails** on the first step whose observed result matches none of its listed outcomes.
+
+Unlike `consume engine`, which sends a linear payload list and always follows each valid payload with a forkchoice update to it, `consume reorg` fixtures describe explicit forkchoice states (head, safe, finalized), client-built payloads bound to new labels via `engine_getPayloadVX`, and assertions of observable state (`eth_getBalance`, `eth_getLogs`, `eth_getTransactionReceipt`, ...) after each forkchoice update. See the [Blockchain Engine Reorg Tests](./test_formats/blockchain_test_engine_reorg.md) format page for the full fixture structure.
 
 ## Block Building
 

--- a/docs/running_tests/test_formats/blockchain_test_engine_reorg.md
+++ b/docs/running_tests/test_formats/blockchain_test_engine_reorg.md
@@ -1,0 +1,244 @@
+# Blockchain Engine Reorg Tests  <!-- markdownlint-disable MD051 (MD051=link-fragments "Link fragments should be valid") -->
+
+The Blockchain Engine Reorg Test fixture format tests are included in the fixtures subdirectory `blockchain_tests_engine_reorg`, and describe a DAG of Engine API payloads plus a branching script of Engine API / JSON-RPC steps to verify chain reorganization behavior.
+
+These are produced by the `ReorgTest` test spec.
+
+## Description
+
+Unlike [`BlockchainEngineFixture`](./blockchain_test_engine.md) (a linear payload list where the consumer always sends `forkchoiceUpdated(head=payload)` after each payload), this format lets a test describe side chains, explicit forkchoice states (head, safe, finalized), multiple legal outcomes per step, outcome-specific follow-up steps (branches), client-built payloads (`getPayload` binds the built payload to a new label), transaction-pool observations, and a second client for sync-delivered reorgs.
+
+Every block in the DAG names its parent by label instead of relying on list order, so sibling blocks and blocks built on top of an invalid block are first-class. Every hash-valued step field is a label (`"genesis"` is reserved for the genesis block, `"zero"` for the zero hash; labels introduced by `getPayload.bind` are resolved at run time); the consumer resolves labels to hashes itself, so fixtures are byte-identical across clients.
+
+Each step's `expect` field is a list of legal outcomes (the [Engine API reference model](../../library/execution_testing_specs.md#execution_testing.specs.engine_model) fills it in at fill time for any step an author left unannotated, deriving the outcomes the [execution-apis](https://github.com/ethereum/execution-apis) specification allows a conformant client to return); the consumer selects the first outcome matching the observed response and runs that outcome's `branches` steps.
+
+A single JSON fixture file is composed of a JSON object where each key-value pair is a different [`HiveFixture`](#hivefixture) test object, with the key string representing the test name.
+
+## Consumption
+
+For each [`HiveFixture`](#hivefixture) test object in the JSON fixture file, perform the following steps:
+
+1. Start the main client using:
+
+    - [`network`](#-network-fork) to configure the execution fork schedule according to the [`Fork`](./common_types.md#fork) type definition.
+    - [`pre`](#-pre-alloc) as the starting state allocation of the execution environment for the test.
+    - [`genesisBlockHeader`](#-genesisblockheader-fixtureheader) as the genesis block header.
+    - The client environment's `HIVE_*` variables from [`requires`](#-requires-optionalmappingstringstring), if present.
+
+2. If [`clients`](#-clients-mappingstringfixtureclient) is non-empty, start one additional client per entry, of the same client type as the main client, peered with it via `admin_addPeer`.
+
+3. Send an initial `engine_forkchoiceUpdatedVX` to the genesis block on every client and verify each returns `VALID`; verify each client's genesis block hash via `eth_getBlockByNumber(0)`.
+
+4. Run [`steps`](#-steps-liststep) in order. For each step:
+
+    1. Resolve every label referenced by the step to a hash (or to the label itself, for a client-built payload not yet bound).
+    2. Send the request (or perform the RPC observation) against the client named by the step's `on` field (`"main"` by default).
+    3. Select the first entry of the step's `expect` list whose constraints match the observed response; fail the test if none match.
+    4. Run the steps listed in `branches` under the matched outcome's `id`, if any (recursively).
+
+## Structures
+
+### `HiveFixture`
+
+#### - `network`: [`Fork`](./common_types.md#fork)
+
+Fork configuration for the test. It is guaranteed that this field contains the same value as `config.network`.
+
+#### - `config`: [`FixtureConfig`](./blockchain_test_engine.md#fixtureconfig)
+
+Chain configuration object to be applied to every client running the test.
+
+#### - `genesisBlockHeader`: [`FixtureHeader`](./blockchain_test.md#fixtureheader)
+
+Genesis block header.
+
+#### - `pre`: [`Alloc`](./common_types.md#alloc-mappingaddressaccount)
+
+Starting account allocation for the test. State root calculated from this allocation must match the one in the genesis block.
+
+#### - `blocks`: [`Mapping`](./common_types.md#mapping)`[`[`String`](./common_types.md#string)`, `[`FixtureReorgBlock`](#fixturereorgblock)`]`
+
+The block DAG, keyed by label.
+
+#### - `steps`: [`List`](./common_types.md#list)`[`[`Step`](#step)`]`
+
+Ordered, branching script of Engine API / JSON-RPC steps.
+
+#### - `clients`: [`Mapping`](./common_types.md#mapping)`[`[`String`](./common_types.md#string)`, `[`FixtureClient`](#fixtureclient)`]`
+
+Additional clients besides `main`, keyed by the name used in a step's `on` field. Empty when the test only exercises a single client.
+
+#### - `requires`: [`Optional`](./common_types.md#optional)`[`[`Mapping`](./common_types.md#mapping)`[`[`String`](./common_types.md#string)`, `[`String`](./common_types.md#string)`]]`
+
+Client environment (`HIVE_*`) variables the consumer applies at client start, e.g. a client-specific reorg-depth cap. `None` means client defaults.
+
+#### - `meta`: [`Mapping`](./common_types.md#mapping)`[`[`String`](./common_types.md#string)`, `[`Any`](./common_types.md#any)`]`
+
+Free-form metadata about the test (e.g. `class`, `reorgDepth`) for offline analysis; not consumed by the runner.
+
+### `FixtureReorgBlock`
+
+#### - `parent`: [`String`](./common_types.md#string)
+
+Label of the parent block (`"genesis"` for a block extending the genesis block).
+
+#### - `payload`: [`FixtureEngineNewPayload`](./blockchain_test_engine.md#fixtureenginenewpayload)
+
+The block's `engine_newPayloadVX` directive.
+
+### `FixtureClient`
+
+#### - `description`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+Human-readable description of the client's role in the test.
+
+### `Step`
+
+A step is one of the variants below, distinguished by its `type` field. Every variant shares:
+
+#### - `type`: [`String`](./common_types.md#string)
+
+One of `newPayload`, `forkchoiceUpdated`, `getPayload`, `assertHead`, `waitForHead`, `assertCanonical`, `assertState`, `assertReceipt`, `assertLogs`, `sendRawTransaction`, `assertTxStatus`.
+
+#### - `on`: [`String`](./common_types.md#string)
+
+Name of the client the step is executed on; `"main"` unless the step targets one of `clients`.
+
+#### - `description`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+Human-readable description of the step, for logging.
+
+#### `newPayload`
+
+- `block`: [`String`](./common_types.md#string) — label of the block (or a `getPayload`-bound label) to send via `engine_newPayloadVX`.
+- `expect`: [`List`](./common_types.md#list)`[`[`Outcome`](#outcome)`]` — legal outcomes.
+- `branches`: [`Mapping`](./common_types.md#mapping)`[`[`String`](./common_types.md#string)`, `[`List`](./common_types.md#list)`[`[`Step`](#step)`]]` — follow-up steps per matched outcome id.
+
+#### `forkchoiceUpdated`
+
+- `head` / `safe` / `finalized`: [`String`](./common_types.md#string) — labels; `safe`/`finalized` default to `"zero"`.
+- `version`: [`Number`](./common_types.md#number) — `engine_forkchoiceUpdatedVX` version; derived from the head block's fork when unset.
+- `payloadAttributes`: [`Optional`](./common_types.md#optional)`[`[`FixturePayloadAttributes`](#fixturepayloadattributes)`]` — if set, a payload build is requested.
+- `expect` / `branches`: as above.
+
+#### `getPayload`
+
+- `bind`: [`String`](./common_types.md#string) — new label for the built payload.
+- `version`: [`Number`](./common_types.md#number) — `engine_getPayloadVX` version.
+- `delay`: [`Number`](./common_types.md#number) — seconds to wait after the build request before retrieving; default `1.0`.
+- `parent`: [`String`](./common_types.md#string) — expected parent of the built payload.
+- `transactionsInclude` / `transactionsExclude`: [`List`](./common_types.md#list)`[`[`TxRef`](#txref)`]` — transactions that must (or must not) be in the built payload.
+
+#### `assertHead`
+
+- `latest` / `safe` / `finalized`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]` — expected labels, checked via `eth_getBlockByNumber`.
+
+#### `waitForHead`
+
+- `latest`: [`String`](./common_types.md#string) — label to poll `eth_getBlockByNumber("latest")` for.
+- `timeout`: [`Number`](./common_types.md#number) — seconds; default `60`.
+
+#### `assertCanonical`
+
+- `blocks`: [`Mapping`](./common_types.md#mapping)`[`[`HexNumber`](./common_types.md#hexnumber)`, `[`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]]` — expected label (or `None` for "no block") at each height.
+
+#### `assertState`
+
+- `at`: [`String`](./common_types.md#string) — block label, or `"latest"`.
+- `accounts`: [`Mapping`](./common_types.md#mapping)`[`[`Address`](./common_types.md#address)`, `[`AccountExpectation`](#accountexpectation)`]`.
+
+#### `assertReceipt`
+
+- `tx`: [`TxRef`](#txref).
+- `block`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]` — expected receipt block label, or `None` for no receipt.
+- `status`: [`Optional`](./common_types.md#optional)`[`[`HexNumber`](./common_types.md#hexnumber)`]`.
+
+#### `assertLogs`
+
+- `address`: [`Optional`](./common_types.md#optional)`[`[`Address`](./common_types.md#address)`]`.
+- `fromBlock` / `toBlock`: [`HexNumber`](./common_types.md#hexnumber)` | `[`String`](./common_types.md#string) — defaults `"earliest"` / `"latest"`.
+- `blocks`: [`List`](./common_types.md#list)`[`[`String`](./common_types.md#string)`]` — labels whose logs must appear, one entry per expected log.
+
+#### `sendRawTransaction`
+
+- `tx`: [`TxRef`](#txref).
+- `expect`: [`List`](./common_types.md#list)`[`[`String`](./common_types.md#string)`]` — subset of `["accepted", "rejected"]`; default `["accepted"]`.
+
+#### `assertTxStatus`
+
+- `tx`: [`TxRef`](#txref).
+- `expect`: [`List`](./common_types.md#list)`[`[`String`](./common_types.md#string)`]` — subset of `["included", "pending", "dropped"]`.
+- `includedIn`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]` — required block label when `included` matches.
+
+### `Outcome`
+
+One legal outcome of an Engine API step. Every set field is a constraint; unset fields are not checked.
+
+#### - `id`: [`String`](./common_types.md#string)
+
+Identifier; selects the `branches` entry to run when matched.
+
+#### - `disputed`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+If set, the specification is ambiguous about this outcome; the value is a reference (e.g. an issue URL). A disputed outcome still passes.
+
+#### - `status`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+Expected `payloadStatus.status` (`VALID`, `INVALID`, `SYNCING`, `ACCEPTED`).
+
+#### - `latestValidHash`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+Expected `latestValidHash` as a block label, `"null"`, or `"any"`.
+
+#### - `errorCode`: [`Optional`](./common_types.md#optional)`[`[`Number`](./common_types.md#number)`]`
+
+Expected JSON-RPC error code (e.g. `-38002`, `-38006`).
+
+#### - `anyError`: [`Optional`](./common_types.md#optional)`[`[`Bool`](./common_types.md#bool)`]`
+
+If `true`, any JSON-RPC error matches (for uncoded errors).
+
+#### - `headMoved`: [`Optional`](./common_types.md#optional)`[`[`Bool`](./common_types.md#bool)`]`
+
+`forkchoiceUpdated` only: whether `latest` equals the requested head right after the call. Distinguishes an applied update from a no-op when both answer `VALID` with the same `latestValidHash`.
+
+#### - `validationError`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+`"required"` or `"none"`: whether `validationError` must be present or absent.
+
+#### - `payloadId`: [`Optional`](./common_types.md#optional)`[`[`String`](./common_types.md#string)`]`
+
+`"nonNull"` or `"null"`, for a `forkchoiceUpdated` with payload attributes.
+
+### `FixturePayloadAttributes`
+
+Payload attributes sent with `forkchoiceUpdated` to start a build; fields match the Engine API's `PayloadAttributesVX`.
+
+### `AccountExpectation`
+
+#### - `balance` / `nonce`: [`Optional`](./common_types.md#optional)`[`[`HexNumber`](./common_types.md#hexnumber)`]`
+
+#### - `storage`: [`Optional`](./common_types.md#optional)`[`[`Mapping`](./common_types.md#mapping)`[`[`Hash`](./common_types.md#hash)`, `[`Hash`](./common_types.md#hash)`]]`
+
+### `TxRef`
+
+Reference to a transaction of a fixture block.
+
+#### - `block`: [`String`](./common_types.md#string)
+
+#### - `index`: [`Number`](./common_types.md#number)
+
+Default `0`.
+
+## Differences from Blockchain Engine Tests
+
+1. **Block DAG, not a list**: blocks name their parent by label, so side chains, invalid-block descendants and re-convergence are first-class.
+2. **Branching step script**: `steps` is not a flat payload list; a step's `expect` can list several spec-legal outcomes and `branches` continues down the outcome that was actually observed.
+3. **Explicit forkchoice state**: `forkchoiceUpdated` steps set `head`/`safe`/`finalized` independently instead of always following the last payload.
+4. **Client-built payloads**: `getPayload` retrieves and binds a payload the client built itself, which can then be delivered back via `newPayload`.
+5. **Multiple clients**: `clients` lets a test start additional, peered clients and target steps at them via `on`, to cover reorgs delivered by sync rather than direct submission.
+6. **State observations**: `assertState`/`assertReceipt`/`assertLogs`/`assertTxStatus` steps check observable RPC state after a forkchoice update, instead of a single fixture-wide `post` allocation.
+
+## Fork Support
+
+Blockchain Engine Reorg Tests are only supported for post-merge forks (Paris and later), as they rely entirely on the Engine API.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/consume.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/consume.py
@@ -51,9 +51,12 @@ def get_command_logic_test_paths(command_name: str) -> List[Path]:
             / "simulator_logic"
             / f"test_via_{test_command}.py"
         ]
-    elif command_name == "sync":
+    elif command_name in ["sync", "reorg"]:
         command_logic_test_paths = [
-            base_path / "simulators" / "simulator_logic" / "test_via_sync.py"
+            base_path
+            / "simulators"
+            / "simulator_logic"
+            / f"test_via_{command_name}.py"
         ]
     elif command_name == "direct":
         command_logic_test_paths = [
@@ -129,6 +132,12 @@ def enginex() -> None:
 @consume_command(is_hive=True)
 def sync() -> None:
     """Client consumes via the Engine API with sync testing."""
+    pass
+
+
+@consume_command(is_hive=True)
+def reorg() -> None:
+    """Client consumes Engine API reorg tests (payload DAG + step script)."""
     pass
 
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/hive_simulators_reorg/__init__.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/hive_simulators_reorg/__init__.py
@@ -1,1 +1,0 @@
-"""Hive simulators reorganization consumer plugin."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/base.py
@@ -66,6 +66,7 @@ def check_live_port(test_suite_name: str) -> Literal[8545, 8551]:
         "eels/consume-engine",
         "eels/consume-enginex",
         "eels/consume-sync",
+        "eels/consume-reorg",
         "eels/build-block",
     }:
         return 8551

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/genesis.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/genesis.py
@@ -1,0 +1,80 @@
+"""Genesis handshake shared by the engine-family hive simulators."""
+
+from execution_testing.fixtures.blockchain import FixtureHeader
+from execution_testing.logging import get_logger
+from execution_testing.rpc import (
+    EngineRPC,
+    EthRPC,
+    ForkchoiceUpdateTimeoutError,
+)
+from execution_testing.rpc.rpc_types import ForkchoiceState, PayloadStatusEnum
+
+from .exceptions import GenesisBlockMismatchExceptionError, LoggedError
+from .timing import TimingData
+
+logger = get_logger(__name__)
+
+
+def send_forkchoice_update_to_genesis(
+    engine_rpc: EngineRPC,
+    *,
+    genesis_header: FixtureHeader,
+    forkchoice_version: int,
+    timing_data: TimingData,
+    label: str = "",
+) -> None:
+    """
+    Send `engine_forkchoiceUpdatedVX` to genesis and require VALID.
+
+    ``label``, if given, is appended to the timing section name and log
+    lines to distinguish multiple clients in one test.
+    """
+    suffix = f" ({label})" if label else ""
+    with timing_data.time(f"Initial forkchoice update{suffix}"):
+        logger.info(
+            f"Sending initial forkchoice update to genesis block{suffix}..."
+        )
+        try:
+            response = engine_rpc.forkchoice_updated_with_retry(
+                forkchoice_state=ForkchoiceState(
+                    head_block_hash=genesis_header.block_hash,
+                ),
+                forkchoice_version=forkchoice_version,
+                max_attempts=30,
+                wait_fixed=1.0,
+            )
+            if response.payload_status.status != PayloadStatusEnum.VALID:
+                raise LoggedError(
+                    f"Unexpected status on forkchoice updated to genesis"
+                    f"{suffix}: {response.payload_status.status}"
+                )
+        except ForkchoiceUpdateTimeoutError as e:
+            raise LoggedError(
+                f"Timed out waiting for forkchoice update to genesis"
+                f"{suffix}: {e}"
+            ) from None
+
+
+def verify_genesis_block_hash(
+    eth_rpc: EthRPC,
+    genesis_header: FixtureHeader,
+    timing_data: TimingData,
+    label: str = "",
+) -> None:
+    """Verify the client's genesis block hash matches the fixture's."""
+    suffix = f" ({label})" if label else ""
+    with timing_data.time(f"Get genesis block{suffix}"):
+        logger.info("Calling getBlockByNumber to get genesis block...")
+        genesis_block = eth_rpc.get_block_by_number(0)
+        assert genesis_block is not None, "genesis_block is None"
+        if genesis_block["hash"] != str(genesis_header.block_hash):
+            expected = genesis_header.block_hash
+            got = genesis_block["hash"]
+            logger.fail(
+                f"Genesis block hash mismatch{suffix}. "
+                f"Expected: {expected}, Got: {got}"
+            )
+            raise GenesisBlockMismatchExceptionError(
+                expected_header=genesis_header,
+                got_genesis_block=genesis_block,
+            )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/reorg/__init__.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/reorg/__init__.py
@@ -1,0 +1,1 @@
+"""Hive simulator for `blockchain_test_engine_reorg` fixtures."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/reorg/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/reorg/conftest.py
@@ -1,0 +1,163 @@
+"""
+Pytest fixtures for the `consume reorg` simulator.
+
+One fresh client per fixture; the client environment is the standard engine
+environment plus the fixture's ``requires`` (``HIVE_*``) variables, if any.
+Additional clients declared in ``fixture.clients`` are started with the same
+client type and peered with the main client (bootnode + ``admin_addPeer``).
+"""
+
+import io
+import json
+import logging
+import time
+from contextlib import ExitStack
+from typing import Any, Dict, Generator, Literal, Mapping
+
+import pytest
+from hive.client import Client, ClientType
+from hive.testing import HiveTest
+
+from execution_testing.exceptions import ExceptionMapper
+from execution_testing.fixtures import BlockchainEngineReorgFixture
+from execution_testing.fixtures.blockchain import FixtureHeader
+from execution_testing.rpc import AdminRPC, EngineRPC, EthRPC
+
+from ..helpers.timing import TimingData
+from ..simulator_logic.test_via_reorg import ClientRPC
+from ..single_test_client import client_environment
+
+pytest_plugins = (
+    "execution_testing.cli.pytest_commands.plugins.pytest_hive.pytest_hive",
+    "execution_testing.cli.pytest_commands.plugins.consume.simulators.base",
+    "execution_testing.cli.pytest_commands.plugins.consume.simulators.single_test_client",
+    "execution_testing.cli.pytest_commands.plugins.consume.simulators.test_case_description",
+    "execution_testing.cli.pytest_commands.plugins.consume.simulators.timing_data",
+    "execution_testing.cli.pytest_commands.plugins.consume.simulators.exceptions",
+    "execution_testing.cli.pytest_commands.plugins.consume.simulators.engine_api",
+)
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Set the supported fixture formats for the reorg simulator."""
+    config.supported_fixture_formats = [BlockchainEngineReorgFixture]  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="module")
+def test_suite_name() -> str:
+    """The name of the hive test suite used in this simulator."""
+    return "eels/consume-reorg"
+
+
+@pytest.fixture(scope="module")
+def test_suite_description() -> str:
+    """The description of the hive test suite used in this simulator."""
+    return (
+        "Execute Engine API reorg tests against clients: a DAG of payloads "
+        "and an ordered list of newPayload/forkchoiceUpdated/RPC steps with "
+        "expected outcomes."
+    )
+
+
+@pytest.fixture(scope="function")
+def environment(
+    fixture: BlockchainEngineReorgFixture,
+    check_live_port: Literal[8545, 8551],
+) -> dict:
+    """
+    Client environment: standard engine ruleset plus the fixture's
+    ``requires`` variables (client tuning such as reorg-depth caps).
+    """
+    env = client_environment(
+        fixture.fork, fixture.config.chain_id, check_live_port
+    )
+    if fixture.requires:
+        env.update(fixture.requires)
+    return env
+
+
+@pytest.fixture(scope="function")
+def client_files(
+    buffered_genesis: io.BufferedReader,
+) -> Mapping[str, io.BufferedReader]:
+    """Define the files that hive will start the client with."""
+    return {"/genesis.json": buffered_genesis}
+
+
+@pytest.fixture(scope="function")
+def genesis_header(fixture: BlockchainEngineReorgFixture) -> FixtureHeader:
+    """Provide the genesis header from the fixture."""
+    return fixture.genesis
+
+
+@pytest.fixture(scope="function")
+def peer_rpcs(
+    request: pytest.FixtureRequest,
+    fixture: BlockchainEngineReorgFixture,
+    hive_test: HiveTest,
+    client: Client,
+    client_type: ClientType,
+    client_genesis: dict,
+    environment: dict,
+    client_exception_mapper: ExceptionMapper | None,
+    total_timing_data: TimingData,
+) -> Generator[Dict[str, ClientRPC], None, None]:
+    """
+    Start the fixture's additional clients (same client type as ``main``),
+    peered with the main client, and expose their RPC endpoints by name.
+    """
+    if not fixture.clients:
+        yield {}
+        return
+
+    enode = client.enode()
+    main_enode = f"enode://{enode.id}@{client.ip}:{enode.port}"
+    peer_env = dict(environment)
+    peer_env["HIVE_MINER"] = ""
+    peer_env["HIVE_BOOTNODE"] = main_enode
+
+    peers: Dict[str, Client] = {}
+    rpcs: Dict[str, ClientRPC] = {}
+    with ExitStack() as stack:
+        for name in fixture.clients:
+            genesis_bytes = json.dumps(client_genesis).encode("utf-8")
+            files = {
+                "/genesis.json": io.BufferedReader(io.BytesIO(genesis_bytes))
+            }
+            with total_timing_data.time(f"Start peer {name}"):
+                peer = hive_test.start_client(
+                    client_type=client_type, environment=peer_env, files=files
+                )
+            assert peer is not None, f"Unable to start peer client {name!r}"
+            peers[name] = peer
+            eth = stack.enter_context(EthRPC(f"http://{peer.ip}:8545"))
+            engine_kwargs: Dict[str, Any] = (
+                {
+                    "response_validation_context": {
+                        "exception_mapper": client_exception_mapper
+                    }
+                }
+                if client_exception_mapper
+                else {}
+            )
+            engine = stack.enter_context(
+                EngineRPC(f"http://{peer.ip}:8551", **engine_kwargs)
+            )
+            rpcs[name] = ClientRPC(name, eth, engine)
+            with AdminRPC(f"http://{peer.ip}:8545") as admin:
+                try:
+                    admin.add_peer(main_enode)
+                except Exception as e:  # noqa: BLE001 - best effort
+                    logger.warning(f"admin_addPeer on {name} failed: {e}")
+            logger.info(
+                f"Peer {name} ({client_type.name}) started at {peer.ip}"
+            )
+        yield rpcs
+        result_call = getattr(request.node, "result_call", None)
+        if result_call is not None and result_call.failed:
+            time.sleep(1)
+        for name, peer in peers.items():
+            with total_timing_data.time(f"Stop peer {name}"):
+                peer.stop()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -23,20 +23,17 @@ from execution_testing.fixtures import (
 )
 from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.logging import get_logger
-from execution_testing.rpc import (
-    EngineRPC,
-    EthRPC,
-    ForkchoiceUpdateTimeoutError,
-)
+from execution_testing.rpc import EngineRPC, EthRPC
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
     JSONRPCError,
     PayloadStatusEnum,
 )
 
-from ..helpers.exceptions import (
-    GenesisBlockMismatchExceptionError,
-    LoggedError,
+from ..helpers.exceptions import LoggedError
+from ..helpers.genesis import (
+    send_forkchoice_update_to_genesis,
+    verify_genesis_block_hash,
 )
 from ..helpers.rejected_blocks import (
     BlockRejectionTracker,
@@ -82,45 +79,15 @@ def test_blockchain_via_engine(
     therefore verified against the error from the client's first rejection
     of the same block before failing the test.
     """
-    with timing_data.time("Initial forkchoice update"):
-        logger.info("Sending initial forkchoice update to genesis block...")
-        try:
-            response = engine_rpc.forkchoice_updated_with_retry(
-                forkchoice_state=ForkchoiceState(
-                    head_block_hash=genesis_header.block_hash,
-                ),
-                forkchoice_version=fixture.payloads[
-                    0
-                ].forkchoice_updated_version,
-                max_attempts=30,
-                wait_fixed=1.0,
-            )
-            if response.payload_status.status != PayloadStatusEnum.VALID:
-                raise LoggedError(
-                    f"Unexpected status on forkchoice updated to genesis: "
-                    f"{response.payload_status.status}"
-                )
-        except ForkchoiceUpdateTimeoutError as e:
-            raise LoggedError(
-                f"Timed out waiting for forkchoice update to genesis: {e}"
-            ) from None
+    send_forkchoice_update_to_genesis(
+        engine_rpc,
+        genesis_header=genesis_header,
+        forkchoice_version=fixture.payloads[0].forkchoice_updated_version,
+        timing_data=timing_data,
+    )
 
     if client.id not in genesis_verified_clients:
-        with timing_data.time("Get genesis block"):
-            logger.info("Calling getBlockByNumber to get genesis block...")
-            genesis_block = eth_rpc.get_block_by_number(0)
-            assert genesis_block is not None, "genesis_block is None"
-            if genesis_block["hash"] != str(genesis_header.block_hash):
-                expected = genesis_header.block_hash
-                got = genesis_block["hash"]
-                logger.fail(
-                    f"Genesis block hash mismatch. "
-                    f"Expected: {expected}, Got: {got}"
-                )
-                raise GenesisBlockMismatchExceptionError(
-                    expected_header=genesis_header,
-                    got_genesis_block=genesis_block,
-                )
+        verify_genesis_block_hash(eth_rpc, genesis_header, timing_data)
         # Genesis is immutable per client, so verify it once per client. In
         # shared-client (enginex) mode the same client serves every test in a
         # pre-alloc group, so later tests skip the redundant getBlockByNumber

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_reorg.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_reorg.py
@@ -1,0 +1,668 @@
+"""
+A hive based simulator that executes `blockchain_test_engine_reorg` fixtures.
+
+The fixture is a DAG of payloads plus an ordered list of steps. The simulator
+resolves block labels to hashes, sends each Engine API request verbatim,
+selects the first listed outcome that matches the observed response, logs it,
+runs that outcome's branch steps, and fails on the first step whose observed
+result matches none of its listed outcomes. There is no runtime policy: every
+decision is in the fixture.
+
+Steps may target additional clients (``on``) declared in ``fixture.clients``;
+those are started peered with the main client so reorgs can also be delivered
+by sync.
+"""
+
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from hive.client import Client
+
+from execution_testing.base_types import Bytes, Hash
+from execution_testing.fixtures import BlockchainEngineReorgFixture
+from execution_testing.fixtures.blockchain import (
+    FixtureExecutionPayload,
+    FixtureHeader,
+)
+from execution_testing.fixtures.reorg import (
+    LATEST_VALID_HASH_ANY,
+    LATEST_VALID_HASH_NULL,
+    MAIN_CLIENT,
+    AssertCanonicalStep,
+    AssertHeadStep,
+    AssertLogsStep,
+    AssertReceiptStep,
+    AssertStateStep,
+    AssertTxStatusStep,
+    ForkchoiceUpdatedStep,
+    GetPayloadStep,
+    NewPayloadStep,
+    Outcome,
+    SendRawTransactionStep,
+    Step,
+    TxRef,
+    WaitForHeadStep,
+)
+from execution_testing.logging import get_logger
+from execution_testing.rpc import EngineRPC, EthRPC
+from execution_testing.rpc.rpc_types import (
+    ForkchoiceState,
+    JSONRPCError,
+    PayloadAttributes,
+)
+
+from ..helpers.exceptions import LoggedError
+from ..helpers.genesis import (
+    send_forkchoice_update_to_genesis,
+    verify_genesis_block_hash,
+)
+from ..helpers.timing import TimingData
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class Observed:
+    """Normalized observation of an Engine API response."""
+
+    status: str | None = None
+    latest_valid_hash: Hash | None = None
+    validation_error: Any = None
+    error_code: int | None = None
+    error_message: str | None = None
+    payload_id: Bytes | None = None
+    head_moved: bool | None = None
+
+    def describe(self) -> str:
+        """Human-readable summary."""
+        if self.error_code is not None:
+            return f"error {self.error_code}: {self.error_message}"
+        return (
+            f"status={self.status} latestValidHash={self.latest_valid_hash} "
+            f"validationError={self.validation_error!r}"
+            + (f" payloadId={self.payload_id}" if self.payload_id else "")
+            + (
+                f" headMoved={self.head_moved}"
+                if self.head_moved is not None
+                else ""
+            )
+        )
+
+
+@dataclass
+class ClientRPC:
+    """RPC endpoints of one client."""
+
+    name: str
+    eth: EthRPC
+    engine: EngineRPC
+
+
+@dataclass
+class BoundPayload:
+    """A client-built payload bound to a label by ``getPayload``."""
+
+    payload: FixtureExecutionPayload
+    versioned_hashes: List[Hash]
+    parent_beacon_block_root: Hash | None
+    execution_requests: List[Bytes] | None
+    label_parent: str
+
+
+class StepRunner:
+    """Executes fixture steps against one or more clients."""
+
+    def __init__(
+        self,
+        fixture: BlockchainEngineReorgFixture,
+        clients: Dict[str, ClientRPC],
+        timing_data: TimingData,
+    ) -> None:
+        """Initialize with the fixture and per-client RPC endpoints."""
+        self.fixture = fixture
+        self.clients = clients
+        self.timing_data = timing_data
+        self.labels_by_hash = fixture.labels_by_hash()
+        self.bound: Dict[str, BoundPayload] = {}
+        self.last_payload_id: Dict[str, Bytes | None] = {}
+        self.last_payload_attributes: Dict[str, PayloadAttributes | None] = {}
+        self.matched: List[str] = []
+        """Log of ``<step>:<outcome id>`` selections, for offline analysis."""
+
+    # -- helpers ---------------------------------------------------------
+
+    def rpc(self, on: str) -> ClientRPC:
+        """RPC endpoints of a named client."""
+        if on not in self.clients:
+            raise LoggedError(f"step targets unknown client {on!r}")
+        return self.clients[on]
+
+    def resolve(self, label: str) -> Hash | None:
+        """Resolve a static or bound label to a hash."""
+        if label in self.bound:
+            return self.bound[label].payload.block_hash
+        return self.fixture.resolve(label)
+
+    def label_of(self, block_hash: Hash | str | None) -> str:
+        """Block label for a hash (or the hash itself if unknown)."""
+        if block_hash is None:
+            return "null"
+        h = Hash(block_hash)
+        return self.labels_by_hash.get(h, str(h))
+
+    def block_number(self, label: str) -> int:
+        """Height of a labeled block."""
+        if label == "genesis":
+            return int(self.fixture.genesis.number)
+        if label in self.bound:
+            return int(self.bound[label].payload.number)
+        return int(self.fixture.blocks[label].payload.params[0].number)
+
+    def block_timestamp(self, label: str) -> int:
+        """Timestamp of a labeled block."""
+        if label == "genesis":
+            return int(self.fixture.genesis.timestamp)
+        if label in self.bound:
+            return int(self.bound[label].payload.timestamp)
+        return int(self.fixture.blocks[label].payload.params[0].timestamp)
+
+    def tx_hash(self, ref: TxRef) -> Hash:
+        """Hash of a referenced transaction (fixture or bound block)."""
+        if ref.block in self.bound:
+            return Hash(
+                self.bound[ref.block]
+                .payload.transactions[ref.index]
+                .keccak256()
+            )
+        return self.fixture.tx_hash(ref)
+
+    def tx_rlp(self, ref: TxRef) -> Bytes:
+        """Raw bytes of a referenced transaction."""
+        if ref.block in self.bound:
+            return self.bound[ref.block].payload.transactions[ref.index]
+        return self.fixture.tx_rlp(ref)
+
+    def matches(self, outcome: Outcome, observed: Observed) -> bool:
+        """Whether an observed response satisfies an outcome's constraints."""
+        if outcome.error_code is not None:
+            return observed.error_code == outcome.error_code
+        if outcome.any_error:
+            return observed.error_code is not None
+        if observed.error_code is not None:
+            return False
+        if outcome.status is not None and observed.status != outcome.status:
+            return False
+        if outcome.latest_valid_hash is not None:
+            want = outcome.latest_valid_hash
+            if want == LATEST_VALID_HASH_NULL:
+                if observed.latest_valid_hash is not None:
+                    return False
+            elif want != LATEST_VALID_HASH_ANY:
+                if observed.latest_valid_hash != self.resolve(want):
+                    return False
+        if outcome.validation_error == "required":
+            if observed.validation_error is None:
+                return False
+        elif outcome.validation_error == "none":
+            if observed.validation_error is not None:
+                return False
+        if outcome.payload_id == "nonNull" and observed.payload_id is None:
+            return False
+        if outcome.payload_id == "null" and observed.payload_id is not None:
+            return False
+        if (
+            outcome.head_moved is not None
+            and observed.head_moved != outcome.head_moved
+        ):
+            return False
+        return True
+
+    def select(
+        self, step_name: str, expect: List[Outcome], observed: Observed
+    ) -> Outcome:
+        """Pick the first matching outcome or fail."""
+        if not expect:
+            raise LoggedError(
+                f"{step_name}: fixture step has no expected outcomes "
+                "(unannotated fixture)"
+            )
+        for outcome in expect:
+            if self.matches(outcome, observed):
+                note = (
+                    f" (disputed: {outcome.disputed})"
+                    if outcome.disputed
+                    else ""
+                )
+                logger.info(
+                    f"{step_name}: observed {observed.describe()} -> "
+                    f"outcome '{outcome.id}'{note}"
+                )
+                self.matched.append(f"{step_name}:{outcome.id}")
+                return outcome
+        legal = ", ".join(
+            f"{o.id}(status={o.status}, lvh={o.latest_valid_hash}, "
+            f"error={o.error_code})"
+            for o in expect
+        )
+        raise LoggedError(
+            f"{step_name}: observed {observed.describe()} matches none of "
+            f"the legal outcomes [{legal}]"
+        )
+
+    # -- steps -----------------------------------------------------------
+
+    def run(self, steps: List[Step], depth: int = 0) -> None:
+        """Run a step list, recursing into selected branches."""
+        for i, step in enumerate(steps):
+            on = "" if step.on == MAIN_CLIENT else f"@{step.on} "
+            name = f"{'  ' * depth}step {i + 1}/{len(steps)} {on}{step.type}"
+            if isinstance(step, NewPayloadStep):
+                self.new_payload(name, step, depth)
+            elif isinstance(step, ForkchoiceUpdatedStep):
+                self.forkchoice_updated(name, step, depth)
+            elif isinstance(step, GetPayloadStep):
+                self.get_payload(name, step)
+            elif isinstance(step, AssertHeadStep):
+                self.assert_head(name, step)
+            elif isinstance(step, WaitForHeadStep):
+                self.wait_for_head(name, step)
+            elif isinstance(step, AssertCanonicalStep):
+                self.assert_canonical(name, step)
+            elif isinstance(step, AssertStateStep):
+                self.assert_state(name, step)
+            elif isinstance(step, AssertReceiptStep):
+                self.assert_receipt(name, step)
+            elif isinstance(step, AssertLogsStep):
+                self.assert_logs(name, step)
+            elif isinstance(step, SendRawTransactionStep):
+                self.send_raw_transaction(name, step)
+            elif isinstance(step, AssertTxStatusStep):
+                self.assert_tx_status(name, step)
+            else:  # pragma: no cover - schema is closed
+                raise LoggedError(f"{name}: unsupported step type")
+
+    def _new_payload_params(self, label: str) -> tuple[list, int]:
+        """(params, version) for a fixture or bound block."""
+        if label not in self.bound:
+            payload = self.fixture.blocks[label].payload
+            return list(payload.params), int(payload.new_payload_version)
+        bound = self.bound[label]
+        fork = self.fixture.fork.fork_at(
+            block_number=int(bound.payload.number),
+            timestamp=int(bound.payload.timestamp),
+        )
+        version = fork.engine_new_payload_version()
+        assert version is not None
+        params: list = [bound.payload]
+        if fork.engine_new_payload_blob_hashes():
+            params.append(bound.versioned_hashes)
+        if fork.engine_new_payload_beacon_root():
+            params.append(bound.parent_beacon_block_root)
+        if fork.engine_new_payload_requests():
+            params.append(bound.execution_requests or [])
+        return params, version
+
+    def new_payload(self, name: str, step: NewPayloadStep, depth: int) -> None:
+        """Send ``engine_newPayloadVX`` and check the outcome."""
+        rpc = self.rpc(step.on)
+        params, version = self._new_payload_params(step.block)
+        name = f"{name}({step.block})"
+        with self.timing_data.time(
+            f"engine_newPayloadV{version} {step.block}"
+        ):
+            try:
+                response = rpc.engine.new_payload(*params, version=version)
+                observed = Observed(
+                    status=response.status.value,
+                    latest_valid_hash=response.latest_valid_hash,
+                    validation_error=response.validation_error,
+                )
+            except JSONRPCError as e:
+                observed = Observed(error_code=e.code, error_message=e.message)
+        outcome = self.select(name, step.expect, observed)
+        self.run(step.branches.get(outcome.id, []), depth + 1)
+
+    def forkchoice_updated(
+        self, name: str, step: ForkchoiceUpdatedStep, depth: int
+    ) -> None:
+        """Send ``engine_forkchoiceUpdatedVX`` and check the outcome."""
+        rpc = self.rpc(step.on)
+        name = (
+            f"{name}(head={step.head}, safe={step.safe}, fin={step.finalized})"
+        )
+        if step.version is None:
+            raise LoggedError(f"{name}: fixture step has no version")
+        state = ForkchoiceState(
+            head_block_hash=self.resolve(step.head),
+            safe_block_hash=self.resolve(step.safe),
+            finalized_block_hash=self.resolve(step.finalized),
+        )
+        attributes: PayloadAttributes | None = None
+        if step.payload_attributes is not None:
+            attributes = PayloadAttributes(
+                **step.payload_attributes.model_dump(exclude_none=True)
+            )
+        with self.timing_data.time(f"engine_forkchoiceUpdatedV{step.version}"):
+            try:
+                response = rpc.engine.forkchoice_updated(
+                    forkchoice_state=state,
+                    payload_attributes=attributes,
+                    version=step.version,
+                )
+                ps = response.payload_status
+                observed = Observed(
+                    status=ps.status.value,
+                    latest_valid_hash=ps.latest_valid_hash,
+                    validation_error=ps.validation_error,
+                    payload_id=response.payload_id,
+                )
+                self.last_payload_id[step.on] = response.payload_id
+                self.last_payload_attributes[step.on] = attributes
+            except JSONRPCError as e:
+                observed = Observed(error_code=e.code, error_message=e.message)
+        if observed.error_code is None and any(
+            o.head_moved is not None for o in step.expect
+        ):
+            observed.head_moved = self._head_hash(
+                rpc, "latest"
+            ) == self.resolve(step.head)
+        outcome = self.select(name, step.expect, observed)
+        self.run(step.branches.get(outcome.id, []), depth + 1)
+
+    def get_payload(self, name: str, step: GetPayloadStep) -> None:
+        """Retrieve the payload built after the last FCU and bind it."""
+        rpc = self.rpc(step.on)
+        name = f"{name}(bind={step.bind})"
+        payload_id = self.last_payload_id.get(step.on)
+        if payload_id is None:
+            raise LoggedError(
+                f"{name}: no payloadId from previous forkchoiceUpdated"
+            )
+        if step.version is None:
+            raise LoggedError(f"{name}: fixture step has no version")
+        if step.delay > 0:
+            time.sleep(step.delay)
+        with self.timing_data.time(f"engine_getPayloadV{step.version}"):
+            response = rpc.engine.get_payload(payload_id, version=step.version)
+        payload = response.execution_payload
+        want_parent = self.resolve(step.parent)
+        if payload.parent_hash != want_parent:
+            raise LoggedError(
+                f"{name}: built payload parent is "
+                f"{self.label_of(payload.parent_hash)}, expected {step.parent}"
+            )
+        included = {Hash(tx.keccak256()) for tx in payload.transactions}
+        for ref in step.transactions_include:
+            if self.tx_hash(ref) not in included:
+                raise LoggedError(
+                    f"{name}: built payload misses tx {ref.block}:{ref.index}"
+                )
+        for ref in step.transactions_exclude:
+            if self.tx_hash(ref) in included:
+                raise LoggedError(
+                    f"{name}: built payload includes excluded tx "
+                    f"{ref.block}:{ref.index}"
+                )
+        versioned_hashes: List[Hash] = []
+        if response.blobs_bundle is not None:
+            versioned_hashes = [
+                Hash(bytes([1]) + hashlib.sha256(bytes(c)).digest()[1:])
+                for c in response.blobs_bundle.commitments
+            ]
+        attributes = self.last_payload_attributes.get(step.on)
+        self.bound[step.bind] = BoundPayload(
+            payload=payload,
+            versioned_hashes=versioned_hashes,
+            parent_beacon_block_root=(
+                attributes.parent_beacon_block_root if attributes else None
+            ),
+            execution_requests=response.execution_requests,
+            label_parent=step.parent,
+        )
+        self.labels_by_hash[payload.block_hash] = step.bind
+        logger.info(
+            f"{name}: bound block {payload.number} {payload.block_hash} "
+            f"({len(payload.transactions)} txs) on {step.parent}"
+        )
+
+    def _head_hash(self, rpc: ClientRPC, tag: str) -> Hash | None:
+        try:
+            block = rpc.eth.get_block_by_number(tag)  # type: ignore[arg-type]
+        except JSONRPCError as e:
+            logger.info(
+                f"eth_getBlockByNumber({tag!r}) error {e.code}: {e.message}"
+            )
+            return None
+        return Hash(block["hash"]) if block else None
+
+    def assert_head(self, name: str, step: AssertHeadStep) -> None:
+        """Check latest/safe/finalized via ``eth_getBlockByNumber``."""
+        rpc = self.rpc(step.on)
+        for tag, label in (
+            ("latest", step.latest),
+            ("safe", step.safe),
+            ("finalized", step.finalized),
+        ):
+            if label is None:
+                continue
+            got = self._head_hash(rpc, tag)
+            want = self.resolve(label)
+            if got != want:
+                raise LoggedError(
+                    f"{name}: '{tag}' is {self.label_of(got)} ({got}), "
+                    f"expected {label} ({want})"
+                )
+            logger.info(f"{name}: {tag} == {label}")
+
+    def wait_for_head(self, name: str, step: WaitForHeadStep) -> None:
+        """Poll ``latest`` until it equals the label or time runs out."""
+        rpc = self.rpc(step.on)
+        want = self.resolve(step.latest)
+        deadline = time.monotonic() + step.timeout
+        got: Hash | None = None
+        while time.monotonic() < deadline:
+            got = self._head_hash(rpc, "latest")
+            if got == want:
+                logger.info(f"{name}: latest == {step.latest}")
+                return
+            time.sleep(1.0)
+        raise LoggedError(
+            f"{name}: timed out after {step.timeout}s; latest is "
+            f"{self.label_of(got)}, expected {step.latest}"
+        )
+
+    def assert_canonical(self, name: str, step: AssertCanonicalStep) -> None:
+        """Check the block at each height via ``eth_getBlockByNumber``."""
+        rpc = self.rpc(step.on)
+        for number, label in step.blocks.items():
+            block = rpc.eth.get_block_by_number(int(number))
+            got = Hash(block["hash"]) if block else None
+            want = None if label is None else self.resolve(label)
+            if got != want:
+                raise LoggedError(
+                    f"{name}: block {int(number)} is {self.label_of(got)} "
+                    f"({got}), expected {label} ({want})"
+                )
+            logger.info(f"{name}: block {int(number)} == {label}")
+
+    def assert_state(self, name: str, step: AssertStateStep) -> None:
+        """Check account fields via ``eth_getBalance`` and friends."""
+        rpc = self.rpc(step.on)
+        at: Any = (
+            "latest" if step.at == "latest" else self.block_number(step.at)
+        )
+        for address, expected in step.accounts.items():
+            if expected.balance is not None:
+                got_balance = rpc.eth.get_balance(address, at)
+                if got_balance != int(expected.balance):
+                    raise LoggedError(
+                        f"{name}: balance of {address} at {step.at} is "
+                        f"{got_balance}, expected {int(expected.balance)}"
+                    )
+            if expected.nonce is not None:
+                got_nonce = rpc.eth.get_transaction_count(address, at)
+                if got_nonce != int(expected.nonce):
+                    raise LoggedError(
+                        f"{name}: nonce of {address} at {step.at} is "
+                        f"{got_nonce}, expected {int(expected.nonce)}"
+                    )
+            if expected.storage:
+                for key, value in expected.storage.items():
+                    got = rpc.eth.get_storage_at(address, key, at)
+                    if got != value:
+                        raise LoggedError(
+                            f"{name}: storage {key} of {address} at {step.at} "
+                            f"is {got}, expected {value}"
+                        )
+        logger.info(f"{name}: state at {step.at} matches")
+
+    def assert_receipt(self, name: str, step: AssertReceiptStep) -> None:
+        """Check ``eth_getTransactionReceipt`` block hash (or absence)."""
+        rpc = self.rpc(step.on)
+        tx_hash = self.tx_hash(step.tx)
+        receipt = rpc.eth.get_transaction_receipt(tx_hash)
+        ref = f"{step.tx.block}:{step.tx.index}"
+        if step.block is None:
+            if receipt is not None:
+                raise LoggedError(
+                    f"{name}: tx {ref} has a receipt in block "
+                    f"{self.label_of(receipt.get('blockHash'))}, expected none"
+                )
+            logger.info(f"{name}: tx {ref} has no receipt")
+            return
+        if receipt is None:
+            raise LoggedError(
+                f"{name}: tx {ref} has no receipt, expected block {step.block}"
+            )
+        got = Hash(receipt["blockHash"])
+        if got != self.resolve(step.block):
+            raise LoggedError(
+                f"{name}: tx {ref} receipt is in {self.label_of(got)}, "
+                f"expected {step.block}"
+            )
+        if step.status is not None and int(receipt["status"], 16) != int(
+            step.status
+        ):
+            raise LoggedError(
+                f"{name}: tx {ref} receipt status {receipt['status']}, "
+                f"expected {int(step.status)}"
+            )
+        logger.info(f"{name}: tx {ref} receipt in {step.block}")
+
+    def assert_logs(self, name: str, step: AssertLogsStep) -> None:
+        """Check ``eth_getLogs`` returns exactly the expected blocks' logs."""
+        rpc = self.rpc(step.on)
+        params: Dict[str, Any] = {
+            "fromBlock": step.from_block
+            if isinstance(step.from_block, str)
+            else hex(int(step.from_block)),
+            "toBlock": step.to_block
+            if isinstance(step.to_block, str)
+            else hex(int(step.to_block)),
+        }
+        if step.address is not None:
+            params["address"] = f"{step.address}"
+        from execution_testing.rpc.rpc_types import RPCCall
+
+        logs = rpc.eth.post_request(
+            request=RPCCall(method="getLogs", params=[params])
+        ).result_or_raise()
+        got = sorted(self.label_of(log["blockHash"]) for log in logs)
+        want = sorted(step.blocks)
+        if got != want:
+            raise LoggedError(
+                f"{name}: eth_getLogs returned logs from {got}, "
+                f"expected {want}"
+            )
+        logger.info(f"{name}: logs from {want}")
+
+    def send_raw_transaction(
+        self, name: str, step: SendRawTransactionStep
+    ) -> None:
+        """Send a fixture transaction and check acceptance."""
+        rpc = self.rpc(step.on)
+        ref = f"{step.tx.block}:{step.tx.index}"
+        try:
+            rpc.eth.send_raw_transaction(self.tx_rlp(step.tx))
+            result = "accepted"
+            detail = ""
+        except JSONRPCError as e:
+            result = "rejected"
+            detail = f" ({e.code}: {e.message})"
+        if result not in step.expect:
+            raise LoggedError(
+                f"{name}: tx {ref} {result}{detail}, expected {step.expect}"
+            )
+        logger.info(f"{name}: tx {ref} {result}{detail}")
+        self.matched.append(f"{name}:{result}")
+
+    def assert_tx_status(self, name: str, step: AssertTxStatusStep) -> None:
+        """Check ``eth_getTransactionByHash`` pool/chain status."""
+        rpc = self.rpc(step.on)
+        ref = f"{step.tx.block}:{step.tx.index}"
+        tx = rpc.eth.get_transaction_by_hash(self.tx_hash(step.tx))
+        if tx is None:
+            status = "dropped"
+        elif tx.block_hash is None:
+            status = "pending"
+        else:
+            status = "included"
+        if status not in step.expect:
+            raise LoggedError(
+                f"{name}: tx {ref} is {status}, expected {step.expect}"
+            )
+        if status == "included" and step.included_in is not None:
+            assert tx is not None and tx.block_hash is not None
+            if tx.block_hash != self.resolve(step.included_in):
+                raise LoggedError(
+                    f"{name}: tx {ref} included in "
+                    f"{self.label_of(tx.block_hash)}, "
+                    f"expected {step.included_in}"
+                )
+        logger.info(f"{name}: tx {ref} is {status}")
+        self.matched.append(f"{name}:{status}")
+
+
+def test_reorg_via_engine(
+    timing_data: TimingData,
+    eth_rpc: EthRPC,
+    engine_rpc: EngineRPC,
+    client: Client,
+    peer_rpcs: Dict[str, ClientRPC],
+    fixture: BlockchainEngineReorgFixture,
+    genesis_header: FixtureHeader,
+) -> None:
+    """
+    Execute a reorg fixture against a fresh client (plus declared peers).
+
+    1. Send an initial forkchoiceUpdated to genesis (readiness + head reset).
+    2. Verify the client's genesis hash.
+    3. Run the fixture's steps.
+    """
+    del client
+    fcu_version = fixture.fork.fork_at(
+        block_number=0, timestamp=int(genesis_header.timestamp)
+    ).engine_forkchoice_updated_version()
+    assert fcu_version is not None, "reorg fixtures require the Engine API"
+
+    clients = {MAIN_CLIENT: ClientRPC(MAIN_CLIENT, eth_rpc, engine_rpc)}
+    clients.update(peer_rpcs)
+
+    for rpc in clients.values():
+        send_forkchoice_update_to_genesis(
+            rpc.engine,
+            genesis_header=genesis_header,
+            forkchoice_version=fcu_version,
+            timing_data=timing_data,
+            label=rpc.name,
+        )
+        verify_genesis_block_hash(
+            rpc.eth, genesis_header, timing_data, label=rpc.name
+        )
+
+    runner = StepRunner(fixture, clients, timing_data)
+    with timing_data.time("Steps"):
+        runner.run(fixture.steps)
+    logger.info(f"All steps passed. Outcomes: {runner.matched}")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/single_test_client.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/single_test_client.py
@@ -15,6 +15,7 @@ from hive.testing import HiveTest
 from execution_testing.base_types import Number, to_json
 from execution_testing.fixtures import BlockchainFixtureCommon
 from execution_testing.fixtures.blockchain import FixtureHeader
+from execution_testing.forks import Fork, TransitionFork
 
 from .helpers.ruleset import (
     ruleset,  # TODO: generate dynamically
@@ -37,25 +38,34 @@ def client_genesis(fixture: BlockchainFixtureCommon) -> dict:
     return genesis
 
 
+def client_environment(
+    fork: Fork | TransitionFork,
+    chain_id: int,
+    check_live_port: Literal[8545, 8551],
+) -> dict:
+    """Build the base HIVE_* environment shared by every simulator."""
+    assert fork in ruleset, f"fork '{fork}' missing in hive ruleset"
+    chain_id_str = str(Number(chain_id))
+    return {
+        "HIVE_CHAIN_ID": chain_id_str,
+        # Use same value for P2P network compatibility
+        "HIVE_NETWORK_ID": chain_id_str,
+        "HIVE_FORK_DAO_VOTE": "1",
+        "HIVE_NODETYPE": "full",
+        "HIVE_CHECK_LIVE_PORT": str(check_live_port),
+        **{k: f"{v:d}" for k, v in ruleset[fork].items()},
+    }
+
+
 @pytest.fixture(scope="function")
 def environment(
     fixture: BlockchainFixtureCommon,
     check_live_port: Literal[8545, 8551],
 ) -> dict:
     """Define the environment that hive will start the client with."""
-    assert fixture.fork in ruleset, (
-        f"fork '{fixture.fork}' missing in hive ruleset"
+    return client_environment(
+        fixture.fork, fixture.config.chain_id, check_live_port
     )
-    chain_id = str(Number(fixture.config.chain_id))
-    return {
-        "HIVE_CHAIN_ID": chain_id,
-        # Use same value for P2P network compatibility
-        "HIVE_NETWORK_ID": chain_id,
-        "HIVE_FORK_DAO_VOTE": "1",
-        "HIVE_NODETYPE": "full",
-        "HIVE_CHECK_LIVE_PORT": str(check_live_port),
-        **{k: f"{v:d}" for k, v in ruleset[fixture.fork].items()},
-    }
 
 
 @pytest.fixture(scope="function")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/processors.py
@@ -124,6 +124,7 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
             "enginex",
             "sync",
             "rlp",
+            "reorg",
             "build_block",
         }
         if self.command_name in simulator_commands:

--- a/packages/testing/src/execution_testing/fixtures/__init__.py
+++ b/packages/testing/src/execution_testing/fixtures/__init__.py
@@ -30,6 +30,7 @@ from .pre_alloc_groups import (
     PreAllocGroups,
     pack_pre_alloc_groups,
 )
+from .reorg import BlockchainEngineReorgFixture
 from .state import StateFixture
 from .transaction import TransactionFixture
 
@@ -40,6 +41,7 @@ __all__ = [
     "BlockchainEngineStatefulFixture",
     "BlockchainEngineSyncFixture",
     "BlockchainEngineXFixture",
+    "BlockchainEngineReorgFixture",
     "BlockchainFixture",
     "BlockchainFixtureCommon",
     "FixtureCollector",

--- a/packages/testing/src/execution_testing/fixtures/reorg.py
+++ b/packages/testing/src/execution_testing/fixtures/reorg.py
@@ -1,0 +1,375 @@
+"""
+Reorg fixture format: a DAG of engine payloads plus an ordered, branching list
+of Engine API / JSON-RPC steps with expected outcomes.
+
+Unlike ``BlockchainEngineFixture`` (a linear payload list where the consumer
+always sends ``forkchoiceUpdated(head=payload)`` after each payload), this
+format lets a test describe side chains, explicit forkchoice states (head,
+safe, finalized), multiple legal outcomes per step (``expect`` is a list of
+outcomes; the first one that matches wins), outcome-specific follow-up steps
+(``branches``), client-built payloads (``getPayload`` binds the built payload
+to a new label), transaction-pool observations, and a second client
+(``clients``/``on``) for sync-delivered reorgs.
+
+Block labels are the identifiers used throughout: ``blocks`` maps a label to a
+payload and its parent label; every hash-valued step field is a label
+(``"genesis"`` is reserved for the genesis block, ``"zero"`` for the zero hash;
+labels introduced by ``getPayload.bind`` are resolved at run time). The
+consumer resolves labels to hashes, so fixtures are byte-identical across
+clients.
+"""
+
+from typing import Annotated, Any, ClassVar, Dict, List, Literal, Union
+
+from pydantic import Field
+
+from execution_testing.base_types import (
+    Address,
+    Alloc,
+    Bytes,
+    CamelModel,
+    Hash,
+    HexNumber,
+)
+from execution_testing.forks import Fork, Paris, TransitionFork
+from execution_testing.test_types import Withdrawal
+
+from .base import BaseFixture
+from .blockchain import (
+    FixtureConfig,
+    FixtureEngineNewPayload,
+    FixtureHeader,
+)
+
+GENESIS_LABEL = "genesis"
+ZERO_LABEL = "zero"
+MAIN_CLIENT = "main"
+"""Reserved labels / client names."""
+
+LATEST_VALID_HASH_ANY = "any"
+LATEST_VALID_HASH_NULL = "null"
+"""Special values for ``Outcome.latest_valid_hash``."""
+
+
+class Outcome(CamelModel):
+    """
+    One legal outcome of an Engine API step.
+
+    Every set field is a constraint; unset fields are not checked. A step's
+    ``expect`` is a list of outcomes and the first matching one is selected.
+    """
+
+    id: str
+    """Identifier; selects the ``branches`` entry to run when matched."""
+    disputed: str | None = None
+    """
+    If set, the spec is ambiguous about this outcome; the value is a
+    reference (issue URL). A disputed outcome still passes.
+    """
+    status: str | None = None
+    """
+    Expected ``payloadStatus.status`` (VALID, INVALID, SYNCING, ACCEPTED).
+    """
+    latest_valid_hash: str | None = None
+    """
+    Expected ``latestValidHash`` as a block label, ``"null"``, or ``"any"``.
+    Unset means not checked.
+    """
+    error_code: int | None = None
+    """Expected JSON-RPC error code (e.g. -38002, -38006)."""
+    any_error: bool | None = None
+    """If true, any JSON-RPC error matches (for uncoded errors)."""
+    head_moved: bool | None = None
+    """
+    ``forkchoiceUpdated`` only: whether ``latest`` equals the requested head
+    right after the call. Distinguishes ``applied`` from ``noop`` when both
+    answer VALID with the same ``latestValidHash``.
+    """
+    validation_error: Literal["required", "none"] | None = None
+    """Whether ``validationError`` must be present or absent."""
+    payload_id: Literal["nonNull", "null"] | None = None
+    """For ``forkchoiceUpdated`` with payload attributes."""
+
+
+class TxRef(CamelModel):
+    """Reference to a transaction of a fixture block."""
+
+    block: str
+    index: int = 0
+
+
+class FixturePayloadAttributes(CamelModel):
+    """Payload attributes sent with ``forkchoiceUpdated`` to start a build."""
+
+    timestamp: HexNumber
+    prev_randao: Hash
+    suggested_fee_recipient: Address
+    withdrawals: List[Withdrawal] | None = None
+    parent_beacon_block_root: Hash | None = None
+
+
+class StepBase(CamelModel):
+    """Common fields of every step."""
+
+    description: str | None = None
+    on: str = MAIN_CLIENT
+    """Client the step is executed on (``main`` or a key of ``clients``)."""
+
+
+class NewPayloadStep(StepBase):
+    """Send ``engine_newPayloadVX`` for a labeled (or bound) block."""
+
+    type: Literal["newPayload"] = "newPayload"
+    block: str
+    expect: List[Outcome] = Field(default_factory=list)
+    """Legal outcomes; filled by the reference model when left empty."""
+    branches: Dict[str, List["Step"]] = Field(default_factory=dict)
+
+
+class ForkchoiceUpdatedStep(StepBase):
+    """Send ``engine_forkchoiceUpdatedVX`` with labeled hashes."""
+
+    type: Literal["forkchoiceUpdated"] = "forkchoiceUpdated"
+    head: str
+    safe: str = ZERO_LABEL
+    finalized: str = ZERO_LABEL
+    version: int | None = None
+    """Engine API version; derived from the head block's fork when unset."""
+    payload_attributes: FixturePayloadAttributes | None = None
+    """If set, a payload build is requested; ``payloadId`` is kept for the
+    next ``getPayload`` step."""
+    expect: List[Outcome] = Field(default_factory=list)
+    """Legal outcomes; filled by the reference model when left empty."""
+    branches: Dict[str, List["Step"]] = Field(default_factory=dict)
+
+
+class GetPayloadStep(StepBase):
+    """
+    Send ``engine_getPayloadVX`` with the id returned by the previous
+    ``forkchoiceUpdated`` and bind the built payload to a new label.
+    """
+
+    type: Literal["getPayload"] = "getPayload"
+    bind: str
+    """New label for the built payload (usable in later steps)."""
+    version: int | None = None
+    delay: float = 1.0
+    """Seconds to wait after the build request before retrieving (clients
+    return the best payload built so far; give them time to include pool
+    transactions)."""
+    parent: str
+    """Expected parent of the built payload."""
+    transactions_include: List[TxRef] = Field(default_factory=list)
+    """Transactions that must be in the built payload."""
+    transactions_exclude: List[TxRef] = Field(default_factory=list)
+    """Transactions that must not be in the built payload."""
+
+
+class AssertHeadStep(StepBase):
+    """Assert ``eth_getBlockByNumber`` for latest / safe / finalized."""
+
+    type: Literal["assertHead"] = "assertHead"
+    latest: str | None = None
+    safe: str | None = None
+    finalized: str | None = None
+
+
+class WaitForHeadStep(StepBase):
+    """Poll ``eth_getBlockByNumber("latest")`` until it equals a label."""
+
+    type: Literal["waitForHead"] = "waitForHead"
+    latest: str
+    timeout: int = 60
+    """Seconds."""
+
+
+class AssertCanonicalStep(StepBase):
+    """
+    Assert which block occupies each height (``eth_getBlockByNumber(n)``).
+
+    A ``None`` value asserts that no block is canonical at that height.
+    """
+
+    type: Literal["assertCanonical"] = "assertCanonical"
+    blocks: Dict[HexNumber, str | None]
+
+
+class AccountExpectation(CamelModel):
+    """Subset of account fields to verify."""
+
+    balance: HexNumber | None = None
+    nonce: HexNumber | None = None
+    storage: Dict[Hash, Hash] | None = None
+
+
+class AssertStateStep(StepBase):
+    """Assert account state via ``eth_getBalance`` etc. at a block."""
+
+    type: Literal["assertState"] = "assertState"
+    at: str = "latest"
+    """Block label, or ``"latest"``."""
+    accounts: Dict[Address, AccountExpectation]
+
+
+class AssertReceiptStep(StepBase):
+    """
+    Assert ``eth_getTransactionReceipt`` for a fixture transaction.
+
+    ``block`` is the label the receipt must point to; ``None`` asserts there
+    is no receipt (transaction not in the canonical chain).
+    """
+
+    type: Literal["assertReceipt"] = "assertReceipt"
+    tx: TxRef
+    block: str | None = None
+    status: HexNumber | None = None
+
+
+class AssertLogsStep(StepBase):
+    """
+    Assert ``eth_getLogs`` over a block range.
+
+    ``blocks`` lists the labels whose logs must appear (one entry per expected
+    log); logs from other blocks are a failure.
+    """
+
+    type: Literal["assertLogs"] = "assertLogs"
+    address: Address | None = None
+    from_block: HexNumber | Literal["earliest"] = "earliest"
+    to_block: HexNumber | Literal["latest"] = "latest"
+    blocks: List[str]
+
+
+class SendRawTransactionStep(StepBase):
+    """Send a fixture transaction via ``eth_sendRawTransaction``."""
+
+    type: Literal["sendRawTransaction"] = "sendRawTransaction"
+    tx: TxRef
+    expect: List[Literal["accepted", "rejected"]] = ["accepted"]
+    """``rejected`` = any JSON-RPC error (e.g. already known)."""
+
+
+class AssertTxStatusStep(StepBase):
+    """
+    Assert the pool/chain status of a fixture transaction via
+    ``eth_getTransactionByHash``: ``included`` (block hash set), ``pending``
+    (known, no block), ``dropped`` (unknown).
+    """
+
+    type: Literal["assertTxStatus"] = "assertTxStatus"
+    tx: TxRef
+    expect: List[Literal["included", "pending", "dropped"]]
+    included_in: str | None = None
+    """If ``included`` matches, the block label it must be included in."""
+
+
+Step = Annotated[
+    Union[
+        NewPayloadStep,
+        ForkchoiceUpdatedStep,
+        GetPayloadStep,
+        AssertHeadStep,
+        WaitForHeadStep,
+        AssertCanonicalStep,
+        AssertStateStep,
+        AssertReceiptStep,
+        AssertLogsStep,
+        SendRawTransactionStep,
+        AssertTxStatusStep,
+    ],
+    Field(discriminator="type"),
+]
+
+NewPayloadStep.model_rebuild()
+ForkchoiceUpdatedStep.model_rebuild()
+
+
+class FixtureReorgBlock(CamelModel):
+    """A block of the DAG: its parent label and engine payload."""
+
+    parent: str
+    payload: FixtureEngineNewPayload
+
+    @property
+    def block_hash(self) -> Hash:
+        """Hash of the block."""
+        return self.payload.params[0].block_hash
+
+    @property
+    def transactions(self) -> List[Bytes]:
+        """Raw transactions of the block."""
+        return self.payload.params[0].transactions
+
+
+class FixtureClient(CamelModel):
+    """An additional client started for the test (peered with ``main``)."""
+
+    description: str | None = None
+
+
+class BlockchainEngineReorgFixture(BaseFixture):
+    """Engine API reorg test fixture."""
+
+    format_name: ClassVar[str] = "blockchain_test_engine_reorg"
+    description: ClassVar[str] = (
+        "Tests that describe a DAG of payloads and an ordered list of "
+        "Engine API / JSON-RPC steps with expected outcomes, to verify chain "
+        "reorganization behavior."
+    )
+    transition_tool_cache_key: ClassVar[str] = "blockchain_test"
+
+    fork: Fork | TransitionFork = Field(..., alias="network")
+    config: FixtureConfig
+    genesis: FixtureHeader = Field(..., alias="genesisBlockHeader")
+    pre: Alloc
+    blocks: Dict[str, FixtureReorgBlock]
+    steps: List[Step]
+    clients: Dict[str, FixtureClient] = Field(default_factory=dict)
+    """Additional clients besides ``main``."""
+    requires: Dict[str, str] | None = None
+    """
+    Client environment (``HIVE_*`` variables) the consumer applies at client
+    start. Absent means client defaults.
+    """
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+    def get_fork(self) -> Fork | TransitionFork | None:
+        """Return fixture's `Fork`."""
+        return self.fork
+
+    @classmethod
+    def supports_fork(cls, fork: Fork | TransitionFork) -> bool:
+        """The Engine API is available only on Paris and afterwards."""
+        return fork.fork_at(block_number=0, timestamp=0) >= Paris
+
+    def resolve(self, label: str) -> Hash | None:
+        """
+        Resolve a static label to a block hash.
+
+        Returns ``None`` for the ``"null"`` special value. Bound labels are
+        resolved by the consumer.
+        """
+        if label == GENESIS_LABEL:
+            return self.genesis.block_hash
+        if label == ZERO_LABEL:
+            return Hash(0)
+        if label == LATEST_VALID_HASH_NULL:
+            return None
+        if label not in self.blocks:
+            raise KeyError(f"unknown block label: {label}")
+        return self.blocks[label].block_hash
+
+    def labels_by_hash(self) -> Dict[Hash, str]:
+        """Reverse map from block hash to label (incl. genesis)."""
+        result = {self.genesis.block_hash: GENESIS_LABEL}
+        for label, block in self.blocks.items():
+            result[block.block_hash] = label
+        return result
+
+    def tx_rlp(self, ref: TxRef) -> Bytes:
+        """Raw transaction bytes referenced by ``ref``."""
+        return self.blocks[ref.block].transactions[ref.index]
+
+    def tx_hash(self, ref: TxRef) -> Hash:
+        """Hash of the transaction referenced by ``ref``."""
+        return Hash(self.tx_rlp(ref).keccak256())

--- a/packages/testing/src/execution_testing/specs/__init__.py
+++ b/packages/testing/src/execution_testing/specs/__init__.py
@@ -15,6 +15,7 @@ from .blockchain import (
     BlockchainTestSpec,
     Header,
 )
+from .reorg import ReorgBlock, ReorgTest, ReorgTestFiller, ReorgTestSpec
 from .state import StateTest, StateTestFiller, StateTestSpec
 from .transaction import (
     TransactionTest,
@@ -38,6 +39,10 @@ __all__ = (
     "Block",
     "Header",
     "OpcodeTarget",
+    "ReorgBlock",
+    "ReorgTest",
+    "ReorgTestFiller",
+    "ReorgTestSpec",
     "StateTest",
     "StateTestFiller",
     "StateTestSpec",

--- a/packages/testing/src/execution_testing/specs/engine_model.py
+++ b/packages/testing/src/execution_testing/specs/engine_model.py
@@ -1,0 +1,450 @@
+"""
+Engine API reference model used to annotate reorg tests.
+
+The model simulates the forkchoice-relevant state of an execution client
+(known blocks and their validity, head/safe/finalized) over the block DAG of a
+reorg test, and derives the set of spec-legal outcomes for every
+``newPayload`` / ``forkchoiceUpdated`` step whose ``expect`` was left empty.
+It also appends ``assertHead`` steps to each outcome's ``branches`` so the
+observable head is verified after every forkchoice update.
+
+Rules follow `execution-apis` ``paris.md`` as amended by PR #786:
+
+- ``newPayload``: unknown parent → SYNCING; execution-invalid → INVALID with
+  ``latestValidHash`` = last valid ancestor; child of a known-invalid block →
+  INVALID (lvh = last valid ancestor) or SYNCING; extends head → VALID;
+  known parent on a side chain → VALID or ACCEPTED.
+- ``forkchoiceUpdated``: unknown head → SYNCING; invalid head → INVALID; safe
+  or finalized not on head's chain → ``-38002``; head is a VALID ancestor of
+  the latest known finalized block → VALID no-op; head extends current head →
+  VALID; otherwise (rewind or side-chain reorg) → VALID (applied) or
+  ``-38006`` (refused, implementation-specific depth cap).
+
+Authors may always provide ``expect`` explicitly; the model never widens an
+author-provided set.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from execution_testing.fixtures.reorg import (
+    GENESIS_LABEL,
+    LATEST_VALID_HASH_ANY,
+    LATEST_VALID_HASH_NULL,
+    MAIN_CLIENT,
+    ZERO_LABEL,
+    AssertHeadStep,
+    ForkchoiceUpdatedStep,
+    GetPayloadStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+    WaitForHeadStep,
+)
+
+INVALID_FORKCHOICE_STATE = -38002
+TOO_DEEP_REORG = -38006
+
+DISPUTED_HEAD_EQUALS_FINALIZED = (
+    "execution-apis#786: no-reorg shortcut applies to an *ancestor* of "
+    "finalized; head == finalized is unspecified"
+)
+DISPUTED_PRE_786_NOOP = (
+    "paris.md before execution-apis#786 lets a client skip the update when "
+    "head is any ancestor of the canonical head; #786 restricts the shortcut "
+    "to ancestors of finalized"
+)
+UNKNOWN_LABEL = "?"
+"""
+Model head/safe/finalized after an errored forkchoice update (unspecified).
+"""
+
+
+@dataclass
+class ModelDag:
+    """Block DAG known at fill time."""
+
+    parent: Dict[str, str]
+    """label -> parent label (``genesis`` has no entry)."""
+    valid: Dict[str, bool]
+    """label -> whether the block passes execution validation."""
+
+    def number(self, label: str) -> int:
+        """Block height of a label."""
+        n = 0
+        while label != GENESIS_LABEL:
+            label = self.parent[label]
+            n += 1
+        return n
+
+    def ancestors(self, label: str) -> List[str]:
+        """Labels from ``label`` (inclusive) back to genesis."""
+        chain = [label]
+        while label != GENESIS_LABEL:
+            label = self.parent[label]
+            chain.append(label)
+        return chain
+
+    def is_ancestor(self, ancestor: str, label: str) -> bool:
+        """Whether ``ancestor`` is a strict ancestor of ``label``."""
+        return ancestor in self.ancestors(label)[1:]
+
+    def last_valid_ancestor(self, label: str) -> str:
+        """
+        Closest ancestor (inclusive) that is valid and whose ancestors are.
+        """
+        for candidate in self.ancestors(label):
+            if self.fully_valid(candidate):
+                return candidate
+        return GENESIS_LABEL
+
+    def fully_valid(self, label: str) -> bool:
+        """Block and all its ancestors are execution-valid."""
+        return all(self.valid.get(a, True) for a in self.ancestors(label))
+
+
+@dataclass
+class ClientModel:
+    """Simulated client forkchoice state."""
+
+    dag: ModelDag
+    known: Dict[str, bool] = field(default_factory=dict)
+    """label -> known validity (True valid, False invalid)."""
+    head: str = GENESIS_LABEL
+    safe: str = ZERO_LABEL
+    finalized: str = ZERO_LABEL
+
+    def __post_init__(self) -> None:
+        """Genesis is always known and valid."""
+        self.known.setdefault(GENESIS_LABEL, True)
+
+    # -- newPayload -----------------------------------------------------
+
+    def new_payload_outcomes(self, block: str) -> List[Outcome]:
+        """Legal outcomes of ``newPayload(block)``."""
+        parent = self.dag.parent[block]
+        if parent not in self.known:
+            return [Outcome(id="syncing", status="SYNCING")]
+        if not self.known[parent]:
+            lva = self.dag.last_valid_ancestor(parent)
+            return [
+                Outcome(id="invalid", status="INVALID", latest_valid_hash=lva),
+                Outcome(id="syncing", status="SYNCING"),
+            ]
+        if not self.dag.valid.get(block, True):
+            # The spec only says validationError MAY be set; required here
+            # (unlike the propagated-invalid-parent and FCU-invalid-head
+            # cases) because this is the block a client itself executed and
+            # rejected, matching the stricter check test_via_engine.py and
+            # test_via_sync.py already apply to every own-block INVALID.
+            return [
+                Outcome(
+                    id="invalid",
+                    status="INVALID",
+                    latest_valid_hash=parent,
+                    validation_error="required",
+                )
+            ]
+        if parent == self.head:
+            return [
+                Outcome(id="valid", status="VALID", latest_valid_hash=block)
+            ]
+        return [
+            Outcome(id="valid", status="VALID", latest_valid_hash=block),
+            Outcome(
+                id="accepted",
+                status="ACCEPTED",
+                latest_valid_hash=LATEST_VALID_HASH_NULL,
+            ),
+        ]
+
+    def apply_new_payload(self, block: str, outcomes: List[Outcome]) -> None:
+        """
+        Update model state after ``newPayload``.
+
+        A block that may be INVALID (itself or via a known-invalid ancestor)
+        is recorded as known-invalid: clients that cache bad blocks answer
+        INVALID for its descendants, others SYNCING — both remain legal for
+        every descendant, so the chain must never become canonical.
+        """
+        statuses = {o.status for o in outcomes}
+        if statuses & {"VALID", "ACCEPTED"}:
+            self.known[block] = True
+        elif "INVALID" in statuses:
+            self.known[block] = False
+        # SYNCING-only: block remains unknown.
+
+    # -- forkchoiceUpdated ----------------------------------------------
+
+    def _on_chain(self, label: str, head: str) -> bool:
+        """Whether ``label`` is ``zero``, ``head`` or an ancestor of it."""
+        return (
+            label == ZERO_LABEL
+            or label == head
+            or self.dag.is_ancestor(label, head)
+        )
+
+    def forkchoice_outcomes(
+        self, step: ForkchoiceUpdatedStep
+    ) -> List[Outcome]:
+        """
+        Legal outcomes of a ``forkchoiceUpdated`` step.
+
+        When payload attributes are supplied, an applied VALID outcome must
+        return a ``payloadId``; a no-op must not start a build.
+        """
+        outcomes = self._forkchoice_outcomes(step)
+        if step.payload_attributes is not None:
+            for outcome in outcomes:
+                if outcome.id == "applied":
+                    outcome.payload_id = "nonNull"
+                elif outcome.id == "noop":
+                    outcome.payload_id = "null"
+        return outcomes
+
+    def _forkchoice_outcomes(
+        self, step: ForkchoiceUpdatedStep
+    ) -> List[Outcome]:
+        head = step.head
+        if head not in self.known:
+            return [Outcome(id="syncing", status="SYNCING")]
+        if not self.known[head]:
+            return [
+                Outcome(
+                    id="invalid",
+                    status="INVALID",
+                    latest_valid_hash=self.dag.last_valid_ancestor(head),
+                )
+            ]
+        # Step 2: no-reorg shortcut for ancestors of the latest known
+        # finalized.
+        if self.finalized not in (ZERO_LABEL, UNKNOWN_LABEL):
+            if self.dag.is_ancestor(head, self.finalized):
+                return [
+                    Outcome(id="noop", status="VALID", latest_valid_hash=head)
+                ]
+            if head == self.finalized and head != self.head:
+                return [
+                    Outcome(
+                        id="applied", status="VALID", latest_valid_hash=head
+                    ),
+                    Outcome(
+                        id="noop",
+                        status="VALID",
+                        latest_valid_hash=head,
+                        disputed=DISPUTED_HEAD_EQUALS_FINALIZED,
+                    ),
+                ]
+        # Step 5: consistency of safe/finalized with head.
+        if not self._on_chain(step.safe, head) or not self._on_chain(
+            step.finalized, head
+        ):
+            return [
+                Outcome(id="inconsistent", error_code=INVALID_FORKCHOICE_STATE)
+            ]
+        if self.head != UNKNOWN_LABEL:
+            # Extending the current head (or re-sending it): always applied.
+            if head == self.head or self.dag.is_ancestor(self.head, head):
+                return [
+                    Outcome(
+                        id="applied", status="VALID", latest_valid_hash=head
+                    )
+                ]
+            # Rewind to a canonical ancestor: applied, skipped (pre-#786
+            # shortcut, disputed) or refused as too deep.
+            if self.dag.is_ancestor(head, self.head):
+                return [
+                    Outcome(
+                        id="applied", status="VALID", latest_valid_hash=head
+                    ),
+                    Outcome(
+                        id="noop",
+                        status="VALID",
+                        latest_valid_hash=head,
+                        disputed=DISPUTED_PRE_786_NOOP,
+                    ),
+                    Outcome(id="refused", error_code=TOO_DEEP_REORG),
+                ]
+        # Side-chain reorg (or unknown current head): applied or too deep.
+        return [
+            Outcome(id="applied", status="VALID", latest_valid_hash=head),
+            Outcome(id="refused", error_code=TOO_DEEP_REORG),
+        ]
+
+    def apply_forkchoice(
+        self, step: ForkchoiceUpdatedStep, outcome: Outcome
+    ) -> None:
+        """
+        Update model state assuming ``outcome`` happened.
+
+        An ``-38002`` (inconsistent forkchoice state) error leaves the head
+        unspecified: clients differ on whether the head was already moved
+        before the safe/finalized check failed (geth and reth move it).
+        """
+        if outcome.id == "applied":
+            self.head = step.head
+            self.safe = step.safe
+            self.finalized = step.finalized
+        elif outcome.error_code == INVALID_FORKCHOICE_STATE:
+            self.head = self.safe = self.finalized = UNKNOWN_LABEL
+
+    def head_assertion(self) -> Optional[AssertHeadStep]:
+        """``assertHead`` for the current model state; None if unspecified."""
+        if self.head == UNKNOWN_LABEL:
+            return None
+        return AssertHeadStep(
+            latest=self.head,
+            safe=None
+            if self.safe in (ZERO_LABEL, UNKNOWN_LABEL)
+            else self.safe,
+            finalized=None
+            if self.finalized in (ZERO_LABEL, UNKNOWN_LABEL)
+            else self.finalized,
+        )
+
+    def assign(self, other: "ClientModel") -> None:
+        """Take over another model's state (same DAG)."""
+        self.known = dict(other.known)
+        self.head = other.head
+        self.safe = other.safe
+        self.finalized = other.finalized
+
+    def copy(self) -> "ClientModel":
+        """Independent copy for branch exploration."""
+        return ClientModel(
+            dag=self.dag,
+            known=dict(self.known),
+            head=self.head,
+            safe=self.safe,
+            finalized=self.finalized,
+        )
+
+
+def annotate_steps(
+    steps: List[Step],
+    model: ClientModel,
+    fcu_version: Optional[Dict[str, int]] = None,
+    models: Optional[Dict[str, ClientModel]] = None,
+) -> List[Step]:
+    """
+    Fill empty ``expect`` lists and ``version`` fields in ``steps`` using the
+    model, appending an ``assertHead`` step to every forkchoice outcome branch.
+
+    ``model`` is the state of the ``main`` client; steps executed ``on`` other
+    clients use (and lazily create) per-client models sharing the same DAG.
+    Branch step lists are annotated recursively with copies of the models in
+    which that outcome happened. Sibling steps after a multi-outcome step are
+    annotated with the models of the first (canonical) outcome.
+
+    ``getPayload`` binds a new label: it is added to the DAG as a valid child
+    of its declared parent (the client builds it, so it is execution-valid).
+    ``waitForHead`` marks the awaited label (and its ancestors) known and
+    canonical on that client.
+    """
+    if models is None:
+        models = {MAIN_CLIENT: model}
+    else:
+        models.setdefault(MAIN_CLIENT, model)
+
+    def client(name: str) -> ClientModel:
+        if name not in models:
+            models[name] = ClientModel(dag=model.dag)
+        return models[name]
+
+    def fork(sub_models: Dict[str, ClientModel]) -> Dict[str, ClientModel]:
+        return {k: v.copy() for k, v in sub_models.items()}
+
+    def continue_from(branch_models: Dict[str, ClientModel]) -> None:
+        """Sibling steps continue from the state after the first branch."""
+        for name, bm in branch_models.items():
+            client(name).assign(bm)
+
+    for step in steps:
+        m = client(step.on)
+        if isinstance(step, NewPayloadStep):
+            if not step.expect:
+                step.expect = m.new_payload_outcomes(step.block)
+            first_models: Optional[Dict[str, ClientModel]] = None
+            for outcome in step.expect:
+                branch_models = fork(models)
+                branch_models[step.on].apply_new_payload(step.block, [outcome])
+                if outcome.id in step.branches:
+                    annotate_steps(
+                        step.branches[outcome.id],
+                        branch_models[MAIN_CLIENT],
+                        fcu_version,
+                        branch_models,
+                    )
+                if first_models is None:
+                    first_models = branch_models
+            # Continuation: known-ness follows the whole outcome set (a block
+            # that may be INVALID is treated as known-invalid), head follows
+            # the first outcome's branch.
+            m.apply_new_payload(step.block, step.expect)
+            if first_models is not None and step.branches:
+                known = dict(m.known)
+                continue_from(first_models)
+                m.known = known
+        elif isinstance(step, ForkchoiceUpdatedStep):
+            if step.version is None:
+                if fcu_version is None:
+                    raise ValueError(
+                        "forkchoiceUpdated step without version and no "
+                        "version map provided"
+                    )
+                step.version = fcu_version[step.head]
+            if not step.expect:
+                step.expect = m.forkchoice_outcomes(step)
+            ids = {o.id for o in step.expect}
+            if {"applied", "noop"} <= ids:
+                for outcome in step.expect:
+                    if outcome.id == "applied":
+                        outcome.head_moved = True
+                    elif outcome.id == "noop":
+                        outcome.head_moved = False
+            first_models = None
+            for outcome in step.expect:
+                branch_models = fork(models)
+                branch_models[step.on].apply_forkchoice(step, outcome)
+                branch = step.branches.setdefault(outcome.id, [])
+                annotate_steps(
+                    branch,
+                    branch_models[MAIN_CLIENT],
+                    fcu_version,
+                    branch_models,
+                )
+                if outcome.status != "SYNCING":
+                    head_step = branch_models[step.on].head_assertion()
+                    if head_step is not None:
+                        head_step.on = step.on
+                        branch.append(head_step)
+                if first_models is None:
+                    first_models = branch_models
+            # Sibling steps continue from the state after the first
+            # (canonical) outcome's branch has executed.
+            assert first_models is not None
+            continue_from(first_models)
+        elif isinstance(step, GetPayloadStep):
+            model.dag.parent[step.bind] = step.parent
+            model.dag.valid[step.bind] = True
+            if fcu_version is not None:
+                fcu_version.setdefault(step.bind, fcu_version[step.parent])
+            if step.version is None:
+                if fcu_version is None:
+                    raise ValueError("getPayload step without version")
+                step.version = fcu_version[step.parent]
+        elif isinstance(step, WaitForHeadStep):
+            for ancestor in model.dag.ancestors(step.latest):
+                m.known.setdefault(ancestor, True)
+            m.head = step.latest
+    return steps
+
+
+__all__ = [
+    "ClientModel",
+    "ModelDag",
+    "annotate_steps",
+    "INVALID_FORKCHOICE_STATE",
+    "TOO_DEEP_REORG",
+    "LATEST_VALID_HASH_ANY",
+]

--- a/packages/testing/src/execution_testing/specs/engine_model.py
+++ b/packages/testing/src/execution_testing/specs/engine_model.py
@@ -430,9 +430,9 @@ def annotate_steps(
             if fcu_version is not None:
                 fcu_version.setdefault(step.bind, fcu_version[step.parent])
             if step.version is None:
-                if fcu_version is None:
-                    raise ValueError("getPayload step without version")
-                step.version = fcu_version[step.parent]
+                # Set by ReorgTest from the fork of the payload being built;
+                # forkchoiceUpdated's version is not a valid substitute.
+                raise ValueError("getPayload step without version")
         elif isinstance(step, WaitForHeadStep):
             for ancestor in model.dag.ancestors(step.latest):
                 m.known.setdefault(ancestor, True)

--- a/packages/testing/src/execution_testing/specs/reorg.py
+++ b/packages/testing/src/execution_testing/specs/reorg.py
@@ -20,6 +20,7 @@ from typing import (
     Generator,
     List,
     Sequence,
+    Tuple,
     Type,
 )
 
@@ -208,25 +209,43 @@ class ReorgTest(BlockchainTest):
                 self._validate_step_labels(branch, set(labels))
 
     def _resolve_payload_attributes(
-        self, steps: List[Step], timestamps: Dict[str, int]
+        self,
+        steps: List[Step],
+        timestamps: Dict[str, int],
+        build_timestamps: Dict[Tuple[str, str], int] | None = None,
     ) -> None:
         """
         Fill defaults of ``forkchoiceUpdated.payload_attributes``: a zero
         timestamp becomes ``parent + 12``; Shanghai+ gets empty withdrawals;
         Cancun+ gets a deterministic parent beacon block root. Bound labels
-        (client-built payloads) get ``parent + 12`` relative to the parent of
-        the build request, which is the previous step's head.
+        (client-built payloads) take the timestamp of their build request and
+        the ``getPayload`` version of the fork active at that timestamp.
         """
+        if build_timestamps is None:
+            build_timestamps = {}
         for step in steps:
             if isinstance(step, GetPayloadStep):
-                # Best effort: bound payloads inherit their parent's slot + 12.
-                if step.parent in timestamps:
-                    timestamps[step.bind] = timestamps[step.parent] + 12
+                # The built payload's timestamp is the one requested by the
+                # preceding build request; fall back to parent slot + 12.
+                built_ts = build_timestamps.get(
+                    (step.on, step.parent), timestamps.get(step.parent, 0) + 12
+                )
+                timestamps[step.bind] = built_ts
+                if step.version is None:
+                    # getPayload is versioned by the fork of the payload being
+                    # built (V3 Cancun, V4 Prague, V5 Osaka); it does not track
+                    # forkchoiceUpdated, which stays at V3 from Cancun on.
+                    step.version = self.fork.fork_at(
+                        block_number=0, timestamp=built_ts
+                    ).engine_get_payload_version()
             if isinstance(step, ForkchoiceUpdatedStep):
                 attrs = step.payload_attributes
                 if attrs is not None:
                     if int(attrs.timestamp) == 0:
                         attrs.timestamp = HexNumber(timestamps[step.head] + 12)
+                    build_timestamps[(step.on, step.head)] = int(
+                        attrs.timestamp
+                    )
                     fork = self.fork.fork_at(
                         block_number=0, timestamp=int(attrs.timestamp)
                     )
@@ -241,7 +260,9 @@ class ReorgTest(BlockchainTest):
                     ):
                         attrs.parent_beacon_block_root = Hash(0xBEAC0)
             for branch in getattr(step, "branches", {}).values():
-                self._resolve_payload_attributes(branch, timestamps)
+                self._resolve_payload_attributes(
+                    branch, timestamps, dict(build_timestamps)
+                )
 
     def make_reorg_fixture(self, t8n: FillerBackend) -> FillResult:
         """Execute every block against its labeled parent, emit fixture."""

--- a/packages/testing/src/execution_testing/specs/reorg.py
+++ b/packages/testing/src/execution_testing/specs/reorg.py
@@ -1,0 +1,366 @@
+"""
+Reorg test specification.
+
+A ``ReorgTest`` describes a DAG of blocks (each block names its parent by
+label, so side chains are first-class) and an ordered list of Engine API /
+JSON-RPC steps that drive a client through reorganizations and verify the
+observable results.
+
+Every block is executed by the transition tool against the post-state of its
+labeled parent, so sibling blocks and blocks built on top of an invalid block
+have correct headers and payloads. Steps whose ``expect`` is left empty are
+annotated by the Engine API reference model (``engine_model``).
+"""
+
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generator,
+    List,
+    Sequence,
+    Type,
+)
+
+from pydantic import Field
+
+from execution_testing.base_types import Hash, HexNumber
+from execution_testing.client_clis import FillerBackend, LazyAlloc
+from execution_testing.fixtures import (
+    BlockchainEngineReorgFixture,
+    FixtureFormat,
+    LabeledFixtureFormat,
+)
+from execution_testing.fixtures.blockchain import (
+    FixtureBlobSchedule,
+    FixtureConfig,
+)
+from execution_testing.fixtures.post_verifications import PostVerifications
+from execution_testing.fixtures.reorg import (
+    GENESIS_LABEL,
+    MAIN_CLIENT,
+    ZERO_LABEL,
+    AssertCanonicalStep,
+    AssertHeadStep,
+    AssertLogsStep,
+    AssertReceiptStep,
+    AssertStateStep,
+    AssertTxStatusStep,
+    FixtureClient,
+    FixtureReorgBlock,
+    ForkchoiceUpdatedStep,
+    GetPayloadStep,
+    NewPayloadStep,
+    SendRawTransactionStep,
+    Step,
+    TxRef,
+    WaitForHeadStep,
+)
+from execution_testing.test_types import Alloc, Environment
+
+from .base import ExecuteFormat, FillResult
+from .blockchain import (
+    Block,
+    BlockchainTest,
+    apply_new_parent,
+    environment_from_parent_header,
+)
+from .engine_model import ClientModel, ModelDag, annotate_steps
+
+
+class ReorgBlock(Block):
+    """
+    A block of the reorg DAG.
+
+    ``parent`` names the parent block by label; when unset the block extends
+    the previous block in the list (or genesis for the first block).
+    """
+
+    label: str
+    parent: str | None = None
+    payload_block_hash: Hash | None = None
+    """Override ``blockHash`` in the engine payload only (hash mismatch)."""
+    payload_parent_hash: Hash | None = None
+    """Override ``parentHash`` in the engine payload only."""
+
+    @property
+    def payload_corrupted(self) -> bool:
+        """Whether the engine payload is deliberately inconsistent."""
+        return (
+            self.payload_block_hash is not None
+            or self.payload_parent_hash is not None
+        )
+
+
+class ReorgTest(BlockchainTest):
+    """
+    Filler type for Engine API reorg tests: a block DAG plus a step script.
+    """
+
+    blocks: List[ReorgBlock]  # type: ignore[assignment]
+    steps: List[Step]
+    post: Alloc = Field(default_factory=Alloc)
+    """Optional; ``assertState`` steps are the primary state verification."""
+    requires: Dict[str, str] | None = None
+    """Client environment variables (``HIVE_*``) required by this test."""
+    clients: Dict[str, FixtureClient] = Field(default_factory=dict)
+    """
+    Additional clients (peers of ``main``) used by ``on``/``waitForHead``.
+    """
+    meta: Dict[str, str | int] = Field(default_factory=dict)
+
+    supported_fixture_formats: ClassVar[
+        Sequence[FixtureFormat | LabeledFixtureFormat]
+    ] = [BlockchainEngineReorgFixture]
+    supported_execute_formats: ClassVar[Sequence] = []
+    supported_markers: ClassVar[Dict[str, str]] = {}
+
+    def model_post_init(self, __context: Any, /) -> None:
+        """
+        Run static checks.
+
+        ``BlockchainTest``'s inclusion-test check assumes ``self.blocks`` is
+        a linear chain (only the last block may carry the trailing invalid
+        transaction); a labeled DAG has no single "last" block, so the
+        marker that requests it is rejected here instead of silently
+        checking it against list order. Verify inclusion with
+        ``assertTxStatus``/``assertReceipt`` steps instead.
+        """
+        if self.is_inclusion_test:
+            raise ValueError("ReorgTest does not support inclusion tests")
+        super().model_post_init(__context)
+
+    def validate_dag(self) -> None:
+        """
+        Check labels are unique, reserved names unused, parents resolvable.
+        """
+        seen = {GENESIS_LABEL}
+        for block in self.blocks:
+            if block.label in (GENESIS_LABEL, ZERO_LABEL, "null", "any"):
+                raise ValueError(f"reserved block label: {block.label}")
+            if block.label in seen:
+                raise ValueError(f"duplicate block label: {block.label}")
+            if block.parent is not None and block.parent not in seen:
+                raise ValueError(
+                    f"block {block.label!r} references unknown parent "
+                    f"{block.parent!r} (parents must be defined earlier)"
+                )
+            seen.add(block.label)
+        self._validate_step_labels(self.steps, seen)
+
+    def _validate_step_labels(self, steps: List[Step], labels: set) -> None:
+        clients = {MAIN_CLIENT, *self.clients}
+        for step in steps:
+            if step.on not in clients:
+                raise ValueError(f"step targets unknown client {step.on!r}")
+            refs: List[str] = []
+            tx_refs: List[TxRef] = []
+            if isinstance(step, NewPayloadStep):
+                refs = [step.block]
+            elif isinstance(step, ForkchoiceUpdatedStep):
+                refs = [step.head, step.safe, step.finalized]
+            elif isinstance(step, GetPayloadStep):
+                refs = [step.parent]
+                if step.bind in labels or step.bind in (
+                    ZERO_LABEL,
+                    "null",
+                    "any",
+                ):
+                    raise ValueError(
+                        f"getPayload bind label {step.bind!r} already used"
+                    )
+                tx_refs = step.transactions_include + step.transactions_exclude
+            elif isinstance(step, (AssertHeadStep,)):
+                refs = [
+                    x
+                    for x in (step.latest, step.safe, step.finalized)
+                    if x is not None
+                ]
+            elif isinstance(step, WaitForHeadStep):
+                refs = [step.latest]
+            elif isinstance(step, AssertCanonicalStep):
+                refs = [x for x in step.blocks.values() if x is not None]
+            elif isinstance(step, AssertStateStep):
+                refs = [] if step.at == "latest" else [step.at]
+            elif isinstance(step, AssertReceiptStep):
+                refs = [step.block] if step.block is not None else []
+                tx_refs = [step.tx]
+            elif isinstance(step, AssertLogsStep):
+                refs = list(step.blocks)
+            elif isinstance(step, SendRawTransactionStep):
+                tx_refs = [step.tx]
+            elif isinstance(step, AssertTxStatusStep):
+                refs = [step.included_in] if step.included_in else []
+                tx_refs = [step.tx]
+            for ref in refs:
+                if ref not in labels and ref != ZERO_LABEL:
+                    raise ValueError(f"step references unknown label {ref!r}")
+            for tx_ref in tx_refs:
+                if tx_ref.block not in labels or tx_ref.block == GENESIS_LABEL:
+                    raise ValueError(
+                        f"step references transaction of unknown block "
+                        f"{tx_ref.block!r}"
+                    )
+            if isinstance(step, GetPayloadStep):
+                labels.add(step.bind)
+            for branch in getattr(step, "branches", {}).values():
+                self._validate_step_labels(branch, set(labels))
+
+    def _resolve_payload_attributes(
+        self, steps: List[Step], timestamps: Dict[str, int]
+    ) -> None:
+        """
+        Fill defaults of ``forkchoiceUpdated.payload_attributes``: a zero
+        timestamp becomes ``parent + 12``; Shanghai+ gets empty withdrawals;
+        Cancun+ gets a deterministic parent beacon block root. Bound labels
+        (client-built payloads) get ``parent + 12`` relative to the parent of
+        the build request, which is the previous step's head.
+        """
+        for step in steps:
+            if isinstance(step, GetPayloadStep):
+                # Best effort: bound payloads inherit their parent's slot + 12.
+                if step.parent in timestamps:
+                    timestamps[step.bind] = timestamps[step.parent] + 12
+            if isinstance(step, ForkchoiceUpdatedStep):
+                attrs = step.payload_attributes
+                if attrs is not None:
+                    if int(attrs.timestamp) == 0:
+                        attrs.timestamp = HexNumber(timestamps[step.head] + 12)
+                    fork = self.fork.fork_at(
+                        block_number=0, timestamp=int(attrs.timestamp)
+                    )
+                    if (
+                        attrs.withdrawals is None
+                        and fork.header_withdrawals_required()
+                    ):
+                        attrs.withdrawals = []
+                    if (
+                        attrs.parent_beacon_block_root is None
+                        and fork.header_beacon_root_required()
+                    ):
+                        attrs.parent_beacon_block_root = Hash(0xBEAC0)
+            for branch in getattr(step, "branches", {}).values():
+                self._resolve_payload_attributes(branch, timestamps)
+
+    def make_reorg_fixture(self, t8n: FillerBackend) -> FillResult:
+        """Execute every block against its labeled parent, emit fixture."""
+        self.validate_dag()
+
+        pre, genesis = self.make_genesis(apply_pre_allocation_blockchain=True)
+
+        # Per-label state needed to build children: environment of the next
+        # block and post-state allocation.
+        child_env: Dict[str, Environment] = {
+            GENESIS_LABEL: environment_from_parent_header(genesis.header)
+        }
+        child_alloc: Dict[str, Alloc | LazyAlloc] = {GENESIS_LABEL: pre}
+        fixture_blocks: Dict[str, FixtureReorgBlock] = {}
+        dag_parent: Dict[str, str] = {}
+        dag_valid: Dict[str, bool] = {}
+        fcu_version: Dict[str, int] = {}
+
+        genesis_fcu = (
+            self.fork.transitions_from().engine_forkchoice_updated_version()
+        )
+        assert genesis_fcu is not None, "reorg tests require the Engine API"
+        fcu_version[GENESIS_LABEL] = genesis_fcu
+
+        previous_label = GENESIS_LABEL
+        for block in self.blocks:
+            parent = block.parent or previous_label
+            built = self.generate_block_data(
+                t8n=t8n,
+                block=block,
+                previous_env=child_env[parent],
+                previous_alloc=child_alloc[parent],
+            )
+            if built.result.receipts:
+                self.validate_receipt_status(
+                    receipts=built.result.receipts,
+                    block_number=int(built.header.number),
+                )
+            payload = built.get_fixture_engine_new_payload()
+            if block.payload_corrupted:
+                overrides: Dict[str, Hash] = {}
+                if block.payload_block_hash is not None:
+                    overrides["block_hash"] = block.payload_block_hash
+                if block.payload_parent_hash is not None:
+                    overrides["parent_hash"] = block.payload_parent_hash
+                params: List[Any] = list(payload.params)
+                params[0] = params[0].model_copy(update=overrides)
+                payload = payload.model_copy(update={"params": tuple(params)})
+            fixture_blocks[block.label] = FixtureReorgBlock(
+                parent=parent, payload=payload
+            )
+            dag_parent[block.label] = parent
+            dag_valid[block.label] = (
+                block.exception is None and not block.payload_corrupted
+            )
+            fcu_version[block.label] = int(payload.forkchoice_updated_version)
+            # Children of an invalid block are built on the (correct)
+            # post-state of its execution and on its (modified) header.
+            child_env[block.label] = apply_new_parent(built.env, built.header)
+            child_alloc[block.label] = built.alloc
+            previous_label = block.label
+
+        timestamps: Dict[str, int] = {
+            GENESIS_LABEL: int(genesis.header.timestamp),
+            **{
+                label: int(b.payload.params[0].timestamp)
+                for label, b in fixture_blocks.items()
+            },
+        }
+        steps = [s.model_copy(deep=True) for s in self.steps]
+        self._resolve_payload_attributes(steps, timestamps)
+        model = ClientModel(dag=ModelDag(parent=dag_parent, valid=dag_valid))
+        steps = annotate_steps(steps, model, fcu_version)
+
+        fixture = BlockchainEngineReorgFixture(
+            fork=self.fork,
+            genesis=genesis.header,
+            pre=pre,
+            blocks=fixture_blocks,
+            steps=steps,
+            requires=self.requires,
+            clients=dict(self.clients),
+            meta=dict(self.meta),
+            config=FixtureConfig(
+                fork=self.fork,
+                chain_id=self.chain_id,
+                blob_schedule=FixtureBlobSchedule.from_blob_schedule(
+                    self.fork.transitions_to().blob_schedule()
+                ),
+            ),
+        )
+        return FillResult(
+            fixture=fixture,
+            gas_optimization=None,
+            post_verifications=PostVerifications.from_alloc(self.post),
+        )
+
+    def generate(
+        self,
+        t8n: FillerBackend,
+        fixture_format: FixtureFormat | LabeledFixtureFormat,
+    ) -> FillResult:
+        """Generate the reorg fixture."""
+        if fixture_format == BlockchainEngineReorgFixture:
+            return self.make_reorg_fixture(t8n)
+        raise Exception(f"Unknown fixture format: {fixture_format}")
+
+    def execute(self, *, execute_format: ExecuteFormat) -> None:  # type: ignore[override]
+        """Reorg tests cannot be executed against a live network."""
+        raise Exception(f"Unsupported execute format: {execute_format}")
+
+
+ReorgTestSpec = Callable[[str], Generator[ReorgTest, None, None]]
+ReorgTestFiller = Type[ReorgTest]
+
+__all__ = [
+    "ReorgBlock",
+    "ReorgTest",
+    "ReorgTestFiller",
+    "ReorgTestSpec",
+    "Hash",
+]

--- a/packages/testing/src/execution_testing/specs/tests/test_engine_model.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_engine_model.py
@@ -1,0 +1,301 @@
+"""Unit tests for the Engine API reference model used by reorg tests."""
+
+from typing import List
+
+import pytest
+
+from execution_testing.fixtures.reorg import (
+    AssertHeadStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+)
+
+from ..engine_model import (
+    INVALID_FORKCHOICE_STATE,
+    TOO_DEEP_REORG,
+    ClientModel,
+    ModelDag,
+    annotate_steps,
+)
+
+
+def dag_linear_with_fork() -> ModelDag:
+    r"""
+    Genesis <- a1 <- a2 <- a3.
+                 \\- b2 <- b3      (b3 execution-invalid).
+    """
+    return ModelDag(
+        parent={
+            "a1": "genesis",
+            "a2": "a1",
+            "a3": "a2",
+            "b2": "a1",
+            "b3": "b2",
+        },
+        valid={"a1": True, "a2": True, "a3": True, "b2": True, "b3": False},
+    )
+
+
+def ids(outcomes: List[Outcome]) -> List[str]:
+    """Outcome ids."""
+    return [o.id for o in outcomes]
+
+
+def test_number_and_ancestry() -> None:  # noqa: D103
+    dag = dag_linear_with_fork()
+    assert dag.number("genesis") == 0
+    assert dag.number("a3") == 3
+    assert dag.number("b3") == 3
+    assert dag.is_ancestor("a1", "b3")
+    assert not dag.is_ancestor("a2", "b3")
+    assert not dag.is_ancestor("a3", "a3")
+    assert dag.last_valid_ancestor("b3") == "b2"
+
+
+def test_new_payload_unknown_parent_is_syncing() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    assert ids(model.new_payload_outcomes("a2")) == ["syncing"]
+
+
+def test_new_payload_extends_head_is_valid_only() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    outcomes = model.new_payload_outcomes("a1")
+    assert ids(outcomes) == ["valid"]
+    assert outcomes[0].latest_valid_hash == "a1"
+
+
+def test_new_payload_side_chain_valid_or_accepted() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True})
+    model.head = "a2"
+    assert ids(model.new_payload_outcomes("b2")) == ["valid", "accepted"]
+
+
+def test_new_payload_invalid_block() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "b2": True})
+    model.head = "b2"
+    outcomes = model.new_payload_outcomes("b3")
+    assert ids(outcomes) == ["invalid"]
+    assert outcomes[0].latest_valid_hash == "b2"
+    assert outcomes[0].validation_error == "required"
+
+
+def test_new_payload_child_of_known_invalid() -> None:  # noqa: D103
+    dag = dag_linear_with_fork()
+    dag.parent["b4"] = "b3"
+    dag.valid["b4"] = True
+    model = ClientModel(dag=dag)
+    model.known.update({"a1": True, "b2": True, "b3": False})
+    outcomes = model.new_payload_outcomes("b4")
+    assert ids(outcomes) == ["invalid", "syncing"]
+    assert outcomes[0].latest_valid_hash == "b2"
+    # A grandchild of the invalid block is also INVALID-or-SYNCING, never
+    # SYNCING-only: clients with a bad-block cache answer INVALID.
+    model.apply_new_payload("b4", outcomes)
+    dag.parent["b5"] = "b4"
+    dag.valid["b5"] = True
+    outcomes = model.new_payload_outcomes("b5")
+    assert ids(outcomes) == ["invalid", "syncing"]
+    assert outcomes[0].latest_valid_hash == "b2"
+
+
+def test_fcu_unknown_head_is_syncing() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    step = ForkchoiceUpdatedStep(head="a1")
+    assert ids(model.forkchoice_outcomes(step)) == ["syncing"]
+
+
+def test_fcu_extend_head_is_applied_only() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known["a1"] = True
+    step = ForkchoiceUpdatedStep(head="a1")
+    outcomes = model.forkchoice_outcomes(step)
+    assert ids(outcomes) == ["applied"]
+    model.apply_forkchoice(step, outcomes[0])
+    assert model.head == "a1"
+
+
+def test_fcu_side_chain_reorg_applied_or_refused() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "b2": True})
+    model.head = "a2"
+    outcomes = model.forkchoice_outcomes(ForkchoiceUpdatedStep(head="b2"))
+    assert ids(outcomes) == ["applied", "refused"]
+    assert outcomes[1].error_code == TOO_DEEP_REORG
+
+
+def test_fcu_rewind_to_canonical_ancestor_above_finalized() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "a3": True})
+    model.head = "a3"
+    model.finalized = "a1"
+    # a2 is above finalized: #786 requires a real rewind or -38006; the
+    # pre-#786 skip is legal today and recorded as disputed.
+    outcomes = model.forkchoice_outcomes(
+        ForkchoiceUpdatedStep(head="a2", finalized="a1")
+    )
+    assert ids(outcomes) == ["applied", "noop", "refused"]
+    assert outcomes[1].disputed
+
+
+def test_fcu_inconsistent_state_leaves_head_unspecified() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "a3": True, "b2": True})
+    model.head = "a3"
+    step = ForkchoiceUpdatedStep(head="b2", safe="a3", finalized="zero")
+    outcomes = model.forkchoice_outcomes(step)
+    assert ids(outcomes) == ["inconsistent"]
+    model.apply_forkchoice(step, outcomes[0])
+    assert model.head_assertion() is None
+    # A later side-chain FCU is still annotated (applied or too deep).
+    assert ids(
+        model.forkchoice_outcomes(ForkchoiceUpdatedStep(head="a3"))
+    ) == [
+        "applied",
+        "refused",
+    ]
+
+
+def test_fcu_ancestor_of_finalized_is_noop() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "a3": True})
+    model.head = "a3"
+    model.finalized = "a2"
+    outcomes = model.forkchoice_outcomes(
+        ForkchoiceUpdatedStep(head="a1", finalized="a2")
+    )
+    assert ids(outcomes) == ["noop"]
+    assert outcomes[0].status == "VALID"
+
+
+def test_fcu_head_equals_finalized_is_disputed() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "a3": True})
+    model.head = "a3"
+    model.finalized = "a2"
+    outcomes = model.forkchoice_outcomes(
+        ForkchoiceUpdatedStep(head="a2", finalized="a2")
+    )
+    assert ids(outcomes) == ["applied", "noop"]
+    assert outcomes[1].disputed is not None
+
+
+def test_fcu_inconsistent_finalized_is_error() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "b2": True})
+    model.head = "a2"
+    outcomes = model.forkchoice_outcomes(
+        ForkchoiceUpdatedStep(head="a2", finalized="b2")
+    )
+    assert ids(outcomes) == ["inconsistent"]
+    assert outcomes[0].error_code == INVALID_FORKCHOICE_STATE
+
+
+def test_fcu_invalid_head() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "b2": True, "b3": False})
+    outcomes = model.forkchoice_outcomes(ForkchoiceUpdatedStep(head="b3"))
+    assert ids(outcomes) == ["invalid"]
+    assert outcomes[0].latest_valid_hash == "b2"
+
+
+def test_annotate_fills_expect_and_head_assertions() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(head="a1"),
+        NewPayloadStep(block="a2"),
+        ForkchoiceUpdatedStep(head="a2"),
+        NewPayloadStep(block="b2"),
+        ForkchoiceUpdatedStep(head="b2"),
+    ]
+    versions = {"a1": 3, "a2": 3, "b2": 3}
+    annotate_steps(steps, model, versions)
+
+    np_a1, fcu_a1, np_a2, fcu_a2, np_b2, fcu_b2 = steps
+    assert isinstance(np_a1, NewPayloadStep)
+    assert ids(np_a1.expect) == ["valid"]
+    assert isinstance(fcu_a1, ForkchoiceUpdatedStep)
+    assert fcu_a1.version == 3
+    assert ids(fcu_a1.expect) == ["applied"]
+    applied = fcu_a1.branches["applied"]
+    assert isinstance(applied[-1], AssertHeadStep)
+    assert applied[-1].latest == "a1"
+    assert isinstance(np_b2, NewPayloadStep)
+    assert ids(np_b2.expect) == ["valid", "accepted"]
+    assert isinstance(fcu_b2, ForkchoiceUpdatedStep)
+    assert ids(fcu_b2.expect) == ["applied", "refused"]
+    # applied branch asserts the new head, refused branch asserts the old.
+    assert fcu_b2.branches["applied"][-1].latest == "b2"  # type: ignore
+    assert fcu_b2.branches["refused"][-1].latest == "a2"  # type: ignore
+
+
+def test_annotate_does_not_widen_author_expectations() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "b2": True})
+    model.head = "a2"
+    step = ForkchoiceUpdatedStep(
+        head="b2",
+        version=3,
+        expect=[Outcome(id="applied", status="VALID")],
+    )
+    annotate_steps([step], model)
+    assert ids(step.expect) == ["applied"]
+    assert model.head == "b2"
+
+
+def test_annotate_requires_version_map_when_unset() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known["a1"] = True
+    with pytest.raises(ValueError):
+        annotate_steps([ForkchoiceUpdatedStep(head="a1")], model)
+
+
+def test_annotate_continues_from_first_branch_state() -> None:
+    """
+    Steps after a branching step run after that branch; the model must carry
+    the branch's effects (a nested reorg) into the continuation.
+    """
+    dag = ModelDag(
+        parent={"a1": "genesis", "p": "a1", "q": "a1"},
+        valid={"a1": True, "p": True, "q": True},
+    )
+    model = ClientModel(dag=dag)
+    versions = {"genesis": 3, "a1": 3, "p": 3, "q": 3}
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(
+            head="a1",
+            branches={
+                "applied": [
+                    NewPayloadStep(block="p"),
+                    ForkchoiceUpdatedStep(head="p"),
+                ]
+            },
+        ),
+    ]
+    annotate_steps(steps, model, versions)
+    outer = steps[1]
+    assert isinstance(outer, ForkchoiceUpdatedStep)
+    tail = outer.branches["applied"][-1]
+    # The outer branch's trailing head assertion reflects the nested reorg.
+    assert isinstance(tail, AssertHeadStep) and tail.latest == "p"
+    assert model.head == "p"
+
+
+def test_annotate_marks_head_moved_for_applied_vs_noop() -> None:  # noqa: D103
+    model = ClientModel(dag=dag_linear_with_fork())
+    model.known.update({"a1": True, "a2": True, "a3": True})
+    model.head = "a3"
+    steps = annotate_steps(
+        [ForkchoiceUpdatedStep(head="a1", version=3)], model
+    )
+    fcu = steps[0]
+    assert isinstance(fcu, ForkchoiceUpdatedStep)
+    by_id = {o.id: o for o in fcu.expect}
+    assert by_id["applied"].head_moved is True
+    assert by_id["noop"].head_moved is False
+    assert by_id["refused"].head_moved is None

--- a/packages/testing/src/execution_testing/specs/tests/test_reorg.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_reorg.py
@@ -1,0 +1,170 @@
+"""Tests for the ``ReorgTest`` spec: DAG filling and fixture emission."""
+
+import pytest
+
+from execution_testing.base_types import Account, Address, Hash
+from execution_testing.client_clis import TransitionTool
+from execution_testing.exceptions import BlockException
+from execution_testing.fixtures import BlockchainEngineReorgFixture
+from execution_testing.fixtures.reorg import (
+    AssertHeadStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+)
+from execution_testing.forks import Cancun, Fork, Prague
+from execution_testing.test_types import Alloc, Environment, Transaction
+
+from ..blockchain import Header
+from ..reorg import ReorgBlock, ReorgTest
+
+SENDER = Address(0xA94F5374FCE5EDBC8E2A8697C15331677E6EBF0B)
+RECIPIENT = Address(0xC0DE)
+
+
+def pre_alloc() -> Alloc:
+    """Funded sender."""
+    return Alloc({SENDER: Account(balance=10**21, nonce=0)})
+
+
+def tx(nonce: int, value: int) -> Transaction:
+    """Simple value transfer from the funded sender."""
+    return Transaction(
+        nonce=nonce,
+        to=RECIPIENT,
+        value=value,
+        gas_limit=21_000,
+        gas_price=10,
+        secret_key=Hash(
+            0x45A915E4D060149EB4365960E6A7A45F334393093061116B197E3240065FF2D8
+        ),
+    )
+
+
+@pytest.mark.parametrize("fork", [Cancun, Prague])
+def test_fill_sibling_and_invalid_child(
+    fork: Fork, default_t8n: TransitionTool
+) -> None:
+    r"""
+    Fill a DAG with a sibling block and a block built on an invalid parent.
+
+    genesis <- a1 <- a2
+                 \\- b2 (same height as a2, different tx)
+                 \\- i2 (invalid state root) <- i3 (valid child of invalid)
+    """
+    test = ReorgTest(
+        fork=fork,
+        genesis_environment=Environment(),
+        pre=pre_alloc(),
+        blocks=[
+            ReorgBlock(label="a1", txs=[tx(0, 1)]),
+            ReorgBlock(label="a2", txs=[tx(1, 2)]),
+            ReorgBlock(label="b2", parent="a1", txs=[tx(1, 3)]),
+            ReorgBlock(
+                label="i2",
+                parent="a1",
+                txs=[tx(1, 4)],
+                rlp_modifier=Header(state_root=Hash(1)),
+                exception=[
+                    BlockException.INVALID_STATE_ROOT,
+                    BlockException.INVALID_BLOCK_HASH,
+                ],
+            ),
+            ReorgBlock(label="i3", parent="i2", txs=[tx(2, 5)]),
+        ],
+        steps=[
+            NewPayloadStep(block="a1"),
+            ForkchoiceUpdatedStep(head="a1"),
+            NewPayloadStep(block="a2"),
+            ForkchoiceUpdatedStep(head="a2"),
+            NewPayloadStep(block="b2"),
+            ForkchoiceUpdatedStep(head="b2"),
+            NewPayloadStep(block="i2"),
+            NewPayloadStep(block="i3"),
+        ],
+    )
+    fixture = test.generate(
+        t8n=default_t8n, fixture_format=BlockchainEngineReorgFixture
+    ).fixture
+    assert isinstance(fixture, BlockchainEngineReorgFixture)
+
+    blocks = fixture.blocks
+    assert set(blocks) == {"a1", "a2", "b2", "i2", "i3"}
+    p = {k: v.payload.params[0] for k, v in blocks.items()}
+
+    # Parent links follow the labeled DAG, not list order.
+    assert p["a2"].parent_hash == p["a1"].block_hash
+    assert p["b2"].parent_hash == p["a1"].block_hash
+    assert p["i2"].parent_hash == p["a1"].block_hash
+    assert p["i3"].parent_hash == p["i2"].block_hash
+    # Siblings occupy the same height with distinct hashes.
+    assert p["a2"].number == p["b2"].number == 2
+    assert p["a2"].block_hash != p["b2"].block_hash
+    # Invalid block carries the corrupted state root; its child is built on
+    # the correct post-state so its own header is internally consistent.
+    assert p["i2"].state_root == Hash(1)
+    assert p["i3"].state_root != Hash(1)
+    assert blocks["i2"].payload.validation_error is not None
+    assert blocks["i3"].payload.validation_error is None
+
+    # Model annotations.
+    steps = fixture.steps
+    np_b2 = steps[4]
+    assert isinstance(np_b2, NewPayloadStep)
+    assert [o.id for o in np_b2.expect] == ["valid", "accepted"]
+    fcu_b2 = steps[5]
+    assert isinstance(fcu_b2, ForkchoiceUpdatedStep)
+    assert [o.id for o in fcu_b2.expect] == ["applied", "refused"]
+    assert fcu_b2.version == fork.engine_forkchoice_updated_version()
+    assert isinstance(fcu_b2.branches["applied"][-1], AssertHeadStep)
+    np_i2 = steps[6]
+    assert isinstance(np_i2, NewPayloadStep)
+    assert [o.id for o in np_i2.expect] == ["invalid"]
+    assert np_i2.expect[0].latest_valid_hash == "a1"
+    np_i3 = steps[7]
+    assert isinstance(np_i3, NewPayloadStep)
+    assert [o.id for o in np_i3.expect] == ["invalid", "syncing"]
+
+    # Round-trip through JSON keeps the discriminated step union intact.
+    reloaded = BlockchainEngineReorgFixture.model_validate(
+        fixture.json_dict_with_info()
+    )
+    assert reloaded.resolve("b2") == p["b2"].block_hash
+    assert reloaded.resolve("genesis") == fixture.genesis.block_hash
+    assert isinstance(reloaded.steps[5], ForkchoiceUpdatedStep)
+
+
+def test_dag_validation_rejects_unknown_parent() -> None:  # noqa: D103
+    with pytest.raises(ValueError, match="unknown parent"):
+        ReorgTest(
+            fork=Cancun,
+            pre=pre_alloc(),
+            blocks=[ReorgBlock(label="a1", parent="nope")],
+            steps=[],
+        ).validate_dag()
+
+
+def test_dag_validation_rejects_duplicate_and_reserved_labels() -> None:  # noqa: D103
+    with pytest.raises(ValueError, match="duplicate"):
+        ReorgTest(
+            fork=Cancun,
+            pre=pre_alloc(),
+            blocks=[ReorgBlock(label="a"), ReorgBlock(label="a")],
+            steps=[],
+        ).validate_dag()
+    with pytest.raises(ValueError, match="reserved"):
+        ReorgTest(
+            fork=Cancun,
+            pre=pre_alloc(),
+            blocks=[ReorgBlock(label="genesis")],
+            steps=[],
+        ).validate_dag()
+
+
+def test_step_validation_rejects_unknown_label() -> None:  # noqa: D103
+    with pytest.raises(ValueError, match="unknown label"):
+        ReorgTest(
+            fork=Cancun,
+            pre=pre_alloc(),
+            blocks=[ReorgBlock(label="a1")],
+            steps=[ForkchoiceUpdatedStep(head="a9")],
+        ).validate_dag()

--- a/tests/reorg/__init__.py
+++ b/tests/reorg/__init__.py
@@ -1,0 +1,6 @@
+"""
+Engine API reorganization tests.
+
+Cross-client, deterministic reorg conformance tests expressed as a block DAG
+plus a step script (``ReorgTest``), consumed via ``consume reorg`` in hive.
+"""

--- a/tests/reorg/test_depth_matrix.py
+++ b/tests/reorg/test_depth_matrix.py
@@ -1,0 +1,178 @@
+"""
+Reorg depth matrix: side-chain reorgs of depth D at client-default and tuned
+depth caps.
+
+Ports of geth ``testReorgLong``/``TestLargeReorgTrieGC`` (256+ deep reorg
+across the state-pruning horizon), reth ``test_long_reorg`` /
+``test_reorg_through_backfill`` (e2e, depth ~100), erigon
+``TestReorgsWithInsertChain`` (deep unwind), besu ``BackwardSyncContextTest``
+(deep reorg via backward sync), nethermind ``Can_reorganize_to_longer_path``
+scaled up, and hive ``ReOrgBackToCanonicalTest`` for side chains.
+
+Client depth knobs (as run in hive wrappers): geth ``--engine.maxreorgdepth``
+(default 32, 0 = unlimited), erigon ``MAX_REORG_DEPTH`` (512), nethermind
+``Reorganization.MaxDepth`` (64), besu ``--bonsai-historical-block-limit``
+(512 trie logs), reth: none. ``HIVE_ENGINE_MAX_REORG_DEPTH`` is honoured by
+the geth and erigon wrappers.
+"""
+
+from typing import List
+
+import pytest
+from execution_testing import Address, Alloc, Transaction
+from execution_testing.fixtures.reorg import (
+    AssertCanonicalStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/paris.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+TOO_DEEP_REORG = -38006
+
+
+def two_branches(
+    pre: Alloc, depth: int
+) -> tuple[List[ReorgBlock], List[Step]]:
+    """
+    Fork point a1; canonical a2..a{depth+1} (depth blocks); side chain
+    s2..s{depth+2} (depth+1 blocks). Steps deliver and apply the canonical
+    chain then deliver every side payload.
+    """
+    ca = pre.fund_eoa()
+    cs = pre.fund_eoa()
+    sink = Address(0xC0DE)
+    blocks = [
+        ReorgBlock(
+            label="a1",
+            parent="genesis",
+            txs=[Transaction(sender=ca, nonce=0, to=sink, value=1)],
+        )
+    ]
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(head="a1"),
+    ]
+    for i in range(depth):
+        label = f"a{i + 2}"
+        blocks.append(
+            ReorgBlock(
+                label=label,
+                txs=[Transaction(sender=ca, nonce=i + 1, to=sink, value=1)],
+            )
+        )
+        steps += [
+            NewPayloadStep(block=label),
+            ForkchoiceUpdatedStep(head=label),
+        ]
+    for i in range(depth + 1):
+        label = f"s{i + 2}"
+        blocks.append(
+            ReorgBlock(
+                label=label,
+                parent="a1" if i == 0 else None,
+                txs=[Transaction(sender=cs, nonce=i, to=sink, value=2)],
+            )
+        )
+        steps.append(NewPayloadStep(block=label))
+    return blocks, steps
+
+
+def matrix_steps(depth: int, applied_only: bool) -> List[Step]:
+    """FCU to the side tip, then back to the canonical tip."""
+    side_tip = f"s{depth + 2}"
+    canon_tip = f"a{depth + 1}"
+    expect = [
+        Outcome(id="applied", status="VALID", latest_valid_hash=side_tip)
+    ]
+    if not applied_only:
+        expect.append(Outcome(id="refused", error_code=TOO_DEEP_REORG))
+    return [
+        ForkchoiceUpdatedStep(
+            head=side_tip,
+            safe="a1",
+            finalized="a1",
+            expect=expect,
+            branches={
+                "applied": [
+                    AssertCanonicalStep(
+                        blocks={
+                            2: "s2",
+                            depth + 1: f"s{depth + 1}",
+                            depth + 2: side_tip,
+                        }
+                    )
+                ],
+                "refused": [
+                    AssertCanonicalStep(blocks={2: "a2", depth + 1: canon_tip})
+                ],
+            },
+        ),
+        ForkchoiceUpdatedStep(
+            head=canon_tip,
+            safe="a1",
+            finalized="a1",
+            expect=[
+                Outcome(
+                    id="applied", status="VALID", latest_valid_hash=canon_tip
+                ),
+                *(
+                    []
+                    if applied_only
+                    else [Outcome(id="refused", error_code=TOO_DEEP_REORG)]
+                ),
+            ],
+            branches={
+                "applied": [
+                    AssertCanonicalStep(
+                        blocks={2: "a2", depth + 1: canon_tip, depth + 2: None}
+                    )
+                ],
+            },
+        ),
+    ]
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("depth", [1, 8, 31, 32, 64, 128])
+def test_side_chain_reorg_depth_default(
+    reorg_test: ReorgTestFiller, pre: Alloc, depth: int
+) -> None:
+    """
+    Client defaults: depth ≤ 8 must be applied by every client; deeper
+    reorgs may be refused with ``-38006`` (recorded per client) but must
+    never corrupt the canonical mapping.
+    """
+    blocks, steps = two_branches(pre, depth)
+    steps += matrix_steps(depth, applied_only=depth <= 8)
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "deep", "reorgDepth": depth, "variant": "default"},
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("depth", [64, 256])
+def test_side_chain_reorg_depth_tuned(
+    reorg_test: ReorgTestFiller, pre: Alloc, depth: int
+) -> None:
+    """
+    Tuned: the client is started with ``HIVE_ENGINE_MAX_REORG_DEPTH`` above
+    the reorg depth, so the reorg must be applied. Clients without such a
+    knob run their defaults here (reth: unlimited; nethermind: 64; besu 512).
+    """
+    blocks, steps = two_branches(pre, depth)
+    steps += matrix_steps(depth, applied_only=True)
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        requires={"HIVE_ENGINE_MAX_REORG_DEPTH": str(depth + 8)},
+        meta={"class": "deep", "reorgDepth": depth, "variant": "tuned"},
+    )

--- a/tests/reorg/test_fork_boundary_reorg.py
+++ b/tests/reorg/test_fork_boundary_reorg.py
@@ -1,0 +1,198 @@
+"""
+Reorgs across a fork boundary (Shanghai -> Cancun at timestamp 15000).
+
+Ports of hive ``WithdrawalsReorgSpec`` (``suites/withdrawals/tests.go``:
+"Withdrawals Fork on Block N - M Block Re-Org" via NewPayload), hive
+``suites/cancun`` fork-transition payload-version tests, geth
+``TestSetCanonical``-style fork-crossing reorgs, besu
+``MergeCoordinatorTest`` post-fork payload handling, nethermind
+``forkchoiceUpdatedV2/V3`` version tests (wrong version -> -38005).
+
+Genesis is Shanghai; blocks after timestamp 15000 are Cancun and use
+``engine_newPayloadV3``; pre-fork blocks use V2. A reorg may move the head
+from a Cancun block to a Shanghai block and back.
+"""
+
+from typing import List
+
+import pytest
+from execution_testing import Address, Alloc, Transaction
+from execution_testing.fixtures.reorg import (
+    AssertCanonicalStep,
+    AssertHeadStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/cancun.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+FORK_TS = 15_000
+
+
+def applied(head: str) -> List[Outcome]:
+    """Single legal outcome."""
+    return [Outcome(id="applied", status="VALID", latest_valid_hash=head)]
+
+
+@pytest.mark.valid_at_transition_to("Cancun")
+def test_reorg_across_fork_boundary(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Canonical: a1..a3 Shanghai, a4 first Cancun block (ts 15000), a5 Cancun.
+    Side chain off a3: s4 Shanghai (ts 14988), s5 Cancun (ts 15000).
+    Head moves a5 -> s4 (back before the fork) -> s5 -> a5. Every FCU is
+    VALID and the canonical mapping follows.
+    """
+    ca = pre.fund_eoa()
+    cs = pre.fund_eoa()
+    sink = Address(0xC0DE)
+    blocks = [
+        ReorgBlock(
+            label="a1",
+            parent="genesis",
+            txs=[Transaction(sender=ca, nonce=0, to=sink, value=1)],
+        ),
+        ReorgBlock(
+            label="a2", txs=[Transaction(sender=ca, nonce=1, to=sink, value=1)]
+        ),
+        ReorgBlock(
+            label="a3", txs=[Transaction(sender=ca, nonce=2, to=sink, value=1)]
+        ),
+        ReorgBlock(
+            label="a4",
+            timestamp=FORK_TS,
+            txs=[Transaction(sender=ca, nonce=3, to=sink, value=1)],
+        ),
+        ReorgBlock(
+            label="a5", txs=[Transaction(sender=ca, nonce=4, to=sink, value=1)]
+        ),
+        ReorgBlock(
+            label="s4",
+            parent="a3",
+            timestamp=FORK_TS - 12,
+            txs=[Transaction(sender=cs, nonce=0, to=sink, value=2)],
+        ),
+        ReorgBlock(
+            label="s5",
+            timestamp=FORK_TS,
+            txs=[Transaction(sender=cs, nonce=1, to=sink, value=2)],
+        ),
+    ]
+    steps: List[Step] = []
+    for label in ("a1", "a2", "a3", "a4", "a5"):
+        steps += [
+            NewPayloadStep(block=label),
+            ForkchoiceUpdatedStep(head=label),
+        ]
+    steps += [
+        NewPayloadStep(block="s4"),
+        NewPayloadStep(block="s5"),
+        ForkchoiceUpdatedStep(
+            head="s4",
+            expect=applied("s4"),
+            branches={
+                "applied": [AssertCanonicalStep(blocks={4: "s4", 5: None})]
+            },
+        ),
+        ForkchoiceUpdatedStep(
+            head="s5",
+            expect=applied("s5"),
+            branches={
+                "applied": [AssertCanonicalStep(blocks={4: "s4", 5: "s5"})]
+            },
+        ),
+        ForkchoiceUpdatedStep(
+            head="a5",
+            expect=applied("a5"),
+            branches={
+                "applied": [
+                    AssertCanonicalStep(blocks={3: "a3", 4: "a4", 5: "a5"})
+                ]
+            },
+        ),
+        AssertHeadStep(latest="a5"),
+    ]
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "shallow", "forkBoundary": True},
+    )
+
+
+@pytest.mark.valid_at_transition_to("Cancun")
+def test_sibling_first_fork_blocks(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Two competing *first* Cancun blocks on the last Shanghai block (hive
+    ``WithdrawalsReorgSpec`` "Fork on Block 8 - 10 Block Re-Org" reduced):
+    both VALID, head switches between them, then a child of the loser
+    extends and takes the head.
+    """
+    ca = pre.fund_eoa()
+    cs = pre.fund_eoa()
+    sink = Address(0xC0DE)
+    blocks = [
+        ReorgBlock(
+            label="a1",
+            parent="genesis",
+            txs=[Transaction(sender=ca, nonce=0, to=sink, value=1)],
+        ),
+        ReorgBlock(
+            label="a2",
+            timestamp=FORK_TS,
+            txs=[Transaction(sender=ca, nonce=1, to=sink, value=1)],
+        ),
+        ReorgBlock(
+            label="b2",
+            parent="a1",
+            timestamp=FORK_TS + 12,
+            txs=[Transaction(sender=cs, nonce=0, to=sink, value=2)],
+        ),
+        ReorgBlock(
+            label="b3", txs=[Transaction(sender=cs, nonce=1, to=sink, value=2)]
+        ),
+    ]
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(head="a1"),
+        NewPayloadStep(
+            block="a2",
+            expect=[
+                Outcome(id="valid", status="VALID", latest_valid_hash="a2")
+            ],
+        ),
+        NewPayloadStep(
+            block="b2",
+            expect=[
+                Outcome(id="valid", status="VALID", latest_valid_hash="b2")
+            ],
+        ),
+        ForkchoiceUpdatedStep(head="a2", expect=applied("a2")),
+        ForkchoiceUpdatedStep(
+            head="b2",
+            expect=applied("b2"),
+            branches={"applied": [AssertCanonicalStep(blocks={2: "b2"})]},
+        ),
+        ForkchoiceUpdatedStep(head="a2", expect=applied("a2")),
+        NewPayloadStep(block="b3"),
+        ForkchoiceUpdatedStep(
+            head="b3",
+            expect=applied("b3"),
+            branches={
+                "applied": [AssertCanonicalStep(blocks={2: "b2", 3: "b3"})]
+            },
+        ),
+    ]
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "shallow", "forkBoundary": True},
+    )

--- a/tests/reorg/test_fork_boundary_reorg.py
+++ b/tests/reorg/test_fork_boundary_reorg.py
@@ -1,5 +1,6 @@
 """
-Reorgs across a fork boundary (Shanghai -> Cancun at timestamp 15000).
+Reorgs across a fork boundary (transition at timestamp 15000; filled for every
+transition from Shanghai -> Cancun onwards).
 
 Ports of hive ``WithdrawalsReorgSpec`` (``suites/withdrawals/tests.go``:
 "Withdrawals Fork on Block N - M Block Re-Org" via NewPayload), hive
@@ -8,9 +9,10 @@ Ports of hive ``WithdrawalsReorgSpec`` (``suites/withdrawals/tests.go``:
 ``MergeCoordinatorTest`` post-fork payload handling, nethermind
 ``forkchoiceUpdatedV2/V3`` version tests (wrong version -> -38005).
 
-Genesis is Shanghai; blocks after timestamp 15000 are Cancun and use
-``engine_newPayloadV3``; pre-fork blocks use V2. A reorg may move the head
-from a Cancun block to a Shanghai block and back.
+Genesis is the pre-fork; blocks at or after timestamp 15000 are post-fork and
+use the post-fork ``engine_newPayload``/``forkchoiceUpdated`` versions (V2 ->
+V3 -> V4, execution requests on post-fork payloads only). A reorg may move
+the head from a post-fork block to a pre-fork block and back.
 """
 
 from typing import List
@@ -38,13 +40,13 @@ def applied(head: str) -> List[Outcome]:
     return [Outcome(id="applied", status="VALID", latest_valid_hash=head)]
 
 
-@pytest.mark.valid_at_transition_to("Cancun")
+@pytest.mark.valid_at_transition_to("Cancun", subsequent_forks=True)
 def test_reorg_across_fork_boundary(
     reorg_test: ReorgTestFiller, pre: Alloc
 ) -> None:
     """
-    Canonical: a1..a3 Shanghai, a4 first Cancun block (ts 15000), a5 Cancun.
-    Side chain off a3: s4 Shanghai (ts 14988), s5 Cancun (ts 15000).
+    Canonical: a1..a3 pre-fork, a4 first post-fork block (ts 15000), a5 post-fork.
+    Side chain off a3: s4 pre-fork (ts 14988), s5 post-fork (ts 15000).
     Head moves a5 -> s4 (back before the fork) -> s5 -> a5. Every FCU is
     VALID and the canonical mapping follows.
     """
@@ -125,12 +127,12 @@ def test_reorg_across_fork_boundary(
     )
 
 
-@pytest.mark.valid_at_transition_to("Cancun")
+@pytest.mark.valid_at_transition_to("Cancun", subsequent_forks=True)
 def test_sibling_first_fork_blocks(
     reorg_test: ReorgTestFiller, pre: Alloc
 ) -> None:
     """
-    Two competing *first* Cancun blocks on the last Shanghai block (hive
+    Two competing *first* post-fork blocks on the last pre-fork block (hive
     ``WithdrawalsReorgSpec`` "Fork on Block 8 - 10 Block Re-Org" reduced):
     both VALID, head switches between them, then a child of the loser
     extends and takes the head.

--- a/tests/reorg/test_forkchoice_behaviour.py
+++ b/tests/reorg/test_forkchoice_behaviour.py
@@ -1,0 +1,749 @@
+"""
+Forkchoice behaviour across reorganizations (post-merge: the head follows
+``forkchoiceUpdated`` regardless of chain length).
+
+Ports of:
+- geth ``testShorterFork/testLongerFork/testEqualFork`` (AfterMerge),
+  ``testReorgLong/Short``, ``testBlockchainHeaderchainReorgConsistency``,
+  ``testSideLogRebirth`` (side chain with lower difficulty still wins).
+- besu ``DefaultBlockchainTest.appendBlockWithReorgTo{ChainAtEqualHeight,
+  ShorterChain,LongerChain}``, ``appendBlockForFork``,
+  ``MergeCoordinatorTest.forkchoiceUpdateShouldIgnoreAncestorOfChainHead``,
+  ``AbstractEngineForkchoiceUpdatedTest`` (invalid forkchoice state
+  variants, ignore update to old head),
+  ``updateForkChoiceShouldPersistFirstFinalizedBlockHash``.
+- nethermind ``Can_reorganize_to_{shorter,longer,same}_path``,
+  ``Can_reorganize_there_and_back``,
+  ``forkchoiceUpdatedV1_can_reorganize_to_last_block``,
+  ``forkchoiceUpdatedV1_head_block_after_reorg``,
+  ``block_should_not_be_canonical_before_forkchoiceUpdatedV1``,
+  ``block_should_not_be_canonical_after_reorg``,
+  ``forkChoiceUpdatedV1_to_unknown_block_fails``,
+  ``forkChoiceUpdatedV1_to_unknown_safeBlock_hash_should_fail``,
+  ``forkchoiceUpdatedV1_should_update_{finalized,safe}_block_hash``,
+  ``forkchoiceUpdatedV1_should_work_with_zero_keccak_as_safe_block``,
+  ``forkchoiceUpdatedV1_should_change_head_when_all_parameters_are_the_newHeadHash``,
+  ``payloadV1_invalid_parent_hash``,
+  ``inconsistent_{finalized,safe}_hash``.
+- erigon
+  ``TestValidateChainAndUpdateForkChoiceWithSideForksThatGoBackAndForwardInHeight``,
+  ``TestReorgsWithInsertChain``,
+  ``TestFcuAllowsReorgBackOnCanonicalChainWhenAfterFinalisedHash``.
+- reth ``test_tree_state_on_new_head_deep_fork``,
+  ``test_engine_tree_fcu_reorg_with_all_blocks``,
+  ``test_engine_tree_valid_forks_with_older_canonical_head`` (+invalid
+  variant), ``test_engine_tree_fcu_extends_canon_chain``,
+  ``test_engine_tree_buffered_blocks_are_eventually_connected``,
+  ``test_reorg_to_fork_behind_finalized``,
+  ``test_testsuite_{create_fork,reorg_with_tagging,deep_reorg}``,
+  ``test_handle_canonical_head``,
+  ``test_on_forkchoice_updated_integration``.
+- hive ``ReOrgBackToCanonicalTest``, ``ReOrgBackFromSyncingTest``,
+  ``SafeReOrgToSideChainTest``, ``BlockStatus``,
+  ``InconsistentForkchoiceTest``,
+  ``ForkchoiceUpdatedUnknownBlockHashTest``,
+  ``NewPayloadWithMissingFcUTest``, ``ReExecutePayloadTest``,
+  ``MultiplePayloadsExtendingCanonicalChainTest``,
+  ``NewPayloadOnSyncingClientTest``.
+"""
+
+from typing import List, Tuple
+
+import pytest
+from execution_testing import Alloc, BlockException, Hash, Header, Transaction
+from execution_testing.fixtures.reorg import (
+    AssertCanonicalStep,
+    AssertHeadStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/paris.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+INVALID_FORKCHOICE_STATE = -38002
+TOO_DEEP_REORG = -38006
+
+DISPUTED_FORK_BEHIND_FINALIZED = (
+    "execution-apis paris.md step 5 requires -38002 when finalized is not on "
+    "head's chain; reth trusts the CL and applies the update (VALID)"
+)
+DISPUTED_ZERO_SAFE = (
+    "paris.md allows a zero finalizedBlockHash before finality but does "
+    "not say whether a zero safeBlockHash with a non-zero finalized is "
+    "legal; besu rejects it with -38002, nethermind/geth/reth accept it"
+)
+DISPUTED_PRE_786_NOOP = (
+    "paris.md before execution-apis#786: client MAY skip the update when head "
+    "is an ancestor of the canonical head"
+)
+
+
+def rewind_outcomes(head: str) -> List[Outcome]:
+    """FCU to a canonical ancestor: applied, skipped (pre-#786) or too deep."""
+    return [
+        Outcome(id="applied", status="VALID", latest_valid_hash=head),
+        Outcome(
+            id="noop",
+            status="VALID",
+            latest_valid_hash=head,
+            disputed=DISPUTED_PRE_786_NOOP,
+        ),
+        Outcome(id="refused", error_code=TOO_DEEP_REORG),
+    ]
+
+
+def applied(head: str) -> List[Outcome]:
+    """Single legal outcome: applied."""
+    return [Outcome(id="applied", status="VALID", latest_valid_hash=head)]
+
+
+def chain(
+    pre: Alloc,
+    prefix: str,
+    length: int,
+    parent: str = "genesis",
+    start: int = 1,
+    value: int = 1,
+) -> Tuple[List[ReorgBlock], List[Step]]:
+    """
+    ``length`` blocks ``{prefix}{start}..`` on ``parent``, each with one value
+    transfer from a fresh sender (nonces independent per chain), plus the
+    NP/FCU steps that make the last one the head.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    blocks: List[ReorgBlock] = []
+    steps: List[Step] = []
+    for i in range(length):
+        label = f"{prefix}{start + i}"
+        blocks.append(
+            ReorgBlock(
+                label=label,
+                parent=parent if i == 0 else None,
+                txs=[
+                    Transaction(
+                        sender=sender, nonce=i, to=recipient, value=value
+                    )
+                ],
+            )
+        )
+        steps += [
+            NewPayloadStep(block=label),
+            ForkchoiceUpdatedStep(head=label),
+        ]
+    return blocks, steps
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "canonical_len,fork_point,fork_len",
+    [
+        pytest.param(4, 1, 1, id="shorter"),
+        pytest.param(3, 1, 2, id="equal"),
+        pytest.param(3, 1, 4, id="longer"),
+        pytest.param(4, 3, 2, id="near_tip_longer"),
+        pytest.param(4, 0, 2, id="from_genesis_shorter"),
+    ],
+)
+def test_head_follows_fcu_regardless_of_length(
+    reorg_test: ReorgTestFiller,
+    pre: Alloc,
+    canonical_len: int,
+    fork_point: int,
+    fork_len: int,
+) -> None:
+    """
+    Post-merge fork choice: the head is whatever FCU names, whether the fork
+    is shorter, equal or longer than the canonical chain. Heights beyond the
+    new head must no longer be canonical.
+    """
+    a_blocks, steps = chain(pre, "a", canonical_len)
+    parent = "genesis" if fork_point == 0 else f"a{fork_point}"
+    b_blocks, b_steps = chain(
+        pre, "b", fork_len, parent=parent, start=fork_point + 1
+    )
+    blocks = a_blocks + b_blocks
+    fork_tip = f"b{fork_point + fork_len}"
+    canonical_after = {
+        i: f"b{i}" for i in range(fork_point + 1, fork_point + fork_len + 1)
+    }
+    canonical_after.update({i: f"a{i}" for i in range(1, fork_point + 1)})
+    for i in range(fork_point + fork_len + 1, canonical_len + 1):
+        canonical_after[i] = None  # type: ignore[assignment]
+    steps += [NewPayloadStep(block=b.label) for b in b_blocks]
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head=fork_tip,
+            expect=applied(fork_tip),
+            branches={
+                "applied": [AssertCanonicalStep(blocks=canonical_after)]
+            },
+        )
+    )
+    # And back to the original tip.
+    a_tip = f"a{canonical_len}"
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head=a_tip,
+            expect=applied(a_tip),
+            branches={
+                "applied": [
+                    AssertCanonicalStep(
+                        blocks={
+                            i: f"a{i}" for i in range(1, canonical_len + 1)
+                        }
+                    )
+                ]
+            },
+        )
+    )
+    _ = b_steps
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_reorg_back_and_forth_between_branches(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Reth ``test_tree_state_on_new_head_deep_fork`` / nethermind
+    ``Can_reorganize_there_and_back`` / erigon ``TestReorgsWithInsertChain``:
+    two 6-block branches off a 3-block base; the head ping-pongs between
+    branch B's blocks and branch A's tip.
+    """
+    base, steps = chain(pre, "a", 3)
+    a_ext, _ = chain(pre, "a", 6, parent="a3", start=4)
+    b_ext, _ = chain(pre, "b", 6, parent="a3", start=4, value=2)
+    blocks = base + a_ext + b_ext
+    steps += [NewPayloadStep(block=b.label) for b in a_ext + b_ext]
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a9",
+            expect=applied("a9"),
+            branches={
+                "applied": [AssertCanonicalStep(blocks={9: "a9", 4: "a4"})]
+            },
+        )
+    )
+    for i in range(4, 10):
+        steps.append(
+            ForkchoiceUpdatedStep(
+                head=f"b{i}",
+                expect=applied(f"b{i}"),
+                branches={
+                    "applied": [
+                        AssertCanonicalStep(
+                            blocks={
+                                i: f"b{i}",
+                                3: "a3",
+                                **({i + 1: None} if i < 9 else {}),
+                            }
+                        )
+                    ]
+                },
+            )
+        )
+        steps.append(
+            ForkchoiceUpdatedStep(
+                head="a9",
+                expect=applied("a9"),
+                branches={
+                    "applied": [
+                        AssertCanonicalStep(blocks={9: "a9", i: f"a{i}"})
+                    ]
+                },
+            )
+        )
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_reorg_to_older_canonical_ancestor_and_forward(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``ReOrgBackToCanonicalTest`` (depth 1..5) / erigon
+    ``TestFcuAllowsReorgBackOnCanonicalChainWhenAfterFinalisedHash`` / reth
+    ``test_fcu_with_canonical_ancestor_updates_latest_block``: after every
+    new block, FCU back to a5 (a canonical ancestor above finalized) then
+    forward to the tip. #786: the rewind is applied or refused (-38006); the
+    forward FCU must always be VALID.
+    """
+    blocks, steps = chain(pre, "a", 5)
+    more, _ = chain(pre, "a", 5, parent="a5", start=6)
+    blocks += more
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a5", safe="a5", finalized="a1", expect=applied("a5")
+        )
+    )
+    for i in range(6, 11):
+        tip = f"a{i}"
+        steps += [
+            NewPayloadStep(block=tip),
+            ForkchoiceUpdatedStep(
+                head=tip, safe="a5", finalized="a1", expect=applied(tip)
+            ),
+            ForkchoiceUpdatedStep(
+                head="a5",
+                safe="a5",
+                finalized="a1",
+                expect=rewind_outcomes("a5"),
+                branches={
+                    "applied": [
+                        AssertCanonicalStep(blocks={5: "a5", 6: None})
+                    ],
+                    "noop": [AssertCanonicalStep(blocks={5: "a5", i: tip})],
+                    "refused": [AssertCanonicalStep(blocks={5: "a5", i: tip})],
+                },
+            ),
+            ForkchoiceUpdatedStep(
+                head=tip, safe="a5", finalized="a1", expect=applied(tip)
+            ),
+        ]
+    steps.append(
+        AssertCanonicalStep(blocks={i: f"a{i}" for i in range(1, 11)})
+    )
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "shallow", "reorgDepth": 5},
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+def test_fcu_to_unknown_block_is_syncing(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``ReOrgBackFromSyncingTest`` +
+    ``ForkchoiceUpdatedUnknownBlockHashTest``,
+    nethermind ``forkChoiceUpdatedV1_to_unknown_block_fails`` /
+    ``forkChoiceUpdatedV1_to_unknown_safeBlock_hash_should_fail``, reth
+    ``test_engine_tree_fcu_missing_head``.
+
+    A 10-deep side chain exists but only its leaf is ever delivered: the leaf
+    is SYNCING/ACCEPTED, FCU to it is SYNCING, FCU with an unknown safe or
+    finalized hash is an error, and FCU back to the canonical tip is VALID.
+    """
+    blocks, steps = chain(pre, "a", 5)
+    side, _ = chain(pre, "s", 10, parent="a5", start=6, value=3)
+    blocks += side
+    steps += [
+        NewPayloadStep(
+            block="s15",
+            expect=[
+                Outcome(id="syncing", status="SYNCING"),
+                Outcome(
+                    id="accepted", status="ACCEPTED", latest_valid_hash="null"
+                ),
+            ],
+        ),
+        ForkchoiceUpdatedStep(
+            head="s15",
+            expect=[
+                Outcome(
+                    id="syncing", status="SYNCING", latest_valid_hash="null"
+                )
+            ],
+        ),
+        AssertHeadStep(latest="a5"),
+        ForkchoiceUpdatedStep(
+            head="a5",
+            safe="s15",
+            expect=[
+                Outcome(
+                    id="inconsistent", error_code=INVALID_FORKCHOICE_STATE
+                ),
+                Outcome(id="error", any_error=True),
+            ],
+        ),
+        ForkchoiceUpdatedStep(
+            head="a5",
+            finalized="s15",
+            expect=[
+                Outcome(
+                    id="inconsistent", error_code=INVALID_FORKCHOICE_STATE
+                ),
+                Outcome(id="error", any_error=True),
+            ],
+        ),
+        ForkchoiceUpdatedStep(head="a5", expect=applied("a5")),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("field", ["head", "safe", "finalized"])
+def test_inconsistent_forkchoice_state(
+    reorg_test: ReorgTestFiller, pre: Alloc, field: str
+) -> None:
+    """
+    Hive ``InconsistentForkchoiceTest``,
+    nethermind ``inconsistent_finalized_hash`` /
+    ``inconsistent_safe_hash``, besu invalid-forkchoice-state variants: with
+    canonical a1..a3 and a validated sibling chain b1..b3, an FCU whose
+    ``field`` points into the other chain is ``-38002``; the canonical FCU
+    afterwards is VALID.
+    """
+    blocks, steps = chain(pre, "a", 3)
+    side, _ = chain(pre, "b", 3, value=2)
+    blocks += side
+    steps += [NewPayloadStep(block=b.label) for b in side]
+    state = {"head": "a3", "safe": "a2", "finalized": "a1"}
+    state[field] = {"head": "b3", "safe": "b2", "finalized": "b1"}[field]
+    steps += [
+        ForkchoiceUpdatedStep(
+            head=state["head"],
+            safe=state["safe"],
+            finalized=state["finalized"],
+            expect=[
+                Outcome(id="inconsistent", error_code=INVALID_FORKCHOICE_STATE)
+            ],
+        ),
+        ForkchoiceUpdatedStep(
+            head="a3", safe="a2", finalized="a1", expect=applied("a3")
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_safe_finalized_labels_follow_fcu(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``BlockStatus`` + ``SafeReOrgToSideChainTest``, nethermind safe/
+    finalized/zero-keccak tests, besu
+    ``updateForkChoiceShouldPersistFirstFinalizedBlockHash``:
+    ``latest``/``safe``/``finalized`` track every FCU, including a reorg of
+    head and safe onto a side chain while finalized stays pinned, zero safe
+    hash, and all three equal.
+    """
+    blocks, steps = chain(pre, "a", 3)
+    side, _ = chain(pre, "b", 2, parent="a1", start=2, value=2)
+    blocks += side
+    steps = steps[:-1] + [
+        ForkchoiceUpdatedStep(
+            head="a3", safe="a2", finalized="a1", expect=applied("a3")
+        ),
+        NewPayloadStep(block="b2"),
+        NewPayloadStep(block="b3"),
+        ForkchoiceUpdatedStep(
+            head="b3", safe="b2", finalized="a1", expect=applied("b3")
+        ),
+        ForkchoiceUpdatedStep(
+            head="b3",
+            safe="zero",
+            finalized="a1",
+            expect=[
+                *applied("b3"),
+                Outcome(
+                    id="rejected",
+                    error_code=INVALID_FORKCHOICE_STATE,
+                    disputed=DISPUTED_ZERO_SAFE,
+                ),
+            ],
+        ),
+        ForkchoiceUpdatedStep(
+            head="b3", safe="b3", finalized="b3", expect=applied("b3")
+        ),
+        ForkchoiceUpdatedStep(
+            head="a3", safe="a3", finalized="a3", expect=applied("a3")
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_newpayload_does_not_move_head(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``NewPayloadWithMissingFcUTest``, nethermind
+    ``block_should_not_be_canonical_before_forkchoiceUpdatedV1``, reth
+    ``test_testsuite_create_fork``: payloads alone never change ``latest``
+    or the canonical mapping; a single FCU to the tip does.
+    """
+    blocks, _ = chain(pre, "a", 5)
+    steps: List[Step] = [NewPayloadStep(block=f"a{i}") for i in range(1, 6)]
+    steps += [
+        AssertHeadStep(latest="genesis"),
+        AssertCanonicalStep(blocks={1: None, 5: None}),
+        ForkchoiceUpdatedStep(
+            head="a5", safe="a4", finalized="a3", expect=applied("a5")
+        ),
+        AssertCanonicalStep(blocks={i: f"a{i}" for i in range(1, 6)}),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_reexecute_payloads(reorg_test: ReorgTestFiller, pre: Alloc) -> None:
+    """
+    Hive ``ReExecutePayloadTest``, besu
+    ``shouldReturnSuccessOnAlreadyPresent``,
+    reth ``test_find_invalid_ancestor_detects_block_itself``: re-sending a
+    canonical payload stays VALID; re-sending an invalid one stays INVALID.
+    """
+    blocks, steps = chain(pre, "a", 5)
+    sender = pre.fund_eoa()
+    blocks.append(
+        ReorgBlock(
+            label="bad",
+            parent="a5",
+            txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+            rlp_modifier=Header(state_root=Hash(1)),
+            exception=[
+                BlockException.INVALID_STATE_ROOT,
+                BlockException.INVALID_BLOCK_HASH,
+            ],
+        )
+    )
+    for i in range(1, 6):
+        steps.append(
+            NewPayloadStep(
+                block=f"a{i}",
+                expect=[
+                    Outcome(
+                        id="valid", status="VALID", latest_valid_hash=f"a{i}"
+                    )
+                ],
+            )
+        )
+    steps += [
+        NewPayloadStep(block="bad"),
+        NewPayloadStep(
+            block="bad",
+            expect=[
+                Outcome(id="invalid", status="INVALID", latest_valid_hash="a5")
+            ],
+        ),
+        AssertHeadStep(latest="a5"),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_many_siblings_same_parent(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``MultiplePayloadsExtendingCanonicalChainTest``: 40 sibling payloads
+    (differing prevRandao) on the current head are all VALID/ACCEPTED; the
+    canonical block at that height is then applied without error.
+    """
+    blocks, steps = chain(pre, "a", 3)
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    siblings = []
+    for i in range(40):
+        siblings.append(
+            ReorgBlock(
+                label=f"s{i}",
+                parent="a3",
+                prev_randao=Hash(0x1000 + i),
+                txs=[
+                    Transaction(sender=sender, nonce=0, to=recipient, value=1)
+                ],
+            )
+        )
+    canonical = ReorgBlock(
+        label="a4",
+        parent="a3",
+        txs=[Transaction(sender=sender, nonce=0, to=recipient, value=2)],
+    )
+    blocks += siblings + [canonical]
+    steps += [NewPayloadStep(block=s.label) for s in siblings]
+    steps += [
+        NewPayloadStep(block="a4"),
+        ForkchoiceUpdatedStep(
+            head="a4",
+            expect=applied("a4"),
+            branches={"applied": [AssertCanonicalStep(blocks={4: "a4"})]},
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_out_of_order_payload_delivery(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``NewPayloadOnSyncingClientTest``, reth
+    ``test_engine_tree_buffered_blocks_are_eventually_connected``, nethermind
+    ``payloadV1_invalid_parent_hash``: a payload whose parent is unknown is
+    SYNCING/ACCEPTED and FCU to it is SYNCING; once the gap is filled the
+    payload and the FCU are VALID.
+    """
+    blocks, steps = chain(pre, "a", 4)
+    steps = steps[:4]  # a1, a2 delivered and canonical.
+    steps += [
+        NewPayloadStep(
+            block="a4",
+            expect=[
+                Outcome(id="syncing", status="SYNCING"),
+                Outcome(
+                    id="accepted", status="ACCEPTED", latest_valid_hash="null"
+                ),
+            ],
+        ),
+        ForkchoiceUpdatedStep(
+            head="a4", expect=[Outcome(id="syncing", status="SYNCING")]
+        ),
+        NewPayloadStep(
+            block="a3",
+            expect=[
+                Outcome(id="valid", status="VALID", latest_valid_hash="a3")
+            ],
+        ),
+        NewPayloadStep(
+            block="a4",
+            expect=[
+                Outcome(id="valid", status="VALID", latest_valid_hash="a4")
+            ],
+        ),
+        ForkchoiceUpdatedStep(head="a4", expect=applied("a4")),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_alternating_canonical_and_depth1_forks(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Geth ``testBlockchainHeaderchainReorgConsistency`` (16 rounds): for each
+    new canonical block, also apply a sibling fork of depth 1 and back; the
+    head must be consistent after every single FCU.
+    """
+    n = 16
+    blocks, steps = chain(pre, "a", n)
+    sender = pre.fund_eoa()
+    forks = [
+        ReorgBlock(
+            label=f"f{i}",
+            parent="genesis" if i == 1 else f"a{i - 1}",
+            txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+            extra_data=b"f",
+        )
+        for i in range(1, n + 1)
+    ]
+    blocks += forks
+    interleaved: List[Step] = []
+    for i in range(1, n + 1):
+        interleaved += steps[2 * (i - 1) : 2 * i]
+        interleaved += [
+            NewPayloadStep(block=f"f{i}"),
+            ForkchoiceUpdatedStep(head=f"f{i}", expect=applied(f"f{i}")),
+            ForkchoiceUpdatedStep(head=f"a{i}", expect=applied(f"a{i}")),
+        ]
+    reorg_test(
+        pre=pre, blocks=blocks, steps=interleaved, meta={"class": "shallow"}
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+def test_valid_and_invalid_forks_with_older_canonical_head(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Reth ``test_engine_tree_valid_forks_with_older_canonical_head`` and its
+    ``_and_invalid_`` variant: canonical to a6; head moved back to a1; two
+    8-block forks A/B off a6 delivered; FCU(B tip) applied; FCU(A tip) also
+    VALID; an invalid block on top of A is INVALID and the head stays.
+    """
+    blocks, steps = chain(pre, "a", 6)
+    fa, _ = chain(pre, "x", 8, parent="a6", start=7, value=2)
+    fb, _ = chain(pre, "y", 8, parent="a6", start=7, value=3)
+    sender = pre.fund_eoa()
+    bad = ReorgBlock(
+        label="bad",
+        parent="x14",
+        txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+        rlp_modifier=Header(state_root=Hash(1)),
+        exception=[
+            BlockException.INVALID_STATE_ROOT,
+            BlockException.INVALID_BLOCK_HASH,
+        ],
+    )
+    blocks += fa + fb + [bad]
+    steps.append(
+        ForkchoiceUpdatedStep(head="a1", expect=rewind_outcomes("a1"))
+    )
+    steps += [NewPayloadStep(block=b.label) for b in fa + fb]
+    steps += [
+        ForkchoiceUpdatedStep(
+            head="y14",
+            expect=applied("y14"),
+            branches={
+                "applied": [AssertCanonicalStep(blocks={14: "y14", 6: "a6"})]
+            },
+        ),
+        ForkchoiceUpdatedStep(
+            head="x14",
+            expect=applied("x14"),
+            branches={"applied": [AssertCanonicalStep(blocks={14: "x14"})]},
+        ),
+        NewPayloadStep(
+            block="bad",
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash="x14"
+                )
+            ],
+        ),
+        AssertCanonicalStep(blocks={14: "x14", 15: None}),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_reorg_to_fork_behind_finalized(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Reth ``test_reorg_to_fork_behind_finalized``: with finalized = a7 and
+    head = a10, FCU to a fork tip branching at a5 (so a7 is not on its chain)
+    with finalized still a7. Spec: ``-38002``. reth applies it (trusts the
+    CL) — recorded as disputed. After a ``-38002`` the head is unspecified
+    (geth and reth move it to f10 before failing the finalized check), so
+    the canonical mapping is only asserted on the applied branch.
+    """
+    blocks, steps = chain(pre, "a", 10)
+    fork, _ = chain(pre, "f", 5, parent="a5", start=6, value=2)
+    blocks += fork
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a10", safe="a10", finalized="a7", expect=applied("a10")
+        )
+    )
+    steps += [NewPayloadStep(block=b.label) for b in fork]
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="f10",
+            safe="f10",
+            finalized="a7",
+            expect=[
+                Outcome(
+                    id="inconsistent", error_code=INVALID_FORKCHOICE_STATE
+                ),
+                Outcome(
+                    id="applied",
+                    status="VALID",
+                    latest_valid_hash="f10",
+                    disputed=DISPUTED_FORK_BEHIND_FINALIZED,
+                ),
+            ],
+            branches={
+                "applied": [AssertCanonicalStep(blocks={10: "f10"})],
+            },
+        )
+    )
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})

--- a/tests/reorg/test_forkchoice_reorg.py
+++ b/tests/reorg/test_forkchoice_reorg.py
@@ -1,0 +1,415 @@
+"""
+P0 reorg conformance tests.
+
+- Sibling reorg: switch head between two blocks at the same height and verify
+  state, head labels and canonical mapping follow the forkchoice.
+- Invalid side chain: a side chain with one execution-invalid block; the
+  invalid block and everything built on it must never become canonical.
+- execution-apis#786 forkchoice semantics: no-reorg shortcut only below
+  finalized; rewind to a canonical ancestor above finalized is a real reorg
+  (or ``-38006``); finalized regression and inconsistent forkchoice states.
+"""
+
+from typing import List
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    BlockException,
+    Hash,
+    Header,
+    Transaction,
+)
+from execution_testing.fixtures.reorg import (
+    AccountExpectation,
+    AssertCanonicalStep,
+    AssertStateStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/paris.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+INVALID_FORKCHOICE_STATE = -38002
+TOO_DEEP_REORG = -38006
+
+DISPUTED_SHORTCUT_VS_38002 = (
+    "execution-apis#786: no-reorg shortcut (step 2) vs. inconsistent "
+    "forkchoice state (step 5) when head is below finalized but the supplied "
+    "safe/finalized are not on head's chain"
+)
+DISPUTED_SHORTCUT_VS_38006 = (
+    "execution-apis#786: step 2 says a client MAY skip the update when head "
+    "is an ancestor of finalized; a client that does not skip reaches step 6 "
+    "and may refuse the (backwards) reorg with -38006 before step 5 is "
+    "evaluated (observed on reth)"
+)
+DISPUTED_FINALIZED_REGRESSION = (
+    "execution-apis: forkchoiceUpdated with finalizedBlockHash older than "
+    "the previously finalized block is not addressed by the specification"
+)
+
+
+def linear_chain(
+    pre: Alloc, length: int, prefix: str = "a"
+) -> tuple[List[ReorgBlock], Account, List[Step]]:
+    """
+    ``length`` blocks, each with one value transfer, plus the newPayload/FCU
+    steps that make the last one the head.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    blocks = [
+        ReorgBlock(
+            label=f"{prefix}{i}",
+            txs=[
+                Transaction(sender=sender, nonce=i - 1, to=recipient, value=1)
+            ],
+        )
+        for i in range(1, length + 1)
+    ]
+    steps: List[Step] = []
+    for i in range(1, length + 1):
+        steps.append(NewPayloadStep(block=f"{prefix}{i}"))
+        steps.append(ForkchoiceUpdatedStep(head=f"{prefix}{i}"))
+    return blocks, Account(balance=length), steps
+
+
+@pytest.mark.valid_from("Cancun")
+def test_sibling_reorg(reorg_test: ReorgTestFiller, pre: Alloc) -> None:
+    r"""
+    Genesis <- a1 <- a2.
+                 \\- b2.
+
+    Head moves a2 -> b2 -> a2; the recipient balances, ``latest`` and the
+    block at height 2 must follow each forkchoice update.
+    """
+    sender = pre.fund_eoa()
+    recipient_a = pre.fund_eoa(amount=0)
+    recipient_b = pre.fund_eoa(amount=0)
+
+    blocks = [
+        ReorgBlock(
+            label="a1",
+            txs=[Transaction(sender=sender, nonce=0, to=recipient_a, value=1)],
+        ),
+        ReorgBlock(
+            label="a2",
+            txs=[Transaction(sender=sender, nonce=1, to=recipient_a, value=2)],
+        ),
+        ReorgBlock(
+            label="b2",
+            parent="a1",
+            txs=[Transaction(sender=sender, nonce=1, to=recipient_b, value=3)],
+        ),
+    ]
+
+    on_a2 = [
+        AssertCanonicalStep(blocks={2: "a2"}),
+        AssertStateStep(
+            accounts={
+                recipient_a: AccountExpectation(balance=3),
+                recipient_b: AccountExpectation(balance=0),
+            }
+        ),
+    ]
+    on_b2 = [
+        AssertCanonicalStep(blocks={2: "b2"}),
+        AssertStateStep(
+            accounts={
+                recipient_a: AccountExpectation(balance=1),
+                recipient_b: AccountExpectation(balance=3),
+            }
+        ),
+    ]
+
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(head="a1"),
+        NewPayloadStep(block="a2"),
+        ForkchoiceUpdatedStep(head="a2", branches={"applied": list(on_a2)}),
+        NewPayloadStep(block="b2"),
+        # Same-height sibling: depth-1 reorg, must be applied by every client.
+        ForkchoiceUpdatedStep(
+            head="b2",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="b2")
+            ],
+            branches={"applied": list(on_b2)},
+        ),
+        ForkchoiceUpdatedStep(
+            head="a2",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a2")
+            ],
+            branches={"applied": list(on_a2)},
+        ),
+    ]
+
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "shallow", "reorgDepth": 1},
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("invalid_index", [1, 3, 5])
+def test_invalid_side_chain(
+    reorg_test: ReorgTestFiller, pre: Alloc, invalid_index: int
+) -> None:
+    r"""
+    Genesis <- a1 .. a5                 (canonical).
+           \\- s1 .. s5                 (side chain, s_k invalid).
+
+    ``newPayload(s_k)`` must be INVALID with ``latestValidHash`` = s_{k-1};
+    later side blocks are INVALID or SYNCING; ``forkchoiceUpdated(s5)`` must
+    not make the side chain canonical; the canonical chain keeps working.
+    """
+    blocks, _, steps = linear_chain(pre, 5, prefix="a")
+
+    side_sender = pre.fund_eoa()
+    side_recipient = pre.fund_eoa(amount=0)
+    for i in range(1, 6):
+        kwargs: dict = {}
+        if i == invalid_index:
+            kwargs = dict(
+                rlp_modifier=Header(state_root=Hash(1)),
+                exception=[
+                    BlockException.INVALID_STATE_ROOT,
+                    BlockException.INVALID_BLOCK_HASH,
+                ],
+            )
+        blocks.append(
+            ReorgBlock(
+                label=f"s{i}",
+                parent="genesis" if i == 1 else f"s{i - 1}",
+                txs=[
+                    Transaction(
+                        sender=side_sender,
+                        nonce=i - 1,
+                        to=side_recipient,
+                        value=1,
+                    )
+                ],
+                **kwargs,
+            )
+        )
+
+    last_valid = "genesis" if invalid_index == 1 else f"s{invalid_index - 1}"
+    for i in range(1, 6):
+        # `expect` derived by the model: VALID/ACCEPTED before the invalid
+        # block, INVALID at it, INVALID-or-SYNCING after it.
+        steps.append(NewPayloadStep(block=f"s{i}"))
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="s5",
+            expect=[
+                Outcome(
+                    id="invalid",
+                    status="INVALID",
+                    latest_valid_hash=last_valid,
+                ),
+                Outcome(id="syncing", status="SYNCING"),
+            ],
+        )
+    )
+    # Canonical chain is unaffected and still progresses.
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a5",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a5")
+            ],
+            branches={
+                "applied": [
+                    AssertCanonicalStep(
+                        blocks={i: f"a{i}" for i in range(1, 6)}
+                    ),
+                    AssertStateStep(
+                        accounts={
+                            side_recipient: AccountExpectation(balance=0)
+                        }
+                    ),
+                ]
+            },
+        )
+    )
+
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={
+            "class": "shallow",
+            "sideLength": 5,
+            "invalidIndex": invalid_index,
+        },
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+def test_fcu_below_finalized_with_inconsistent_state(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    #786 case (a): finalized = a5, then FCU(head=a2, safe=a2, finalized=a5).
+
+    a2 is an ancestor of finalized so the no-reorg shortcut (step 2) applies
+    and yields VALID; but a5 is not on a2's chain so step 5 would yield
+    ``-38002``, and a client that does not take the optional shortcut may
+    treat the request as a backwards reorg and refuse with ``-38006`` (step
+    6). The spec orders step 2 first; clients differ (geth: VALID no-op;
+    reth 2.5.2: -38006) — recorded as disputed. Either way the head must not
+    move.
+    """
+    blocks, _, steps = linear_chain(pre, 10)
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a10",
+            safe="a10",
+            finalized="a5",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a10")
+            ],
+        )
+    )
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a2",
+            safe="a2",
+            finalized="a5",
+            expect=[
+                Outcome(id="noop", status="VALID", latest_valid_hash="a2"),
+                Outcome(
+                    id="inconsistent",
+                    error_code=INVALID_FORKCHOICE_STATE,
+                    disputed=DISPUTED_SHORTCUT_VS_38002,
+                ),
+                Outcome(
+                    id="refused",
+                    error_code=TOO_DEEP_REORG,
+                    disputed=DISPUTED_SHORTCUT_VS_38006,
+                ),
+            ],
+            branches={
+                "noop": [AssertCanonicalStep(blocks={10: "a10", 2: "a2"})],
+                "inconsistent": [AssertCanonicalStep(blocks={10: "a10"})],
+                "refused": [AssertCanonicalStep(blocks={10: "a10"})],
+            },
+        )
+    )
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_fcu_finalized_regression(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    #786 case (b): finalized = a9, then FCU(head=a10, finalized=a1).
+
+    Moving finalized backwards is not addressed by the specification;
+    accepting it (VALID) or rejecting it (``-38002``) are both recorded.
+    """
+    blocks, _, steps = linear_chain(pre, 10)
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a10",
+            safe="a10",
+            finalized="a9",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a10")
+            ],
+        )
+    )
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a10",
+            safe="a10",
+            finalized="a1",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a10"),
+                Outcome(
+                    id="rejected",
+                    error_code=INVALID_FORKCHOICE_STATE,
+                    disputed=DISPUTED_FINALIZED_REGRESSION,
+                ),
+            ],
+        )
+    )
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_fcu_rewind_to_canonical_ancestor_above_finalized(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    #786 case (c): finalized = a5, head = a10, then FCU(head=a7, safe=a7,
+    finalized=a5).
+
+    a7 is above finalized: the client MUST rewind to a7 (VALID, latest = a7)
+    or refuse with ``-38006``; a pre-#786 VALID no-op that leaves the head at
+    a10 fails. Afterwards FCU(a10) must be VALID in either case and the chain
+    must continue.
+    """
+    blocks, expected_recipient, steps = linear_chain(pre, 10)
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a10",
+            safe="a10",
+            finalized="a5",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a10")
+            ],
+        )
+    )
+    resume = [
+        ForkchoiceUpdatedStep(
+            head="a10",
+            safe="a10",
+            finalized="a5",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a10")
+            ],
+            branches={
+                "applied": [
+                    AssertCanonicalStep(blocks={7: "a7", 8: "a8", 10: "a10"}),
+                ]
+            },
+        )
+    ]
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="a7",
+            safe="a7",
+            finalized="a5",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a7"),
+                Outcome(id="refused", error_code=TOO_DEEP_REORG),
+            ],
+            branches={
+                "applied": [
+                    AssertCanonicalStep(blocks={7: "a7", 8: None, 10: None}),
+                    *resume,
+                ],
+                "refused": [
+                    AssertCanonicalStep(blocks={7: "a7", 10: "a10"}),
+                    *resume,
+                ],
+            },
+        )
+    )
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "shallow", "reorgDepth": 3, "rewind": True},
+    )

--- a/tests/reorg/test_invalid_payloads_reorg.py
+++ b/tests/reorg/test_invalid_payloads_reorg.py
@@ -1,0 +1,472 @@
+"""
+Invalid payloads on side chains and the ``latestValidHash`` contract.
+
+Ports of:
+- hive ``BadHashOnNewPayload`` (canonical / sidechain),
+  ``ParentHashOnNewPayload``, ``InvalidPayloadTestCase`` (per field,
+  canonical and sidechain, non-syncing variants),
+  ``InvalidMissingAncestorReOrgTest`` (payloads via NP, no P2P),
+  ``InvalidTransitionPayload`` is out of scope (genesis is post-merge
+  here).
+- reth ``test_engine_tree_reorg_with_missing_ancestor_expecting_valid``,
+  ``test_find_invalid_ancestor_in_buffered_blocks``,
+  ``test_engine_tree_fcu_canon_chain_insertion``,
+  ``test_handle_invalid_block``.
+- besu ``shouldReturnInvalidWithLatestValidHashIsABadBlock``,
+  ``shouldReturnInvalidBlockHashOnBadHashParameter``,
+  ``shouldReturnInvalidOnBlockExecutionError``,
+  ``shouldReturnInvalidWhenBadBlock``,
+  ``shouldPropagateBadBlockToDescendants`` (bad-block-manager tests).
+- nethermind ``newPayloadV1_should_return_invalid_when_block_hash_wrong``
+  and ``executePayloadV1_invalid_block_...`` family,
+  ``Invalid_blocks_should_be_...``.
+- geth ``TestInvalidBloom``/``TestSideImportPrunedBlocks``-style: an
+  invalid side block never becomes canonical.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+from execution_testing import (
+    Address,
+    Alloc,
+    BlockException,
+    Hash,
+    Header,
+    Transaction,
+)
+from execution_testing.fixtures.reorg import (
+    AssertCanonicalStep,
+    AssertHeadStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    Step,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/paris.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+INVALID_FIELDS: Dict[str, Dict[str, Any]] = {
+    "state_root": {"state_root": Hash(1)},
+    "receipts_root": {"receipts_root": Hash(1)},
+    "number": {"number": 99},
+    "gas_limit": {"gas_limit": 1},
+    "gas_used": {"gas_used": 1},
+    "timestamp": {"timestamp": 1},
+    "base_fee": {"base_fee_per_gas": 1},
+    "logs_bloom": {"logs_bloom": b"\x01" * 256},
+}
+"""Header fields corrupted per hive ``InvalidPayloadTestCase``."""
+
+STATEROOT_OR_HASH = [
+    BlockException.INVALID_STATE_ROOT,
+    BlockException.INVALID_BLOCK_HASH,
+]
+
+
+def linear(
+    pre: Alloc,
+    n: int,
+    prefix: str = "a",
+    parent: str = "genesis",
+    start: int = 1,
+) -> tuple[List[ReorgBlock], List[Step]]:
+    """Linear chain with one value transfer per block."""
+    sender = pre.fund_eoa()
+    blocks = [
+        ReorgBlock(
+            label=f"{prefix}{start + i}",
+            parent=parent if i == 0 else None,
+            txs=[
+                Transaction(
+                    sender=sender, nonce=i, to=Address(0xC0DE), value=1
+                )
+            ],
+        )
+        for i in range(n)
+    ]
+    steps: List[Step] = []
+    for b in blocks:
+        steps += [
+            NewPayloadStep(block=b.label),
+            ForkchoiceUpdatedStep(head=b.label),
+        ]
+    return blocks, steps
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "on_side_chain", [False, True], ids=["canonical", "sidechain"]
+)
+def test_bad_block_hash_on_new_payload(
+    reorg_test: ReorgTestFiller, pre: Alloc, on_side_chain: bool
+) -> None:
+    """
+    Hive ``BadHashOnNewPayload``: a payload whose ``blockHash`` does not match
+    its contents is ``INVALID_BLOCK_HASH`` (Paris) / ``INVALID`` with null
+    latestValidHash (Shanghai+); the head does not move; a valid child of
+    the *real* block remains deliverable.
+    """
+    blocks, steps = linear(pre, 3)
+    parent = "a3"
+    if on_side_chain:
+        side, _ = linear(pre, 1, prefix="s", parent="a2", start=3)
+        blocks += side
+        steps.append(NewPayloadStep(block="s3"))
+        parent = "s3"
+    sender = pre.fund_eoa()
+    blocks.append(
+        ReorgBlock(
+            label="badhash",
+            parent=parent,
+            txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+            payload_block_hash=Hash(0xBAD),
+        )
+    )
+    steps += [
+        NewPayloadStep(
+            block="badhash",
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash="null"
+                ),
+                Outcome(id="invalid_block_hash", status="INVALID_BLOCK_HASH"),
+            ],
+        ),
+        AssertHeadStep(latest="a3"),
+        ForkchoiceUpdatedStep(
+            head="badhash",
+            expect=[
+                Outcome(id="syncing", status="SYNCING"),
+                Outcome(id="invalid", status="INVALID"),
+                Outcome(id="error", any_error=True),
+            ],
+        ),
+        AssertHeadStep(latest="a3"),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_parent_hash_equals_block_hash(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Hive ``ParentHashOnNewPayload``: ``parentHash == blockHash`` (self
+    parent) cannot be a valid block hash: INVALID / INVALID_BLOCK_HASH.
+    """
+    blocks, steps = linear(pre, 2)
+    sender = pre.fund_eoa()
+    blocks.append(
+        ReorgBlock(
+            label="selfparent",
+            parent="a2",
+            txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+            payload_parent_hash=Hash(0x5E1F),
+            payload_block_hash=Hash(0x5E1F),
+        )
+    )
+    steps += [
+        NewPayloadStep(
+            block="selfparent",
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash="null"
+                ),
+                Outcome(id="invalid_block_hash", status="INVALID_BLOCK_HASH"),
+            ],
+        ),
+        AssertHeadStep(latest="a2"),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("field", sorted(INVALID_FIELDS))
+@pytest.mark.parametrize(
+    "on_side_chain", [False, True], ids=["canonical", "sidechain"]
+)
+def test_invalid_payload_field(
+    reorg_test: ReorgTestFiller, pre: Alloc, field: str, on_side_chain: bool
+) -> None:
+    """
+    Hive ``InvalidPayloadTestCase``: a payload with one corrupted header
+    field (hash recomputed, so it is a *well-formed* invalid block) is
+    INVALID with ``latestValidHash`` = its parent, on the canonical chain
+    and on a side chain. A valid sibling afterwards is fine.
+    """
+    blocks, steps = linear(pre, 3)
+    parent = "a3"
+    if on_side_chain:
+        side, _ = linear(pre, 1, prefix="s", parent="a2", start=3)
+        blocks += side
+        steps.append(NewPayloadStep(block="s3"))
+        parent = "s3"
+    sender = pre.fund_eoa()
+    blocks.append(
+        ReorgBlock(
+            label="bad",
+            parent=parent,
+            txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+            rlp_modifier=Header(**INVALID_FIELDS[field]),
+            exception=[
+                BlockException.INVALID_STATE_ROOT,
+                BlockException.INVALID_BLOCK_HASH,
+                BlockException.INVALID_RECEIPTS_ROOT,
+                BlockException.INVALID_GASLIMIT,
+                BlockException.INVALID_GAS_USED,
+                BlockException.INVALID_BLOCK_NUMBER,
+                BlockException.INVALID_BLOCK_TIMESTAMP_OLDER_THAN_PARENT,
+                BlockException.INVALID_BASEFEE_PER_GAS,
+                BlockException.INVALID_LOG_BLOOM,
+                BlockException.INCORRECT_BLOCK_FORMAT,
+            ],
+        )
+    )
+    good = ReorgBlock(
+        label="good",
+        parent=parent,
+        txs=[Transaction(sender=sender, nonce=0, to=sender, value=2)],
+    )
+    blocks.append(good)
+    steps += [
+        NewPayloadStep(
+            block="bad",
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash=parent
+                ),
+                # Some clients reject malformed number/timestamp before
+                # linking the parent and answer with a null lvh.
+                Outcome(
+                    id="invalid_unlinked",
+                    status="INVALID",
+                    latest_valid_hash="null",
+                ),
+                # A wrong number breaks (parentHash, number-1) linking: the
+                # client may treat the parent as unknown (hive allows SYNCING
+                # for InvalidNumber).
+                *(
+                    [Outcome(id="syncing", status="SYNCING")]
+                    if field == "number"
+                    else []
+                ),
+            ],
+        ),
+        ForkchoiceUpdatedStep(
+            head="bad",
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash=parent
+                ),
+                Outcome(id="syncing", status="SYNCING"),
+                Outcome(id="error", any_error=True),
+            ],
+        ),
+        AssertHeadStep(latest="a3"),
+        NewPayloadStep(block="good"),
+        ForkchoiceUpdatedStep(
+            head="good",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="good")
+            ],
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("invalid_index", [1, 3, 5])
+@pytest.mark.parametrize(
+    "reorg_from_canonical",
+    [False, True],
+    ids=["from_genesis", "from_canonical"],
+)
+def test_invalid_missing_ancestor_reorg(
+    reorg_test: ReorgTestFiller,
+    pre: Alloc,
+    invalid_index: int,
+    reorg_from_canonical: bool,
+) -> None:
+    """
+    Hive ``InvalidMissingAncestorReOrgTest`` (NewPayload delivery): a side
+    chain of 10 blocks with block ``invalid_index`` invalid; payloads are
+    delivered in order. The invalid one is INVALID (lvh = its parent), all
+    descendants INVALID (lvh = last valid) or SYNCING/ACCEPTED if the client
+    dropped the invalid block; the head never moves to the side chain.
+    ``reorg_from_canonical`` branches the side chain off a4 rather than
+    genesis.
+    """
+    blocks, steps = linear(pre, 5)
+    parent = "a4" if reorg_from_canonical else "genesis"
+    start = 5 if reorg_from_canonical else 1
+    sender = pre.fund_eoa()
+    side = []
+    for i in range(10):
+        label = f"s{start + i}"
+        kwargs: Dict[str, Any] = {}
+        if i + 1 == invalid_index:
+            kwargs = {
+                "rlp_modifier": Header(state_root=Hash(1)),
+                "exception": STATEROOT_OR_HASH,
+            }
+        side.append(
+            ReorgBlock(
+                label=label,
+                parent=parent if i == 0 else None,
+                txs=[
+                    Transaction(
+                        sender=sender, nonce=i, to=Address(0xC0DE), value=3
+                    )
+                ],
+                **kwargs,
+            )
+        )
+    blocks += side
+    last_valid = (
+        parent if invalid_index == 1 else f"s{start + invalid_index - 2}"
+    )
+    for i, b in enumerate(side):
+        if i + 1 < invalid_index:
+            steps.append(
+                NewPayloadStep(
+                    block=b.label,
+                    expect=[
+                        Outcome(
+                            id="valid",
+                            status="VALID",
+                            latest_valid_hash=b.label,
+                        )
+                    ],
+                )
+            )
+        elif i + 1 == invalid_index:
+            steps.append(
+                NewPayloadStep(
+                    block=b.label,
+                    expect=[
+                        Outcome(
+                            id="invalid",
+                            status="INVALID",
+                            latest_valid_hash=last_valid,
+                        )
+                    ],
+                )
+            )
+        else:
+            steps.append(
+                NewPayloadStep(
+                    block=b.label,
+                    expect=[
+                        Outcome(
+                            id="invalid",
+                            status="INVALID",
+                            latest_valid_hash=last_valid,
+                        ),
+                        Outcome(id="syncing", status="SYNCING"),
+                        Outcome(
+                            id="accepted",
+                            status="ACCEPTED",
+                            latest_valid_hash="null",
+                        ),
+                    ],
+                )
+            )
+    steps += [
+        ForkchoiceUpdatedStep(
+            head=side[-1].label,
+            expect=[
+                Outcome(
+                    id="invalid",
+                    status="INVALID",
+                    latest_valid_hash=last_valid,
+                ),
+                Outcome(id="syncing", status="SYNCING"),
+            ],
+        ),
+        AssertHeadStep(latest="a5"),
+        AssertCanonicalStep(blocks={5: "a5"}),
+        ForkchoiceUpdatedStep(
+            head="a5",
+            expect=[
+                Outcome(id="applied", status="VALID", latest_valid_hash="a5")
+            ],
+        ),
+    ]
+    reorg_test(
+        pre=pre,
+        blocks=blocks,
+        steps=steps,
+        meta={"class": "shallow", "reorgDepth": 5},
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+def test_invalid_ancestor_descendants_delivered_first(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Reth ``test_find_invalid_ancestor_in_buffered_blocks`` /
+    ``test_engine_tree_reorg_with_missing_ancestor_expecting_valid``: the
+    *descendants* of an invalid block are delivered before the invalid
+    block itself (buffered as SYNCING/ACCEPTED); once the invalid ancestor
+    arrives it is INVALID and the buffered descendants, re-sent, are INVALID
+    with lvh = the invalid block's parent.
+    """
+    blocks, steps = linear(pre, 3)
+    sender = pre.fund_eoa()
+    bad = ReorgBlock(
+        label="bad",
+        parent="a3",
+        txs=[Transaction(sender=sender, nonce=0, to=sender, value=1)],
+        rlp_modifier=Header(state_root=Hash(1)),
+        exception=STATEROOT_OR_HASH,
+    )
+    kids, _ = linear(pre, 3, prefix="k", parent="bad", start=5)
+    blocks += [bad] + kids
+    buffered = [
+        Outcome(id="syncing", status="SYNCING"),
+        Outcome(id="accepted", status="ACCEPTED", latest_valid_hash="null"),
+    ]
+    steps += [NewPayloadStep(block=k.label, expect=buffered) for k in kids]
+    steps += [
+        ForkchoiceUpdatedStep(
+            head="k7", expect=[Outcome(id="syncing", status="SYNCING")]
+        ),
+        NewPayloadStep(
+            block="bad",
+            expect=[
+                Outcome(id="invalid", status="INVALID", latest_valid_hash="a3")
+            ],
+        ),
+    ]
+    steps += [
+        NewPayloadStep(
+            block=k.label,
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash="a3"
+                ),
+                Outcome(id="syncing", status="SYNCING"),
+                Outcome(
+                    id="accepted", status="ACCEPTED", latest_valid_hash="null"
+                ),
+            ],
+        )
+        for k in kids
+    ]
+    steps += [
+        ForkchoiceUpdatedStep(
+            head="k7",
+            expect=[
+                Outcome(
+                    id="invalid", status="INVALID", latest_valid_hash="a3"
+                ),
+                Outcome(id="syncing", status="SYNCING"),
+            ],
+        ),
+        AssertHeadStep(latest="a3"),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})

--- a/tests/reorg/test_payload_building_reorg.py
+++ b/tests/reorg/test_payload_building_reorg.py
@@ -1,0 +1,294 @@
+"""
+Payload building on reorganized heads (client-built payloads bound via
+``getPayload``).
+
+Ports of hive `suites/engine/reorg.go`:
+- ``ReOrgPrevValidatedPayloadOnSideChainTest``: reorg to a previously
+  validated non-leaf side payload and build a new payload on top of it.
+- ``SidechainReOrgTest`` (build two payloads on the same parent with
+  different attributes, switch between them).
+- ``TransactionReOrgTest`` (``ReOrgOut``): a transaction sent to the pool is
+  included when building on one head and absent from a payload built on a
+  sibling head.
+"""
+
+from typing import List
+
+import pytest
+from execution_testing import Alloc, Hash, Transaction
+from execution_testing.fixtures.reorg import (
+    AssertCanonicalStep,
+    AssertReceiptStep,
+    FixturePayloadAttributes,
+    ForkchoiceUpdatedStep,
+    GetPayloadStep,
+    NewPayloadStep,
+    Outcome,
+    SendRawTransactionStep,
+    Step,
+    TxRef,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/paris.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+FEE_RECIPIENT = 0x1234
+
+
+def build_attrs(prev_randao: int) -> FixturePayloadAttributes:
+    """Payload attributes; timestamp/withdrawals/beacon root filled at fill."""
+    return FixturePayloadAttributes(
+        timestamp=0,
+        prev_randao=Hash(prev_randao),
+        suggested_fee_recipient=FEE_RECIPIENT,
+    )
+
+
+def applied(head: str, payload_id: bool = False) -> List[Outcome]:
+    """Single legal outcome: applied (optionally with a payload id)."""
+    return [
+        Outcome(
+            id="applied",
+            status="VALID",
+            latest_valid_hash=head,
+            payload_id="nonNull" if payload_id else None,
+        )
+    ]
+
+
+@pytest.mark.valid_from("Cancun")
+def test_build_on_previously_validated_side_payload(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    r"""
+    Port of hive ``ReOrgPrevValidatedPayloadOnSideChainTest``.
+
+    genesis <- a1 <- a2 <- a3
+            \\- s1 <- s2 <- s3      (side chain, validated via newPayload)
+
+    Reorg to the non-leaf side payload s2 while requesting a build; the built
+    payload must have s2 as parent; sending it back is VALID and FCU to it is
+    applied. Then the canonical chain must still be re-appliable.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    blocks = []
+    for i in range(1, 4):
+        blocks.append(
+            ReorgBlock(
+                label=f"a{i}",
+                txs=[
+                    Transaction(
+                        sender=sender, nonce=i - 1, to=recipient, value=1
+                    )
+                ],
+            )
+        )
+    for i in range(1, 4):
+        blocks.append(
+            ReorgBlock(
+                label=f"s{i}",
+                parent="genesis" if i == 1 else f"s{i - 1}",
+                txs=[
+                    Transaction(
+                        sender=sender, nonce=i - 1, to=recipient, value=2
+                    )
+                ],
+            )
+        )
+    steps: List[Step] = []
+    for i in range(1, 4):
+        steps += [
+            NewPayloadStep(block=f"a{i}"),
+            ForkchoiceUpdatedStep(head=f"a{i}"),
+        ]
+    for i in range(1, 4):
+        steps.append(NewPayloadStep(block=f"s{i}"))
+    steps += [
+        ForkchoiceUpdatedStep(
+            head="s2",
+            payload_attributes=build_attrs(0xAA),
+            expect=applied("s2", payload_id=True),
+            branches={
+                "applied": [
+                    GetPayloadStep(bind="s3x", parent="s2"),
+                    NewPayloadStep(block="s3x"),
+                    ForkchoiceUpdatedStep(
+                        head="s3x",
+                        expect=applied("s3x"),
+                        branches={
+                            "applied": [
+                                AssertCanonicalStep(blocks={2: "s2", 3: "s3x"})
+                            ]
+                        },
+                    ),
+                ]
+            },
+        ),
+        ForkchoiceUpdatedStep(
+            head="a3",
+            expect=applied("a3"),
+            branches={"applied": [AssertCanonicalStep(blocks={3: "a3"})]},
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_two_built_payloads_same_parent(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Port of hive ``SidechainReOrgTest``: build two payloads on the same
+    parent with different ``prevRandao``, switch head between them, verify
+    ``latest`` and the canonical mapping each time.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    blocks = [
+        ReorgBlock(
+            label="a1",
+            txs=[Transaction(sender=sender, nonce=0, to=recipient, value=1)],
+        )
+    ]
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(
+            head="a1",
+            payload_attributes=build_attrs(0x01),
+            expect=applied("a1", payload_id=True),
+            branches={
+                "applied": [
+                    GetPayloadStep(bind="p", parent="a1"),
+                    ForkchoiceUpdatedStep(
+                        head="a1",
+                        payload_attributes=build_attrs(0x02),
+                        expect=applied("a1", payload_id=True),
+                        branches={
+                            "applied": [
+                                GetPayloadStep(bind="q", parent="a1"),
+                                NewPayloadStep(block="p"),
+                                NewPayloadStep(block="q"),
+                                ForkchoiceUpdatedStep(
+                                    head="p",
+                                    expect=applied("p"),
+                                    branches={
+                                        "applied": [
+                                            AssertCanonicalStep(
+                                                blocks={2: "p"}
+                                            )
+                                        ]
+                                    },
+                                ),
+                                ForkchoiceUpdatedStep(
+                                    head="q",
+                                    expect=applied("q"),
+                                    branches={
+                                        "applied": [
+                                            AssertCanonicalStep(
+                                                blocks={2: "q"}
+                                            )
+                                        ]
+                                    },
+                                ),
+                                ForkchoiceUpdatedStep(
+                                    head="p",
+                                    expect=applied("p"),
+                                    branches={
+                                        "applied": [
+                                            AssertCanonicalStep(
+                                                blocks={2: "p"}
+                                            )
+                                        ]
+                                    },
+                                ),
+                            ]
+                        },
+                    ),
+                ]
+            },
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_pool_tx_reorged_out_of_built_payload(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    """
+    Port of hive ``TransactionReOrgTest`` (``ReOrgOut`` / ``ReOrgBackIn``).
+
+    A pool transaction is included in a payload built on a1 (bound ``p``);
+    after FCU to ``p`` its receipt exists. Reorg to sibling b1 (which does
+    not contain it): no receipt. Reorg back to ``p``: receipt is back.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    # Tip above geth's default ``--miner.gasprice`` (1 gwei): the pool accepts
+    # cheaper txs but the payload builder skips them.
+    tx = Transaction(
+        sender=sender,
+        nonce=0,
+        to=recipient,
+        value=7,
+        gas_limit=21_000,
+        gas_price=30 * 10**9,
+    )
+    blocks = [
+        ReorgBlock(label="a1", txs=[]),
+        ReorgBlock(label="b1", parent="genesis", txs=[], extra_data=b"b"),
+        # Carrier block for the raw tx bytes (never sent as a payload).
+        ReorgBlock(
+            label="carrier", parent="genesis", txs=[tx], extra_data=b"c"
+        ),
+    ]
+    pool_tx = TxRef(block="carrier", index=0)
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        NewPayloadStep(block="b1"),
+        ForkchoiceUpdatedStep(head="a1"),
+        SendRawTransactionStep(tx=pool_tx),
+        ForkchoiceUpdatedStep(
+            head="a1",
+            payload_attributes=build_attrs(0x0A),
+            expect=applied("a1", payload_id=True),
+            branches={
+                "applied": [
+                    GetPayloadStep(
+                        bind="p", parent="a1", transactions_include=[pool_tx]
+                    ),
+                    NewPayloadStep(block="p"),
+                    ForkchoiceUpdatedStep(
+                        head="p",
+                        expect=applied("p"),
+                        branches={
+                            "applied": [
+                                AssertReceiptStep(tx=pool_tx, block="p")
+                            ]
+                        },
+                    ),
+                    ForkchoiceUpdatedStep(
+                        head="b1",
+                        expect=applied("b1"),
+                        branches={
+                            "applied": [
+                                AssertReceiptStep(tx=pool_tx, block=None)
+                            ]
+                        },
+                    ),
+                    ForkchoiceUpdatedStep(
+                        head="p",
+                        expect=applied("p"),
+                        branches={
+                            "applied": [
+                                AssertReceiptStep(tx=pool_tx, block="p")
+                            ]
+                        },
+                    ),
+                ]
+            },
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})

--- a/tests/reorg/test_tx_receipts_logs_reorg.py
+++ b/tests/reorg/test_tx_receipts_logs_reorg.py
@@ -1,0 +1,279 @@
+"""
+Transaction, receipt, log and transaction-pool behaviour across reorgs.
+
+Ports of:
+- go-ethereum `core/blockchain_test.go:testChainTxReorgs` (shared /
+  dropped / postponed / added transactions) and `testLogReorgs`.
+- besu `DefaultBlockchainTest.reorgWithOverlappingTransactions`.
+- erigon `engine_api_reorg_test.go`:
+  `TestEthGetLogsDoNotGetAffectedAfterNewPayloadOnSideChain`.
+- reth `e2e/pool.rs:maintain_txpool_reorg`, besu
+  `shouldReAddTransactionsFromThePreviousCanonicalHeadWhenAReorgOccurs`
+  / `shouldNotReAddTransactionsThatAreInBothForksWhenReorgHappens`, geth
+  `legacypool.reset` (pool re-injection is client policy: recorded, not
+  required).
+"""
+
+from typing import List
+
+import pytest
+from execution_testing import Alloc, Transaction
+from execution_testing.fixtures.reorg import (
+    AssertCanonicalStep,
+    AssertLogsStep,
+    AssertReceiptStep,
+    AssertTxStatusStep,
+    ForkchoiceUpdatedStep,
+    NewPayloadStep,
+    Outcome,
+    SendRawTransactionStep,
+    Step,
+    TxRef,
+)
+from execution_testing.specs import ReorgBlock, ReorgTestFiller
+from execution_testing.vm import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "src/engine/paris.md"
+REFERENCE_SPEC_VERSION = "execution-apis#786"
+
+
+def applied(head: str) -> List[Outcome]:
+    """Single legal outcome: the forkchoice update is applied."""
+    return [Outcome(id="applied", status="VALID", latest_valid_hash=head)]
+
+
+@pytest.mark.valid_from("Cancun")
+def test_tx_reorg_shared_dropped_postponed_added(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    r"""
+    Port of geth ``testChainTxReorgs``.
+
+    genesis <- a1 <- a2 <- a3        (canonical first)
+            \\- b1 <- b2 <- b3 <- b4  (reorg target)
+
+    - shared: in a1 and b1 (same tx) — stays included after the reorg.
+    - dropped: only in a-chain — no receipt after the reorg.
+    - postponed: in a2, re-included later in b4.
+    - added: only in b-chain — receipt appears after the reorg.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    other = pre.fund_eoa()
+
+    shared = Transaction(sender=sender, nonce=0, to=recipient, value=1)
+    dropped = Transaction(sender=sender, nonce=1, to=recipient, value=2)
+    postponed = Transaction(sender=other, nonce=0, to=recipient, value=3)
+    added = Transaction(sender=sender, nonce=1, to=recipient, value=4)
+    filler_b2 = Transaction(sender=other, nonce=1, to=recipient, value=5)
+
+    blocks = [
+        ReorgBlock(label="a1", txs=[shared]),
+        ReorgBlock(label="a2", txs=[dropped, postponed]),
+        ReorgBlock(label="a3", txs=[]),
+        ReorgBlock(
+            label="b1", parent="genesis", txs=[shared], extra_data=b"b"
+        ),
+        ReorgBlock(label="b2", txs=[added]),
+        ReorgBlock(label="b3", txs=[]),
+        ReorgBlock(label="b4", txs=[postponed, filler_b2]),
+    ]
+
+    after_a = [
+        AssertReceiptStep(tx=TxRef(block="a1", index=0), block="a1"),
+        AssertReceiptStep(tx=TxRef(block="a2", index=0), block="a2"),
+        AssertReceiptStep(tx=TxRef(block="a2", index=1), block="a2"),
+        AssertReceiptStep(tx=TxRef(block="b2", index=0), block=None),
+        AssertTxStatusStep(
+            tx=TxRef(block="a2", index=0),
+            expect=["included"],
+            included_in="a2",
+        ),
+    ]
+    after_b = [
+        # shared: same hash, now in b1.
+        AssertReceiptStep(tx=TxRef(block="a1", index=0), block="b1"),
+        # dropped: gone from the canonical chain; pool re-injection is policy.
+        AssertReceiptStep(tx=TxRef(block="a2", index=0), block=None),
+        AssertTxStatusStep(
+            tx=TxRef(block="a2", index=0), expect=["pending", "dropped"]
+        ),
+        # postponed: now in b4.
+        AssertReceiptStep(tx=TxRef(block="a2", index=1), block="b4"),
+        # added: now included.
+        AssertReceiptStep(tx=TxRef(block="b2", index=0), block="b2"),
+        AssertCanonicalStep(blocks={1: "b1", 2: "b2", 3: "b3", 4: "b4"}),
+    ]
+
+    steps: List[Step] = []
+    for label in ("a1", "a2", "a3"):
+        steps += [
+            NewPayloadStep(block=label),
+            ForkchoiceUpdatedStep(head=label),
+        ]
+    steps[-1] = ForkchoiceUpdatedStep(head="a3", branches={"applied": after_a})
+    for label in ("b1", "b2", "b3", "b4"):
+        steps.append(NewPayloadStep(block=label))
+    steps.append(
+        ForkchoiceUpdatedStep(
+            head="b4", expect=applied("b4"), branches={"applied": after_b}
+        )
+    )
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_logs_follow_reorg(reorg_test: ReorgTestFiller, pre: Alloc) -> None:
+    r"""
+    Port of geth ``testLogReorgs`` and erigon
+    ``TestEthGetLogsDoNotGetAffectedAfterNewPayloadOnSideChain``.
+
+    genesis <- a1(log) <- a2(log)
+            \\- b1(log) <- b2
+
+    ``eth_getLogs`` over the whole range must return the canonical chain's
+    logs only: a non-canonical ``newPayload`` must not leak logs; after the
+    reorg the a-chain logs disappear and the b-chain logs appear.
+    """
+    sender = pre.fund_eoa()
+    emitter = pre.deploy_contract(code=Op.LOG1(0, 0, 0x1234) + Op.STOP)
+
+    def emit(nonce: int, value: int) -> Transaction:
+        return Transaction(
+            sender=sender,
+            nonce=nonce,
+            to=emitter,
+            value=value,
+            gas_limit=100_000,
+        )
+
+    blocks = [
+        ReorgBlock(label="a1", txs=[emit(0, 1)]),
+        ReorgBlock(label="a2", txs=[emit(1, 2)]),
+        ReorgBlock(label="b1", parent="genesis", txs=[emit(0, 3)]),
+        ReorgBlock(label="b2", txs=[]),
+    ]
+    steps: List[Step] = [
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(head="a1"),
+        NewPayloadStep(block="a2"),
+        ForkchoiceUpdatedStep(
+            head="a2",
+            branches={
+                "applied": [
+                    AssertLogsStep(address=emitter, blocks=["a1", "a2"])
+                ]
+            },
+        ),
+        # Side chain known but not canonical: logs unaffected.
+        NewPayloadStep(block="b1"),
+        NewPayloadStep(block="b2"),
+        AssertLogsStep(address=emitter, blocks=["a1", "a2"]),
+        ForkchoiceUpdatedStep(
+            head="b2",
+            expect=applied("b2"),
+            branches={
+                "applied": [
+                    AssertLogsStep(address=emitter, blocks=["b1"]),
+                    AssertReceiptStep(
+                        tx=TxRef(block="a2", index=0), block=None
+                    ),
+                ]
+            },
+        ),
+        # And back.
+        ForkchoiceUpdatedStep(
+            head="a2",
+            expect=applied("a2"),
+            branches={
+                "applied": [
+                    AssertLogsStep(address=emitter, blocks=["a1", "a2"])
+                ]
+            },
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})
+
+
+@pytest.mark.valid_from("Cancun")
+def test_txpool_reinjection_after_reorg(
+    reorg_test: ReorgTestFiller, pre: Alloc
+) -> None:
+    r"""
+    Port of reth ``maintain_txpool_reorg`` / besu txpool re-add tests / geth
+    ``legacypool.reset``.
+
+    genesis <- a1(tx1)
+            \\- b1(tx2, same sender+nonce, conflicting)
+
+    tx1 is sent through the pool, then included in a1. After the reorg to b1
+    (which contains the conflicting tx2), tx1 is no longer canonical; whether
+    the client re-injects it into the pool (``pending``) or drops it is
+    client policy and is recorded. tx2 must be ``included`` in b1. Reorging
+    back to a1 must restore tx1's receipt.
+    """
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    # Explicit gas limit: raw-sent txs must not inherit the block-filling
+    # default the filler assigns to payload txs.
+    tx1 = Transaction(
+        sender=sender, nonce=0, to=recipient, value=1, gas_limit=21_000
+    )
+    tx2 = Transaction(
+        sender=sender, nonce=0, to=recipient, value=2, gas_limit=21_000
+    )
+    blocks = [
+        ReorgBlock(label="a1", txs=[tx1]),
+        ReorgBlock(label="b1", parent="genesis", txs=[tx2]),
+    ]
+    steps: List[Step] = [
+        SendRawTransactionStep(tx=TxRef(block="a1", index=0)),
+        AssertTxStatusStep(tx=TxRef(block="a1", index=0), expect=["pending"]),
+        NewPayloadStep(block="a1"),
+        ForkchoiceUpdatedStep(
+            head="a1",
+            branches={
+                "applied": [
+                    AssertTxStatusStep(
+                        tx=TxRef(block="a1", index=0),
+                        expect=["included"],
+                        included_in="a1",
+                    )
+                ]
+            },
+        ),
+        NewPayloadStep(block="b1"),
+        ForkchoiceUpdatedStep(
+            head="b1",
+            expect=applied("b1"),
+            branches={
+                "applied": [
+                    AssertReceiptStep(
+                        tx=TxRef(block="b1", index=0), block="b1"
+                    ),
+                    AssertReceiptStep(
+                        tx=TxRef(block="a1", index=0), block=None
+                    ),
+                    AssertTxStatusStep(
+                        tx=TxRef(block="a1", index=0),
+                        expect=["pending", "dropped"],
+                    ),
+                ]
+            },
+        ),
+        ForkchoiceUpdatedStep(
+            head="a1",
+            expect=applied("a1"),
+            branches={
+                "applied": [
+                    AssertReceiptStep(
+                        tx=TxRef(block="a1", index=0), block="a1"
+                    ),
+                    AssertReceiptStep(
+                        tx=TxRef(block="b1", index=0), block=None
+                    ),
+                ]
+            },
+        ),
+    ]
+    reorg_test(pre=pre, blocks=blocks, steps=steps, meta={"class": "shallow"})


### PR DESCRIPTION
### Description

Adds a new fixture format, spec type, reference model and hive simulator for testing chain reorg behavior via the Engine API, written in EELS. This is the execution-specs half of the reorg-testing work happening alongside a companion hive branch; the fixtures produced here are consumed by a `consume-reorg` hive simulator on that branch.

### Related Issues or PRs

https://github.com/ethereum/hive/pull/1608

### Checklist

- [x] Ran fast static checks to avoid CI fails: `ruff format --check`, `ruff check`, `mypy`, `codespell` all pass on every file this PR touches.
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate `C-<type>`, respectively `A-<area>`, label.

### Cute Animal Picture

TBD
