### PR TITLE
feat(tests): fork-aware EIP-7623 refunds under EIP-8037

### DIFF
--- a/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
@@ -14,6 +14,7 @@ from execution_testing import (
     Fork,
     GasConsumer,
     Op,
+    RecipientType,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
@@ -68,15 +69,29 @@ def data_test_type() -> DataTestType:
 
 @pytest.fixture
 def authorization_list(
-    pre: Alloc, refund_type: RefundType
+    pre: Alloc, refund_type: RefundType, fork: Fork
 ) -> List[AuthorizationTuple] | None:
     """
     Modify fixture from conftest to automatically read the refund_type
     information.
+
+    On EIP-8037 / EIP-2780 an existing funded authority pays only the
+    top-frame ``AUTH_BASE`` (no ``NEW_ACCOUNT`` / ``ACCOUNT_WRITE``, and no
+    existing-authority refund), so the tuple is annotated accordingly.
     """
     if RefundType.AUTHORIZATION_EXISTING_AUTHORITY not in refund_type:
         return None
-    return [AuthorizationTuple(signer=pre.fund_eoa(1), address=Address(1))]
+    signer = pre.fund_eoa(1)
+    if fork.is_eip_enabled(8037):
+        return [
+            AuthorizationTuple(
+                signer=signer,
+                address=Address(1),
+                creates_account=False,
+                writes_delegation=True,
+            )
+        ]
+    return [AuthorizationTuple(signer=signer, address=Address(1))]
 
 
 @pytest.fixture
@@ -91,13 +106,29 @@ def ty(refund_type: RefundType) -> int:
 
 
 @pytest.fixture
-def state_gas_refund(fork: Fork, refund_type: RefundType) -> int:
-    """Return the state gas refund (direct return, not subject to 1/5 cap)."""
-    auth_existing = RefundType.AUTHORIZATION_EXISTING_AUTHORITY
-    if fork.is_eip_enabled(8037) and auth_existing in refund_type:
-        gas_costs = fork.gas_costs()
-        return gas_costs.REFUND_AUTH_PER_EXISTING_ACCOUNT
-    return 0
+def top_frame_execution(
+    fork: Fork, authorization_list: List[AuthorizationTuple] | None
+) -> int:
+    """Top-frame execution gas charged for authorizations (EIP-8037)."""
+    if not authorization_list or not fork.is_eip_enabled(8037):
+        return 0
+    return fork.transaction_top_frame_execution_gas(
+        recipient_type=RecipientType.CONTRACT,
+        authorizations=authorization_list,
+    )
+
+
+@pytest.fixture
+def top_frame_state(
+    fork: Fork, authorization_list: List[AuthorizationTuple] | None
+) -> int:
+    """Top-frame state gas charged for authorizations (EIP-8037)."""
+    if not authorization_list or not fork.is_eip_enabled(8037):
+        return 0
+    return fork.transaction_top_frame_state_gas(
+        recipient_type=RecipientType.CONTRACT,
+        authorizations=authorization_list,
+    )
 
 
 @pytest.fixture
@@ -110,6 +141,9 @@ def max_refund(fork: Fork, refund_type: RefundType) -> int:
         else 0
     )
     auth_existing = RefundType.AUTHORIZATION_EXISTING_AUTHORITY
+    # Pre-EIP-8037: existing-authority auth refund lands in refund_counter
+    # (EIP-3529 1/5 cap). EIP-8037 / EIP-2780 charge AUTH_BASE directly at
+    # the top frame with no existing-authority refund.
     if not fork.is_eip_enabled(8037) and auth_existing in refund_type:
         max_refund += gas_costs.REFUND_AUTH_PER_EXISTING_ACCOUNT
     return max_refund
@@ -159,7 +193,12 @@ def contract_creating_tx() -> bool:
 
 
 @pytest.fixture
-def intrinsic_gas_data_floor_minimum_delta() -> int:
+def intrinsic_gas_data_floor_minimum_delta(
+    fork: Fork,
+    prefix_code_gas: int,
+    top_frame_execution: int,
+    top_frame_state: int,
+) -> int:
     """
     Induce a minimum delta between the transaction intrinsic gas cost and the
     floor data gas cost.
@@ -170,10 +209,18 @@ def intrinsic_gas_data_floor_minimum_delta() -> int:
     would always be the below the execution gas cost even after the refund is
     applied.
 
-    This value has been set as of Prague and should be adjusted if the gas
-    costs change.
+    On EIP-8037 the SSTORE schedule is higher and existing-authority auths add
+    top-frame ``AUTH_BASE`` state gas, so the delta must cover those too.
     """
-    return 250
+    if not fork.is_eip_enabled(8037):
+        return 250
+    # Floor is searched as ~intrinsic + delta. Post-refund cost at
+    # prefix-only (+ top-frame) consumption is at most
+    # intrinsic + top_frame + prefix (when refund is zero) and still
+    # above intrinsic + (top_frame + prefix) * 4/5 when the EIP-3529
+    # cap binds. Cover the no-refund upper bound so all three
+    # refund-vs-floor cases remain reachable.
+    return top_frame_execution + top_frame_state + prefix_code_gas + 500
 
 
 @pytest.fixture
