### PR TITLE
feat(forks,tests): implement EIP-8337 Validated EVM Code

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7979.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_7979.py
@@ -1,0 +1,40 @@
+"""
+EIP-7979: Call and Return Opcodes for the EVM.
+
+Three instructions and a return stack: CALLSUB, CALLDEST and RETURNSUB.
+
+https://eips.ethereum.org/EIPS/eip-7979
+"""
+
+from typing import Callable, Dict, List
+
+from execution_testing.vm import OpcodeBase, Opcodes
+
+from ....base_fork import BaseFork
+
+
+class EIP7979(BaseFork):
+    """EIP-7979 class."""
+
+    @classmethod
+    def valid_opcodes(cls) -> List[Opcodes]:
+        """Add CALLSUB, CALLDEST and RETURNSUB to valid opcodes."""
+        return [
+            Opcodes.CALLSUB,
+            Opcodes.CALLDEST,
+            Opcodes.RETURNSUB,
+        ] + super(EIP7979, cls).valid_opcodes()
+
+    @classmethod
+    def opcode_gas_map(
+        cls,
+    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
+        """Add the gas costs of CALLSUB, CALLDEST and RETURNSUB."""
+        gas_costs = cls.gas_costs()
+        base_map = super(EIP7979, cls).opcode_gas_map()
+        return {
+            **base_map,
+            Opcodes.CALLSUB: gas_costs.MID,
+            Opcodes.CALLDEST: gas_costs.OPCODE_JUMPDEST,
+            Opcodes.RETURNSUB: gas_costs.LOW,
+        }

--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8337.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8337.py
@@ -1,0 +1,16 @@
+"""
+EIP-8337: Validated EVM Code.
+
+Code prefixed with MAGIC bytes is validated at CREATE time to have fully
+static control flow and never underflow the data stack. No new opcodes.
+
+https://eips.ethereum.org/EIPS/eip-8337
+"""
+
+from ....base_fork import BaseFork
+
+
+class EIP8337(BaseFork):
+    """EIP-8337 class."""
+
+    pass

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -5274,6 +5274,98 @@ class Opcodes(Opcode, Enum):
     Source: [evm.codes/#A4](https://www.evm.codes/#A4)
     """
 
+    CALLSUB = Opcode(0xB0, popped_stack_items=1, kwargs=["pc"])
+    """
+    CALLSUB(pc)
+    ----
+
+    Description
+    ----
+    Transfer control to a subroutine (EIP-7979): push the position of the
+    next instruction onto the return stack and jump to `pc`, which must be a
+    CALLDEST instruction. Halts if `pc` is not a CALLDEST or the return stack
+    already holds 1024 items.
+
+    Inputs
+    ----
+    - pc: byte offset in the deployed code of the subroutine entry.
+          Must be a CALLDEST instruction
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    EIP-7979
+
+    Gas
+    ----
+    8
+
+    Source: [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979)
+    """
+
+    CALLDEST = Opcode(0xB1)
+    """
+    CALLDEST()
+    ----
+
+    Description
+    ----
+    Mark a subroutine entry (EIP-7979). Like JUMPDEST it is otherwise a
+    no-op. It is the only valid CALLSUB destination, and also a valid JUMP
+    and JUMPI destination, so a jump may enter a subroutine without pushing
+    a return address.
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    EIP-7979
+
+    Gas
+    ----
+    1
+
+    Source: [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979)
+    """
+
+    RETURNSUB = Opcode(0xB2)
+    """
+    RETURNSUB()
+    ----
+
+    Description
+    ----
+    Return control to the most recent caller (EIP-7979): pop the return
+    stack into the program counter. Halts if the return stack is empty.
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    EIP-7979
+
+    Gas
+    ----
+    5
+
+    Source: [EIP-7979](https://eips.ethereum.org/EIPS/eip-7979)
+    """
+
     DUPN = Opcode(
         0xE6,
         pushed_stack_items=1,

--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -14,6 +14,7 @@ deterministic ``CREATE2`` factory predeploy.
 - [EIP-7981: Increase Access List Cost][EIP-7981]
 - [EIP-7997: Deterministic Factory Predeploy][EIP-7997]
 - [EIP-8024: Stack Access Instructions][EIP-8024]
+- [EIP-7979: Call and Return Opcodes for the EVM][EIP-7979]
 - [EIP-8037: State Creation Gas Cost Increase][EIP-8037]
 - [EIP-8038: State Access Gas Cost Increase][EIP-8038]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
@@ -32,6 +33,7 @@ deterministic ``CREATE2`` factory predeploy.
 [EIP-7981]: https://eips.ethereum.org/EIPS/eip-7981
 [EIP-7997]: https://eips.ethereum.org/EIPS/eip-7997
 [EIP-8024]: https://eips.ethereum.org/EIPS/eip-8024
+[EIP-7979]: https://eips.ethereum.org/EIPS/eip-7979
 [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 [EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246

--- a/src/ethereum/forks/amsterdam/__init__.py
+++ b/src/ethereum/forks/amsterdam/__init__.py
@@ -15,6 +15,7 @@ deterministic ``CREATE2`` factory predeploy.
 - [EIP-7997: Deterministic Factory Predeploy][EIP-7997]
 - [EIP-8024: Stack Access Instructions][EIP-8024]
 - [EIP-7979: Call and Return Opcodes for the EVM][EIP-7979]
+- [EIP-8337: Validated EVM Code][EIP-8337]
 - [EIP-8037: State Creation Gas Cost Increase][EIP-8037]
 - [EIP-8038: State Access Gas Cost Increase][EIP-8038]
 - [EIP-8246: Remove SELFDESTRUCT balance burn][EIP-8246]
@@ -34,6 +35,7 @@ deterministic ``CREATE2`` factory predeploy.
 [EIP-7997]: https://eips.ethereum.org/EIPS/eip-7997
 [EIP-8024]: https://eips.ethereum.org/EIPS/eip-8024
 [EIP-7979]: https://eips.ethereum.org/EIPS/eip-7979
+[EIP-8337]: https://eips.ethereum.org/EIPS/eip-8337
 [EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 [EIP-8038]: https://eips.ethereum.org/EIPS/eip-8038
 [EIP-8246]: https://eips.ethereum.org/EIPS/eip-8246

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -36,6 +36,10 @@ from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
 from .gas import GasMeter, repay_state_gas_spill
 
+# EIP-7979: the maximum number of return addresses a frame's return stack
+# may hold. A `CALLSUB` that would exceed it is an exceptional halt.
+RETURN_STACK_LIMIT = Uint(1024)
+
 __all__ = ("Environment", "Evm")
 TRANSFER_TOPIC = keccak256(b"Transfer(address,address,uint256)")
 SYSTEM_ADDRESS = Address(
@@ -160,11 +164,17 @@ class Evm:
 
     pc: Uint
     stack: List[U256]
+    # EIP-7979: return addresses, pushed only by `CALLSUB`, popped only by
+    # `RETURNSUB`, and not otherwise accessible to EVM code.
+    return_stack: List[Uint]
     memory: bytearray
     # Init code for a creation; the resolved code for a call.
     code: Bytes
     gas_meter: GasMeter
     valid_jump_destinations: Set[Uint]
+    # EIP-7979: positions of `CALLDEST` instructions, the only valid
+    # destinations of a `CALLSUB`. Every one is also a valid jump destination.
+    valid_call_destinations: Set[Uint]
     logs: Tuple[Log, ...]
     running: bool
 

--- a/src/ethereum/forks/amsterdam/vm/exceptions.py
+++ b/src/ethereum/forks/amsterdam/vm/exceptions.py
@@ -75,10 +75,32 @@ class InvalidJumpDestError(ExceptionalHalt):
     following criteria.
 
       * The jump destination is less than the length of the code.
-      * The jump destination should have the `JUMPDEST` opcode (0x5B).
+      * The jump destination should have the `JUMPDEST` opcode (0x5B), or
+        the `CALLDEST` opcode (0xB1, EIP-7979).
       * The jump destination shouldn't be part of the data corresponding to
         `PUSH-N` opcodes.
+
+    Also raised by `CALLSUB` (EIP-7979) when its destination is not a
+    `CALLDEST` meeting the same criteria.
     """
+
+
+class ReturnStackOverflowError(ExceptionalHalt):
+    """
+    Raised when `CALLSUB` would push a return address onto a return stack
+    that already holds `RETURN_STACK_LIMIT` (1024) items (EIP-7979).
+    """
+
+    pass
+
+
+class ReturnStackUnderflowError(ExceptionalHalt):
+    """
+    Raised when `RETURNSUB` is executed with an empty return stack
+    (EIP-7979).
+    """
+
+    pass
 
 
 class StackDepthLimitError(ExceptionalHalt):

--- a/src/ethereum/forks/amsterdam/vm/exceptions.py
+++ b/src/ethereum/forks/amsterdam/vm/exceptions.py
@@ -85,6 +85,15 @@ class InvalidJumpDestError(ExceptionalHalt):
     """
 
 
+class InvalidValidatedCode(ExceptionalHalt):
+    """
+    Raised at `CREATE` when code beginning with the `MAGIC` bytes fails
+    validation (EIP-8337).
+    """
+
+    pass
+
+
 class ReturnStackOverflowError(ExceptionalHalt):
     """
     Raised when `CALLSUB` would push a return address onto a return stack

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -205,6 +205,10 @@ class GasCosts:
     OPCODE_JUMP: Final[ExecutionGas] = MID
     OPCODE_JUMPI: Final[ExecutionGas] = HIGH
     OPCODE_JUMPDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    # EIP-7979: Call and return opcodes
+    OPCODE_CALLSUB: Final[ExecutionGas] = MID
+    OPCODE_CALLDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    OPCODE_RETURNSUB: Final[ExecutionGas] = LOW
     OPCODE_CALLDATALOAD: Final[ExecutionGas] = VERY_LOW
     OPCODE_BLOCKHASH: Final[ExecutionGas] = ExecutionGas(Uint(20))
     OPCODE_COINBASE: Final[ExecutionGas] = BASE

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -205,6 +205,8 @@ class GasCosts:
     OPCODE_JUMP: Final[ExecutionGas] = MID
     OPCODE_JUMPI: Final[ExecutionGas] = HIGH
     OPCODE_JUMPDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))
+    # EIP-8337: validation of MAGIC code at CREATE, per byte of code
+    VALIDATION_BYTE: Final[ExecutionGas] = ExecutionGas(Uint(64))
     # EIP-7979: Call and return opcodes
     OPCODE_CALLSUB: Final[ExecutionGas] = MID
     OPCODE_CALLDEST: Final[ExecutionGas] = ExecutionGas(Uint(1))

--- a/src/ethereum/forks/amsterdam/vm/instructions/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/__init__.py
@@ -194,6 +194,11 @@ class Ops(enum.Enum):
     SWAPN = 0xE7
     EXCHANGE = 0xE8
 
+    # EIP-7979: Call and return instructions
+    CALLSUB = 0xB0
+    CALLDEST = 0xB1
+    RETURNSUB = 0xB2
+
     # Memory Operations
     MLOAD = 0x51
     MSTORE = 0x52
@@ -291,6 +296,9 @@ op_implementation: Dict[Ops, Callable] = {
     Ops.PC: control_flow_instructions.pc,
     Ops.GAS: control_flow_instructions.gas_left,
     Ops.JUMPDEST: control_flow_instructions.jumpdest,
+    Ops.CALLSUB: control_flow_instructions.callsub,
+    Ops.CALLDEST: control_flow_instructions.calldest,
+    Ops.RETURNSUB: control_flow_instructions.returnsub,
     Ops.POP: stack_instructions.pop,
     Ops.PUSH0: stack_instructions.push0,
     Ops.PUSH1: stack_instructions.push1,

--- a/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
@@ -11,7 +11,7 @@ Introduction
 Implementations of the EVM control flow instructions.
 """
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ...vm.gas import (
     GasCosts,
@@ -199,7 +199,7 @@ def callsub(evm: Evm) -> None:
     # OPERATION
     if destination not in evm.valid_call_destinations:
         raise InvalidJumpDestError
-    if Uint(len(evm.return_stack)) >= RETURN_STACK_LIMIT:
+    if ulen(evm.return_stack) >= RETURN_STACK_LIMIT:
         raise ReturnStackOverflowError
     evm.return_stack.append(evm.pc + Uint(1))
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/control_flow.py
@@ -17,8 +17,12 @@ from ...vm.gas import (
     GasCosts,
     charge_gas,
 )
-from .. import Evm
-from ..exceptions import InvalidJumpDestError
+from .. import RETURN_STACK_LIMIT, Evm
+from ..exceptions import (
+    InvalidJumpDestError,
+    ReturnStackOverflowError,
+    ReturnStackUnderflowError,
+)
 from ..stack import pop, push
 
 
@@ -172,3 +176,83 @@ def jumpdest(evm: Evm) -> None:
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)
+
+
+def callsub(evm: Evm) -> None:
+    """
+    Transfer control to a subroutine (EIP-7979): push the position of the
+    next instruction onto the return stack and jump to the `CALLDEST` whose
+    position is on top of the data stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    """
+    # STACK
+    destination = Uint(pop(evm.stack))
+
+    # GAS
+    charge_gas(evm, GasCosts.OPCODE_CALLSUB)
+
+    # OPERATION
+    if destination not in evm.valid_call_destinations:
+        raise InvalidJumpDestError
+    if Uint(len(evm.return_stack)) >= RETURN_STACK_LIMIT:
+        raise ReturnStackOverflowError
+    evm.return_stack.append(evm.pc + Uint(1))
+
+    # PROGRAM COUNTER
+    evm.pc = destination
+
+
+def calldest(evm: Evm) -> None:
+    """
+    Mark a subroutine entry (EIP-7979). Like `JUMPDEST`, this is a noop:
+    it is the only valid destination of a `CALLSUB`, and also a valid
+    destination of `JUMP` and `JUMPI`, which enter the subroutine without
+    pushing a return address.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    """
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GasCosts.OPCODE_CALLDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
+    evm.pc += Uint(1)
+
+
+def returnsub(evm: Evm) -> None:
+    """
+    Return control to the most recent caller (EIP-7979): pop the return
+    stack into the program counter.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    """
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GasCosts.OPCODE_RETURNSUB)
+
+    # OPERATION
+    if len(evm.return_stack) == 0:
+        raise ReturnStackUnderflowError
+
+    # PROGRAM COUNTER
+    evm.pc = evm.return_stack.pop()

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -411,6 +411,8 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         params.memory_input_size,
     )
 
+    from ...vm.validation import code_entry_point
+
     valid_jump_destinations, valid_call_destinations = get_valid_destinations(
         params.code
     )
@@ -440,7 +442,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
             state_gas_left=params.state_gas_reservoir,
             state_gas_baseline=params.state_gas_reservoir,
         ),
-        pc=Uint(0),
+        pc=code_entry_point(params.code),
         stack=[],
         return_stack=[],
         memory=bytearray(),

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -82,7 +82,7 @@ def generic_create(
     # These imports cause a circular import error
     # if they're not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create
-    from ...vm.runtime import get_valid_jump_destinations
+    from ...vm.runtime import get_valid_destinations
 
     tx_state = evm.tx_env.state
 
@@ -136,6 +136,9 @@ def generic_create(
     increment_nonce(tx_state, sender_address)
 
     # DISPATCH
+    valid_jump_destinations, valid_call_destinations = get_valid_destinations(
+        init_code
+    )
 
     child_evm = Evm(
         # Context
@@ -154,7 +157,8 @@ def generic_create(
         # Code
         code_address=None,
         code=init_code,
-        valid_jump_destinations=get_valid_jump_destinations(init_code),
+        valid_jump_destinations=valid_jump_destinations,
+        valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=GasMeter(
             gas_left=create_message_gas,
@@ -163,6 +167,7 @@ def generic_create(
         ),
         pc=Uint(0),
         stack=[],
+        return_stack=[],
         memory=bytearray(),
         return_data=b"",
         # Accrued Effects
@@ -383,7 +388,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
     resolution of its outcome back into the calling frame.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_call
-    from ...vm.runtime import get_valid_jump_destinations
+    from ...vm.runtime import get_valid_destinations
 
     evm.return_data = b""
 
@@ -406,6 +411,10 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         params.memory_input_size,
     )
 
+    valid_jump_destinations, valid_call_destinations = get_valid_destinations(
+        params.code
+    )
+
     child_evm = Evm(
         # Context
         block_env=evm.block_env,
@@ -423,7 +432,8 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         # Code
         code_address=params.code_address,
         code=params.code,
-        valid_jump_destinations=get_valid_jump_destinations(params.code),
+        valid_jump_destinations=valid_jump_destinations,
+        valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=GasMeter(
             gas_left=params.gas,
@@ -432,6 +442,7 @@ def generic_call(evm: Evm, params: GenericCall) -> None:
         ),
         pc=Uint(0),
         stack=[],
+        return_stack=[],
         memory=bytearray(),
         return_data=b"",
         # Accrued Effects

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -79,7 +79,7 @@ from .exceptions import (
     StackDepthLimitError,
 )
 from .instructions import Ops, op_implementation
-from .runtime import get_valid_jump_destinations
+from .runtime import get_valid_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x10000
@@ -201,6 +201,9 @@ def create_evm(
         )
 
     ## Build the frame
+    valid_jump_destinations, valid_call_destinations = get_valid_destinations(
+        code
+    )
     return Evm(
         # Context
         block_env=block_env,
@@ -218,11 +221,13 @@ def create_evm(
         # Code
         code_address=code_address,
         code=code,
-        valid_jump_destinations=get_valid_jump_destinations(code),
+        valid_jump_destinations=valid_jump_destinations,
+        valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=gas_meter,
         pc=Uint(0),
         stack=[],
+        return_stack=[],
         memory=bytearray(),
         return_data=b"",
         # Accrued Effects

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -74,12 +74,14 @@ from .exceptions import (
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
+    InvalidValidatedCode,
     OutOfGasError,
     Revert,
     StackDepthLimitError,
 )
 from .instructions import Ops, op_implementation
 from .runtime import get_valid_destinations
+from .validation import code_entry_point, is_magic_code, validate_code
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x10000
@@ -225,7 +227,7 @@ def create_evm(
         valid_call_destinations=valid_call_destinations,
         # Machine State
         gas_meter=gas_meter,
-        pc=Uint(0),
+        pc=Uint(0) if tx_env.is_create else code_entry_point(code),
         stack=[],
         return_stack=[],
         memory=bytearray(),
@@ -372,10 +374,23 @@ def process_create(evm: Evm) -> Evm:
         contract_code = evm.output
         try:
             if len(contract_code) > 0:
-                if contract_code[0] == 0xEF:
+                if contract_code[0] == 0xEF and not is_magic_code(
+                    contract_code
+                ):
                     raise InvalidContractPrefix
             if len(contract_code) > MAX_CODE_SIZE:
                 raise OutOfGasError
+            if is_magic_code(contract_code):
+                # EIP-8337: validation is paid for before it runs, so an
+                # under-funded creation halts without validating.
+                charge_gas(
+                    evm,
+                    ExecutionGas(
+                        GasCosts.VALIDATION_BYTE * ulen(contract_code)
+                    ),
+                )
+                if not validate_code(contract_code):
+                    raise InvalidValidatedCode
             # Hash cost for computing keccak256 of deployed bytecode
             code_hash_gas = ExecutionGas(
                 GasCosts.OPCODE_KECCAK256_PER_WORD

--- a/src/ethereum/forks/amsterdam/vm/runtime.py
+++ b/src/ethereum/forks/amsterdam/vm/runtime.py
@@ -11,7 +11,7 @@ Introduction
 Runtime related operations used while executing EVM code.
 """
 
-from typing import Set
+from typing import Set, Tuple
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
@@ -19,19 +19,26 @@ from ethereum_types.numeric import Uint, ulen
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
+def get_valid_destinations(code: Bytes) -> Tuple[Set[Uint], Set[Uint]]:
     """
-    Analyze the EVM code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the sets of valid jump destinations and
+    valid call destinations (EIP-7979), in a single pass.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.
-        * The jump destination should have the `JUMPDEST` opcode (0x5B).
+        * The jump destination should have the `JUMPDEST` opcode (0x5B) or
+          the `CALLDEST` opcode (0xB1, EIP-7979).
         * The jump destination shouldn't be part of the data corresponding to
           `PUSH-N` opcodes.
         * The jump destination shouldn't be part of the immediate byte
           corresponding to `DUPN`, `SWAPN`, or `EXCHANGE` opcodes (EIP-8024).
 
-    Note - Jump destinations are 0-indexed.
+    Valid call destinations are the `CALLDEST` positions found by the same
+    scan: a `CALLDEST` is both a valid call destination and a valid jump
+    destination, so that a `JUMP` may enter a subroutine without pushing a
+    return address.
+
+    Note - Destinations are 0-indexed.
 
     Parameters
     ----------
@@ -42,9 +49,12 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     -------
     valid_jump_destinations: `Set[Uint]`
         The set of valid jump destinations in the code.
+    valid_call_destinations: `Set[Uint]`
+        The set of valid call destinations in the code.
 
     """
     valid_jump_destinations = set()
+    valid_call_destinations = set()
     pc = Uint(0)
 
     while pc < ulen(code):
@@ -58,6 +68,9 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
             continue
 
         if current_opcode == Ops.JUMPDEST:
+            valid_jump_destinations.add(pc)
+        elif current_opcode == Ops.CALLDEST:
+            valid_call_destinations.add(pc)
             valid_jump_destinations.add(pc)
         elif Ops.PUSH1.value <= current_opcode.value <= Ops.PUSH32.value:
             # If PUSH-N opcodes are encountered, skip the current opcode along
@@ -92,4 +105,4 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
 
         pc += Uint(1)
 
-    return valid_jump_destinations
+    return valid_jump_destinations, valid_call_destinations

--- a/src/ethereum/forks/amsterdam/vm/runtime.py
+++ b/src/ethereum/forks/amsterdam/vm/runtime.py
@@ -17,6 +17,7 @@ from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
+from .validation import code_entry_point
 
 
 def get_valid_destinations(code: Bytes) -> Tuple[Set[Uint], Set[Uint]]:
@@ -38,6 +39,9 @@ def get_valid_destinations(code: Bytes) -> Tuple[Set[Uint], Set[Uint]]:
     destination, so that a `JUMP` may enter a subroutine without pushing a
     return address.
 
+    The scan begins at the code's entry point: immediately after the header
+    of `MAGIC` code (EIP-8337), whose bytes are never instructions.
+
     Note - Destinations are 0-indexed.
 
     Parameters
@@ -55,7 +59,7 @@ def get_valid_destinations(code: Bytes) -> Tuple[Set[Uint], Set[Uint]]:
     """
     valid_jump_destinations = set()
     valid_call_destinations = set()
-    pc = Uint(0)
+    pc = code_entry_point(code)
 
     while pc < ulen(code):
         try:

--- a/src/ethereum/forks/amsterdam/vm/validation.py
+++ b/src/ethereum/forks/amsterdam/vm/validation.py
@@ -1,0 +1,453 @@
+"""
+Ethereum Virtual Machine (EVM) Code Validation (EIP-8337).
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Validation of `MAGIC` code at `CREATE` time, as specified by EIP-8337.
+Code beginning with the `MAGIC` header is proven, once, when it is
+created, to have fully static control flow and to never underflow the
+data stack. Its execution begins immediately after the header.
+
+Placeholders, to be settled by the EIP:
+
+* `MAGIC` is `0xEF 0x79`; `MAGIC_VERSION` (`0x01`) names the validation
+  rules of this fork. The header is `MAGIC + MAGIC_VERSION`.
+* `VALIDATION_BYTE_COST` is 64 gas per byte of created code.
+"""
+
+from collections import defaultdict
+from typing import Dict, List, Optional, Set, Tuple
+
+from ethereum_types.bytes import Bytes
+from ethereum_types.numeric import U8, Uint, ulen
+
+from .exceptions import InvalidParameter
+from .instructions import Ops
+from .stack import decode_pair, decode_single
+
+MAGIC = b"\xef\x79"
+MAGIC_VERSION = b"\x01"
+MAGIC_HEADER = MAGIC + MAGIC_VERSION
+MAGIC_HEADER_LENGTH = ulen(MAGIC_HEADER)
+
+STACK_LIMIT = 1024
+
+# Placeholders for the *entry* of top-level code and for the destination
+# requirement recorded by jumps (`LABEL`: JUMPDEST or CALLDEST) and by
+# calls (`ENTRY`: CALLDEST only).
+_OUTER = -1
+_LABEL = 1
+_ENTRY = 2
+
+
+def is_magic_code(code: Bytes) -> bool:
+    """
+    Return whether `code` begins with the `MAGIC` bytes.
+
+    Parameters
+    ----------
+    code :
+        The code to inspect.
+
+    Returns
+    -------
+    is_magic : `bool`
+        `True` if `code` begins with `MAGIC`.
+
+    """
+    return bytes(code[: len(MAGIC)]) == MAGIC
+
+
+def code_entry_point(code: Bytes) -> Uint:
+    """
+    Return the position at which execution of `code` begins: immediately
+    after the header for `MAGIC` code, position zero otherwise.
+
+    Parameters
+    ----------
+    code :
+        The code to be executed.
+
+    Returns
+    -------
+    entry_point : `Uint`
+        The initial program counter.
+
+    """
+    if is_magic_code(code):
+        return MAGIC_HEADER_LENGTH
+    return Uint(0)
+
+
+def validate_code(code: Bytes) -> bool:
+    """
+    Validate `MAGIC` code: the header must name this fork's validation
+    rules, the body must not be empty, and the body must satisfy the
+    five constraints of EIP-8337.
+
+    Parameters
+    ----------
+    code :
+        The complete created code, including the header.
+
+    Returns
+    -------
+    valid : `bool`
+        `True` if the code is valid.
+
+    """
+    if bytes(code[: len(MAGIC_HEADER)]) != MAGIC_HEADER:
+        return False
+    if ulen(code) <= MAGIC_HEADER_LENGTH:
+        return False
+    return validate(code, int(MAGIC_HEADER_LENGTH))
+
+
+def _push_value(code: Bytes, pc: int) -> int:
+    """
+    Immediate value of the `PUSH` at `pc`, zero-padded past end of code.
+    """
+    n = code[pc] - Ops.PUSH0.value
+    data = bytes(code[pc + 1 : pc + 1 + n]).ljust(n, b"\x00")
+    return int.from_bytes(data, "big")
+
+
+# (pops, pushes, is_terminator) for opcodes without a data portion and
+# with fixed stack effects, for the instruction set of this fork.
+# Opcodes absent from this table (and not handled by ranges in
+# `_opcode_info`) are invalid. A terminator cannot fall through to the
+# next instruction.
+_TABLE: Dict[int, Tuple[int, int, bool]] = {
+    Ops.STOP.value: (0, 0, True),
+    **dict.fromkeys(
+        (
+            *range(0x01, 0x08),  # ADD..SMOD
+            0x0A,  # EXP
+            0x0B,  # SIGNEXTEND
+            *range(0x10, 0x15),  # LT..EQ
+            0x16,  # AND
+            0x17,  # OR
+            0x18,  # XOR
+            *range(0x1A, 0x1E),  # BYTE..SAR
+            0x20,  # KECCAK256
+        ),
+        (2, 1, False),
+    ),
+    0x08: (3, 1, False),  # ADDMOD
+    0x09: (3, 1, False),  # MULMOD
+    **dict.fromkeys(
+        (
+            0x15,  # ISZERO
+            0x19,  # NOT
+            0x1E,  # CLZ
+            0x31,  # BALANCE
+            0x35,  # CALLDATALOAD
+            0x3B,  # EXTCODESIZE
+            0x3F,  # EXTCODEHASH
+            0x40,  # BLOCKHASH
+            0x49,  # BLOBHASH
+            0x51,  # MLOAD
+            0x54,  # SLOAD
+            0x5C,  # TLOAD
+        ),
+        (1, 1, False),
+    ),
+    **dict.fromkeys(
+        (
+            0x30,  # ADDRESS
+            0x32,  # ORIGIN
+            0x33,  # CALLER
+            0x34,  # CALLVALUE
+            0x36,  # CALLDATASIZE
+            0x38,  # CODESIZE
+            0x3A,  # GASPRICE
+            0x3D,  # RETURNDATASIZE
+            *range(0x41, 0x49),  # COINBASE..BASEFEE
+            0x4A,  # BLOBBASEFEE
+            0x4B,  # SLOTNUM
+            0x58,  # PC
+            0x59,  # MSIZE
+            0x5A,  # GAS
+        ),
+        (0, 1, False),
+    ),
+    # CALLDATACOPY, CODECOPY, RETURNDATACOPY, MCOPY
+    **dict.fromkeys((0x37, 0x39, 0x3E, 0x5E), (3, 0, False)),
+    0x3C: (4, 0, False),  # EXTCODECOPY
+    0x50: (1, 0, False),  # POP
+    # MSTORE, MSTORE8, SSTORE, TSTORE
+    **dict.fromkeys((0x52, 0x53, 0x55, 0x5D), (2, 0, False)),
+    Ops.JUMP.value: (1, 0, True),
+    Ops.JUMPI.value: (2, 0, False),
+    Ops.JUMPDEST.value: (0, 0, False),
+    Ops.CALLSUB.value: (1, 0, True),
+    Ops.CALLDEST.value: (0, 0, False),
+    Ops.RETURNSUB.value: (0, 0, True),
+    0xF0: (3, 1, False),  # CREATE
+    0xF5: (4, 1, False),  # CREATE2
+    0xF1: (7, 1, False),  # CALL
+    0xF2: (7, 1, False),  # CALLCODE
+    0xF4: (6, 1, False),  # DELEGATECALL
+    0xFA: (6, 1, False),  # STATICCALL
+    0xF3: (2, 0, True),  # RETURN
+    0xFD: (2, 0, True),  # REVERT
+    0xFE: (0, 0, True),  # INVALID
+    0xFF: (1, 0, True),  # SELFDESTRUCT
+}
+
+
+def _opcode_info(code: Bytes, pc: int) -> Tuple[int, int, int, bool]:
+    """
+    Return `(size, pops, pushes, is_terminator)` for the instruction at
+    `pc`. A size of 0 marks an invalid instruction, including an EIP-8024
+    instruction whose immediate is out of range.
+    """
+    op = code[pc]
+    if Ops.PUSH0.value <= op <= Ops.PUSH32.value:
+        return op - Ops.PUSH0.value + 1, 0, 1, False
+    if 0x80 <= op <= 0x8F:  # DUP1..DUP16
+        n = op - 0x7F
+        return 1, n, n + 1, False
+    if 0x90 <= op <= 0x9F:  # SWAP1..SWAP16
+        n = op - 0x8F
+        return 1, n + 1, n + 1, False
+    if 0xA0 <= op <= 0xA4:  # LOG0..LOG4
+        return 1, op - 0xA0 + 2, 0, False
+    if op in (Ops.DUPN.value, Ops.SWAPN.value, Ops.EXCHANGE.value):
+        if pc + 1 >= len(code):
+            return 0, 0, 0, False
+        immediate = U8(code[pc + 1])
+        try:
+            if op == Ops.DUPN.value:
+                n = int(decode_single(immediate))
+                return 2, n, n + 1, False
+            if op == Ops.SWAPN.value:
+                n = int(decode_single(immediate))
+                return 2, n + 1, n + 1, False
+            a, b = decode_pair(immediate)
+            depth = max(int(a), int(b)) + 1
+            return 2, depth, depth, False
+        except InvalidParameter:
+            return 0, 0, 0, False
+    if op in _TABLE:
+        pops, pushes, term = _TABLE[op]
+        return 1, pops, pushes, term
+    return 0, 0, 0, False
+
+
+def _instruction_positions(code: Bytes, start: int) -> Set[int]:
+    """
+    The sequential scan from `start`: the positions that are instructions
+    rather than immediate data, following the same rules as the JUMPDEST
+    analysis (`PUSH` data and valid EIP-8024 immediates are skipped).
+    """
+    instructions: Set[int] = set()
+    i = start
+    n = len(code)
+    while i < n:
+        instructions.add(i)
+        op = code[i]
+        if Ops.PUSH1.value <= op <= Ops.PUSH32.value:
+            i += op - Ops.PUSH0.value
+        elif op in (Ops.DUPN.value, Ops.SWAPN.value):
+            if not (i + 1 < n and 0x5B <= code[i + 1] <= 0x7F):
+                i += 1
+        elif op == Ops.EXCHANGE.value:
+            if not (i + 1 < n and 0x52 <= code[i + 1] <= 0x7F):
+                i += 1
+        i += 1
+    return instructions
+
+
+def validate(code: Bytes, start: int, stack_limit: int = STACK_LIMIT) -> bool:
+    """
+    Return whether the code from `start` satisfies the five constraints
+    of EIP-8337: valid opcodes, proven destinations, framed returns, no
+    data-stack underflow, and one static stack offset per instruction.
+
+    The traversal visits every reachable instruction once, following both
+    arms of every `JUMPI`, and measures the data stack relative to the
+    subroutine being traversed, so that each subroutine is checked once
+    however many call sites invoke it.
+
+    Parameters
+    ----------
+    code :
+        The code, including any header before `start`.
+    start :
+        The position at which execution begins.
+    stack_limit :
+        The data-stack limit, bounding subroutine demands.
+
+    Returns
+    -------
+    valid : `bool`
+        `True` if the code is valid.
+
+    """
+    if len(code) <= start:
+        return False
+
+    instructions = _instruction_positions(code, start)
+
+    # pc -> (offset, entry, framed) at first visit
+    visited: Dict[int, Tuple[int, int, bool]] = {}
+    # pc -> _LABEL or _ENTRY, set by jumps and calls
+    required: Dict[int, int] = {}
+    # entry -> its net stack effect, once known
+    net_effect: Dict[int, int] = {}
+    # entry -> its demand: the items it needs from its caller
+    inputs: Dict[int, int] = defaultdict(int)
+    # Two parent lists with different lifetimes. `parents` is permanent
+    # and complete (every call and entrance) for propagating demands.
+    # `enter_parents` holds only arrivals whose entry's net is still
+    # unknown; each record is consumed once, when that net is first set.
+    parents: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+    enter_parents: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+    # entry -> return points waiting on its net
+    pending: Dict[int, List[Tuple[int, int, int, bool]]] = defaultdict(list)
+    # (pc, offset, entry, framed, preceding push value)
+    work_items: List[Tuple[int, int, int, bool, Optional[int]]] = [
+        (start, 0, _OUTER, False, None)
+    ]
+
+    def resolve(entry: int, value: int) -> bool:
+        """
+        Record an entry's net: release the return points waiting on it,
+        and settle the entries that jump or fall into it, whose nets
+        follow from this one. Return `False` on a conflict.
+        """
+        settle = [(entry, value)]
+        while settle:
+            e, v = settle.pop()
+            if e in net_effect:
+                if net_effect[e] != v:
+                    return False  # Constraint 5: one net per entry
+                continue
+            net_effect[e] = v
+            for ret_pc, offset, caller, framed in pending.pop(e, []):
+                work_items.append((ret_pc, offset + v, caller, framed, None))
+            for parent, d in enter_parents[e]:
+                settle.append((parent, d + v))
+        return True
+
+    while work_items:
+        pc, offset, entry, framed, push = work_items.pop()
+        if pc >= len(code):
+            continue  # implicit STOP: a valid end
+        if pc not in instructions:
+            return False  # Constraints 2, 3: immediate data
+        op = code[pc]
+        size, pops, pushes, term = _opcode_info(code, pc)
+        if size == 0:
+            return False  # Constraint 1: not a valid instruction
+
+        # A CALLDEST is visited at offset 0, as its own entry; arriving
+        # any other way first records the link between the subroutines.
+        if op == Ops.CALLDEST.value and (entry != pc or offset != 0):
+            parents[pc].append((entry, offset))
+            if pc in net_effect:  # settled: the arriving net follows
+                if not resolve(entry, offset + net_effect[pc]):
+                    return False
+            else:  # each record is consumed exactly once
+                enter_parents[pc].append((entry, offset))
+            offset, entry = 0, pc
+
+        if pc in visited:
+            # Constraint 5: paths must agree.
+            if visited[pc] != (offset, entry, framed):
+                return False
+            continue
+        visited[pc] = (offset, entry, framed)
+
+        # Constraints 2 and 3: a required destination type, if any.
+        requirement = required.get(pc)
+        if requirement == _LABEL and op not in (
+            Ops.JUMPDEST.value,
+            Ops.CALLDEST.value,
+        ):
+            return False
+        if requirement == _ENTRY and op != Ops.CALLDEST.value:
+            return False
+
+        # Constraint 4: items used from below the subroutine's start.
+        need = pops - offset
+        if need > inputs[entry]:
+            if need > stack_limit:
+                return False
+            inputs[entry] = need
+        offset += pushes - pops
+        nxt = pc + size
+
+        if op == Ops.CALLSUB.value:
+            if push is None:
+                return False  # Constraint 3: PUSH before CALLSUB
+            dest = push
+            if dest >= len(code):
+                return False
+            if dest in visited and code[dest] != Ops.CALLDEST.value:
+                return False
+            required[dest] = _ENTRY  # a jump's LABEL upgrades to ENTRY
+            parents[dest].append((entry, offset))
+            work_items.append((dest, 0, dest, True, None))
+            if dest in net_effect:
+                # Return point: call-site offset plus the callee's net.
+                work_items.append(
+                    (nxt, offset + net_effect[dest], entry, framed, None)
+                )
+            else:
+                pending[dest].append((nxt, offset, entry, framed))
+        elif op == Ops.RETURNSUB.value:
+            if not framed:
+                return False  # no CALLSUB to return from
+            if not resolve(entry, offset):
+                return False
+        elif op in (Ops.JUMP.value, Ops.JUMPI.value):
+            if push is None:
+                return False  # Constraint 2: PUSH before JUMP/JUMPI
+            dest = push
+            if dest >= len(code):
+                return False
+            if dest in visited and code[dest] not in (
+                Ops.JUMPDEST.value,
+                Ops.CALLDEST.value,
+            ):
+                return False
+            required.setdefault(dest, _LABEL)
+            work_items.append((dest, offset, entry, framed, None))
+            if op == Ops.JUMPI.value:  # and the fall-through arm
+                work_items.append((nxt, offset, entry, framed, None))
+        elif not term:  # everything else falls through
+            value: Optional[int] = None
+            if Ops.PUSH0.value <= op <= Ops.PUSH32.value:
+                value = _push_value(code, pc)
+            work_items.append((nxt, offset, entry, framed, value))
+
+    # The demand checking: a subroutine's demand for caller items, less
+    # the depth already on the stack at the entrance, becomes its
+    # parent's demand. Demands only rise and the limit caps them, so
+    # this ends.
+    queue: List[int] = [e for e in inputs if inputs[e]]
+    queued: Set[int] = set(queue)
+    head = 0
+    while head < len(queue):
+        e = queue[head]
+        head += 1
+        queued.discard(e)
+        for parent, d in parents[e]:
+            need = inputs[e] - d
+            if need > inputs[parent]:
+                if need > stack_limit:
+                    return False
+                inputs[parent] = need
+                if parent not in queued:
+                    queue.append(parent)
+                    queued.add(parent)
+
+    # Top-level code has no caller to take items from.
+    return inputs[_OUTER] == 0

--- a/tests/amsterdam/eip7979_callsub/__init__.py
+++ b/tests/amsterdam/eip7979_callsub/__init__.py
@@ -1,0 +1,5 @@
+"""
+Tests for [EIP-7979: Call and Return Opcodes for the EVM](https://eips.ethereum.org/EIPS/eip-7979).
+
+CALLSUB, CALLDEST, RETURNSUB and the return stack.
+"""

--- a/tests/amsterdam/eip7979_callsub/helpers.py
+++ b/tests/amsterdam/eip7979_callsub/helpers.py
@@ -1,0 +1,62 @@
+"""Shared bytecode builders for the EIP-7979 tests."""
+
+from typing import Callable, Tuple
+
+from execution_testing import Address, Bytecode, Op
+
+# Storage slots used by callers to record what they observed.
+SLOT_CALL_SUCCESS = 0
+SLOT_MARKER = 1
+SLOT_MARKER_AFTER_RETURN = 2
+
+MARKER_IN_SUBROUTINE = 0xA1
+MARKER_AFTER_RETURN = 0xB2
+
+# Gas handed to a callee so that its exceptional halts cannot starve the
+# caller, which still has to record the outcome.
+CALLEE_GAS = 500_000
+
+# Gas limit for the transactions in these tests.
+TX_GAS_LIMIT = 1_000_000
+
+
+def caller_recording_success(
+    callee: Address, gas: int = CALLEE_GAS
+) -> Bytecode:
+    """
+    Return caller code that CALLs `callee` and stores the success flag
+    at ``SLOT_CALL_SUCCESS``.
+
+    An exceptional halt in the callee yields 0, normal completion yields 1.
+    """
+    return Op.SSTORE(SLOT_CALL_SUCCESS, Op.CALL(gas=gas, address=callee))
+
+
+def subroutine_storing_marker() -> Bytecode:
+    """
+    Return a subroutine: CALLDEST, store ``MARKER_IN_SUBROUTINE`` at
+    ``SLOT_MARKER``, RETURNSUB.
+    """
+    return (
+        Op.CALLDEST
+        + Op.SSTORE(SLOT_MARKER, MARKER_IN_SUBROUTINE)
+        + Op.RETURNSUB
+    )
+
+
+def program(
+    main_for: Callable[[int], Bytecode], subroutine: Bytecode
+) -> Tuple[Bytecode, int]:
+    """
+    Assemble ``main_for(offset) + STOP + subroutine`` where `offset` is the
+    code offset of the subroutine.
+
+    `main_for` builds the main code given the subroutine's offset; it must
+    produce code of the same length for any offset below 256 (use PUSH1).
+    Returns the whole program and the offset.
+    """
+    offset = len(main_for(0)) + 1  # + STOP
+    assert offset < 256, "keep test programs under 256 bytes"
+    main = main_for(offset)
+    assert len(main) == len(main_for(0))
+    return main + Op.STOP + subroutine, offset

--- a/tests/amsterdam/eip7979_callsub/spec.py
+++ b/tests/amsterdam/eip7979_callsub/spec.py
@@ -1,0 +1,34 @@
+"""Reference spec for [EIP-7979: Call and Return Opcodes for the EVM](https://eips.ethereum.org/EIPS/eip-7979)."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Reference specification."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7979 = ReferenceSpec(
+    git_path="EIPS/eip-7979.md",
+    version="0b9221c7958ba4c5f2d11bfba355cafdbf2a3e1e",
+)
+
+
+class Spec:
+    """Constants and parameters from EIP-7979."""
+
+    # Placeholder opcode values, to be confirmed on final assignment.
+    CALLSUB_OPCODE: int = 0xB0
+    CALLDEST_OPCODE: int = 0xB1
+    RETURNSUB_OPCODE: int = 0xB2
+
+    # Gas costs: mid, jumpdest, low.
+    CALLSUB_GAS: int = 8
+    CALLDEST_GAS: int = 1
+    RETURNSUB_GAS: int = 5
+
+    # Maximum number of return addresses a frame's return stack may hold.
+    RETURN_STACK_LIMIT: int = 1024

--- a/tests/amsterdam/eip7979_callsub/test_call_elimination.py
+++ b/tests/amsterdam/eip7979_callsub/test_call_elimination.py
@@ -1,0 +1,179 @@
+"""
+CALLDEST as a jump destination: call elimination.
+
+A JUMP or JUMPI may land on a CALLDEST. Doing so enters the subroutine
+without pushing a return address, so the subroutine's RETURNSUB returns to
+the original caller. Compilers use this for tail calls and shared epilogues.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import (
+    CALLEE_GAS,
+    MARKER_AFTER_RETURN,
+    MARKER_IN_SUBROUTINE,
+    SLOT_CALL_SUCCESS,
+    SLOT_MARKER,
+    SLOT_MARKER_AFTER_RETURN,
+    TX_GAS_LIMIT,
+    caller_recording_success,
+    program,
+    subroutine_storing_marker,
+)
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+@pytest.mark.parametrize("conditional", [False, True], ids=["jump", "jumpi"])
+def test_jump_to_calldest(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    conditional: bool,
+) -> None:
+    """
+    JUMP and JUMPI accept a CALLDEST as destination. The subroutine body
+    runs; its RETURNSUB is not reached because the body ends with STOP.
+    """
+    subroutine = (
+        Op.CALLDEST + Op.SSTORE(SLOT_MARKER, MARKER_IN_SUBROUTINE) + Op.STOP
+    )
+
+    def main(offset: int) -> Bytecode:
+        if conditional:
+            return Op.JUMPI(offset, 1)
+        return Op.JUMP(offset)
+
+    code, _ = program(main, subroutine)
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: MARKER_IN_SUBROUTINE})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_tail_call(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Subroutine `f` ends by jumping to subroutine `g` instead of calling it.
+    `g`'s RETURNSUB returns directly to `f`'s caller, and the return stack
+    never holds more than one address.
+    """
+
+    def main(f_offset: int) -> Bytecode:
+        return Op.CALLSUB(f_offset) + Op.SSTORE(
+            SLOT_MARKER_AFTER_RETURN, MARKER_AFTER_RETURN
+        )
+
+    # Layout: main, STOP, f, g. `g` is the marker-storing subroutine.
+    g = subroutine_storing_marker()
+
+    def f_for(g_offset: int) -> Bytecode:
+        return Op.CALLDEST + Op.JUMP(g_offset)
+
+    f_offset = len(main(0)) + 1
+    g_offset = f_offset + len(f_for(0))
+    code = main(f_offset) + Op.STOP + f_for(g_offset) + g
+    assert len(code) < 256
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {
+        contract: Account(
+            storage={
+                SLOT_MARKER: MARKER_IN_SUBROUTINE,
+                SLOT_MARKER_AFTER_RETURN: MARKER_AFTER_RETURN,
+            }
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_returnsub_after_unframed_jump_halts(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Entering a subroutine by JUMP from top-level code pushes no return
+    address, so its RETURNSUB underflows.
+    """
+    callee_code = (
+        Op.PUSH1[0x04] + Op.JUMP + Op.STOP + Op.CALLDEST + Op.RETURNSUB
+    )
+    callee = pre.deploy_contract(callee_code)
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_mutual_recursion_at_constant_depth(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Two subroutines that jump to each other run a loop of 2000 iterations
+    at constant return-stack depth, well past the 1024 limit that calls
+    would hit. The counter lives on the data stack.
+    """
+    iterations = 2000
+
+    def main(a_offset: int) -> Bytecode:
+        return (
+            Op.PUSH2[iterations]
+            + Op.CALLSUB(a_offset)
+            + Op.POP
+            + Op.SSTORE(SLOT_MARKER, 1)
+        )
+
+    def a_for(b_offset: int, done: int) -> Bytecode:
+        # a: if counter == 0 return; counter -= 1; jump b
+        return (
+            Op.CALLDEST
+            + Op.DUP1
+            + Op.ISZERO
+            + Op.PUSH1[done]
+            + Op.JUMPI
+            + Op.PUSH1[1]
+            + Op.SWAP1
+            + Op.SUB
+            + Op.PUSH1[b_offset]
+            + Op.JUMP
+            + Op.JUMPDEST  # done:
+            + Op.RETURNSUB
+        )
+
+    def b_for(a_offset: int) -> Bytecode:
+        # b: jump a
+        return Op.CALLDEST + Op.PUSH1[a_offset] + Op.JUMP
+
+    a_offset = len(main(0)) + 1
+    b_offset = a_offset + len(a_for(0, 0))
+    done = b_offset - 2
+    code = main(a_offset) + Op.STOP + a_for(b_offset, done) + b_for(a_offset)
+    assert len(code) < 256
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: 1})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_callsub.py
+++ b/tests/amsterdam/eip7979_callsub/test_callsub.py
@@ -1,0 +1,185 @@
+"""
+CALLSUB destination checks and the basic call/return round trip.
+
+A CALLSUB whose destination is not a CALLDEST instruction is an exceptional
+halt: a JUMPDEST, a byte inside PUSH data, a byte inside an EIP-8024
+immediate, and any position outside the code all fail.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import (
+    CALLEE_GAS,
+    MARKER_AFTER_RETURN,
+    MARKER_IN_SUBROUTINE,
+    SLOT_CALL_SUCCESS,
+    SLOT_MARKER,
+    SLOT_MARKER_AFTER_RETURN,
+    TX_GAS_LIMIT,
+    caller_recording_success,
+    program,
+    subroutine_storing_marker,
+)
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+def test_call_and_return(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    CALLSUB enters the subroutine, RETURNSUB comes back to the instruction
+    after the CALLSUB, and execution continues from there.
+    """
+    code, _ = program(
+        lambda offset: Op.CALLSUB(offset)
+        + Op.SSTORE(SLOT_MARKER_AFTER_RETURN, MARKER_AFTER_RETURN),
+        subroutine_storing_marker(),
+    )
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {
+        contract: Account(
+            storage={
+                SLOT_MARKER: MARKER_IN_SUBROUTINE,
+                SLOT_MARKER_AFTER_RETURN: MARKER_AFTER_RETURN,
+            }
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_subroutine_called_twice(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    A subroutine may be called any number of times; each call returns to
+    its own call site.
+    """
+
+    def main(offset: int) -> Bytecode:
+        return (
+            Op.CALLSUB(offset)
+            + Op.SSTORE(SLOT_MARKER_AFTER_RETURN, 1)
+            + Op.CALLSUB(offset)
+            + Op.SSTORE(
+                SLOT_MARKER_AFTER_RETURN,
+                Op.ADD(Op.SLOAD(SLOT_MARKER_AFTER_RETURN), 1),
+            )
+        )
+
+    # The subroutine increments SLOT_MARKER on every entry.
+    subroutine = (
+        Op.CALLDEST
+        + Op.SSTORE(SLOT_MARKER, Op.ADD(Op.SLOAD(SLOT_MARKER), 1))
+        + Op.RETURNSUB
+    )
+    code, _ = program(main, subroutine)
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {
+        contract: Account(
+            storage={SLOT_MARKER: 2, SLOT_MARKER_AFTER_RETURN: 2}
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "callee_code",
+    [
+        pytest.param(
+            # Destination is a JUMPDEST, not a CALLDEST.
+            Op.PUSH1[0x04] + Op.CALLSUB + Op.STOP + Op.JUMPDEST + Op.RETURNSUB,
+            id="jumpdest",
+        ),
+        pytest.param(
+            # Destination 5 is the 0xB1 byte inside the PUSH1 immediate.
+            Op.PUSH1[0x05] + Op.CALLSUB + Op.STOP + Op.PUSH1[0xB1] + Op.STOP,
+            id="calldest_byte_in_push_data",
+        ),
+        pytest.param(
+            # Destination 5 is the 0xB1 byte inside a DUPN immediate
+            # (EIP-8024): the scan skips it, so it is not an instruction.
+            Op.PUSH1[0x05] + Op.CALLSUB + Op.STOP + Op.DUPN[0xB1] + Op.STOP,
+            id="calldest_byte_in_dupn_immediate",
+        ),
+        pytest.param(
+            # Destination is one past the end of the code.
+            Op.PUSH1[0x06] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            id="past_end_of_code",
+        ),
+        pytest.param(
+            # Destination does not fit in 64 bits.
+            Op.PUSH32[2**256 - 1]
+            + Op.CALLSUB
+            + Op.STOP
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+            id="destination_overflows_uint64",
+        ),
+        pytest.param(
+            # Destination is the CALLSUB itself.
+            Op.PUSH1[0x02] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            id="callsub_to_itself",
+        ),
+        pytest.param(
+            # CALLSUB with an empty data stack.
+            Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            id="stack_underflow",
+        ),
+    ],
+)
+def test_invalid_callsub_destination(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    callee_code: Op,
+) -> None:
+    """
+    A CALLSUB to anything but a CALLDEST instruction is an exceptional
+    halt.
+    """
+    callee = pre.deploy_contract(callee_code)
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_calldest_reached_by_fall_through(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """CALLDEST executed in sequence is a no-op, like JUMPDEST."""
+    code = (
+        Op.CALLDEST
+        + Op.CALLDEST
+        + Op.SSTORE(SLOT_MARKER, MARKER_IN_SUBROUTINE)
+        + Op.STOP
+    )
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: MARKER_IN_SUBROUTINE})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_eip_vectors.py
+++ b/tests/amsterdam/eip7979_callsub/test_eip_vectors.py
@@ -1,0 +1,100 @@
+"""
+EIP-7979 test vectors.
+
+The five programs given in the EIP, run byte-for-byte as callees. The caller
+records the call's success flag; the gas each program consumes is checked
+implicitly through the post-state root, and explicitly in ``test_gas.py``.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import SLOT_CALL_SUCCESS, TX_GAS_LIMIT, caller_recording_success
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+@pytest.mark.parametrize(
+    "bytecode,success",
+    [
+        pytest.param(
+            # PUSH1 0x04, CALLSUB, STOP, CALLDEST, RETURNSUB
+            Op.PUSH1[0x04] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            True,
+            id="simple_routine",
+        ),
+        pytest.param(
+            # PUSH1 0x04, CALLSUB, STOP, CALLDEST, PUSH1 0x09, CALLSUB,
+            # RETURNSUB, CALLDEST, RETURNSUB
+            Op.PUSH1[0x04]
+            + Op.CALLSUB
+            + Op.STOP
+            + Op.CALLDEST
+            + Op.PUSH1[0x09]
+            + Op.CALLSUB
+            + Op.RETURNSUB
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+            True,
+            id="two_levels_of_subroutines",
+        ),
+        pytest.param(
+            # PUSH1 0xFF, CALLSUB, STOP, CALLDEST, RETURNSUB:
+            # destination 255 is outside the 6-byte code.
+            Op.PUSH1[0xFF] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            False,
+            id="failure_invalid_destination",
+        ),
+        pytest.param(
+            # RETURNSUB with an empty return stack.
+            Op.RETURNSUB,
+            False,
+            id="failure_empty_return_stack",
+        ),
+        pytest.param(
+            # PUSH1 0x05, JUMP, CALLDEST, RETURNSUB, JUMPDEST, PUSH1 0x03,
+            # CALLSUB: the CALLSUB is the last byte of code; RETURNSUB
+            # returns to the implicit STOP past the end of the code.
+            Op.PUSH1[0x05]
+            + Op.JUMP
+            + Op.CALLDEST
+            + Op.RETURNSUB
+            + Op.JUMPDEST
+            + Op.PUSH1[0x03]
+            + Op.CALLSUB,
+            True,
+            id="subroutine_at_end_of_code",
+        ),
+    ],
+)
+def test_eip_vectors(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    bytecode: Op,
+    success: bool,
+) -> None:
+    """Run each EIP test vector verbatim and record whether it halted."""
+    expected_hex = {
+        "simple_routine": "6004b000b1b2",
+        "two_levels_of_subroutines": "6004b000b16009b0b2b1b2",
+        "failure_invalid_destination": "60ffb000b1b2",
+        "failure_empty_return_stack": "b2",
+        "subroutine_at_end_of_code": "600556b1b25b6003b0",
+    }
+    assert bytes(bytecode).hex() in expected_hex.values()
+
+    callee = pre.deploy_contract(bytecode)
+    caller = pre.deploy_contract(caller_recording_success(callee))
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: int(success)})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_execution_contexts.py
+++ b/tests/amsterdam/eip7979_callsub/test_execution_contexts.py
@@ -1,0 +1,131 @@
+"""
+CALLSUB, CALLDEST and RETURNSUB in initcode and in delegated code.
+
+The message-frame tests are in ``test_returnsub.py``; these cover the two
+other places code runs: contract creation (transaction initcode and
+CREATE/CREATE2) and an EIP-7702 delegated EOA.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    AuthorizationTuple,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import (
+    MARKER_IN_SUBROUTINE,
+    SLOT_MARKER,
+    TX_GAS_LIMIT,
+    program,
+    subroutine_storing_marker,
+)
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+def initcode_using_subroutine() -> Bytecode:
+    """
+    Return initcode that calls a subroutine which stores a marker, then
+    returns a one-byte runtime code (STOP).
+    """
+
+    def main(offset: int) -> Bytecode:
+        return (
+            Op.CALLSUB(offset) + Op.MSTORE8(0, Op.STOP.int()) + Op.RETURN(0, 1)
+        )
+
+    code, _ = program(main, subroutine_storing_marker())
+    return code
+
+
+def test_subroutine_in_transaction_initcode(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """A creation transaction's initcode may use subroutines."""
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=initcode_using_subroutine(),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    created = compute_create_address(address=sender, nonce=0)
+    post = {
+        created: Account(
+            code=Op.STOP, storage={SLOT_MARKER: MARKER_IN_SUBROUTINE}
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
+def test_subroutine_in_create_initcode(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    create_opcode: Op,
+) -> None:
+    """Initcode run by CREATE and CREATE2 may use subroutines."""
+    initcode = initcode_using_subroutine()
+    factory_code = Op.CALLDATACOPY(offset=0, size=len(initcode)) + Op.SSTORE(
+        0, create_opcode(offset=0, size=len(initcode))
+    )
+    factory = pre.deploy_contract(factory_code)
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=factory,
+        data=initcode,
+        gas_limit=TX_GAS_LIMIT,
+    )
+    if create_opcode == Op.CREATE:
+        created = compute_create_address(address=factory, nonce=1)
+    else:
+        created = compute_create_address(
+            address=factory, initcode=initcode, salt=0, opcode=Op.CREATE2
+        )
+    post = {
+        factory: Account(storage={0: created}),
+        created: Account(
+            code=Op.STOP, storage={SLOT_MARKER: MARKER_IN_SUBROUTINE}
+        ),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_subroutine_in_delegated_code(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    An EIP-7702 delegated EOA runs subroutines in its own storage
+    context.
+    """
+    code, _ = program(
+        lambda offset: Op.CALLSUB(offset), subroutine_storing_marker()
+    )
+    delegate_to = pre.deploy_contract(code)
+    auth_signer = pre.fund_eoa(0)
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=auth_signer,
+        gas_limit=TX_GAS_LIMIT,
+        authorization_list=[
+            AuthorizationTuple(
+                address=delegate_to, nonce=0, signer=auth_signer
+            ),
+        ],
+    )
+    post = {
+        auth_signer: Account(storage={SLOT_MARKER: MARKER_IN_SUBROUTINE}),
+    }
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_fork_transition.py
+++ b/tests/amsterdam/eip7979_callsub/test_fork_transition.py
@@ -1,0 +1,101 @@
+"""Fork-transition tests for EIP-7979 (CALLSUB, CALLDEST, RETURNSUB)."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytecode,
+    Op,
+    Transaction,
+)
+
+from .helpers import MARKER_IN_SUBROUTINE, TX_GAS_LIMIT
+from .spec import ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+FORK_TIMESTAMP = 15_000
+
+
+def marker_via_callsub() -> Bytecode:
+    """
+    Return code that calls a subroutine and stores the marker at the slot
+    keyed by block NUMBER. Before the fork, CALLSUB is undefined and the
+    frame halts before any write.
+    """
+    main = Op.PUSH1[0] + Op.CALLSUB + Op.STOP  # patched below
+    offset = len(main)
+    main = Op.PUSH1[offset] + Op.CALLSUB + Op.STOP
+    subroutine = (
+        Op.CALLDEST
+        + Op.PUSH1[MARKER_IN_SUBROUTINE]
+        + Op.NUMBER
+        + Op.SSTORE
+        + Op.RETURNSUB
+    )
+    return main + subroutine
+
+
+def marker_via_jump_to_calldest() -> Bytecode:
+    """
+    Return code that JUMPs to a CALLDEST and stores the marker at the slot
+    keyed by block NUMBER. Before the fork a 0xB1 byte is not a valid jump
+    destination, so the JUMP halts the frame.
+    """
+    main = Op.PUSH1[0] + Op.JUMP + Op.STOP
+    offset = len(main)
+    main = Op.PUSH1[offset] + Op.JUMP + Op.STOP
+    subroutine = (
+        Op.CALLDEST
+        + Op.PUSH1[MARKER_IN_SUBROUTINE]
+        + Op.NUMBER
+        + Op.SSTORE
+        + Op.STOP
+    )
+    return main + subroutine
+
+
+@pytest.mark.valid_at_transition_to("EIP7979")
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(marker_via_callsub(), id="callsub"),
+        pytest.param(marker_via_jump_to_calldest(), id="jump_to_calldest"),
+    ],
+)
+def test_opcodes_at_fork_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    code: Bytecode,
+) -> None:
+    """
+    Before the fork the new opcodes are undefined and 0xB1 is not a jump
+    destination; from the fork onward the code runs and stores its marker.
+
+    Storage is keyed by block NUMBER so each block's outcome is visible:
+    block 1 (pre-fork) stays 0; blocks 2 and 3 hold the marker.
+    """
+    sender = pre.fund_eoa()
+    contract = pre.deploy_contract(code)
+    blocks = [
+        Block(
+            timestamp=ts,
+            txs=[
+                Transaction(sender=sender, to=contract, gas_limit=TX_GAS_LIMIT)
+            ],
+        )
+        for ts in (FORK_TIMESTAMP - 1, FORK_TIMESTAMP, FORK_TIMESTAMP + 1)
+    ]
+    post = {
+        contract: Account(
+            storage={
+                1: 0,
+                2: MARKER_IN_SUBROUTINE,
+                3: MARKER_IN_SUBROUTINE,
+            }
+        )
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip7979_callsub/test_gas.py
+++ b/tests/amsterdam/eip7979_callsub/test_gas.py
@@ -1,0 +1,122 @@
+"""
+Gas costs of CALLSUB (mid, 8), CALLDEST (jumpdest, 1) and RETURNSUB (low, 5).
+
+Each measurement wraps a call sequence in GAS reads and stores the
+difference; the subroutine bodies live after the measured code.
+"""
+
+from typing import Callable
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    CodeGasMeasure,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import TX_GAS_LIMIT
+from .spec import Spec, ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+PUSH1_GAS = 3
+
+
+def measured_program(
+    measured_for: Callable[[int], Bytecode],
+    subroutines_for: Callable[[int], Bytecode],
+) -> Bytecode:
+    """
+    Build ``CodeGasMeasure(measured_for(offset)) + STOP +
+    subroutines_for(offset)``, where `offset` is the code offset at which
+    the subroutines start.
+    """
+    probe = CodeGasMeasure(code=measured_for(0), sstore_key=0)
+    offset = len(probe) + 1  # + STOP
+    assert offset < 256
+    measure = CodeGasMeasure(code=measured_for(offset), sstore_key=0)
+    assert len(measure) == len(probe)
+    return measure + Op.STOP + subroutines_for(offset)
+
+
+@pytest.mark.parametrize(
+    "case,expected_gas",
+    [
+        pytest.param(
+            "call_and_return",
+            PUSH1_GAS
+            + Spec.CALLSUB_GAS
+            + Spec.CALLDEST_GAS
+            + Spec.RETURNSUB_GAS,
+            id="call_and_return_17",
+        ),
+        pytest.param(
+            "two_levels",
+            2
+            * (
+                PUSH1_GAS
+                + Spec.CALLSUB_GAS
+                + Spec.CALLDEST_GAS
+                + Spec.RETURNSUB_GAS
+            ),
+            id="two_levels_34",
+        ),
+        pytest.param("calldest_alone", Spec.CALLDEST_GAS, id="calldest_1"),
+        pytest.param(
+            "two_calldests_in_subroutine",
+            PUSH1_GAS
+            + Spec.CALLSUB_GAS
+            + 2 * Spec.CALLDEST_GAS
+            + Spec.RETURNSUB_GAS,
+            id="extra_calldest_18",
+        ),
+    ],
+)
+def test_gas_costs(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    case: str,
+    expected_gas: int,
+) -> None:
+    """
+    Measure the gas of call sequences.
+
+    The totals match the EIP's worked examples.
+    """
+    if case == "call_and_return":
+        code = measured_program(
+            lambda offset: Op.CALLSUB(offset),
+            lambda _: Op.CALLDEST + Op.RETURNSUB,
+        )
+    elif case == "two_levels":
+        # sub1 (5 bytes: CALLDEST, PUSH1, CALLSUB, RETURNSUB) at `offset`
+        # calls sub2 at `offset + 5`.
+        code = measured_program(
+            lambda offset: Op.CALLSUB(offset),
+            lambda offset: Op.CALLDEST
+            + Op.CALLSUB(offset + 5)
+            + Op.RETURNSUB
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+        )
+    elif case == "calldest_alone":
+        code = measured_program(lambda _: Op.CALLDEST, lambda _: Op.STOP)
+    else:
+        code = measured_program(
+            lambda offset: Op.CALLSUB(offset),
+            lambda _: Op.CALLDEST + Op.CALLDEST + Op.RETURNSUB,
+        )
+
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={0: expected_gas})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7979_callsub/test_returnsub.py
+++ b/tests/amsterdam/eip7979_callsub/test_returnsub.py
@@ -1,0 +1,220 @@
+"""
+RETURNSUB and the return stack: underflow, the 1024-entry limit, and the
+frame boundary.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Bytecode,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import (
+    CALLEE_GAS,
+    SLOT_CALL_SUCCESS,
+    SLOT_MARKER,
+    TX_GAS_LIMIT,
+    caller_recording_success,
+    program,
+)
+from .spec import Spec, ref_spec_7979
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7979.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7979.version
+
+pytestmark = pytest.mark.valid_from("EIP7979")
+
+
+@pytest.mark.parametrize(
+    "callee_code",
+    [
+        pytest.param(Op.RETURNSUB, id="first_instruction"),
+        pytest.param(
+            # Falling into a subroutine pushes no return address.
+            Op.CALLDEST + Op.RETURNSUB,
+            id="after_fall_through_into_calldest",
+        ),
+        pytest.param(
+            # One CALLSUB, two RETURNSUBs: the second underflows.
+            Op.PUSH1[0x04]
+            + Op.CALLSUB
+            + Op.RETURNSUB
+            + Op.CALLDEST
+            + Op.RETURNSUB,
+            id="second_returnsub_after_one_callsub",
+        ),
+    ],
+)
+def test_returnsub_underflow(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    callee_code: Op,
+) -> None:
+    """RETURNSUB with an empty return stack is an exceptional halt."""
+    callee = pre.deploy_contract(callee_code)
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def counted_recursion(depth: int) -> Bytecode:
+    """
+    Return a program whose subroutine calls itself `depth` times, using a
+    counter on the data stack, then stores 1 at ``SLOT_MARKER``.
+
+    The return stack reaches `depth` + 1 entries: one for the outer call
+    plus one per recursive call.
+    """
+
+    def main(offset: int) -> Bytecode:
+        return (
+            Op.PUSH2[depth]
+            + Op.CALLSUB(offset)
+            + Op.POP
+            + Op.SSTORE(SLOT_MARKER, 1)
+        )
+
+    def subroutine_for(offset: int, done: int) -> Bytecode:
+        return (
+            Op.CALLDEST
+            # if counter == 0: jump to done
+            + Op.DUP1
+            + Op.ISZERO
+            + Op.PUSH1[done]
+            + Op.JUMPI
+            # counter -= 1
+            + Op.PUSH1[1]
+            + Op.SWAP1
+            + Op.SUB
+            # recurse
+            + Op.PUSH1[offset]
+            + Op.CALLSUB
+            + Op.RETURNSUB
+            + Op.JUMPDEST  # done:
+            + Op.RETURNSUB
+        )
+
+    offset = len(main(0)) + 1
+    # `done` is the JUMPDEST just before the last RETURNSUB.
+    done = offset + len(subroutine_for(0, 0)) - 2
+    code = main(offset) + Op.STOP + subroutine_for(offset, done)
+    assert len(code) < 256
+    return code
+
+
+@pytest.mark.parametrize(
+    "depth,success",
+    [
+        pytest.param(Spec.RETURN_STACK_LIMIT - 1, True, id="at_limit"),
+        pytest.param(Spec.RETURN_STACK_LIMIT, False, id="over_limit"),
+    ],
+)
+def test_return_stack_limit(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    depth: int,
+    success: bool,
+) -> None:
+    """
+    The return stack holds at most 1024 addresses: recursion 1023 deep
+    (1024 entries) completes, one level deeper halts.
+    """
+    callee = pre.deploy_contract(counted_recursion(depth))
+    caller = pre.deploy_contract(
+        caller_recording_success(callee, gas=CALLEE_GAS)
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {
+        caller: Account(storage={SLOT_CALL_SUCCESS: int(success)}),
+        callee: Account(storage={SLOT_MARKER: int(success)}),
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_unbounded_recursion_halts(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Recursion with no base case halts on return-stack overflow, not on
+    running out of gas.
+    """
+    # PUSH1 4, CALLSUB, STOP, CALLDEST, PUSH1 4, CALLSUB, RETURNSUB
+    callee_code = (
+        Op.PUSH1[0x04]
+        + Op.CALLSUB
+        + Op.STOP
+        + Op.CALLDEST
+        + Op.PUSH1[0x04]
+        + Op.CALLSUB
+        + Op.RETURNSUB
+    )
+    callee = pre.deploy_contract(callee_code)
+    # Record the gas left after the call: an overflow halt consumes only
+    # the callee's gas, so the caller keeps roughly what it withheld.
+    caller_code = Op.SSTORE(
+        SLOT_CALL_SUCCESS, Op.CALL(gas=CALLEE_GAS, address=callee)
+    ) + Op.SSTORE(SLOT_MARKER, Op.GT(Op.GAS, 100_000))
+    caller = pre.deploy_contract(caller_code)
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_CALL_SUCCESS: 0, SLOT_MARKER: 1})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "call_opcode",
+    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL],
+)
+@pytest.mark.parametrize(
+    "callee_code,callee_success",
+    [
+        pytest.param(Op.RETURNSUB, 0, id="callee_underflows_own_return_stack"),
+        pytest.param(
+            Op.PUSH1[0x04] + Op.CALLSUB + Op.STOP + Op.CALLDEST + Op.RETURNSUB,
+            1,
+            id="callee_uses_own_return_stack",
+        ),
+    ],
+)
+def test_return_stack_is_per_frame(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+    callee_code: Op,
+    callee_success: int,
+) -> None:
+    """
+    Each message frame has its own return stack. A callee starts with an
+    empty one even while the caller's holds a return address, and the
+    caller's return address survives the nested call.
+    """
+    callee = pre.deploy_contract(callee_code)
+
+    def main(offset: int) -> Bytecode:
+        # Call the subroutine, which performs the nested call; then store
+        # a marker to prove RETURNSUB brought us back here.
+        return Op.CALLSUB(offset) + Op.SSTORE(SLOT_MARKER, 1)
+
+    subroutine = (
+        Op.CALLDEST
+        + Op.SSTORE(
+            SLOT_CALL_SUCCESS, call_opcode(gas=CALLEE_GAS, address=callee)
+        )
+        + Op.RETURNSUB
+    )
+    code, _ = program(main, subroutine)
+    caller = pre.deploy_contract(code)
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {
+        caller: Account(
+            storage={SLOT_CALL_SUCCESS: callee_success, SLOT_MARKER: 1}
+        )
+    }
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8337_validated_code/__init__.py
+++ b/tests/amsterdam/eip8337_validated_code/__init__.py
@@ -1,0 +1,6 @@
+"""
+Tests for [EIP-8337: Validated EVM Code](https://eips.ethereum.org/EIPS/eip-8337).
+
+Validation of MAGIC-prefixed code at CREATE, the validation gas charge, and
+execution of MAGIC code from its entry point.
+"""

