### PR TITLE
feat(forks,tests): implement EIP-7979 Call and Return Opcodes

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7979.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7979.py
@@ -1,0 +1,40 @@
+"""
+EIP-7979: Call and Return Opcodes for the EVM.
+
+Three instructions and a return stack: CALLSUB, CALLDEST and RETURNSUB.
+
+https://eips.ethereum.org/EIPS/eip-7979
+"""
+
+from typing import Callable, Dict, List
+
+from execution_testing.vm import OpcodeBase, Opcodes
+
+from ....base_fork import BaseFork
+
+
+class EIP7979(BaseFork):
+    """EIP-7979 class."""
+
+    @classmethod
+    def valid_opcodes(cls) -> List[Opcodes]:
+        """Add CALLSUB, CALLDEST and RETURNSUB to valid opcodes."""
+        return [
+            Opcodes.CALLSUB,
+            Opcodes.CALLDEST,
+            Opcodes.RETURNSUB,
+        ] + super(EIP7979, cls).valid_opcodes()
+
+    @classmethod
+    def opcode_gas_map(
+        cls,
+    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
+        """Add the gas costs of CALLSUB, CALLDEST and RETURNSUB."""
+        gas_costs = cls.gas_costs()
+        base_map = super(EIP7979, cls).opcode_gas_map()
+        return {
+            **base_map,
+            Opcodes.CALLSUB: gas_costs.MID,
+            Opcodes.CALLDEST: gas_costs.OPCODE_JUMPDEST,
+            Opcodes.RETURNSUB: gas_costs.LOW,
+        }

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -5274,6 +5274,98 @@ class Opcodes(Opcode, Enum):
     Source: [evm.codes/#A4](https://www.evm.codes/#A4)
     """
 
+    CALLSUB = Opcode(0xB0, popped_stack_items=1, kwargs=["pc"])
+    """
+    CALLSUB(pc)
+    ----
+
+    Description
+    ----
+    Transfer control to a subroutine (EIP-7979): push the position of the
+    next instruction onto the return stack and jump to `pc`, which must be a
+    CALLDEST instruction. Halts if `pc` is not a CALLDEST or the return stack
+    already holds 1024 items.
+
+    Inputs
+    ----
+    - pc: byte offset in the deployed code of the subroutine entry.
+          Must be a CALLDEST instruction
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    EIP-7979
+
+    Gas
+    ----
+    8
+
+    Source: [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979)
+    """
+
+    CALLDEST = Opcode(0xB1)
+    """
+    CALLDEST()
+    ----
+
+    Description
+    ----
+    Mark a subroutine entry (EIP-7979). Like JUMPDEST it is otherwise a
+    no-op. It is the only valid CALLSUB destination, and also a valid JUMP
+    and JUMPI destination, so a jump may enter a subroutine without pushing
+    a return address.
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    EIP-7979
+
+    Gas
+    ----
+    1
+
+    Source: [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979)
+    """
+
+    RETURNSUB = Opcode(0xB2)
+    """
+    RETURNSUB()
+    ----
+
+    Description
+    ----
+    Return control to the most recent caller (EIP-7979): pop the return
+    stack into the program counter. Halts if the return stack is empty.
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    EIP-7979
+
+    Gas
+    ----
+    5
+
+    Source: [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979)
+    """
+
     DUPN = Opcode(
         0xE6,
         pushed_stack_items=1,

--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -14,6 +14,7 @@ deterministic ``CREATE2`` factory predeploy.
 - [EIP-7981: Increase Access List Cost][EIP-7981]
 - [EIP-7997: Deterministic Factory Predeploy][EIP-7997]
 - [EIP-8024: Stack Access Instructions][EIP-8024]
+- [EIP-7979: Call and Return Opcodes for the EVM][EIP-7979]
 - [EIP-8037: State Creation Gas Cost Increase][EIP-8037]
 - [EIP-8038: State Access Gas Cost Increase][EIP-8038]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
@@ -32,6 +33,7 @@ deterministic ``CREATE2`` factory predeploy.
 [EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
 [EIP-7997]: https://eips.ethereum.org/EIPS/eip-7997
 [EIP-8024]: https://eips.ethereum.org/EIPS/eip-8024
+[EIP-7979]: https://eips.ethereum.org/EIPS/eip-7979
 [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 [EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -36,6 +36,10 @@ from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
 from .gas import GasMeter, repay_state_gas_spill
 
+# EIP-7979: the maximum number of return addresses a frame's return stack
+# may hold. A `CALLSUB` that would exceed it is an exceptional halt.
+RETURN_STACK_LIMIT = Uint(1024)
+
 __all__ = ("Environment", "Evm")
 TRANSFER_TOPIC = keccak256(b"Transfer(address,address,uint256)")
 SYSTEM_ADDRESS = Address(
@@ -160,11 +164,17 @@ class Evm:
 
     pc: Uint
     stack: List[U256]
+    # EIP-7979: return addresses, pushed only by `CALLSUB`, popped only by
+    # `RETURNSUB`, and not otherwise accessible to EVM code.
+    return_stack: List[Uint]
     memory: bytearray
     # Init code for a creation; the resolved code for a call.
     code: Bytes
     gas_meter: GasMeter
     valid_jump_destinations: Set[Uint]
+    # EIP-7979: positions of `CALLDEST` instructions, the only valid
+    # destinations of a `CALLSUB`. Every one is also a valid jump destination.
+    valid_call_destinations: Set[Uint]
     logs: Tuple[Log, ...]
     running: bool
 

--- a/src/ethereum/forks/amsterdam/vm/exceptions.py
+++ b/src/ethereum/forks/amsterdam/vm/exceptions.py
@@ -75,10 +75,32 @@ class InvalidJumpDestError(ExceptionalHalt):
     following criteria.
 
       * The jump destination is less than the length of the code.
-      * The jump destination should have the `JUMPDEST` opcode (0x5B).
+      * The jump destination should have the `JUMPDEST` opcode (0x5B), or
+        the `CALLDEST` opcode (0xB1, EIP-7979).
       * The jump destination shouldn't be part of the data corresponding to
         `PUSH-N` opcodes.
+
+    Also raised by `CALLSUB` (EIP-7979) when its destination is not a
+    `CALLDEST` meeting the same criteria.
     """
+
+
+class ReturnStackOverflowError(ExceptionalHalt):
+    """
+    Raised when `CALLSUB` would push a return address onto a return stack
+    that already holds `RETURN_STACK_LIMIT` (1024) items (EIP-7979).
+    """
+
+    pass
+
+
+class ReturnStackUnderflowError(ExceptionalHalt):
+    """
+    Raised when `RETURNSUB` is executed with an empty return stack
+    (EIP-7979).
+    """
+
+    pass
 
 
 class StackDepthLimitError(ExceptionalHalt):

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -205,6 +205,10 @@ class GasCosts:
     OPCODE_JUMP: Final[ExecutionGas] = MID
     OPCODE_JUMPI: Final[ExecutionGas] = HIGH
     OPCODE_JUMPDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    # EIP-7979: Call and return opcodes
+    OPCODE_CALLSUB: Final[ExecutionGas] = MID
+    OPCODE_CALLDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    OPCODE_RETURNSUB: Final[ExecutionGas] = LOW
     OPCODE_CALLDATALOAD: Final[ExecutionGas] = VERY_LOW
     OPCODE_BLOCKHASH: Final[ExecutionGas] = ExecutionGas(Uint(20))
     OPCODE_COINBASE: Final[ExecutionGas] = BASE

--- a/src/ethereum/forks/amsterdam/vm/instructions/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/__init__.py
@@ -194,6 +194,11 @@ class Ops(enum.Enum):
     SWAPN = 0xE7
     EXCHANGE = 0xE8
 
+    # EIP-7979: Call and return instructions
+    CALLSUB = 0xB0
+    CALLDEST = 0xB1
+    RETURNSUB = 0xB2
+
     # Memory Operations
     MLOAD = 0x51
     MSTORE = 0x52
@@ -291,6 +296,9 @@ op_implementation: Dict[Ops, Callable] = {
     Ops.PC: control_flow_instructions.pc,
     Ops.GAS: control_flow_instructions.gas_left,
     Ops.JUMPDEST: control_flow_instructions.jumpdest,
+    Ops.CALLSUB: control_flow_instructions.callsub,
+    Ops.CALLDEST: control_flow_instructions.calldest,
+    Ops.RETURNSUB: control_flow_instructions.returnsub,
     Ops.POP: stack_instructions.pop,
     Ops.PUSH0: stack_instructions.push0,
     Ops.PUSH1: stack_instructions.push1,

--- a/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
@@ -11,7 +11,7 @@ Introduction
 Implementations of the EVM control flow instructions.
 """
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ...vm.gas import (
     GasCosts,
@@ -199,7 +199,7 @@ def callsub(evm: Evm) -> None:
     # OPERATION
     if destination not in evm.valid_call_destinations:
         raise InvalidJumpDestError
-    if Uint(len(evm.return_stack)) >= RETURN_STACK_LIMIT:
+    if ulen(evm.return_stack) >= RETURN_STACK_LIMIT:
         raise ReturnStackOverflowError
     evm.return_stack.append(evm.pc + Uint(1))
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
@@ -17,8 +17,12 @@ from ...vm.gas import (
     GasCosts,
     charge_gas,
 )
-from .. import Evm
-from ..exceptions import InvalidJumpDestError
+from .. import RETURN_STACK_LIMIT, Evm
+from ..exceptions import (
+    InvalidJumpDestError,
+    ReturnStackOverflowError,
+    ReturnStackUnderflowError,
+)
 from ..stack import pop, push
 
 
@@ -172,3 +176,83 @@ def jumpdest(evm: Evm) -> None:
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)
+
+
+def callsub(evm: Evm) -> None:
+    """
+    Transfer control to a subroutine (EIP-7979): push the position of the
+    next instruction onto the return stack and jump to the `CALLDEST` whose
+    position is on top of the data stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    """
+    # STACK
+    destination = Uint(pop(evm.stack))
+
+    # GAS
+    charge_gas(evm, GasCosts.OPCODE_CALLSUB)
+
+    # OPERATION
+    if destination not in evm.valid_call_destinations:
+        raise InvalidJumpDestError
+    if Uint(len(evm.return_stack)) >= RETURN_STACK_LIMIT:
+        raise ReturnStackOverflowError
+    evm.return_stack.append(evm.pc + Uint(1))
+
+    # PROGRAM COUNTER
+    evm.pc = destination
+
+
+def calldest(evm: Evm) -> None:
+    """
+    Mark a subroutine entry (EIP-7979). Like `JUMPDEST`, this is a noop:
+    it is the only valid destination of a `CALLSUB`, and also a valid
+    destination of `JUMP` and `JUMPI`, which enter the subroutine without
+    pushing a return address.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    """
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GasCosts.OPCODE_CALLDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
+    evm.pc += Uint(1)
+
+
+def returnsub(evm: Evm) -> None:
+    """
+    Return control to the most recent caller (EIP-7979): pop the return
+    stack into the program counter.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    """
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GasCosts.OPCODE_RETURNSUB)
+
+    # OPERATION
+    if len(evm.return_stack) == 0:
+        raise ReturnStackUnderflowError
+
+    # PROGRAM COUNTER
+    evm.pc = evm.return_stack.pop()

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -82,7 +82,7 @@ def generic_create(
     # These imports cause a circular import error
     # if they're not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create
-    from ...vm.runtime import get_valid_jump_destinations
+    from ...vm.runtime import get_valid_destinations
 
     tx_state = evm.tx_env.state
 
@@ -136,6 +136,9 @@ def generic_create(
     increment_nonce(tx_state, sender_address)
 
     # DISPATCH
+    valid_jump_destinations, valid_call_destinations = get_valid_destinations(
+        init_code
+    )
 
     child_evm = Evm(
         # Context
@@ -154,7 +157,8 @@ def generic_create(
         # Code
         code_address=None,
         code=init_code,
-        valid_jump_destinations=get_valid_jump_destinations(init_code),
+        valid_jump_destinations=valid_jump_destinations,
+        valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=GasMeter(
             gas_left=create_message_gas,
@@ -163,6 +167,7 @@ def generic_create(
         ),
         pc=Uint(0),
         stack=[],
+        return_stack=[],
         memory=bytearray(),
         return_data=b"",
         # Accrued Effects
@@ -383,7 +388,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     resolution of its outcome back into the calling frame.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_call
-    from ...vm.runtime import get_valid_jump_destinations
+    from ...vm.runtime import get_valid_destinations
 
     evm.return_data = b""
 
@@ -406,6 +411,10 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         params.memory_input_size,
     )
 
+    valid_jump_destinations, valid_call_destinations = get_valid_destinations(
+        params.code
+    )
+
     child_evm = Evm(
         # Context
         block_env=evm.block_env,
@@ -423,7 +432,8 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         # Code
         code_address=params.code_address,
         code=params.code,
-        valid_jump_destinations=get_valid_jump_destinations(params.code),
+        valid_jump_destinations=valid_jump_destinations,
+        valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=GasMeter(
             gas_left=params.gas,
@@ -432,6 +442,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         ),
         pc=Uint(0),
         stack=[],
+        return_stack=[],
         memory=bytearray(),
         return_data=b"",
         # Accrued Effects

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -79,7 +79,7 @@ from .exceptions import (
     StackDepthLimitError,
 )
 from .instructions import Ops, op_implementation
-from .runtime import get_valid_jump_destinations
+from .runtime import get_valid_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x10000
@@ -201,6 +201,9 @@ def create_evm(
         )
 
     ## Build the frame
+    valid_jump_destinations, valid_call_destinations = get_valid_destinations(
+        code
+    )
     return Evm(
         # Context
         block_env=block_env,
@@ -218,11 +221,13 @@ def create_evm(
         # Code
         code_address=code_address,
         code=code,
-        valid_jump_destinations=get_valid_jump_destinations(code),
+        valid_jump_destinations=valid_jump_destinations,
+        valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=gas_meter,
         pc=Uint(0),
         stack=[],
+        return_stack=[],
         memory=bytearray(),
         return_data=b"",
         # Accrued Effects

--- a/src/ethereum/forks/amsterdam/vm/runtime.py
+++ b/src/ethereum/forks/amsterdam/vm/runtime.py
@@ -11,7 +11,7 @@ Introduction
 Runtime related operations used while executing EVM code.
 """
 
-from typing import Set
+from typing import Set, Tuple
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
@@ -19,19 +19,26 @@ from ethereum_types.numeric import Uint, ulen
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
+def get_valid_destinations(code: Bytes) -> Tuple[Set[Uint], Set[Uint]]:
     """
-    Analyze the EVM code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the sets of valid jump destinations and
+    valid call destinations (EIP-7979), in a single pass.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.
-        * The jump destination should have the `JUMPDEST` opcode (0x5B).
+        * The jump destination should have the `JUMPDEST` opcode (0x5B) or
+          the `CALLDEST` opcode (0xB1, EIP-7979).
         * The jump destination shouldn't be part of the data corresponding to
           `PUSH-N` opcodes.
         * The jump destination shouldn't be part of the immediate byte
           corresponding to `DUPN`, `SWAPN`, or `EXCHANGE` opcodes (EIP-8024).
 
-    Note - Jump destinations are 0-indexed.
+    Valid call destinations are the `CALLDEST` positions found by the same
+    scan: a `CALLDEST` is both a valid call destination and a valid jump
+    destination, so that a `JUMP` may enter a subroutine without pushing a
+    return address.
+
+    Note - Destinations are 0-indexed.
 
     Parameters
     ----------
@@ -42,9 +49,12 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     -------
     valid_jump_destinations: `Set[Uint]`
         The set of valid jump destinations in the code.
+    valid_call_destinations: `Set[Uint]`
+        The set of valid call destinations in the code.
 
     """
     valid_jump_destinations = set()
+    valid_call_destinations = set()
     pc = Uint(0)
 
     while pc < ulen(code):
@@ -58,6 +68,9 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
             continue
 
         if current_opcode == Ops.JUMPDEST:
+            valid_jump_destinations.add(pc)
+        elif current_opcode == Ops.CALLDEST:
+            valid_call_destinations.add(pc)
             valid_jump_destinations.add(pc)
         elif Ops.PUSH1.value <= current_opcode.value <= Ops.PUSH32.value:
             # If PUSH-N opcodes are encountered, skip the current opcode along
@@ -92,4 +105,4 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
 
         pc += Uint(1)
 
-    return valid_jump_destinations
+    return valid_jump_destinations, valid_call_destinations

--- a/tests/amsterdam/eip7979_callsub/__init__.py
+++ b/tests/amsterdam/eip7979_callsub/__init__.py
@@ -1,0 +1,5 @@
+"""
+Tests for [EIP-7979: Call and Return Opcodes for the EVM](https://eips.ethereum.org/EIPS/eip-7979).
+
+CALLSUB, CALLDEST, RETURNSUB and the return stack.
+"""

--- a/tests/amsterdam/eip7979_callsub/helpers.py
+++ b/tests/amsterdam/eip7979_callsub/helpers.py
@@ -1,0 +1,62 @@
+"""Shared bytecode builders for the EIP-7979 tests."""
+
+from typing import Callable, Tuple
+
+from execution_testing import Address, Bytecode, Op
+
+# Storage slots used by callers to record what they observed.
+SLOT_CALL_SUCCESS = 0
+SLOT_MARKER = 1
+SLOT_MARKER_AFTER_RETURN = 2
+
+MARKER_IN_SUBROUTINE = 0xA1
+MARKER_AFTER_RETURN = 0xB2
+
+# Gas handed to a callee so that its exceptional halts cannot starve the
+# caller, which still has to record the outcome.
+CALLEE_GAS = 500_000
+
+# Gas limit for the transactions in these tests.
+TX_GAS_LIMIT = 1_000_000
+
+
+def caller_recording_success(
+    callee: Address, gas: int = CALLEE_GAS
+) -> Bytecode:
+    """
+    Return caller code that CALLs `callee` and stores the success flag
+    at ``SLOT_CALL_SUCCESS``.
+
+    An exceptional halt in the callee yields 0, normal completion yields 1.
+    """
+    return Op.SSTORE(SLOT_CALL_SUCCESS, Op.CALL(gas=gas, address=callee))
+
+
+def subroutine_storing_marker() -> Bytecode:
+    """
+    Return a subroutine: CALLDEST, store ``MARKER_IN_SUBROUTINE`` at
+    ``SLOT_MARKER``, RETURNSUB.
+    """
+    return (
+        Op.CALLDEST
+        + Op.SSTORE(SLOT_MARKER, MARKER_IN_SUBROUTINE)
+        + Op.RETURNSUB
+    )
+
+
+def program(
+    main_for: Callable[[int], Bytecode], subroutine: Bytecode
+) -> Tuple[Bytecode, int]:
+    """
+    Assemble ``main_for(offset) + STOP + subroutine`` where `offset` is the
+    code offset of the subroutine.
+
+    `main_for` builds the main code given the subroutine's offset; it must
+    produce code of the same length for any offset below 256 (use PUSH1).
+    Returns the whole program and the offset.
+    """
+    offset = len(main_for(0)) + 1  # + STOP
+    assert offset < 256, "keep test programs under 256 bytes"
+    main = main_for(offset)
+    assert len(main) == len(main_for(0))
+    return main + Op.STOP + subroutine, offset

--- a/tests/amsterdam/eip7979_callsub/spec.py
+++ b/tests/amsterdam/eip7979_callsub/spec.py
@@ -1,0 +1,34 @@
+"""Reference spec for [EIP-7979: Call and Return Opcodes for the EVM](https://eips.ethereum.org/EIPS/eip-7979)."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Reference specification."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7979 = ReferenceSpec(
+    git_path="EIPS/eip-7979.md",
+    version="0b9221c7958ba4c5f2d11bfba355cafdbf2a3e1e",
+)
+
+
+class Spec:
+    """Constants and parameters from EIP-7979."""
+
+    # Placeholder opcode values, to be confirmed on final assignment.
+    CALLSUB_OPCODE: int = 0xB0
+    CALLDEST_OPCODE: int = 0xB1
+    RETURNSUB_OPCODE: int = 0xB2
+
+    # Gas costs: mid, jumpdest, low.
+    CALLSUB_GAS: int = 8
+    CALLDEST_GAS: int = 1
+    RETURNSUB_GAS: int = 5
+
+    # Maximum number of return addresses a frame's return stack may hold.
+    RETURN_STACK_LIMIT: int = 1024

--- a/tests/amsterdam/eip7979_callsub/test_call_elimination.py
+++ b/tests/amsterdam/eip7979_callsub/test_call_elimination.py
@@ -1,0 +1,179 @@
+"""
+CALLDEST as a jump destination: call elimination.
+
+A JUMP or JUMPI may land on a CALLDEST. Doing so enters the subroutine
+without pushing a return address, so the subroutine's RETURNSUB returns to
+the original caller. Compilers use this for tail calls and shared epilogues.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import (
+    CALLEE_GAS,
+    MARKER_AFTER_RETURN,
+    MARKER_IN_SUBROUTINE,
+    SLOT_CALL_SUCCESS,
+    SLOT_MARKER,
+    SLOT_MARKER_AFTER_RETURN,
+    TX_GAS_LIMIT,
+    caller_recording_success,
+    program,
+    subroutine_storing_marker,
+)
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+@pytest.mark.parametrize("conditional", [False, True], ids=["jump", "jumpi"])
+def test_jump_to_calldest(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    conditional: bool,
+) -> None:
+    """
+    JUMP and JUMPI accept a CALLDEST as destination. The subroutine body
+    runs; its RETURNSUB is not reached because the body ends with STOP.
+    """
+    subroutine = (
+        Op.CALLDEST + Op.SSTORE(SLOT_MARKER, MARKER_IN_SUBROUTINE) + Op.STOP
+    )
+
+    def main(offset: int) -> Bytecode:
+        if conditional:
+            return Op.JUMPI(offset, 1)
+        return Op.JUMP(offset)
+
+    code, _ = program(main, subroutine)
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: MARKER_IN_SUBROUTINE})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_tail_call(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Subroutine `f` ends by jumping to subroutine `g` instead of calling it.
+    `g`'s RETURNSUB returns directly to `f`'s caller, and the return stack
+    never holds more than one address.
+    """
+
+    def main(f_offset: int) -> Bytecode:
+        return Op.CALLSUB(f_offset) + Op.SSTORE(
+            SLOT_MARKER_AFTER_RETURN, MARKER_AFTER_RETURN
+        )
+
+    # Layout: main, STOP, f, g. `g` is the marker-storing subroutine.
+    g = subroutine_storing_marker()
+
+    def f_for(g_offset: int) -> Bytecode:
+        return Op.CALLDEST + Op.JUMP(g_offset)
+
+    f_offset = len(main(0)) + 1
+    g_offset = f_offset + len(f_for(0))
+    code = main(f_offset) + Op.STOP + f_for(g_offset) + g
+    assert len(code) < 256
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {
+        contract: Account(
+            storage={
+                SLOT_MARKER: MARKER_IN_SUBROUTINE,
+                SLOT_MARKER_AFTER_RETURN: MARKER_AFTER_RETURN,
+            }
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_returnsub_after_unframed_jump_halts(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Entering a subroutine by JUMP from top-level code pushes no return
+    address, so its RETURNSUB underflows.
+    """
+    callee_code = (
+        Op.PUSH1[0x04] + Op.JUMP + Op.STOP + Op.CALLDEST + Op.RETURNSUB
+    )
+    callee = pre.deploy_contract(callee_code)
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_mutual_recursion_at_constant_depth(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Two subroutines that jump to each other run a loop of 2000 iterations
+    at constant return-stack depth, well past the 1024 limit that calls
+    would hit. The counter lives on the data stack.
+    """
+    iterations = 2000
+
+    def main(a_offset: int) -> Bytecode:
+        return (
+            Op.PUSH2[iterations]
+            + Op.CALLSUB(a_offset)
+            + Op.POP
+            + Op.SSTORE(SLOT_MARKER, 1)
+        )
+
+    def a_for(b_offset: int, done: int) -> Bytecode:
+        # a: if counter == 0 return; counter -= 1; jump b
+        return (
+            Op.CALLDEST
+            + Op.DUP1
+            + Op.ISZERO
+            + Op.PUSH1[done]
+            + Op.JUMPI
+            + Op.PUSH1[1]
+            + Op.SWAP1
+            + Op.SUB
+            + Op.PUSH1[b_offset]
+            + Op.JUMP
+            + Op.JUMPDEST  # done:
+            + Op.RETURNSUB
+        )
+
+    def b_for(a_offset: int) -> Bytecode:
+        # b: jump a
+        return Op.CALLDEST + Op.PUSH1[a_offset] + Op.JUMP
+
+    a_offset = len(main(0)) + 1
+    b_offset = a_offset + len(a_for(0, 0))
+    done = b_offset - 2
+    code = main(a_offset) + Op.STOP + a_for(b_offset, done) + b_for(a_offset)
+    assert len(code) < 256
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: 1})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_callsub.py
+++ b/tests/amsterdam/eip7979_callsub/test_callsub.py
@@ -1,0 +1,185 @@
+"""
+CALLSUB destination checks and the basic call/return round trip.
+
+A CALLSUB whose destination is not a CALLDEST instruction is an exceptional
+halt: a JUMPDEST, a byte inside PUSH data, a byte inside an EIP-8024
+immediate, and any position outside the code all fail.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import (
+    CALLEE_GAS,
+    MARKER_AFTER_RETURN,
+    MARKER_IN_SUBROUTINE,
+    SLOT_CALL_SUCCESS,
+    SLOT_MARKER,
+    SLOT_MARKER_AFTER_RETURN,
+    TX_GAS_LIMIT,
+    caller_recording_success,
+    program,
+    subroutine_storing_marker,
+)
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+def test_call_and_return(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    CALLSUB enters the subroutine, RETURNSUB comes back to the instruction
+    after the CALLSUB, and execution continues from there.
+    """
+    code, _ = program(
+        lambda offset: Op.CALLSUB(offset)
+        + Op.SSTORE(SLOT_MARKER_AFTER_RETURN, MARKER_AFTER_RETURN),
+        subroutine_storing_marker(),
+    )
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {
+        contract: Account(
+            storage={
+                SLOT_MARKER: MARKER_IN_SUBROUTINE,
+                SLOT_MARKER_AFTER_RETURN: MARKER_AFTER_RETURN,
+            }
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_subroutine_called_twice(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    A subroutine may be called any number of times; each call returns to
+    its own call site.
+    """
+
+    def main(offset: int) -> Bytecode:
+        return (
+            Op.CALLSUB(offset)
+            + Op.SSTORE(SLOT_MARKER_AFTER_RETURN, 1)
+            + Op.CALLSUB(offset)
+            + Op.SSTORE(
+                SLOT_MARKER_AFTER_RETURN,
+                Op.ADD(Op.SLOAD(SLOT_MARKER_AFTER_RETURN), 1),
+            )
+        )
+
+    # The subroutine increments SLOT_MARKER on every entry.
+    subroutine = (
+        Op.CALLDEST
+        + Op.SSTORE(SLOT_MARKER, Op.ADD(Op.SLOAD(SLOT_MARKER), 1))
+        + Op.RETURNSUB
+    )
+    code, _ = program(main, subroutine)
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {
+        contract: Account(
+            storage={SLOT_MARKER: 2, SLOT_MARKER_AFTER_RETURN: 2}
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "callee_code",
+    [
+        pytest.param(
+            # Destination is a JUMPDEST, not a CALLDEST.
+            Op.PUSH1[0x04] + Op.CALLSUB + Op.STOP + Op.JUMPDEST + Op.RETURNSUB,
+            id="jumpdest",
+        ),
+        pytest.param(
+            # Destination 5 is the 0xB1 byte inside the PUSH1 immediate.
+            Op.PUSH1[0x05] + Op.CALLSUB + Op.STOP + Op.PUSH1[0xB1] + Op.STOP,
+            id="calldest_byte_in_push_data",
+        ),
+        pytest.param(
+            # Destination 5 is the 0xB1 byte inside a DUPN immediate
+            # (EIP-8024): the scan skips it, so it is not an instruction.
+            Op.PUSH1[0x05] + Op.CALLSUB + Op.STOP + Op.DUPN[0xB1] + Op.STOP,
+            id="calldest_byte_in_dupn_immediate",
+        ),
+        pytest.param(
+            # Destination is one past the end of the code.
+            Op.PUSH1[0x06] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            id="past_end_of_code",
+        ),
+        pytest.param(
+            # Destination does not fit in 64 bits.
+            Op.PUSH32[2**256 - 1]
+            + Op.CALLSUB
+            + Op.STOP
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+            id="destination_overflows_uint64",
+        ),
+        pytest.param(
+            # Destination is the CALLSUB itself.
+            Op.PUSH1[0x02] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            id="callsub_to_itself",
+        ),
+        pytest.param(
+            # CALLSUB with an empty data stack.
+            Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            id="stack_underflow",
+        ),
+    ],
+)
+def test_invalid_callsub_destination(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    callee_code: Op,
+) -> None:
+    """
+    A CALLSUB to anything but a CALLDEST instruction is an exceptional
+    halt.
+    """
+    callee = pre.deploy_contract(callee_code)
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_calldest_reached_by_fall_through(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """CALLDEST executed in sequence is a no-op, like JUMPDEST."""
+    code = (
+        Op.CALLDEST
+        + Op.CALLDEST
+        + Op.SSTORE(SLOT_MARKER, MARKER_IN_SUBROUTINE)
+        + Op.STOP
+    )
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: MARKER_IN_SUBROUTINE})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_eip_vectors.py
+++ b/tests/amsterdam/eip7979_callsub/test_eip_vectors.py
@@ -1,0 +1,100 @@
+"""
+EIP-7979 test vectors.
+
+The five programs given in the EIP, run byte-for-byte as callees. The caller
+records the call's success flag; the gas each program consumes is checked
+implicitly through the post-state root, and explicitly in ``test_gas.py``.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import SLOT_CALL_SUCCESS, TX_GAS_LIMIT, caller_recording_success
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+@pytest.mark.parametrize(
+    "bytecode,success",
+    [
+        pytest.param(
+            # PUSH1 0x04, CALLSUB, STOP, CALLDEST, RETURNSUB
+            Op.PUSH1[0x04] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            True,
+            id="simple_routine",
+        ),
+        pytest.param(
+            # PUSH1 0x04, CALLSUB, STOP, CALLDEST, PUSH1 0x09, CALLSUB,
+            # RETURNSUB, CALLDEST, RETURNSUB
+            Op.PUSH1[0x04]
+            + Op.CALLSUB
+            + Op.STOP
+            + Op.CALLDEST
+            + Op.PUSH1[0x09]
+            + Op.CALLSUB
+            + Op.RETURNSUB
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+            True,
+            id="two_levels_of_subroutines",
+        ),
+        pytest.param(
+            # PUSH1 0xFF, CALLSUB, STOP, CALLDEST, RETURNSUB:
+            # destination 255 is outside the 6-byte code.
+            Op.PUSH1[0xFF] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            False,
+            id="failure_invalid_destination",
+        ),
+        pytest.param(
+            # RETURNSUB with an empty return stack.
+            Op.RETURNSUB,
+            False,
+            id="failure_empty_return_stack",
+        ),
+        pytest.param(
+            # PUSH1 0x05, JUMP, CALLDEST, RETURNSUB, JUMPDEST, PUSH1 0x03,
+            # CALLSUB: the CALLSUB is the last byte of code; RETURNSUB
+            # returns to the implicit STOP past the end of the code.
+            Op.PUSH1[0x05]
+            + Op.JUMP
+            + Op.CALLDEST
+            + Op.RETURNSUB
+            + Op.JUMPDEST
+            + Op.PUSH1[0x03]
+            + Op.CALLSUB,
+            True,
+            id="subroutine_at_end_of_code",
+        ),
+    ],
+)
+def test_eip_vectors(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    bytecode: Op,
+    success: bool,
+) -> None:
+    """Run each EIP test vector verbatim and record whether it halted."""
+    expected_hex = {
+        "simple_routine": "6004b000b1b2",
+        "two_levels_of_subroutines": "6004b000b16009b0b2b1b2",
+        "failure_invalid_destination": "60ffb000b1b2",
+        "failure_empty_return_stack": "b2",
+        "subroutine_at_end_of_code": "600556b1b25b6003b0",
+    }
+    assert bytes(bytecode).hex() in expected_hex.values()
+
+    callee = pre.deploy_contract(bytecode)
+    caller = pre.deploy_contract(caller_recording_success(callee))
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: int(success)})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_execution_contexts.py
+++ b/tests/amsterdam/eip7979_callsub/test_execution_contexts.py
@@ -1,0 +1,131 @@
+"""
+CALLSUB, CALLDEST and RETURNSUB in initcode and in delegated code.
+
+The message-frame tests are in ``test_returnsub.py``; these cover the two
+other places code runs: contract creation (transaction initcode and
+CREATE/CREATE2) and an EIP-7702 delegated EOA.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    AuthorizationTuple,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import (
+    MARKER_IN_SUBROUTINE,
+    SLOT_MARKER,
+    TX_GAS_LIMIT,
+    program,
+    subroutine_storing_marker,
+)
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+def initcode_using_subroutine() -> Bytecode:
+    """
+    Return initcode that calls a subroutine which stores a marker, then
+    returns a one-byte runtime code (STOP).
+    """
+
+    def main(offset: int) -> Bytecode:
+        return (
+            Op.CALLSUB(offset) + Op.MSTORE8(0, Op.STOP.int()) + Op.RETURN(0, 1)
+        )
+
+    code, _ = program(main, subroutine_storing_marker())
+    return code
+
+
+def test_subroutine_in_transaction_initcode(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """A creation transaction's initcode may use subroutines."""
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode_using_subroutine(),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    created = compute_create_address(address=sender, nonce=0)
+    post = {
+        created: Account(
+            code=Op.STOP, storage={SLOT_MARKER: MARKER_IN_SUBROUTINE}
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
+def test_subroutine_in_create_initcode(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    create_opcode: Op,
+) -> None:
+    """Initcode run by CREATE and CREATE2 may use subroutines."""
+    initcode = initcode_using_subroutine()
+    factory_code = Op.CALLDATACOPY(offset=0, size=len(initcode)) + Op.SSTORE(
+        0, create_opcode(offset=0, size=len(initcode))
+    )
+    factory = pre.deploy_contract(factory_code)
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=factory,
+        data=initcode,
+        gas_limit=TX_GAS_LIMIT,
+    )
+    if create_opcode == Op.CREATE:
+        created = compute_create_address(address=factory, nonce=1)
+    else:
+        created = compute_create_address(
+            address=factory, initcode=initcode, salt=0, opcode=Op.CREATE2
+        )
+    post = {
+        factory: Account(storage={0: created}),
+        created: Account(
+            code=Op.STOP, storage={SLOT_MARKER: MARKER_IN_SUBROUTINE}
+        ),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_subroutine_in_delegated_code(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    An EIP-7702 delegated EOA runs subroutines in its own storage
+    context.
+    """
+    code, _ = program(
+        lambda offset: Op.CALLSUB(offset), subroutine_storing_marker()
+    )
+    delegate_to = pre.deploy_contract(code)
+    auth_signer = pre.fund_eoa(0)
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=auth_signer,
+        gas_limit=TX_GAS_LIMIT,
+        authorization_list=[
+            AuthorizationTuple(
+                address=delegate_to, nonce=0, signer=auth_signer
+            ),
+        ],
+    )
+    post = {
+        auth_signer: Account(storage={SLOT_MARKER: MARKER_IN_SUBROUTINE}),
+    }
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_fork_transition.py
+++ b/tests/amsterdam/eip7979_callsub/test_fork_transition.py
@@ -1,0 +1,101 @@
+"""Fork-transition tests for EIP-7979 (CALLSUB, CALLDEST, RETURNSUB)."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytecode,
+    Op,
+    Transaction,
+)
+
+from .helpers import MARKER_IN_SUBROUTINE, TX_GAS_LIMIT
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+FORK_TIMESTAMP = 15_000
+
+
+def marker_via_callsub() -> Bytecode:
+    """
+    Return code that calls a subroutine and stores the marker at the slot
+    keyed by block NUMBER. Before the fork, CALLSUB is undefined and the
+    frame halts before any write.
+    """
+    main = Op.PUSH1[0] + Op.CALLSUB + Op.STOP  # patched below
+    offset = len(main)
+    main = Op.PUSH1[offset] + Op.CALLSUB + Op.STOP
+    subroutine = (
+        Op.CALLDEST
+        + Op.PUSH1[MARKER_IN_SUBROUTINE]
+        + Op.NUMBER
+        + Op.SSTORE
+        + Op.RETURNSUB
+    )
+    return main + subroutine
+
+
+def marker_via_jump_to_calldest() -> Bytecode:
+    """
+    Return code that JUMPs to a CALLDEST and stores the marker at the slot
+    keyed by block NUMBER. Before the fork a 0xB1 byte is not a valid jump
+    destination, so the JUMP halts the frame.
+    """
+    main = Op.PUSH1[0] + Op.JUMP + Op.STOP
+    offset = len(main)
+    main = Op.PUSH1[offset] + Op.JUMP + Op.STOP
+    subroutine = (
+        Op.CALLDEST
+        + Op.PUSH1[MARKER_IN_SUBROUTINE]
+        + Op.NUMBER
+        + Op.SSTORE
+        + Op.STOP
+    )
+    return main + subroutine
+
+
+@pytest.mark.valid_at_transition_to("EIP7979")
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(marker_via_callsub(), id="callsub"),
+        pytest.param(marker_via_jump_to_calldest(), id="jump_to_calldest"),
+    ],
+)
+def test_opcodes_at_fork_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    code: Bytecode,
+) -> None:
+    """
+    Before the fork the new opcodes are undefined and 0xB1 is not a jump
+    destination; from the fork onward the code runs and stores its marker.
+
+    Storage is keyed by block NUMBER so each block's outcome is visible:
+    block 1 (pre-fork) stays 0; blocks 2 and 3 hold the marker.
+    """
+    sender = pre.fund_eoa()
+    contract = pre.deploy_contract(code)
+    blocks = [
+        Block(
+            timestamp=ts,
+            txs=[
+                Transaction(sender=sender, to=contract, gas_limit=TX_GAS_LIMIT)
+            ],
+        )
+        for ts in (FORK_TIMESTAMP - 1, FORK_TIMESTAMP, FORK_TIMESTAMP + 1)
+    ]
+    post = {
+        contract: Account(
+            storage={
+                1: 0,
+                2: MARKER_IN_SUBROUTINE,
+                3: MARKER_IN_SUBROUTINE,
+            }
+        )
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip7979_callsub/test_gas.py
+++ b/tests/amsterdam/eip7979_callsub/test_gas.py
@@ -1,0 +1,122 @@
+"""
+Gas costs of CALLSUB (mid, 8), CALLDEST (jumpdest, 1) and RETURNSUB (low, 5).
+
+Each measurement wraps a call sequence in GAS reads and stores the
+difference; the subroutine bodies live after the measured code.
+"""
+
+from typing import Callable
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    CodeGasMeasure,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import TX_GAS_LIMIT
+from .spec import Spec, ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+PUSH1_GAS = 3
+
+
+def measured_program(
+    measured_for: Callable[[int], Bytecode],
+    subroutines_for: Callable[[int], Bytecode],
+) -> Bytecode:
+    """
+    Build ``CodeGasMeasure(measured_for(offset)) + STOP +
+    subroutines_for(offset)``, where `offset` is the code offset at which
+    the subroutines start.
+    """
+    probe = CodeGasMeasure(code=measured_for(0), sstore_key=0)
+    offset = len(probe) + 1  # + STOP
+    assert offset < 256
+    measure = CodeGasMeasure(code=measured_for(offset), sstore_key=0)
+    assert len(measure) == len(probe)
+    return measure + Op.STOP + subroutines_for(offset)
+
+
+@pytest.mark.parametrize(
+    "case,expected_gas",
+    [
+        pytest.param(
+            "call_and_return",
+            PUSH1_GAS
+            + Spec.CALLSUB_GAS
+            + Spec.CALLDEST_GAS
+            + Spec.RETURNSUB_GAS,
+            id="call_and_return_17",
+        ),
+        pytest.param(
+            "two_levels",
+            2
+            * (
+                PUSH1_GAS
+                + Spec.CALLSUB_GAS
+                + Spec.CALLDEST_GAS
+                + Spec.RETURNSUB_GAS
+            ),
+            id="two_levels_34",
+        ),
+        pytest.param("calldest_alone", Spec.CALLDEST_GAS, id="calldest_1"),
+        pytest.param(
+            "two_calldests_in_subroutine",
+            PUSH1_GAS
+            + Spec.CALLSUB_GAS
+            + 2 * Spec.CALLDEST_GAS
+            + Spec.RETURNSUB_GAS,
+            id="extra_calldest_18",
+        ),
+    ],
+)
+def test_gas_costs(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    case: str,
+    expected_gas: int,
+) -> None:
+    """
+    Measure the gas of call sequences.
+
+    The totals match the EIP's worked examples.
+    """
+    if case == "call_and_return":
+        code = measured_program(
+            lambda offset: Op.CALLSUB(offset),
+            lambda _: Op.CALLDEST + Op.RETURNSUB,
+        )
+    elif case == "two_levels":
+        # sub1 (5 bytes: CALLDEST, PUSH1, CALLSUB, RETURNSUB) at `offset`
+        # calls sub2 at `offset + 5`.
+        code = measured_program(
+            lambda offset: Op.CALLSUB(offset),
+            lambda offset: Op.CALLDEST
+            + Op.CALLSUB(offset + 5)
+            + Op.RETURNSUB
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+        )
+    elif case == "calldest_alone":
+        code = measured_program(lambda _: Op.CALLDEST, lambda _: Op.STOP)
+    else:
+        code = measured_program(
+            lambda offset: Op.CALLSUB(offset),
+            lambda _: Op.CALLDEST + Op.CALLDEST + Op.RETURNSUB,
+        )
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={0: expected_gas})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_returnsub.py
+++ b/tests/amsterdam/eip7979_callsub/test_returnsub.py
@@ -1,0 +1,220 @@
+"""
+RETURNSUB and the return stack: underflow, the 1024-entry limit, and the
+frame boundary.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import (
+    CALLEE_GAS,
+    SLOT_CALL_SUCCESS,
+    SLOT_MARKER,
+    TX_GAS_LIMIT,
+    caller_recording_success,
+    program,
+)
+from .spec import Spec, ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+@pytest.mark.parametrize(
+    "callee_code",
+    [
+        pytest.param(Op.RETURNSUB, id="first_instruction"),
+        pytest.param(
+            # Falling into a subroutine pushes no return address.
+            Op.CALLDEST + Op.RETURNSUB,
+            id="after_fall_through_into_calldest",
+        ),
+        pytest.param(
+            # One CALLSUB, two RETURNSUBs: the second underflows.
+            Op.PUSH1[0x04]
+            + Op.CALLSUB
+            + Op.RETURNSUB
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+            id="second_returnsub_after_one_callsub",
+        ),
+    ],
+)
+def test_returnsub_underflow(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    callee_code: Op,
+) -> None:
+    """RETURNSUB with an empty return stack is an exceptional halt."""
+    callee = pre.deploy_contract(callee_code)
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def counted_recursion(depth: int) -> Bytecode:
+    """
+    Return a program whose subroutine calls itself `depth` times, using a
+    counter on the data stack, then stores 1 at ``SLOT_MARKER``.
+
+    The return stack reaches `depth` + 1 entries: one for the outer call
+    plus one per recursive call.
+    """
+
+    def main(offset: int) -> Bytecode:
+        return (
+            Op.PUSH2[depth]
+            + Op.CALLSUB(offset)
+            + Op.POP
+            + Op.SSTORE(SLOT_MARKER, 1)
+        )
+
+    def subroutine_for(offset: int, done: int) -> Bytecode:
+        return (
+            Op.CALLDEST
+            # if counter == 0: jump to done
+            + Op.DUP1
+            + Op.ISZERO
+            + Op.PUSH1[done]
+            + Op.JUMPI
+            # counter -= 1
+            + Op.PUSH1[1]
+            + Op.SWAP1
+            + Op.SUB
+            # recurse
+            + Op.PUSH1[offset]
+            + Op.CALLSUB
+            + Op.RETURNSUB
+            + Op.JUMPDEST  # done:
+            + Op.RETURNSUB
+        )
+
+    offset = len(main(0)) + 1
+    # `done` is the JUMPDEST just before the last RETURNSUB.
+    done = offset + len(subroutine_for(0, 0)) - 2
+    code = main(offset) + Op.STOP + subroutine_for(offset, done)
+    assert len(code) < 256
+    return code
+
+
+@pytest.mark.parametrize(
+    "depth,success",
+    [
+        pytest.param(Spec.RETURN_STACK_LIMIT - 1, True, id="at_limit"),
+        pytest.param(Spec.RETURN_STACK_LIMIT, False, id="over_limit"),
+    ],
+)
+def test_return_stack_limit(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    depth: int,
+    success: bool,
+) -> None:
+    """
+    The return stack holds at most 1024 addresses: recursion 1023 deep
+    (1024 entries) completes, one level deeper halts.
+    """
+    callee = pre.deploy_contract(counted_recursion(depth))
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {
+        caller: Account(storage={SLOT_CALL_SUCCESS: int(success)}),
+        callee: Account(storage={SLOT_MARKER: int(success)}),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_unbounded_recursion_halts(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Recursion with no base case halts on return-stack overflow, not on
+    running out of gas.
+    """
+    # PUSH1 4, CALLSUB, STOP, CALLDEST, PUSH1 4, CALLSUB, RETURNSUB
+    callee_code = (
+        Op.PUSH1[0x04]
+        + Op.CALLSUB
+        + Op.STOP
+        + Op.CALLDEST
+        + Op.PUSH1[0x04]
+        + Op.CALLSUB
+        + Op.RETURNSUB
+    )
+    callee = pre.deploy_contract(callee_code)
+    # Record the gas left after the call: an overflow halt consumes only
+    # the callee's gas, so the caller keeps roughly what it withheld.
+    caller_code = Op.SSTORE(
+        SLOT_CALL_SUCCESS, Op.CALL(gas=CALLEE_GAS, address=callee)
+    ) + Op.SSTORE(SLOT_MARKER, Op.GT(Op.GAS, 100_000))
+    caller = pre.deploy_contract(caller_code)
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0, SLOT_MARKER: 1})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "call_opcode",
+    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL],
+)
+@pytest.mark.parametrize(
+    "callee_code,callee_success",
+    [
+        pytest.param(Op.RETURNSUB, 0, id="callee_underflows_own_return_stack"),
+        pytest.param(
+            Op.PUSH1[0x04] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            1,
+            id="callee_uses_own_return_stack",
+        ),
+    ],
+)
+def test_return_stack_is_per_frame(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+    callee_code: Op,
+    callee_success: int,
+) -> None:
+    """
+    Each message frame has its own return stack. A callee starts with an
+    empty one even while the caller's holds a return address, and the
+    caller's return address survives the nested call.
+    """
+    callee = pre.deploy_contract(callee_code)
+
+    def main(offset: int) -> Bytecode:
+        # Call the subroutine, which performs the nested call; then store
+        # a marker to prove RETURNSUB brought us back here.
+        return Op.CALLSUB(offset) + Op.SSTORE(SLOT_MARKER, 1)
+
+    subroutine = (
+        Op.CALLDEST
+        + Op.SSTORE(
+            SLOT_CALL_SUCCESS, call_opcode(gas=CALLEE_GAS, address=callee)
+        )
+        + Op.RETURNSUB
+    )
+    code, _ = program(main, subroutine)
+    caller = pre.deploy_contract(code)
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {
+        caller: Account(
+            storage={SLOT_CALL_SUCCESS: callee_success, SLOT_MARKER: 1}
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -46,6 +46,13 @@ def prepare_stack(opcode: Opcode) -> Bytecode:
         return Op.PUSH1(1) + Op.PUSH1(5)
     if opcode == Op.JUMP:
         return Op.PUSH1(3)
+    if opcode == Op.CALLSUB:
+        # EIP-7979: call the CALLDEST placed right after the CALLSUB.
+        return Op.PUSH1(3)
+    if opcode == Op.RETURNSUB:
+        # EIP-7979: jump over the RETURNSUB to the suffix, which calls the
+        # CALLDEST just before it; the RETURNSUB then returns to the STOP.
+        return Op.PUSH1(5) + Op.JUMP + Op.CALLDEST
     if opcode == Op.RETURNDATACOPY:
         return Op.PUSH1(0) * 3
     return Op.PUSH1(0x01) * 32
@@ -55,6 +62,10 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     """Prepare after opcode instructions."""
     if opcode == Op.JUMPI or opcode == Op.JUMP:
         return Op.JUMPDEST
+    if opcode == Op.CALLSUB:
+        return Op.CALLDEST
+    if opcode == Op.RETURNSUB:
+        return Op.JUMPDEST + Op.PUSH1(3) + Op.CALLSUB + Op.STOP
     return Op.STOP
 
 
@@ -217,6 +228,8 @@ def fork_opcodes_with_non_increasing_stack(
                 # Incompatible with this test:
                 Op.REVERT,  # Reverts the storage required
                 Op.JUMP,  # Tries to jump to non-jumpdest
+                Op.CALLSUB,  # Tries to call a non-calldest (EIP-7979)
+                Op.RETURNSUB,  # Empty return stack (EIP-7979)
                 Op.BLOCKHASH,  # Incompatible with state_test
                 Op.SELFDESTRUCT,  # selfdestructs the contract in old forks
             ]:
@@ -270,7 +283,7 @@ def prepare_stack_constant_gas_oog(opcode: Opcode) -> Bytecode:
     """Prepare valid stack for opcode."""
     if opcode == Op.JUMPI:
         return Op.PUSH1(1) + Op.PUSH1(3) + Op.PC + Op.ADD
-    if opcode == Op.JUMP:
+    if opcode == Op.JUMP or opcode == Op.CALLSUB:
         return Op.PUSH1(3) + Op.PC + Op.ADD
     if opcode == Op.BLOCKHASH:
         return Op.PUSH1(0x01)
@@ -291,6 +304,11 @@ def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
         # the state reservoir that cannot be measured via the GAS opcode
         # delta used by gas_test. Excluded to keep the test meaningful.
         if fork.is_eip_enabled(8037) and opcode in (Op.CREATE, Op.CREATE2):
+            continue
+        # EIP-7979: RETURNSUB needs a CALLSUB in the same frame, which this
+        # harness cannot arrange; its cost is measured in
+        # tests/amsterdam/eip7979_callsub/test_gas.py.
+        if opcode == Op.RETURNSUB:
             continue
         yield pytest.param(
             opcode,


### PR DESCRIPTION
Reference implementation and tests for [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979), proposed for Hegotá (PFI, ethspecs/pm#72). All 130 fixtures fill against the spec; 'just static' is clean.

EIP-7979 adds explicit call and return instructions to the EVM: a per-frame return stack and three opcodes, CALLSUB (0xB0), CALLDEST (0xB1) and RETURNSUB (0xB2), using the EIP's placeholder values.

Spec (src/ethereum/forks/amsterdam):
- Evm gains `return_stack` and `valid_call_destinations`; RETURN_STACK_LIMIT = 1024.
- The JUMPDEST scan becomes a single pass, `get_valid_destinations`, returning both the jump and the call destination sets. A CALLDEST is both, so JUMP and JUMPI need no change. The EIP-8024 immediate handling is preserved.
- callsub/calldest/returnsub in control_flow.py; ReturnStackOverflowError and ReturnStackUnderflowError; gas costs mid (8), jumpdest (1) and low (5).

Framework (packages/testing):
- Opcode table entries and the EIP7979 fork mixin, picked up by Amsterdam automatically.

Tests (tests/amsterdam/eip7979_callsub, 44 tests, 130 fixtures):
- The EIP's five vectors byte-for-byte; invalid destinations (JUMPDEST, PUSH data, DUPN immediate, out of range, uint64 overflow, self, stack underflow); return-stack underflow; the 1024 limit by counted recursion; per-frame isolation across all four call opcodes; call elimination via JUMP/JUMPI, tail call and mutual recursion at constant depth; exact gas by measurement; initcode, CREATE, CREATE2 and 7702 contexts; fork transition.
- tests/frontier/opcodes/test_all_opcodes.py: CALLSUB and RETURNSUB get the same special-casing as JUMP in the generic harness.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ X] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [X ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture
<img width="201" height="267" alt="image" src="https://github.com/user-attachments/assets/3d2ed2cb-d7d0-4bfd-a8e7-1c97d532764c" />

