### PR TITLE
refactor(tests): use GasConsumer for cross-frame refund execution tail

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_cross_frame_refund.py
@@ -27,6 +27,7 @@ from execution_testing import (
     AuthorizationTuple,
     Bytecode,
     Fork,
+    GasConsumer,
     Op,
     Opcode,
     StateTestFiller,
@@ -552,24 +553,17 @@ def test_repaid_credit_funds_execution(
             Op.DELEGATECALL(gas=Op.GAS, address=clearer, address_warm=False)
         )
     )
-    # TODO: The tail spends a set amount of execution gas; a JUMPDEST
-    # run is the most future-proof inline way until a fork util exists.
-    tail_ops = min(
-        sstore_state_gas // Op.JUMPDEST.gas_cost(fork),
-        fork.max_code_size() - len(head),
-    )
-    tail = Op.JUMPDEST * tail_ops
-    code = head + tail
-    contract = pre.deploy_contract(code=code)
-
     # A sliver covering the child's SSTORE stipend sentry through the
     # one-in-64 withholding. It survives the merge unspent.
     sliver = budget_above_sstore_stipend(fork, clearer_code) * 64 // 63 + 1
-    tail_cost = tail.gas_cost(fork)
-    # The tail must overrun the sliver yet fit inside the repaid
-    # credit, or the completion stops demonstrating the repayment buys
-    # execution.
-    assert sliver < tail_cost <= sstore_state_gas
+    # Burn exactly the repaid state-gas credit as execution gas. The
+    # tail must overrun the sliver yet fit inside that credit, or the
+    # completion stops demonstrating the repayment buys execution.
+    tail_cost = sstore_state_gas
+    assert sliver < tail_cost
+    tail = GasConsumer(gas=tail_cost, fork=fork)
+    code = head + tail
+    contract = pre.deploy_contract(code=code)
 
     gas_limit = (
         intrinsic_cost


### PR DESCRIPTION
### Description
Replace the manual JUMPDEST execution-gas tail in test_repaid_credit_funds_execution with GasConsumer, and remove the TODO that waited on a fork util.

GasConsumer landed in #3497. The tail still burns fixed execution-only gas that overruns the merge sliver and fits inside the repaid state-gas credit; it now burns exactly that credit instead of being capped by code size.

Filled locally: uv run fill ...::test_repaid_credit_funds_execution --fork Amsterdam (3 passed).

### Related Issues or PRs
Follow-up to #3497 (same cleanup direction as #3541).

### Checklist
- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture
![corgi](https://images.unsplash.com/photo-1548199973-03cce0bbc87b?auto=format&fit=crop&w=640)