--- a/tests/amsterdam/eip8337_validated_code/helpers.py
+++ b/tests/amsterdam/eip8337_validated_code/helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the EIP-8337 tests."""
+
+from execution_testing import Bytecode, Op
+
+from .spec import Spec
+
+TX_GAS_LIMIT = 2_000_000
+
+SLOT_RESULT = 0
+SLOT_MARKER = 1
+MARKER = 0xA1
+
+
+def raw(data: bytes) -> Bytecode:
+    """Wrap raw bytes as Bytecode with no stack effect."""
+    return Bytecode(data, popped_stack_items=0, pushed_stack_items=0)
+
+
+def magic(body: Bytecode | bytes) -> Bytecode:
+    """Return `body` behind the placeholder MAGIC header."""
+    if isinstance(body, bytes):
+        body = raw(body)
+    return raw(Spec.MAGIC_HEADER) + body
+
+
+def factory_code(create_opcode: Op, initcode_length: int) -> Bytecode:
+    """
+    Return factory code that copies the initcode from calldata, creates
+    with `create_opcode`, and stores the created address (0 on failure) at
+    ``SLOT_RESULT`` and the gas left afterwards at ``SLOT_MARKER``.
+    """
+    return (
+        Op.CALLDATACOPY(offset=0, size=initcode_length)
+        + Op.SSTORE(SLOT_RESULT, create_opcode(offset=0, size=initcode_length))
+        + Op.SSTORE(SLOT_MARKER, Op.GT(Op.GAS, 100_000))
+    )

--- a/tests/amsterdam/eip8337_validated_code/spec.py
+++ b/tests/amsterdam/eip8337_validated_code/spec.py
@@ -1,0 +1,135 @@
+"""Reference spec for [EIP-8337: Validated EVM Code](https://eips.ethereum.org/EIPS/eip-8337)."""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Reference specification."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_8337 = ReferenceSpec(
+    git_path="EIPS/eip-8337.md",
+    version="8a372acd9e931999a260c41d13866f131801c548",
+)
+
+
+class Spec:
+    """Constants and parameters from EIP-8337, with placeholders."""
+
+    # Placeholder MAGIC bytes and the version byte naming this fork's
+    # validation rules; the EIP fixes only that MAGIC begins with 0xEF.
+    MAGIC: bytes = b"\xef\x79"
+    MAGIC_VERSION: bytes = b"\x01"
+    MAGIC_HEADER: bytes = MAGIC + MAGIC_VERSION
+    HEADER_LENGTH: int = 3
+
+    # Gas charged at CREATE per byte of MAGIC code, before validation runs.
+    VALIDATION_BYTE_COST: int = 64
+
+
+def call_chain(n: int) -> str:
+    """
+    Main calls sub 0; sub i calls sub i+1; the last sub returns.
+
+    Return-stack depth reaches `n`. From the EIP's test assets.
+    """
+    code = bytes.fromhex("6004B000")  # PUSH1 4, CALLSUB, STOP
+    for i in range(n - 1):
+        nxt = 4 + 5 * (i + 1)  # each sub is 5 bytes
+        code += bytes([0xB1, 0x60, nxt, 0xB0, 0xB2])
+    code += bytes([0xB1, 0xB2])  # last sub: CALLDEST, RETURNSUB
+    return code.hex().upper()
+
+
+# The validation vectors of the EIP, as (name, bytecode hex, valid). The
+# three overflow vectors are valid here: overflow is not validated.
+VECTORS: List[Tuple[str, str, bool]] = [
+    # The runtime test cases of EIP-7979
+    ("simple_routine", "6004B000B1B2", True),
+    ("two_levels_of_subroutines", "6004B000B16009B0B2B1B2", True),
+    ("destination_outside_code", "60FFB000B1B2", False),
+    ("bare_returnsub", "B2", False),
+    ("subroutine_at_end_of_code", "600556B1B25B6003B0", True),
+    # Constraint 1: opcodes
+    ("lone_stop", "00", True),
+    ("undefined_opcode", "21", False),
+    ("invalid_is_valid", "FE", True),
+    ("undefined_opcode_at_return_point", "6004B021B1B2", False),
+    # Constraints 2 and 3: destinations
+    ("jump_into_push_immediate", "600156", False),
+    ("jump_to_visited_non_jumpdest", "5F5F01600256", False),
+    ("jumpdest_byte_in_push_data", "600456605B00", False),
+    ("jumpdest_byte_in_live_push_data", "36600857615B00005B600556", False),
+    ("calldest_byte_in_push_data", "6004B060B100", False),
+    ("jumpdest_in_unreachable_code", "600456005B00", True),
+    ("jump_not_preceded_by_push", "365B56", False),
+    ("callsub_to_jumpdest", "6004B0005B", False),
+    # Constraint 4: underflow and the return stack
+    ("add_on_empty_stack", "01", False),
+    ("pop_on_empty_stack", "50", False),
+    (
+        "subroutine_consumes_caller_argument",
+        "6002600BB06003600BB000B18002B2",
+        True,
+    ),
+    ("subroutine_underflows_caller", "6004B000B15050B2", False),
+    ("fall_into_subroutine_then_returnsub", "B1B2", False),
+    # Constraint 5: offsets and net effects
+    ("jumpi_arms_disagree_at_join", "366005575F5B00", False),
+    ("jumpi_diamond_consistent", "366006575F005B5F00", True),
+    ("two_returnsubs_disagree", "6004B000B136600A57B25B5FB2", False),
+    ("two_returnsubs_agree", "6004B000B136600A57B25B5F50B2", True),
+    ("stack_neutral_loop", "5B600056", True),
+    # Reuse and multiple entry points
+    ("called_at_two_depths", "6002600BB06003600BB000B18002B2", True),
+    ("fall_through_second_entry", "6008B05F600AB000B15FB150B2", True),
+    # Recursion
+    ("recursion_no_base_case", "6004B000B16004B0B2", True),
+    ("recursion_eats_caller_stack", "6004B000B1506004B0", False),
+    # Jumps to a CALLDEST (call elimination)
+    ("jump_to_calldest", "6004B000B15F600956B150B2", True),
+    ("conditional_jump_to_calldest", "6004B000B136600A57B2B1B2", True),
+    ("jump_to_calldest_nets_disagree", "6004B000B15F36600B57B2B150B2", False),
+    ("unframed_jump_to_called_subroutine", "6006B0600656B1B2", False),
+    # Overflow is not validated
+    ("seventeen_pushes", "5F" * 17 + "00", True),
+    ("sixteen_pushes", "5F" * 16 + "00", True),
+    (
+        "stack_growth_amplified_by_two_calls",
+        "6007B06007B000B1" + "5F" * 9 + "B2",
+        True,
+    ),
+    ("stack_growth_one_call", "6004B000B1" + "5F" * 9 + "B2", True),
+    ("call_chain_depth_17", call_chain(17), True),
+    ("call_chain_depth_16", call_chain(16), True),
+    ("growing_recursion", "6004B000B15F6004B0", True),
+]
+
+
+def relocate(body_hex: str, shift: int = Spec.HEADER_LENGTH) -> bytes:
+    """
+    Shift every PUSH1 immediate of a vector by `shift`, so that destinations
+    written for code starting at position 0 remain correct behind the
+    header. Immediates that would exceed 0xFF are clamped, which keeps
+    out-of-range destinations out of range. Non-destination PUSH1 values
+    are shifted too; validation never interprets them.
+    """
+    code = bytearray(bytes.fromhex(body_hex))
+    i = 0
+    while i < len(code):
+        op = code[i]
+        if op == 0x60:  # PUSH1
+            code[i + 1] = min(0xFF, code[i + 1] + shift)
+            i += 2
+        elif 0x60 < op <= 0x7F:  # PUSH2..PUSH32
+            i += op - 0x5F + 1
+        elif op in (0xE6, 0xE7, 0xE8):  # DUPN, SWAPN, EXCHANGE
+            i += 2
+        else:
+            i += 1
+    return bytes(code)

