### PR TITLE
bench(account-access): add a JUMPDEST target at the fork's MAX_CODE_SIZE

### DIFF
--- a/tests/benchmark/helper/account_creator.py
+++ b/tests/benchmark/helper/account_creator.py
@@ -25,6 +25,8 @@ from tests.benchmark.helper.account_verification import (
     register_target_range,
 )
 
+# Legacy EIP-170 limit. Kept as the default so existing corpora, and the
+# CREATE2 addresses derived from them, stay reproducible.
 DEFAULT_CODE_SIZE = Osaka.max_code_size()
 
 ADDRESS_MASK = (1 << 160) - 1
@@ -56,6 +58,9 @@ class AccountMode(Enum):
 
     # Empty account
     NON_EXISTING_ACCOUNT = auto()
+
+    # As EXISTING_CONTRACT_JUMPDEST, but sized by the fork's MAX_CODE_SIZE.
+    EXISTING_CONTRACT_JUMPDEST_FORK_MAX = auto()
 
 
 class ContractInitcode(Bytecode):
@@ -297,6 +302,7 @@ class AccountCreator:
             AccountMode.EXISTING_CONTRACT_SAME_MAX,
             AccountMode.EXISTING_CONTRACT_DIFF_MAX,
             AccountMode.EXISTING_CONTRACT_JUMPDEST,
+            AccountMode.EXISTING_CONTRACT_JUMPDEST_FORK_MAX,
         }
     )
 
@@ -327,7 +333,10 @@ class AccountCreator:
                 return StopJumpdestInitcode(
                     code_size=self.code_size, diff=True
                 )
-            case AccountMode.EXISTING_CONTRACT_JUMPDEST:
+            case (
+                AccountMode.EXISTING_CONTRACT_JUMPDEST
+                | AccountMode.EXISTING_CONTRACT_JUMPDEST_FORK_MAX
+            ):
                 return JochemnetPredeployContractInitcode(
                     code_size=self.code_size
                 )

--- a/tests/benchmark/stateful/bloatnet/test_account_query.py
+++ b/tests/benchmark/stateful/bloatnet/test_account_query.py
@@ -25,6 +25,7 @@ from execution_testing import (
 )
 
 from tests.benchmark.helper.account_creator import (
+    DEFAULT_CODE_SIZE,
     AccountCreator,
     AccountMode,
 )
@@ -165,7 +166,17 @@ def test_account_access(
     verified_accounts: dict,
 ) -> None:
     """Benchmark account access with caching strategies."""
-    account_creator = AccountCreator(account_mode)
+    # Only *_FORK_MAX is sized by the fork; other modes keep the legacy size.
+    if account_mode is AccountMode.EXISTING_CONTRACT_JUMPDEST_FORK_MAX:
+        code_size = fork.max_code_size()
+        if code_size == DEFAULT_CODE_SIZE:
+            pytest.skip(
+                "fork MAX_CODE_SIZE equals the legacy size; "
+                "EXISTING_CONTRACT_JUMPDEST already covers this"
+            )
+        account_creator = AccountCreator(account_mode, code_size=code_size)
+    else:
+        account_creator = AccountCreator(account_mode)
     address_source = account_creator.address_source(Op.CALLDATALOAD(0))
     increment_op = address_source.next_op()
 


### PR DESCRIPTION
## Problem

`AccountCreator` sizes every target contract with `DEFAULT_CODE_SIZE`, which is
`Osaka.max_code_size()` (24 KiB), and nothing in `tests/benchmark` overrides it:

https://github.com/ethereum/execution-specs/blob/benchmarks/amsterdam/tests/benchmark/helper/account_creator.py#L28

From Amsterdam, EIP-7954 raises `MAX_CODE_SIZE` to 64 KiB, so the suite never builds a
target at the fork's actual limit.

This matters specifically for `EXISTING_CONTRACT_JUMPDEST`. A 64 KiB target is **2.7x more
JUMPDEST analysis per CALL**, and because clients cache code and analysis **keyed by code
hash under a byte-bounded capacity**, it simultaneously cuts how many targets fit in those
caches by 2.7x:

| client cache | entries at 24 KiB | entries at 64 KiB |
|---|---|---|
| geth code cache (256 MiB) | 10,922 | **4,096** |
| geth jumpdest LRU (64 MiB) | 20,592 | **8,009** |
| Besu `PathBasedCodeCache` (256 MiB) | ~9,800 | **~3,639** |
| Nethermind code cache (8,192 entries) | 8,192 | 8,192 |

Cold account access is a flat 3000 gas at either size, so the same block gas buys the same
number of CALLs — only the work per CALL moves.

## Why it is invisible today

Measured against geth's own cache implementations (`core.NewJumpDestCache()`, the 256 MiB
`codeCache`, real pebble), at matched CALL counts:

| calls | block MGas | 24 KiB steady | 64 KiB steady | jumpdest hits 24K / 64K |
|---|---|---|---|---|
| 3,300 | 10.0 | >1000 MGas/s | >1000 MGas/s | 3300 / 3300 |
| 16,000 | 48.6 | 252.9 MGas/s | **42.9 MGas/s** | **16000 / 0** |
| 60,000 | 182.1 | 78.1 MGas/s | 26.7 MGas/s | 0 / 0 |

At 16,000 targets the working set is **fully resident at 24 KiB but misses every single time
at 64 KiB** — a 5.9x throughput drop from the size alone. At the 10 MGas the suite commonly
runs at, both sizes look free, which is why the gap does not show up today: you have to be at
64 KiB *and* above ~8,000 distinct targets before it appears.

## Change

Add `EXISTING_CONTRACT_JUMPDEST_FORK_MAX`, which reuses the existing
`JochemnetPredeployContractInitcode` builder at `fork.max_code_size()`, and skip it on forks
where that equals the legacy size.

## Deliberately non-breaking

The new mode is **appended last** in `AccountMode` and every existing mode keeps
`DEFAULT_CODE_SIZE`, so no existing parametrization id changes and no pre-built corpus is
invalidated. Verified with `--collect-only` on Amsterdam:

```
base=200  new=240
BASE ids missing from NEW (renamed/removed): 0
purely NEW ids added:                        40
```

Full `tests/benchmark` tree collects clean (3076 tests, 0 errors).

## Follow-up needed

The new mode needs its own corpus: `code_size` feeds the CREATE2 initcode, so its target
addresses differ from the 24 KiB ones. The bloatnet factory stubs currently stop at
`bloatnet_factory_24kb`, so there is no 64 KiB corpus to point it at yet.

Worth noting for whoever builds it: under EIP-8037 (`cost_per_state_byte = 1530`) a 64 KiB
code deposit costs ~100.3M state gas, so a full-size contract cannot be deployed at all under
a 60M gas limit. A realistic corpus has to be planted offline (state-actor style) or
accumulated over thousands of blocks — which is also how it arises in practice.
