### PR TITLE
chore(skill): refresh skills

### DIFF
--- a/.agents/skills/fill-tests/SKILL.md
+++ b/.agents/skills/fill-tests/SKILL.md
@@ -9,7 +9,7 @@ CLI reference for the `fill` command. Run this skill before filling test fixture
 
 ## Basic Usage
 
-```
+```bash
 uv run fill tests/                                    # Fill all tests
 uv run fill tests/cancun/ --fork Cancun               # Specific fork
 uv run fill tests/path/to/test.py -k "test_name"      # Specific test
@@ -19,13 +19,13 @@ uv run fill --collect-only tests/                      # Dry run: list tests wit
 
 ## Key Flags
 
-- `--fork FORK` / `--until FORK` — target specific fork or range
+- `--fork FORK` / `--until FORK` — target specific fork or range. The default set stops at the last deployed fork, so a fork under development needs one of these.
 - `--output DIR` + `--clean` — output directory; `--clean` required when re-filling
 - `-k "pattern"` — filter tests by name pattern
 - `-m "marker"` — filter by pytest marker (e.g. `-m state_test`, `-m blockchain_test`)
 - `-n auto --maxprocesses N` — parallel execution (use `--dist=loadgroup`)
 - `--evm-bin PATH` — t8n tool; defaults to the in-repo EELS Python spec (`src/ethereum/`)
-- `--verify-fixtures` — verify generated fixtures against geth blocktest
+- `--verify-fixtures` — run geth's `evm blocktest` over the generated fixtures. The default EELS t8n has no blocktest, so pass a geth binary with `--verify-fixtures-bin`. For an EELS-side check use `just validate-blocks <fixtures_dir>`, which is what CI runs.
 - `--generate-all-formats` — generate all fixture formats (2-phase)
 
 ## Debugging
@@ -45,10 +45,11 @@ uv run fill --collect-only tests/                      # Dry run: list tests wit
 - Excluded from a broad `tests/` run: include them by targeting a `tests/benchmark/...` path, or add `--include-benchmark` when also collecting `tests/`.
 - Pick a mode (mutually exclusive): `--gas-benchmark-values 1,10,100` (millions of gas) or `--fixed-opcode-count 1,10,100` (thousands). These parametrize the tests, e.g. `...[fork_Prague-blockchain_test-benchmark-gas-value_1M]`.
 - Backend is optional: omitting `--evm-bin` runs the slow in-repo EELS Python spec; `--evm-bin=evmone` or `--evm-bin=evm` (geth, used by `just bench-gas`) are faster.
+- Stateful benchmarks (`tests/benchmark/stateful/`) are filled by the separate `fill-stateful` command against a live client snapshot and produce `BlockchainEngineStatefulFixture`; see `docs/filling_tests/fill_stateful.md`.
 
 ## Fixture Formats
 
-One test function auto-generates multiple formats: `StateFixture`, `BlockchainFixture`, `BlockchainEngineFixture`. Use `--generate-all-formats` for additional formats via 2-phase execution.
+One test function auto-generates multiple formats: `StateFixture`, `BlockchainFixture`, `BlockchainEngineFixture`. `--generate-all-formats` adds the pre-alloc-group format `BlockchainEngineXFixture` through a 2-phase run (`--generate-pre-alloc-groups`, then `--use-pre-alloc-groups`); `--single-fixture-per-file` writes each fixture to its own JSON file.
 
 ## References
 