--- a/tests/amsterdam/eip8337_validated_code/test_create_paths.py
+++ b/tests/amsterdam/eip8337_validated_code/test_create_paths.py
@@ -1,0 +1,151 @@
+"""
+Validation runs on every creation path: CREATE and CREATE2 as well as
+transaction initcode, and a failed validation costs only the child's gas.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Initcode,
+    Op,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import (
+    SLOT_MARKER,
+    SLOT_RESULT,
+    TX_GAS_LIMIT,
+    factory_code,
+    magic,
+)
+from .spec import Spec, ref_spec_8337
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8337.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8337.version
+
+pytestmark = pytest.mark.valid_from("EIP8337")
+
+VALID_BODY = Op.SSTORE(1, 1) + Op.STOP
+INVALID_BODY = Op.POP + Op.STOP  # underflows
+
+
+@pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
+@pytest.mark.parametrize(
+    "body,valid",
+    [
+        pytest.param(VALID_BODY, True, id="valid"),
+        pytest.param(INVALID_BODY, False, id="invalid"),
+    ],
+)
+def test_create_opcodes_validate(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    create_opcode: Op,
+    body: Op,
+    valid: bool,
+) -> None:
+    """
+    CREATE/CREATE2 of MAGIC code succeeds iff the code validates. A failed
+    validation is an exceptional halt of the child frame: the factory gets
+    0 and keeps its own gas.
+    """
+    code = magic(body)
+    initcode = Initcode(deploy_code=code)
+    factory = pre.deploy_contract(factory_code(create_opcode, len(initcode)))
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=factory,
+        data=initcode,
+        gas_limit=TX_GAS_LIMIT,
+    )
+    if create_opcode == Op.CREATE:
+        created = compute_create_address(address=factory, nonce=1)
+    else:
+        created = compute_create_address(
+            address=factory, initcode=initcode, salt=0, opcode=Op.CREATE2
+        )
+    post = {
+        factory: Account(
+            storage={
+                SLOT_RESULT: created if valid else 0,
+                SLOT_MARKER: 1,  # factory still holds gas after either
+            }
+        ),
+        created: Account(code=code) if valid else Account.NONEXISTENT,
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_magic_initcode_gets_no_entry_point(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Only created code is validated and given an entry point. Initcode that
+    begins with the MAGIC bytes is executed from position 0 like any other
+    initcode, where 0xEF is an invalid opcode, so the creation fails.
+    """
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=magic(Initcode(deploy_code=Op.STOP)),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    created = compute_create_address(address=sender, nonce=0)
+    state_test(pre=pre, post={created: Account.NONEXISTENT}, tx=tx)
+
+
+def test_validation_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Creating MAGIC code costs VALIDATION_BYTE_COST per byte of code more
+    than creating plain code of the same length, and nothing else differs.
+    """
+    body = Op.SSTORE(1, 1) + Op.STOP
+    plain = Op.JUMPDEST * Spec.HEADER_LENGTH + body
+    validated = magic(body)
+    assert len(plain) == len(validated)
+    initcode_plain = Initcode(deploy_code=plain)
+    initcode_magic = Initcode(deploy_code=validated)
+    assert len(initcode_plain) == len(initcode_magic)
+    size = len(initcode_plain)
+
+    # Store the initcodes in memory, create each, and record the gas each
+    # CREATE consumed; then store the difference.
+    factory = pre.deploy_contract(
+        Op.CALLDATACOPY(offset=0, size=size)
+        + Op.CALLDATACOPY(dest_offset=size, offset=size, size=size)
+        + Op.GAS
+        + Op.CREATE(offset=0, size=size)
+        + Op.POP
+        + Op.GAS
+        + Op.SWAP1
+        + Op.SUB  # gas used by the plain create
+        + Op.GAS
+        + Op.CREATE(offset=size, size=size)
+        + Op.POP
+        + Op.GAS
+        + Op.SWAP1
+        + Op.SUB  # gas used by the magic create
+        + Op.SUB  # magic - plain
+        + Op.PUSH1(SLOT_RESULT)
+        + Op.SSTORE
+    )
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=factory,
+        data=bytes(initcode_plain) + bytes(initcode_magic),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    post = {
+        factory: Account(
+            storage={SLOT_RESULT: Spec.VALIDATION_BYTE_COST * len(validated)}
+        ),
+    }
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8337_validated_code/test_execution.py
+++ b/tests/amsterdam/eip8337_validated_code/test_execution.py
@@ -1,0 +1,164 @@
+"""
+Execution of MAGIC code: it begins immediately after the header, positions
+stay absolute (the header is part of the code), and the header is visible
+to CODESIZE and CODECOPY.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+
+from .helpers import MARKER, SLOT_MARKER, SLOT_RESULT, TX_GAS_LIMIT, magic
+from .spec import Spec, ref_spec_8337
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8337.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8337.version
+
+pytestmark = pytest.mark.valid_from("EIP8337")
+
+
+def test_execution_begins_after_header(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    A MAGIC contract stores a marker. Were execution to begin at position
+    0, the 0xEF byte would halt the frame before the store.
+    """
+    contract = pre.deploy_contract(magic(Op.SSTORE(SLOT_MARKER, MARKER)))
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: MARKER})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_codesize_includes_header(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """CODESIZE reports the whole code, header included."""
+    code = magic(Op.SSTORE(SLOT_RESULT, Op.CODESIZE))
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_RESULT: len(code)})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_codecopy_sees_header(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """CODECOPY from position 0 returns the header bytes."""
+    code = magic(
+        Op.CODECOPY(dest_offset=0, offset=0, size=Spec.HEADER_LENGTH)
+        + Op.SSTORE(SLOT_RESULT, Op.MLOAD(0))
+    )
+    contract = pre.deploy_contract(code)
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    expected = int.from_bytes(Spec.MAGIC_HEADER.ljust(32, b"\x00"), "big")
+    post = {contract: Account(storage={SLOT_RESULT: expected})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_jump_and_call_positions_are_absolute(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    JUMP and CALLSUB destinations count from the start of the code,
+    header included: the body jumps over a STOP to a JUMPDEST, then calls
+    a subroutine, using absolute positions.
+    """
+    # Positions after the 3-byte header:
+    #   3: PUSH1 7  5: JUMP  6: STOP  7: JUMPDEST  8: PUSH1 14  10: CALLSUB
+    #  11: PUSH1 slot, SSTORE, STOP; then CALLDEST, PUSH1 marker, RETURNSUB
+    main = (
+        Op.PUSH1[7]
+        + Op.JUMP
+        + Op.STOP
+        + Op.JUMPDEST
+        + Op.PUSH1[0]  # patched to the subroutine position below
+        + Op.CALLSUB
+        + Op.PUSH1[SLOT_MARKER]
+        + Op.SSTORE
+        + Op.STOP
+    )
+    subroutine_pos = Spec.HEADER_LENGTH + len(main)
+    main = (
+        Op.PUSH1[7]
+        + Op.JUMP
+        + Op.STOP
+        + Op.JUMPDEST
+        + Op.PUSH1[subroutine_pos]
+        + Op.CALLSUB
+        + Op.PUSH1[SLOT_MARKER]
+        + Op.SSTORE
+        + Op.STOP
+    )
+    subroutine = Op.CALLDEST + Op.PUSH1[MARKER] + Op.RETURNSUB
+    contract = pre.deploy_contract(magic(main + subroutine))
+    tx = Transaction(
+        sender=pre.fund_eoa(), to=contract, gas_limit=TX_GAS_LIMIT
+    )
+    post = {contract: Account(storage={SLOT_MARKER: MARKER})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "call_opcode",
+    [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL],
+)
+def test_magic_callee_in_every_call_context(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+) -> None:
+    """
+    A MAGIC callee runs from its entry point under every call opcode. It
+    returns the marker through memory so STATICCALL frames can be checked.
+    """
+    callee = pre.deploy_contract(
+        magic(Op.MSTORE(0, MARKER) + Op.RETURN(0, 32))
+    )
+    caller = pre.deploy_contract(
+        Op.SSTORE(
+            SLOT_RESULT,
+            call_opcode(
+                gas=200_000, address=callee, ret_offset=0, ret_size=32
+            ),
+        )
+        + Op.SSTORE(SLOT_MARKER, Op.MLOAD(0))
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_RESULT: 1, SLOT_MARKER: MARKER})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_invalid_magic_code_in_pre_state_still_runs(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Validation happens only at CREATE. MAGIC code placed directly in state
+    (as tests, or a future irregular state change, can do) is executed
+    with the ordinary runtime checks, so a body that would fail validation
+    simply halts at runtime.
+    """
+    # POP on an empty stack: invalid code, halts at runtime.
+    callee = pre.deploy_contract(magic(Op.POP + Op.STOP))
+    caller = pre.deploy_contract(
+        Op.SSTORE(SLOT_RESULT, Op.CALL(gas=200_000, address=callee))
+    )
+    tx = Transaction(sender=pre.fund_eoa(), to=caller, gas_limit=TX_GAS_LIMIT)
+    post = {caller: Account(storage={SLOT_RESULT: 0})}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8337_validated_code/test_fork_transition.py
+++ b/tests/amsterdam/eip8337_validated_code/test_fork_transition.py
@@ -1,0 +1,54 @@
+"""Fork-transition tests for EIP-8337: no MAGIC code before the fork."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Initcode,
+    Op,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import TX_GAS_LIMIT, magic
+from .spec import ref_spec_8337
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8337.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8337.version
+
+FORK_TIMESTAMP = 15_000
+
+
+@pytest.mark.valid_at_transition_to("EIP8337")
+def test_magic_creation_at_fork_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Before the fork, code beginning with 0xEF is rejected at creation
+    (EIP-3541); from the fork onward, valid MAGIC code is created.
+    """
+    sender = pre.fund_eoa()
+    code = magic(Op.SSTORE(1, 1) + Op.STOP)
+    blocks = [
+        Block(
+            timestamp=ts,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    to=None,
+                    data=Initcode(deploy_code=code),
+                    gas_limit=TX_GAS_LIMIT,
+                )
+            ],
+        )
+        for ts in (FORK_TIMESTAMP - 1, FORK_TIMESTAMP, FORK_TIMESTAMP + 1)
+    ]
+    post = {
+        compute_create_address(address=sender, nonce=0): Account.NONEXISTENT,
+        compute_create_address(address=sender, nonce=1): Account(code=code),
+        compute_create_address(address=sender, nonce=2): Account(code=code),
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip8337_validated_code/test_header.py
+++ b/tests/amsterdam/eip8337_validated_code/test_header.py
@@ -1,0 +1,63 @@
+"""
+The MAGIC header at CREATE: which prefixes are accepted, which are
+rejected, and the EIP-3541 boundary for other 0xEF code.
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Initcode,
+    Op,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import TX_GAS_LIMIT, raw
+from .spec import Spec, ref_spec_8337
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8337.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8337.version
+
+pytestmark = pytest.mark.valid_from("EIP8337")
+
+BODY = bytes(Op.SSTORE(1, 1) + Op.STOP)
+
+
+@pytest.mark.parametrize(
+    "code,accepted",
+    [
+        pytest.param(Spec.MAGIC_HEADER + BODY, True, id="magic_valid_body"),
+        pytest.param(Spec.MAGIC_HEADER, False, id="header_only"),
+        pytest.param(Spec.MAGIC + b"\x02" + BODY, False, id="wrong_version"),
+        pytest.param(Spec.MAGIC, False, id="magic_without_version"),
+        pytest.param(b"\xef" + BODY, False, id="eip3541_bare_ef"),
+        pytest.param(b"\xef\x00\x01" + BODY, False, id="eip3541_eof_prefix"),
+        pytest.param(b"\xef\x01\x00" + BODY, False, id="eip3541_7702_prefix"),
+        pytest.param(BODY, True, id="plain_code_unaffected"),
+    ],
+)
+def test_created_code_prefix(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    code: bytes,
+    accepted: bool,
+) -> None:
+    """
+    Only a complete, correct MAGIC header with a valid body is accepted.
+    Every other 0xEF prefix is still rejected as before (EIP-3541), and
+    code that does not begin with 0xEF is unaffected.
+    """
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=Initcode(deploy_code=raw(code)),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    created = compute_create_address(address=sender, nonce=0)
+    post = {
+        created: Account(code=code) if accepted else Account.NONEXISTENT,
+    }
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8337_validated_code/test_validation_vectors.py
+++ b/tests/amsterdam/eip8337_validated_code/test_validation_vectors.py
@@ -1,0 +1,75 @@
+"""
+The EIP's validation vectors, deployed as MAGIC code by a creation
+transaction: valid code is stored, invalid code halts the creation.
+
+Vectors are written for code starting at position 0; behind the 3-byte
+header every PUSH1 destination is shifted by 3 (see ``spec.relocate``).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Initcode,
+    StateTestFiller,
+    Transaction,
+    compute_create_address,
+)
+
+from .helpers import TX_GAS_LIMIT, magic
+from .spec import VECTORS, ref_spec_8337, relocate
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8337.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8337.version
+
+pytestmark = pytest.mark.valid_from("EIP8337")
+
+
+@pytest.mark.parametrize(
+    "body_hex,valid",
+    [pytest.param(body, valid, id=name) for name, body, valid in VECTORS],
+)
+def test_validation_vectors(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    body_hex: str,
+    valid: bool,
+) -> None:
+    """
+    Deploy each vector behind the MAGIC header; the account exists iff
+    the code is valid.
+    """
+    code = magic(relocate(body_hex))
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=Initcode(deploy_code=code),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    created = compute_create_address(address=sender, nonce=0)
+    post = {
+        created: Account(code=code) if valid else Account.NONEXISTENT,
+    }
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_push0_destination_is_the_header(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    The EIP's "PUSH0-preceded JUMP" vector (JUMPDEST, PUSH0, JUMP) is valid
+    bare, where position 0 is the JUMPDEST. Behind a header position 0 is
+    a MAGIC byte, not an instruction, so the same body is invalid.
+    """
+    code = magic(bytes.fromhex("5B5F56"))
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=None,
+        data=Initcode(deploy_code=code),
+        gas_limit=TX_GAS_LIMIT,
+    )
+    created = compute_create_address(address=sender, nonce=0)
+    state_test(pre=pre, post={created: Account.NONEXISTENT}, tx=tx)

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -46,6 +46,13 @@ def prepare_stack(opcode: Opcode) -> Bytecode:
         return Op.PUSH1(1) + Op.PUSH1(5)
     if opcode == Op.JUMP:
         return Op.PUSH1(3)