@@ -181,14 +228,16 @@ def execution_gas_used(
     tx_intrinsic_gas_cost_before_execution: int,
     tx_floor_data_cost: int,
     max_refund: int,
-    state_gas_refund: int,
     prefix_code_gas: int,
+    top_frame_execution: int,
+    top_frame_state: int,
     refund_test_type: RefundTestType,
 ) -> int:
     """
     Return the amount of gas that needs to be consumed by the execution.
 
-    This gas amount is on top of the transaction intrinsic gas cost.
+    This gas amount is on top of the transaction intrinsic gas cost (and, on
+    EIP-8037, on top of the authorization top-frame charge).
 
     If this value were zero it would result in the refund being applied to the
     execution gas cost and the resulting amount being always below the floor
@@ -198,10 +247,14 @@ def execution_gas_used(
     """
 
     def execution_gas_cost(execution_gas: int) -> int:
-        total_gas_used = tx_intrinsic_gas_cost_before_execution + execution_gas
-        effective_gas = total_gas_used - state_gas_refund
-        capped_refund = min(max_refund, effective_gas // 5)
-        return effective_gas - capped_refund
+        total_gas_used = (
+            tx_intrinsic_gas_cost_before_execution
+            + top_frame_execution
+            + top_frame_state
+            + execution_gas
+        )
+        capped_refund = min(max_refund, total_gas_used // 5)
+        return total_gas_used - capped_refund
 
     execution_gas = prefix_code_gas
 
@@ -241,14 +294,17 @@ def refund(
     tx_intrinsic_gas_cost_before_execution: int,
     execution_gas_used: int,
     max_refund: int,
-    state_gas_refund: int,
+    top_frame_execution: int,
+    top_frame_state: int,
 ) -> int:
     """Return the refund gas of the transaction."""
     total_gas_used = (
-        tx_intrinsic_gas_cost_before_execution + execution_gas_used
+        tx_intrinsic_gas_cost_before_execution
+        + top_frame_execution
+        + top_frame_state
+        + execution_gas_used
     )
-    effective_gas = total_gas_used - state_gas_refund
-    return min(max_refund, effective_gas // 5)
+    return min(max_refund, total_gas_used // 5)
 
 
 @pytest.fixture
@@ -274,16 +330,25 @@ def tx_gas_limit(
     tx_intrinsic_gas_cost_including_floor_data_cost: int,
     tx_intrinsic_gas_cost_before_execution: int,
     execution_gas_used: int,
+    top_frame_execution: int,
+    top_frame_state: int,
 ) -> int:
     """
     Gas limit for the transaction.
 
-    The gas delta is added to the intrinsic gas cost to generate different test
-    scenarios.
+    Sized to the exact pre-refund consumption when that already clears the
+    EIP-7623 floor. When consumption sits below the floor (refund-free
+    LESS_THAN cases on EIP-8037), bump the limit up to the floor so the
+    transaction remains intrinsically valid while settlement still sees
+    the lower consumed amount.
     """
-    tx_gas_limit = tx_intrinsic_gas_cost_before_execution + execution_gas_used
-    assert tx_gas_limit >= tx_intrinsic_gas_cost_including_floor_data_cost
-    return tx_gas_limit
+    consumed = (
+        tx_intrinsic_gas_cost_before_execution
+        + top_frame_execution
+        + top_frame_state
+        + execution_gas_used
+    )
+    return max(consumed, tx_intrinsic_gas_cost_including_floor_data_cost)
 
 
 @pytest.mark.parametrize(
@@ -302,9 +367,6 @@ def tx_gas_limit(
         RefundType.AUTHORIZATION_EXISTING_AUTHORITY,
     ],
 )
-# TODO[EIP-8037]: Authorization state gas split affects
-# refund calculations for Amsterdam.
-@pytest.mark.valid_before("EIP8037")
 def test_gas_refunds_from_data_floor(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -313,17 +375,28 @@ def test_gas_refunds_from_data_floor(
     tx_intrinsic_gas_cost_before_execution: int,
     execution_gas_used: int,
     refund: int,
-    state_gas_refund: int,
+    top_frame_execution: int,
+    top_frame_state: int,
     refund_test_type: RefundTestType,
 ) -> None:
     """
     Test gas refunds deducted from the execution gas cost and not the data
     floor.
+
+    Pre-EIP-8037: existing-authority auth refunds flow through
+    ``refund_counter`` (EIP-3529 1/5 cap) together with storage-clear refunds.
+
+    EIP-8037 / EIP-2780: existing-authority auths pay top-frame ``AUTH_BASE``
+    with no auth refund; only storage-clear refunds remain in
+    ``refund_counter``. Receipt ``cumulative_gas_used`` is the sum of
+    intrinsic execution, top-frame execution/state, and EVM gas, minus the
+    capped storage refund, then floored by EIP-7623.
     """
     gas_used = (
         tx_intrinsic_gas_cost_before_execution
+        + top_frame_execution
+        + top_frame_state
         + execution_gas_used
-        - state_gas_refund
         - refund
     )
     if (


### PR DESCRIPTION
### Description
Makes `test_gas_refunds_from_data_floor` fork-aware for EIP-8037 / EIP-2780:

- **Pre-EIP-8037:** existing-authority auth refunds stay in `refund_counter` (EIP-3529 1/5 cap).
- **EIP-8037:** annotate existing-authority auths, charge top-frame `AUTH_BASE` with **no** auth refund, size gas limit / floor delta for Amsterdam costs, and keep storage-clear refunds capped as before.

Verified: `uv run fill …::test_gas_refunds_from_data_floor --fork=Amsterdam|Prague` (27/27 each) and `just static`.

### Related Issues or PRs
N/A.

### Checklist

- [x] Ran fast static checks: `just static`
- [x] PR title has the form `<type>(<area>): <title>`

### Cute Animal Picture

![cat on snow](https://upload.wikimedia.org/wikipedia/commons/b/b6/Felis_catus-cat_on_snow.jpg)