--- a/.agents/skills/lint/SKILL.md
+++ b/.agents/skills/lint/SKILL.md
@@ -33,7 +33,7 @@ just static
 
 - **Remaining ruff issues**: fix manually (auto-fix can't handle all rules)
 - **mypy errors**: fix type annotations, add missing types, correct signatures
-- **codespell errors**: fix typos, or add intentional words via `just whitelist <word>`
+- **codespell errors**: fix typos, or add intentional words to `whitelist.txt` (codespell's ignore list)
 - **ethereum-spec-lint errors**: fix import isolation violations (see `/implement-eip` for import rules)
 - **actionlint errors**: fix workflow YAML issues (see `/edit-workflow`)
 

--- a/.agents/skills/write-test/SKILL.md
+++ b/.agents/skills/write-test/SKILL.md
@@ -12,14 +12,15 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 - All test imports come from `execution_testing` — it is the public API
 - Core fixtures: `pre: Alloc` (pre-state builder), `state_test: StateTestFiller`, `blockchain_test: BlockchainTestFiller`, `fork: Fork`
 - Rule: use `state_test` for single-transaction tests; `fill` auto-derives a `blockchain_test` from each, so no coverage is lost.
-- Exception: use `blockchain_test` when the test needs more than one transaction (a `state_test` holds exactly one) or more than one block (e.g. transaction-ordering or fork-transition tests).
+- Exception: use `blockchain_test` when the test needs more than one transaction (a `state_test` holds exactly one), more than one block (e.g. transaction-ordering or fork-transition tests), or calls a system contract: the state-test pre-alloc omits the predeploys a fork lists only in `pre_allocation_blockchain()`, so the `CALL` hits an empty account, "succeeds", and the test passes vacuously.
 - Anti-pattern: wrapping one transaction in a `Block` to reach `blockchain_test`. A `state_test` can assert the transaction's gas used and receipt logs (the tx's `expected_receipt=TransactionReceipt(cumulative_gas_used=...)`), reserve state gas (the tx's `state_gas_reservoir=`), and other block-header fields (`blockchain_test_header_verify=Header(...)`) without it.
+- If the framework cannot express what a test needs — a fork-derived parameter set, a protocol constant, a cost — add it to the framework (a `fork.*()` accessor, a mixin ClassVar, a covariant marker) instead of building it in the test. Importing a helper from a sibling `test_*.py` is the sign it belongs there.
 
 ## Pre-State Setup
 
-- `pre.fund_eoa()` — create funded EOA, returns Address. Accepts `amount=`, `nonce=`
+- `pre.fund_eoa()` — create funded EOA, returns Address. Accepts `amount=`, `nonce=`. With `amount=0` nothing is added to the pre-alloc; you get a fresh, nonexistent address.
 - `pre.deploy_contract(code=..., storage={...})` — deploy contract, returns Address
-- Anti-pattern: do NOT manipulate `pre` dict directly (`pre[addr] = Account(...)`)
+- Do not assign into `pre` directly. The one exception is overriding a predeploy's code, `pre[addr] = Account(...)` under `@pytest.mark.pre_alloc_mutable`: it replaces the whole account (storage gone, nonce 1) and skips the test in execute mode, so reserve it for scenarios a live chain cannot host.
 
 ## Bytecode Construction
 
@@ -34,6 +35,15 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 - `storage = Storage()` then `storage.store_next(expected_value)` — auto-increments slot
 - `Op.SSTORE(storage.store_next(sender), Op.ORIGIN)` — build bytecode + expected storage in one step
 - Post-state: `post = {contract: Account(storage=storage)}`
+- `Account(storage=...)` compares storage **exhaustively**: any slot you omit must be zero. Opt an omitted key out with `Storage.set_expect_any(key)`.
+
+## Block Access Lists
+
+Every Amsterdam+ fixture carries a BAL whether or not the test asserts one. An `expected_block_access_list=` is a fill-time check that the spec built the BAL you predicted, so write one when the access pattern is the point of the test or a known edge (a revert, a system call, a withdrawal, a self-destruct), not by default. When you do write one, pair it with a `post` witness: the BAL records access, not outcome, so a transaction that ran and failed still merges its touches and satisfies the expectation, and only `post` tells the two apart.
+
+- Field semantics: a field left unset is not checked, `[]` asserts empty, and a non-empty list matches as an **ordered subsequence** (extra actual entries are skipped; yours must appear in order). `BalAccountExpectation()` with no field set raises; use `.empty()` for an account with no changes and `{address: None}` to assert an address is absent.
+- Reads and created accounts survive a frame's revert; writes do not. A test that reverts after touching state still expects those touches, and a missing entry is not evidence the access never happened.
+- Withdrawals and pre/post-execution system calls add entries no transaction accounts for (index `0` before, `len(txs) + 1` after). An expectation built only from the transaction list comes up short.
 
 ## Markers
 
@@ -41,26 +51,40 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 - `@pytest.mark.valid_until("ForkName")` — test only valid up to a fork
 - `@pytest.mark.with_all_tx_types` — parametrize across all tx types
 - `@pytest.mark.with_all_call_opcodes` — parametrize CALL/CALLCODE/DELEGATECALL/STATICCALL
-- `@pytest.mark.with_all_evm_code_types` — parametrize across EVM code types
+- `@pytest.mark.with_all_system_contracts`, `with_all_precompiles`, `with_all_system_contract_request_types` (yields the request *class* as `request_class`), … — parametrize over a fork-derived set; `selector=lambda value: ...` narrows any `with_all_*` marker
 - `@pytest.mark.slow` — excluded by default in fill
-- `@pytest.mark.exception_test` — marks tests expecting exceptions
+- `@pytest.mark.exception_test` — marks tests expecting exceptions.
+- A mark that only some cases earn goes on that case, `pytest.param(..., marks=...)`, not the function: `exception_test` on the function fails the passing cases, and a function-level `EIPChecklist` item stays green after the one case that proved it is deleted.
 
 ## Fork-Aware Logic
 
-- `fork >= Cancun` for conditional behavior based on fork
+- Branch on `fork.is_eip_enabled(N)` for behaviour an EIP introduces; EIPs move between forks, so `fork >= Cancun` is only for facts about the fork itself
 - `fork.fork_at(timestamp=...)` gives the fork active before/after a transition boundary
 - For gas amounts, see **Gas Cost Expectations** below — prefer framework cost constructs over reading `fork.gas_costs()` constants directly
+
+## Pinning Intent
+
+Pinning is a necessity, not a nice-to-have. With thousands of tests nobody re-reads them to confirm they still fill for the reason they were written, so the pin is the only thing that notices when one stops.
+
+- **Pin a value that is as close to unique to this case as possible.** It should hold under the rule the test is about and under no other plausible rule, so that a test drifting onto a different rule, or a fork changing which rule applies, fails `fill` instead of quietly producing a new fixture.
+- **A pin that restates an input is not a pin.** `cumulative_gas_used` equal to the `gas_limit` the test itself set, a storage slot expected to be zero when zero is also the untouched value, an `Account.NONEXISTENT` that a mis-wired setup would produce anyway: each of these passes just as happily under the wrong behavior. Give the transaction slack above the boundary so the charged amount cannot equal the limit, pre-set the witness slot to a sentinel, and assert the created address you actually expect.
+- **The pin has to bite at fill time.** EELS collapses distinctions clients keep apart — both intrinsic-gas rejections map to one error, for instance — so an expectation that only differs under `consume` does not protect the fixture. When the discriminating fact cannot appear in the fixture, assert the premise in the test body: a plain `assert` on which of two thresholds binds, or a helper asserting the preconditions its boundary rests on, fails the fill the moment the assumption stops holding.
+- **Derive parameters from what the test asserts.** If a boundary is `len(slots) * COST`, compute it from the same `slots` the expectation checks, so the two cannot drift apart.
+- **Pin block premises.** A block that must be exactly full asserts its `gas_used` with `header_verify=Header(...)`.
+- **Make a mid-transaction value durable.** A `CALL` result, a `BALANCE`, `GAS` or `EXTCODESIZE` reading only exists while the code runs; `SSTORE` it into a witness slot and assert that slot in `post` (`Storage.store_next(expected)` builds the code and the expectation together).
+- **Say which rule the pinned number comes from.** One short comment naming the rule lets the next reader tell a repricing from a regression.
+- **Break it once.** After the test fills, mutate the setup so the behaviour under test cannot happen and confirm the fill fails for that reason; then restore it.
 
 ## Gas Cost Expectations
 
 Never hand-reconstruct a gas amount by summing `fork.gas_costs()` constants (`NEW_ACCOUNT`, `CALL_VALUE`, `COLD_STORAGE_WRITE`, `VERY_LOW`, ...). Re-deriving the schedule duplicates the framework's own calculation and silently breaks when a future fork reprices. Instead:
 
 - **Read the cost off the bytecode under test.** Set the relevant opcode metadata (`account_new`, `value_transfer`, `address_warm`, `key_warm`/`original_value`/`current_value`/`new_value`, `init_code_size`, `code_deposit_size`, `new_memory_size`, ...) and use `bytecode.gas_cost(fork)` (execution + state), `.execution_cost(fork)`, `.state_cost(fork)`, or `.refund(fork)`. Link the exact opcode to the behavior — e.g. `Op.SELFDESTRUCT(account_new=True).state_cost(fork)`.
-- **Transaction-level costs:** `fork.transaction_intrinsic_cost_calculator()`; `fork.transaction_top_frame_state_gas(contract_creation=True)` for the created account's `NEW_ACCOUNT` (under EIP-2780 it is NOT part of the intrinsic — never subtract it from the intrinsic); `fork.transaction_data_floor_cost_calculator()`; `fork.call_value_stipend()`.
+- **Transaction-level costs:** `fork.transaction_intrinsic_cost_calculator()`; `fork.transaction_top_frame_state_gas(contract_creation=True)` for the created account's `NEW_ACCOUNT` (under EIP-2780 it is NOT part of the intrinsic — never subtract it from the intrinsic); `fork.transaction_data_floor_cost_calculator()` (pass `contract_creation=True` for a creation transaction — its floor is anchored on a create-shaped base and comes out 9000 gas low without it); `fork.call_value_stipend()`.
+- **A gas-limit validity boundary pins one threshold, so name which one.** `fork.transaction_intrinsic_cost_calculator()` returns `max(standard_intrinsic, calldata_floor)`, and on a data-heavy transaction the floor wins by a wide margin. Compute both — `return_cost_deducted_prior_execution=True` for the standard cost, `fork.transaction_data_floor_cost_calculator()` for the floor — set the gas limit from the threshold under test, `assert` it is the greater of the two, and expect that threshold's rejection: `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST` for the floor, `INTRINSIC_GAS_TOO_LOW` for the standard cost (see **Pinning Intent**: EELS maps both to one error, so only the `assert` protects the fixture).
 - **A single bare opcode/schedule cost** (e.g. an account-access constant) comes from a metadata-only opcode: `Op.BALANCE.with_metadata(address_warm=False).gas_cost(fork)`.
 - **Fork-transition / cross-fork comparisons:** evaluate the same bytecode or intrinsic at each fork (`before = fork.fork_at(timestamp=...)`, `after = ...`) and compare `before` vs `after` costs — do not compare raw schedule constants.
 - **Do not add "self-check" asserts** that compare a framework-computed value against a `fork.gas_costs()` decomposition of the same fork; they add no coverage over the runtime behavior the test already exercises and only break on repricing.
-- **If the framework cannot express a cost, fix the framework** (wire the opcode into its gas/state map, add an accessor) rather than reconstructing it in the test. If the use case does not support the framework, the framework needs an update.
 - **Exception:** a test whose *subject* is a specific schedule value (e.g. a regression that an opcode's cost is unchanged) may compare a runtime measurement (`CodeGasMeasure`) against `fork.gas_costs().OPCODE_*`. Even then, never hardcode the literal value.
 
 ## Transactions
@@ -68,16 +92,19 @@ Never hand-reconstruct a gas amount by summing `fork.gas_costs()` constants (`NE
 - Rule: omit `gas_limit`. It auto-fills so the transaction executes in full without running out of gas.
 - Exception: set `gas_limit` explicitly for gas-sensitive tests (intrinsic-gas boundaries, OOG, code-deposit limits, or gas metering).
 - Anti-pattern: the `gas_limit=fork.transaction_gas_limit_cap()` boilerplate is now redundant.
+- A transaction that runs out of gas consumes exactly its `gas_limit`, so calling an `Om.OOG` contract pins a transaction's gas used to a chosen value without any cost arithmetic.
 
 ## Exception Testing
 
 - Pass `error=TransactionException.INTRINSIC_GAS_TOO_LOW` to `Transaction`
 - Common exceptions: `GAS_ALLOWANCE_EXCEEDED`, `NONCE_MISMATCH_TOO_LOW`, `INSUFFICIENT_ACCOUNT_FUNDS`
+- Expect the one exception the spec names. A client that reports a different error first is a mapper fix on the client side, not a reason for `exception=[A, B]`.
 
 ## Test Organization
 
 - Place tests in `tests/<fork>/eip<number>/` where `<fork>` is the fork that introduced the functionality
-- Each EIP directory has `spec.py` with `ReferenceSpec(git_path=..., version=...)` and test files declaring `REFERENCE_SPEC_GIT_PATH` / `REFERENCE_SPEC_VERSION`
+- Each EIP directory has `spec.py` with `ReferenceSpec(git_path=..., version=...)` and test files declaring `REFERENCE_SPEC_GIT_PATH` / `REFERENCE_SPEC_VERSION`. `version` is the EIP file's blob SHA (`gh api repos/ethereum/EIPs/contents/EIPS/eip-N.md --jq .sha`); `uv run check_eip_versions --until <Fork> <path>` flags stale pins.
+- Put a scenario where it earns the most coverage. Before adding a test to a new EIP's module, look in the module that owns the mechanism for one that already runs the case and only needs tightened expectations or an `is_eip_enabled` branch, and amend it; write a new test in the new module only when the branches would cost more readability than the extra fork coverage buys.
 - Use `conftest.py` for shared fixtures within an EIP directory
 
 ## Test Docstrings
@@ -91,6 +118,8 @@ Never hand-reconstruct a gas amount by summing `fork.gas_costs()` constants (`NE
 
 - `@pytest.mark.parametrize("name", [pytest.param(val, id="label"), ...])` with descriptive `id=` strings
 - Stack parametrize decorators for multiple dimensions
+- Handle every parametrized case with an explicit `if`/`elif` and `else: raise ValueError(...)`; an `else` that is a real case silently absorbs values added later.
+- Parametrize the dimensions that take different code paths in clients (warm/cold, empty/funded, same-tx/pre-deployed), not just the ones the spec names.
 
 ## Unit Tests (execution_testing package)
 

--- a/.agents/skills/write-test/SKILL.md
+++ b/.agents/skills/write-test/SKILL.md
@@ -120,6 +120,7 @@ Never hand-reconstruct a gas amount by summing `fork.gas_costs()` constants (`NE
 - Stack parametrize decorators for multiple dimensions
 - Handle every parametrized case with an explicit `if`/`elif` and `else: raise ValueError(...)`; an `else` that is a real case silently absorbs values added later.
 - Parametrize the dimensions that take different code paths in clients (warm/cold, empty/funded, same-tx/pre-deployed), not just the ones the spec names.
+- **Cover the family, not just the instance.** Before fixing the subject of a test, ask whether it is one member of a set the framework already parametrizes: call opcodes, create opcodes, precompiles, system contracts, request classes, tx types. If so, use that `with_all_*` marker and narrow it with `selector=lambda value: ...` when only part of the set can reach the behaviour (only `CALL` and `CALLCODE` carry a value, so only they can fail a sender-balance check). The nearest test proving the same rule for one member usually already carries the marker, so read a model test's decorators and not just its body. If the family is real but no marker covers it, propose a covariant marker (`covariant_decorator` in `plugins/forks/forks.py`) rather than hand-writing the list in the test; framework surface lands in its own change.
 
 ## Unit Tests (execution_testing package)
 


### PR DESCRIPTION
### Description

- Add some useful conventions already present in our best tests to the test-writing skill and refresh stale lines
- Update `fill` skill
- Refresh stale line in lint skill

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

🎠 