+    if opcode == Op.CALLSUB:
+        # EIP-7979: call the CALLDEST placed right after the CALLSUB.
+        return Op.PUSH1(3)
+    if opcode == Op.RETURNSUB:
+        # EIP-7979: jump over the RETURNSUB to the suffix, which calls the
+        # CALLDEST just before it; the RETURNSUB then returns to the STOP.
+        return Op.PUSH1(5) + Op.JUMP + Op.CALLDEST
     if opcode == Op.RETURNDATACOPY:
         return Op.PUSH1(0) * 3
     return Op.PUSH1(0x01) * 32
@@ -55,6 +62,10 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     """Prepare after opcode instructions."""
     if opcode == Op.JUMPI or opcode == Op.JUMP:
         return Op.JUMPDEST
+    if opcode == Op.CALLSUB:
+        return Op.CALLDEST
+    if opcode == Op.RETURNSUB:
+        return Op.JUMPDEST + Op.PUSH1(3) + Op.CALLSUB + Op.STOP
     return Op.STOP
 
 
@@ -217,6 +228,8 @@ def fork_opcodes_with_non_increasing_stack(
                 # Incompatible with this test:
                 Op.REVERT,  # Reverts the storage required
                 Op.JUMP,  # Tries to jump to non-jumpdest
+                Op.CALLSUB,  # Tries to call a non-calldest (EIP-7979)
+                Op.RETURNSUB,  # Empty return stack (EIP-7979)
                 Op.BLOCKHASH,  # Incompatible with state_test
                 Op.SELFDESTRUCT,  # selfdestructs the contract in old forks
             ]:
