### PR TITLE
feat(spec-tests, spec-tools): run fork-transition fixtures through EELS

### DIFF
--- a/src/ethereum_spec_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/loaders/fork_loader.py
@@ -121,6 +121,11 @@ class ForkLoad:
         return self._module("fork").state_transition
 
     @property
+    def apply_fork(self) -> Any:
+        """apply_fork function of the fork."""
+        return self._module("fork").apply_fork
+
+    @property
     def signing_hash(self) -> Any:
         """signing_hash function of the fork."""
         return self._module("transactions").signing_hash

--- a/tests/json_loader/helpers/load_blockchain_tests.py
+++ b/tests/json_loader/helpers/load_blockchain_tests.py
@@ -1,17 +1,21 @@
 """Helpers to load and run blockchain tests from JSON files."""
 
+import re
+from contextlib import ExitStack
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 from unittest.mock import call, patch
 
 import pytest
 from _pytest.config import Config
 from ethereum_rlp import rlp
 from ethereum_rlp.exceptions import RLPException
-from ethereum_types.numeric import U64
+from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import EthereumException, StateWithEmptyAccount
+from ethereum.fork_criteria import ByBlockNumber, ByTimestamp, ForkCriteria
 from ethereum.state_mpt import close_state
 from ethereum.utils.hexadecimal import hex_to_bytes
 from ethereum_spec_tools.loaders.fixture_loader import Load
@@ -21,12 +25,89 @@ from ..stash_keys import desired_forks_key
 from .exceptional_test_patterns import exceptional_blockchain_test_patterns
 from .fixtures import Fixture, FixturesFile, FixtureTestItem
 
+TRANSITION_NETWORK = re.compile(
+    r"^(?P<from_fork>.+?)To(?P<to_fork>.+?)"
+    r"At(?P<by_time>Time)?(?P<value>\d+)(?P<kilo>k)?$"
+)
+"""
+Network name of a fork-transition fixture, such as `BPO2ToAmsterdamAtTime15k`
+or `BerlinToLondonAt5`: the chain starts on the first fork and the second
+fork activates at the given timestamp (`AtTime`) or block number (`At`).
+"""
+
+HEADER_NUMBER_INDEX = 8
+HEADER_TIMESTAMP_INDEX = 11
+"""Positions of the number and timestamp in an RLP-encoded block header."""
+
 
 class NoTestsFoundError(Exception):
     """
     An exception thrown when the test for a particular fork isn't
     available in the json fixture.
     """
