### PR TITLE
fix(test-fill): reset opcode count before generating fill results

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1686,6 +1686,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     self.pre = group.pre
                 fill_result: FillResult | None = None
                 try:
+                    t8n.reset_opcode_count()
                     fill_result = self.generate(
                         t8n=t8n,
                         fixture_format=fixture_format,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_opcode_metadata.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_opcode_metadata.py
@@ -80,12 +80,15 @@ def test_opcode_metadata_excludes_probe(pytester: pytest.Pytester) -> None:
         assert len(fixture["blocks"]) == 1
         assert len(metadata["opcode_count_per_block"]) == 1
         assert metadata["opcode_count"]
-        assert metadata["opcode_count"] == metadata["opcode_count_per_block"][0]
+        assert (
+            metadata["opcode_count"] == metadata["opcode_count_per_block"][0]
+        )
 
     first_metadata, second_metadata = [
         fixture["_info"]["metadata"] for fixture in fixtures
     ]
     assert first_metadata["opcode_count"] == second_metadata["opcode_count"]
-    assert first_metadata["opcode_count_per_block"] == (
-        second_metadata["opcode_count_per_block"]
+    assert (
+        first_metadata["opcode_count_per_block"]
+        == second_metadata["opcode_count_per_block"]
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_opcode_metadata.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_opcode_metadata.py
@@ -1,0 +1,91 @@
+"""Test opcode metadata isolation during fixture generation."""
+
+import json
+import textwrap
+
+import pytest
+
+
+def test_opcode_metadata_excludes_probe(pytester: pytest.Pytester) -> None:
+    """Exclude discarded probe executions from fixture opcode metadata."""
+    test_dir = pytester.mkdir("tests") / "amsterdam"
+    test_dir.mkdir()
+    test_module = test_dir / "test_opcode_count_probe.py"
+    test_module.write_text(
+        textwrap.dedent(
+            """\
+            from copy import deepcopy
+
+            import pytest
+            from execution_testing import (
+                Alloc,
+                Block,
+                BlockchainTest,
+                BlockchainTestFiller,
+                Fork,
+            )
+            from execution_testing.client_clis import TransitionTool
+            from execution_testing.fixtures import BlockchainFixture
+
+            @pytest.mark.valid_at("Amsterdam")
+            @pytest.mark.parametrize("with_probe", [False, True])
+            def test_opcode_count_probe(
+                pre: Alloc,
+                blockchain_test: BlockchainTestFiller,
+                fork: Fork,
+                t8n: TransitionTool,
+                with_probe: bool,
+            ) -> None:
+                if with_probe:
+                    BlockchainTest(
+                        fork=fork,
+                        pre=deepcopy(pre),
+                        blocks=[Block(txs=[])],
+                        post={},
+                    ).generate(t8n=t8n, fixture_format=BlockchainFixture)
+
+                blockchain_test(pre=pre, blocks=[Block(txs=[])], post={})
+            """
+        )
+    )
+    pytester.copy_example(
+        name=(
+            "src/execution_testing/cli/pytest_commands/pytest_ini_files/"
+            "pytest-fill.ini"
+        )
+    )
+    output_dir = pytester.path / "fixtures"
+
+    # Isolate Pydantic's cached wrappers between nested fill sessions.
+    result = pytester.runpytest_subprocess(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Amsterdam",
+        "-m",
+        "blockchain_test",
+        "--no-html",
+        "--output",
+        str(output_dir),
+        str(test_module.relative_to(pytester.path)),
+    )
+    result.assert_outcomes(passed=2)
+
+    fixture_files = list((output_dir / "blockchain_tests").rglob("*.json"))
+    assert len(fixture_files) == 1
+    fixtures = list(json.loads(fixture_files[0].read_text()).values())
+    assert len(fixtures) == 2
+    for fixture in fixtures:
+        metadata = fixture["_info"]["metadata"]
+        assert len(fixture["blocks"]) == 1
+        assert len(metadata["opcode_count_per_block"]) == 1
+        assert metadata["opcode_count"]
+        assert metadata["opcode_count"] == metadata["opcode_count_per_block"][0]
+
+    first_metadata, second_metadata = [
+        fixture["_info"]["metadata"] for fixture in fixtures
+    ]
+    assert first_metadata["opcode_count"] == second_metadata["opcode_count"]
+    assert first_metadata["opcode_count_per_block"] == (
+        second_metadata["opcode_count_per_block"]
+    )


### PR DESCRIPTION
### Description

`fill` includes preparatory transition-tool executions in the opcode metadata of the fixture it emits. A test that generates and discards a probe block before calling `blockchain_test(...)` can produce more `_info.metadata.opcode_count_per_block` entries than fixture blocks. The aggregate `opcode_count` also includes the probe, inflating the reported work.

Both cases fill successfully and emit the same single empty block:

| Case | Fixture blocks | Opcode-count entries | Aggregate opcodes |
| --- | ---: | ---: | ---: |
| Without a probe | 1 | 1 | 346 |
| With a discarded probe | 1 | 2 | 692 |

Both cases should have one opcode-count entry and identical aggregate counts. Consumers that require one entry per block can reject the affected fixture.

<details>
<summary>Minimal reproducer</summary>

Save as `tests/amsterdam/test_opcode_count_probe.py`:

```python
"""Reproduce fixture opcode counts contaminated by a preparatory block."""

from copy import deepcopy

import pytest
from execution_testing import (
    Alloc,
    Block,
    BlockchainTest,
    BlockchainTestFiller,
    Fork,
)
from execution_testing.client_clis import TransitionTool
from execution_testing.fixtures import BlockchainFixture


@pytest.mark.valid_from("Amsterdam")
@pytest.mark.parametrize("with_probe", [False, True])
def test_opcode_count_probe(
    pre: Alloc,
    blockchain_test: BlockchainTestFiller,
    fork: Fork,
    t8n: TransitionTool,
    with_probe: bool,
) -> None:
    """Emit one block after optionally generating a discarded probe block."""
    if with_probe:
        BlockchainTest(
            fork=fork,
            pre=deepcopy(pre),
            blocks=[Block(txs=[])],
            post={},
        ).generate(t8n=t8n, fixture_format=BlockchainFixture)

    blockchain_test(pre=pre, blocks=[Block(txs=[])], post={})
```

Run:

```sh
uv run fill tests/amsterdam/test_opcode_count_probe.py \
  --fork Amsterdam -m blockchain_test \
  --output /tmp/opcode-count-probe-repro --clean
```

Inspect `blocks`, `_info.metadata.opcode_count_per_block`, and `_info.metadata.opcode_count` in the JSON under `/tmp/opcode-count-probe-repro/blockchain_tests/`.

</details>

The transition tool resets its opcode counters once per pytest test. Each call to `evaluate()` then contributes to the same counters, including calls made by a temporary `BlockchainTest.generate(...)`. The filler copies these counters into the final fixture without excluding the probe.

The way I found this situation was by an [existing test for 8025](https://github.com/ethereum/execution-specs/blob/00c8a48dac57a59f74048782fad841826c50a1c1/tests/amsterdam/eip8025_optional_proofs/test_witness_headers.py#L302-L349).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
