### PR TITLE
feat(tests): unskip EIP-7623 type-1/2 create validity under EIP-8037

### DIFF
--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -159,10 +159,6 @@ def test_transaction_validity_type_0(
     "ty",
     [pytest.param(1, id="type_1"), pytest.param(2, id="type_2")],
 )
-# TODO[EIP-8037]: Contract creation state gas
-# (G_TRANSACTION_CREATE) split affects intrinsic gas
-# calculation for Amsterdam.
-@pytest.mark.valid_before("EIP8037")
 def test_transaction_validity_type_1_type_2(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -171,6 +167,11 @@ def test_transaction_validity_type_1_type_2(
     """
     Test transaction validity for transactions with access lists and contract
     creation.
+
+    Under EIP-8037 / EIP-2780, ``NEW_ACCOUNT`` for a create transaction is
+    charged at the top frame (not in the pre-execution intrinsic), so the
+    EIP-7623 floor / intrinsic validity bounds from the shared fixtures
+    already apply on Amsterdam without a separate create-gas path.
     """
     state_test(
         pre=pre,


### PR DESCRIPTION
### Description
Unskips `test_transaction_validity_type_1_type_2` on EIP-8037.

Under EIP-2780, contract-creation \`NEW_ACCOUNT\` is charged at the top frame, not in pre-execution intrinsic. The shared EIP-7623 fixtures already size \`gas_limit\` from that intrinsic + calldata floor, so the old \`valid_before("EIP8037")\` skip is no longer needed.

Verified: \`uv run fill …::test_transaction_validity_type_1_type_2 --fork=Amsterdam|Prague\` (756/756 each) and \`just static\`.

### Related Issues or PRs
N/A.

### Checklist

- [x] Ran fast static checks: \`just static\`
- [x] PR title has the form \`<type>(<area>): <title>\`

### Cute Animal Picture

![otter](https://images.unsplash.com/photo-1425082661705-1834bfd09dca?auto=format&fit=crop&w=640)