+
+
+@dataclass(frozen=True)
+class ForkTransition:
+    """The fork activation described by a transition fixture's network."""
+
+    from_fork: str
+    """JSON test name of the fork the chain starts on."""
+
+    to_fork: str
+    """JSON test name of the fork that activates."""
+
+    criteria: ForkCriteria
+    """When `to_fork` activates."""
+
+    @classmethod
+    def parse(cls, network: str) -> Optional["ForkTransition"]:
+        """
+        Parse a transition fixture's network name, or return `None` for a
+        plain fork name.
+        """
+        match = TRANSITION_NETWORK.match(network)
+        if match is None:
+            return None
+        value = int(match["value"]) * (1000 if match["kilo"] else 1)
+        criteria: ForkCriteria = (
+            ByTimestamp(value) if match["by_time"] else ByBlockNumber(value)
+        )
+        return cls(match["from_fork"], match["to_fork"], criteria)
+
+    def activates(self, json_block: Dict[str, Any]) -> bool:
+        """
+        Return whether `to_fork` is active for `json_block`.
+
+        A block that is expected to be invalid carries only its RLP, so the
+        number and timestamp are read from the encoded header when the
+        decoded header is absent. Their positions in the header are the
+        same in every fork. A block whose RLP does not decode is left to the
+        fork that is active before it.
+        """
+        if "blockHeader" in json_block:
+            json_header = json_block["blockHeader"]
+            number = int(json_header["number"], 16)
+            timestamp = int(json_header["timestamp"], 16)
+        else:
+            try:
+                block = rlp.decode(hex_to_bytes(json_block["rlp"]))
+                if not isinstance(block, list):
+                    return False
+                header = block[0]
+                if not isinstance(header, list):
+                    return False
+                number_bytes = header[HEADER_NUMBER_INDEX]
+                timestamp_bytes = header[HEADER_TIMESTAMP_INDEX]
+                if not isinstance(number_bytes, bytes) or not isinstance(
+                    timestamp_bytes, bytes
+                ):
+                    return False
+            except (RLPException, IndexError):
+                return False
+            number = int.from_bytes(number_bytes, "big")
+            timestamp = int.from_bytes(timestamp_bytes, "big")
+        return self.criteria.check(Uint(number), U256(timestamp))
 
 
 def add_block_to_chain(
@@ -62,6 +143,7 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
     """Single blockchain test fixture from a JSON file."""
 
     fork_name: str
+    transition: Optional[ForkTransition]
 
     def __init__(
         self,
@@ -73,7 +155,11 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
         self.fork_name = self.test_dict["network"]
         self.add_marker(pytest.mark.fork(self.fork_name))
         self.add_marker("json_blockchain_tests")
-        self.eels_fork = FORKS[self.fork_name].short_name
+        self.transition = ForkTransition.parse(self.fork_name)
+        if self.transition is None:
+            self.eels_fork = FORKS[self.fork_name].short_name
+        else:
+            self.eels_fork = FORKS[self.transition.to_fork].short_name
 
         # Mark tests with exceptional markers
         test_patterns = exceptional_blockchain_test_patterns(
@@ -132,8 +218,16 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
             )
 
         load = Load(self.eels_fork)
+        # A transition fixture starts its chain on the previous fork; the
+        # genesis and the blocks before the activation belong to it.
+        if self.transition is None:
+            current = load
+        else:
+            current = Load(FORKS[self.transition.from_fork].short_name)
 
-        genesis_header = load.json_to_header(json_data["genesisBlockHeader"])
+        genesis_header = current.json_to_header(
+            json_data["genesisBlockHeader"]
+        )
         parameters = [
             genesis_header,
             (),
@@ -145,7 +239,7 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
         if hasattr(genesis_header, "requests_root"):
             parameters.append(())
 
-        genesis_block = load.fork.Block(*parameters)
+        genesis_block = current.fork.Block(*parameters)
 
         genesis_header_hash = hex_to_bytes(
             json_data["genesisBlockHeader"]["hash"]
@@ -155,41 +249,58 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
         assert rlp.encode(genesis_block) == genesis_rlp
 
         try:
-            state = load.json_to_state(json_data["pre"])
+            state = current.json_to_state(json_data["pre"])
         except StateWithEmptyAccount as e:
             pytest.xfail(str(e))
 
-        chain = load.fork.BlockChain(
+        chain = current.fork.BlockChain(
             blocks=[genesis_block],
             state=state,
             chain_id=U64(json_data["genesisBlockHeader"].get("chainId", 1)),
         )
 
-        mock_pow = (
-            json_data["sealEngine"] == "NoProof"
-            and not load.fork.proof_of_stake
-        )
+        def mock_pow(fork_load: Load) -> bool:
+            return (
+                json_data["sealEngine"] == "NoProof"
+                and not fork_load.fork.proof_of_stake
+            )
 
-        for json_block in json_data["blocks"]:
-            block_exception = None
-            for key, value in json_block.items():
-                if key.startswith("expectException"):
-                    block_exception = value
-                    break
-                if key == "exceptions":
-                    block_exception = value
-                    break
+        with ExitStack() as stack:
+            if self.transition is not None:
+                self._schedule_fork(stack, load, self.transition.criteria)
 
-            if block_exception:
-                # TODO: Once all the specific exception types are thrown,
-                #       only `pytest.raises` the correct exception type instead
-                #       of all of them.
-                with pytest.raises((EthereumException, RLPException)):
-                    add_block_to_chain(chain, json_block, load, mock_pow)
-                    close_state(chain.state)
-                return
-            else:
-                add_block_to_chain(chain, json_block, load, mock_pow)
+            for json_block in json_data["blocks"]:
+                if (
+                    self.transition is not None
+                    and current is not load
+                    and self.transition.activates(json_block)
+                ):
+                    chain = load.fork.apply_fork(chain)
+                    current = load
+
+                block_exception = None
+                for key, value in json_block.items():
+                    if key.startswith("expectException"):
+                        block_exception = value
+                        break
+                    if key == "exceptions":
+                        block_exception = value
+                        break
+
+                if block_exception:
+                    # TODO: Once all the specific exception types are
+                    #       thrown, only `pytest.raises` the correct
+                    #       exception type instead of all of them.
+                    with pytest.raises((EthereumException, RLPException)):
+                        add_block_to_chain(
+                            chain, json_block, current, mock_pow(current)
+                        )
+                        close_state(chain.state)
+                    return
+                else:
+                    add_block_to_chain(
+                        chain, json_block, current, mock_pow(current)
+                    )
 
         last_block_hash = hex_to_bytes(json_data["lastblockhash"])
         assert (
@@ -197,10 +308,25 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
         )
 
         if has_post_state:
-            expected_post_state = load.json_to_state(json_data["postState"])
+            expected_post_state = current.json_to_state(json_data["postState"])
             assert chain.state == expected_post_state
             close_state(expected_post_state)
         close_state(chain.state)
+
+    @staticmethod
+    def _schedule_fork(
+        stack: ExitStack, load: Load, criteria: ForkCriteria
+    ) -> None:
+        """
+        Make the fork of `load` activate at `criteria` for the duration of
+        `stack`, so that the fork detects its own fork block as a client
+        with a matching chain configuration would.
+        """
+        fork_module = load.fork.hardfork.module("fork")
+        if hasattr(fork_module, "FORK_CRITERIA"):
+            stack.enter_context(
+                patch.object(fork_module, "FORK_CRITERIA", criteria)
+            )
 
     def reportinfo(self) -> Tuple[Path, int, str]:
         """Return information for test reporting."""
@@ -227,8 +353,19 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
     ) -> bool:
         """
         Check if the item fork is in the desired forks list.
+
+        A transition fixture is desired when the fork it activates is, as
+        long as the fork it starts on is known.
         """
         desired_forks = config.stash.get(desired_forks_key, None)
-        if desired_forks is None or test_dict["network"] in desired_forks:
+        if desired_forks is None:
             return True
-        return False
+        network = test_dict["network"]
+        if network in desired_forks:
+            return True
+        transition = ForkTransition.parse(network)
+        return (
+            transition is not None
+            and transition.from_fork in FORKS
+            and transition.to_fork in desired_forks
+        )

--- a/tests/json_loader/test_fork_transition_networks.py
+++ b/tests/json_loader/test_fork_transition_networks.py
@@ -1,0 +1,93 @@
+"""Tests for parsing the network name of fork-transition fixtures."""
+
+from typing import Any, Dict
+
+import pytest
+from ethereum_rlp import rlp
+
+from ethereum.fork_criteria import ByBlockNumber, ByTimestamp
+
+from .helpers.load_blockchain_tests import (
+    HEADER_NUMBER_INDEX,
+    HEADER_TIMESTAMP_INDEX,
+    ForkTransition,
+)
+
+
+def test_parse_timestamp_transition() -> None:
+    """Parse a timestamp transition, expanding the `k` suffix."""
+    transition = ForkTransition.parse("BPO2ToAmsterdamAtTime15k")
+
+    assert transition is not None
+    assert transition.from_fork == "BPO2"
+    assert transition.to_fork == "Amsterdam"
+    assert transition.criteria == ByTimestamp(15_000)
+
+
+def test_parse_block_number_transition() -> None:
+    """Parse a block number transition."""
+    transition = ForkTransition.parse("BerlinToLondonAt5")
+
+    assert transition is not None
+    assert transition.from_fork == "Berlin"
+    assert transition.to_fork == "London"
+    assert transition.criteria == ByBlockNumber(5)
+
+
+@pytest.mark.parametrize("network", ["Amsterdam", "Dao Fork", "EIP150"])
+def test_parse_plain_fork_name(network: str) -> None:
+    """Return `None` for a network that names a single fork."""
+    assert ForkTransition.parse(network) is None
+
+
+def decoded_block(number: int, timestamp: int) -> Dict[str, Any]:
+    """Return a fixture block with a decoded header."""
+    return {
+        "blockHeader": {"number": hex(number), "timestamp": hex(timestamp)}
+    }
+
+
+def encoded_block(number: int, timestamp: int) -> Dict[str, Any]:
+    """Return a fixture block that carries only its RLP."""
+    header = [b""] * (HEADER_TIMESTAMP_INDEX + 1)
+    header[HEADER_NUMBER_INDEX] = number.to_bytes(4, "big").lstrip(b"\0")
+    header[HEADER_TIMESTAMP_INDEX] = timestamp.to_bytes(4, "big").lstrip(b"\0")
+    return {"rlp": "0x" + rlp.encode([header, [], []]).hex()}
+
+
+def test_activates_at_the_transition_timestamp() -> None:
+    """Activate the second fork from the given timestamp on."""
+    transition = ForkTransition.parse("BPO2ToAmsterdamAtTime15k")
+    assert transition is not None
+
+    assert not transition.activates(decoded_block(1, 14_999))
+    assert transition.activates(decoded_block(2, 15_000))
+    assert transition.activates(decoded_block(3, 15_001))
+
+
+def test_activates_from_encoded_header() -> None:
+    """Read the activation point from the RLP of an undecoded block."""
+    transition = ForkTransition.parse("BPO2ToAmsterdamAtTime15k")
+    assert transition is not None
+
+    assert not transition.activates(encoded_block(1, 14_999))
+    assert transition.activates(encoded_block(2, 15_000))
+
+
+def test_activates_by_block_number() -> None:
+    """Activate the second fork from the given block number on."""
+    transition = ForkTransition.parse("BerlinToLondonAt5")
+    assert transition is not None
+
+    assert not transition.activates(decoded_block(4, 0))
+    assert transition.activates(decoded_block(5, 0))
+    assert transition.activates(encoded_block(6, 0))
+
+
+def test_undecodable_block_does_not_activate() -> None:
+    """Leave a block whose RLP does not decode to the fork before it."""
+    transition = ForkTransition.parse("BPO2ToAmsterdamAtTime15k")
+    assert transition is not None
+
+    assert not transition.activates({"rlp": "0xc0"})
+    assert not transition.activates({"rlp": "0xff"})


### PR DESCRIPTION
### Description

Teach the json-loader to run fork-transition fixtures through EELS.

Fork-transition tests are filled in CI, which executes the spec block by block through the in-process t8n. The resulting fixtures were never replayed through the spec's `state_transition`, though: a fixture whose `network` names a transition, such as `BPO2ToAmsterdamAtTime15k` or `BerlinToLondonAt5`, is not in the fork table, so the json-loader job and the `validate-blocks` step from #3552 dropped it at collection. Spec code that runs only in that block-level path at a fork boundary, header validation against the previous fork's parent header, `apply_fork`, and fork-block detection from `FORK_CRITERIA`, was therefore not exercised across a boundary in CI.

The loader now parses the transition name into the starting fork, the activating fork and the activation criteria (timestamp for `AtTime`, block number for `At`). The genesis and the blocks before the activation run on the starting fork. The first block that meets the criteria hands the chain to the activating fork through its `apply_fork`, the same hook the mainnet sync tool uses, and the remaining blocks run there. For the duration of the test the activating fork's `FORK_CRITERIA` is set to the fixture's criteria, the way a client's chain configuration would schedule it, so the fork detects its own fork block. A transition fixture is collected when the fork it activates is among the requested forks.

`ForkLoad` gains an `apply_fork` accessor, and the network parsing has unit tests.

Verified locally by filling every `not slow and primary_format` transition test up to Amsterdam and running `just validate-blocks` over the result; non-transition fixtures are unaffected.

### Related Issues or PRs

Prepares for #3535, whose fork-block nonce bump can only be exercised in the spec by a transition fixture.

### Checklist

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
