### PR TITLE
fix(tests): keep EIP-6110 high call-depth deposits past EIP-8037

### DIFF
--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -580,8 +580,10 @@ pytestmark = pytest.mark.valid_from("Prague")
             ],
             id="single_deposit_from_contract_call_depth_3",
         ),
-        # TODO: Provide a higher transaction gas limit for EIP-8037 state
-        # creation gas costs to extend this test past EIP8037.
+        # High depth under Amsterdam: EIP-7825 caps execution gas at 2^24, and
+        # EIP-8037/8038 raise intrinsic + cold-account costs, so a 271-frame
+        # 63/64 chain OOGs before the deposit lands (270 still passes). Use
+        # 256 so the case stays deep with margin past EIP-8037.
         pytest.param(
             [
                 SystemContractInteractionContract(
@@ -594,11 +596,10 @@ pytestmark = pytest.mark.valid_from("Prague")
                             index=0x0,
                         )
                     ],
-                    call_depth=271,
+                    call_depth=256,
                 ),
             ],
             id="single_deposit_from_contract_call_depth_high",
-            marks=pytest.mark.valid_before("EIP8037"),
         ),
         pytest.param(
             [


### PR DESCRIPTION
### Description
Extends `single_deposit_from_contract_call_depth_high` past EIP-8037 by removing `valid_before("EIP8037")`.

A higher tx gas limit cannot fix this: EIP-7825 still caps execution gas at \(2^{24}\). Amsterdam’s higher intrinsic and cold-account costs leave too little `gas_left` after a 271-frame 63/64 chain for the deposit to land (270 still passes). The case now uses depth 256 so it stays deep with margin.

Filled locally:
```
uv run fill tests/prague/eip6110_deposits/test_deposits.py::test_deposit -k call_depth_high --fork=Amsterdam
uv run fill tests/prague/eip6110_deposits/test_deposits.py::test_deposit -k call_depth_high --fork=Prague
```
and `just static`.

### Related Issues or PRs
N/A.

### Checklist

- [x] Ran fast static checks: `just static`
- [x] PR title has the form `<type>(<area>): <title>`

### Cute Animal Picture

![fox](https://images.unsplash.com/photo-1474511320723-9a56873867b5?auto=format&fit=crop&w=640)