@@ -270,7 +283,7 @@ def prepare_stack_constant_gas_oog(opcode: Opcode) -> Bytecode:
     """Prepare valid stack for opcode."""
     if opcode == Op.JUMPI:
         return Op.PUSH1(1) + Op.PUSH1(3) + Op.PC + Op.ADD
-    if opcode == Op.JUMP:
+    if opcode == Op.JUMP or opcode == Op.CALLSUB:
         return Op.PUSH1(3) + Op.PC + Op.ADD
     if opcode == Op.BLOCKHASH:
         return Op.PUSH1(0x01)
@@ -291,6 +304,11 @@ def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
         # the state reservoir that cannot be measured via the GAS opcode
         # delta used by gas_test. Excluded to keep the test meaningful.
         if fork.is_eip_enabled(8037) and opcode in (Op.CREATE, Op.CREATE2):
+            continue
+        # EIP-7979: RETURNSUB needs a CALLSUB in the same frame, which this
+        # harness cannot arrange; its cost is measured in
+        # tests/amsterdam/eip7979_callsub/test_gas.py.
+        if opcode == Op.RETURNSUB:
             continue
         yield pytest.param(
             opcode,


### PR DESCRIPTION
Draft. Reference implementation and tests for [EIP-8337](https://eips.ethereum.org/EIPS/eip-8337), which adds opt-in validation on top of EIP-7979 (#3575, which this branch includes). Not proposed for Hegotá; posted to show that 7979 can be validated in about 450 lines when the time comes. MAGIC bytes, header layout, and the validation charge are placeholders, each defined in one place. All 200 fixtures fill against the spec; just static is clean.

### Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [ ] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [ ] PR title has the form `<type>(<area>): <title>`, where `<type>` and `<area>` come from an appropriate [`C-<type>`](https://github.com/ethereum/execution-specs/labels?q=C-), respectively [`A-<area>`](https://github.com/ethereum/execution-specs/labels?q=A-), label. The title should match the target squash commit message.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
